### PR TITLE
✨ openstack: close small high-signal gaps in identity, sharing, storage and bare metal

### DIFF
--- a/providers/openstack/resources/coverage_test.go
+++ b/providers/openstack/resources/coverage_test.go
@@ -1,0 +1,176 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
+	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/listeners"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeRBACObjectType(t *testing.T) {
+	// Neutron spells the multi-word RBAC object types with either separator
+	// depending on release. Matching one literal drops the other spelling.
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		{"qos-policy", "qos_policy"},
+		{"qos_policy", "qos_policy"},
+		{"security_group", "security_group"},
+		{"security-group", "security_group"},
+		{"Address-Scope", "address_scope"},
+		{"  subnetpool  ", "subnetpool"},
+		{"network", "network"},
+		{"", ""},
+	} {
+		assert.Equal(t, tc.want, normalizeRBACObjectType(tc.in), tc.in)
+	}
+}
+
+func TestRBACObjectTypeIs(t *testing.T) {
+	t.Run("matches across separator spellings", func(t *testing.T) {
+		assert.True(t, rbacObjectTypeIs("qos_policy", "qos-policy"))
+		assert.True(t, rbacObjectTypeIs("qos-policy", "qos-policy"))
+		assert.True(t, rbacObjectTypeIs("security-group", "security_group"))
+		assert.True(t, rbacObjectTypeIs("address_group", "address_group"))
+	})
+	t.Run("does not match a different type", func(t *testing.T) {
+		// address_scope and address_group differ only in the last word; folding
+		// separators must not fold them together.
+		assert.False(t, rbacObjectTypeIs("address_scope", "address_group"))
+		assert.False(t, rbacObjectTypeIs("network", "subnetpool"))
+		assert.False(t, rbacObjectTypeIs("", "network"))
+	})
+}
+
+func TestHSTSEnabledForMaxAge(t *testing.T) {
+	// HSTS is off unless max-age is positive; includeSubDomains and preload are
+	// inert on their own, so neither may stand in for "HSTS is on".
+	assert.False(t, hstsEnabledForMaxAge(0), "max-age 0 disables HSTS")
+	assert.False(t, hstsEnabledForMaxAge(-1), "a negative max-age is not enabled")
+	assert.True(t, hstsEnabledForMaxAge(1))
+	assert.True(t, hstsEnabledForMaxAge(31536000))
+}
+
+func TestListenerHSTSDecode(t *testing.T) {
+	// Pin the wire names of the HSTS fields: a mistyped tag reads max_age as 0
+	// on a listener that has HSTS on, which reports the listener as unprotected.
+	body := []byte(`{
+		"id": "00000000-0000-0000-0000-000000000001",
+		"hsts_max_age": 31536000,
+		"hsts_include_subdomains": true,
+		"hsts_preload": true
+	}`)
+	var l listeners.Listener
+	require.NoError(t, json.Unmarshal(body, &l))
+	assert.Equal(t, 31536000, l.HSTSMaxAge)
+	assert.True(t, l.HSTSIncludeSubdomains)
+	assert.True(t, l.HSTSPreload)
+	assert.True(t, hstsEnabledForMaxAge(int64(l.HSTSMaxAge)))
+
+	t.Run("listener without the HSTS fields reads as not enabled", func(t *testing.T) {
+		// Pre-microversion-2.27 Octavia omits the fields entirely. The safe
+		// reading is "not enabled", which fails an HSTS assertion rather than
+		// passing it vacuously.
+		var old listeners.Listener
+		require.NoError(t, json.Unmarshal([]byte(`{"id":"x"}`), &old))
+		assert.Equal(t, 0, old.HSTSMaxAge)
+		assert.False(t, hstsEnabledForMaxAge(int64(old.HSTSMaxAge)))
+	})
+}
+
+func TestNodeAutomatedCleanDecode(t *testing.T) {
+	// automated_clean is nullable: false means disks are not wiped between
+	// tenants, while null means the node defers to the conductor default. The
+	// two must not collapse into one another.
+	t.Run("explicit false", func(t *testing.T) {
+		var n nodes.Node
+		require.NoError(t, json.Unmarshal([]byte(`{"automated_clean": false}`), &n))
+		require.NotNil(t, n.AutomatedClean)
+		assert.False(t, *n.AutomatedClean)
+	})
+	t.Run("explicit true", func(t *testing.T) {
+		var n nodes.Node
+		require.NoError(t, json.Unmarshal([]byte(`{"automated_clean": true}`), &n))
+		require.NotNil(t, n.AutomatedClean)
+		assert.True(t, *n.AutomatedClean)
+	})
+	t.Run("absent stays null", func(t *testing.T) {
+		var n nodes.Node
+		require.NoError(t, json.Unmarshal([]byte(`{"uuid":"x"}`), &n))
+		assert.Nil(t, n.AutomatedClean, "absent must not read as false")
+	})
+	t.Run("explicit null stays null", func(t *testing.T) {
+		var n nodes.Node
+		require.NoError(t, json.Unmarshal([]byte(`{"automated_clean": null}`), &n))
+		assert.Nil(t, n.AutomatedClean)
+	})
+	t.Run("retirement fields", func(t *testing.T) {
+		var n nodes.Node
+		require.NoError(t, json.Unmarshal(
+			[]byte(`{"retired": true, "retired_reason": "end of lease"}`), &n))
+		assert.True(t, n.Retired)
+		assert.Equal(t, "end of lease", n.RetiredReason)
+	})
+}
+
+func TestRedactContainerMetadata(t *testing.T) {
+	// Swift returns the temp-URL signing keys as ordinary X-Container-Meta-*
+	// headers, so they land in the metadata map next to user labels. Anyone
+	// holding one can mint unauthenticated pre-signed URLs, so the value must
+	// never leave the provider.
+	in := map[string]string{
+		"Owner":          "platform-team",
+		"Temp-Url-Key":   "not-a-real-key",
+		"Temp-Url-Key-2": "not-a-real-key-either",
+		"Retention":      "30d",
+	}
+	out := redactContainerMetadata(in)
+	assert.Equal(t, map[string]string{
+		"Owner":     "platform-team",
+		"Retention": "30d",
+	}, out)
+
+	t.Run("input is not mutated", func(t *testing.T) {
+		assert.Len(t, in, 4, "redaction must copy, not strip the cached map")
+	})
+	t.Run("casing does not defeat redaction", func(t *testing.T) {
+		// net/http canonicalizes header casing, and Swift itself accepts any
+		// casing on the way in, so match case-insensitively.
+		out := redactContainerMetadata(map[string]string{
+			"TEMP-URL-KEY":   "not-a-real-key",
+			"temp-url-key-2": "not-a-real-key-either",
+			"Keep":           "value",
+		})
+		assert.Equal(t, map[string]string{"Keep": "value"}, out)
+	})
+	t.Run("a similarly named key is kept", func(t *testing.T) {
+		out := redactContainerMetadata(map[string]string{"Temp-Url-Key-Rotated-At": "2026-01-01"})
+		assert.Equal(t, map[string]string{"Temp-Url-Key-Rotated-At": "2026-01-01"}, out)
+	})
+	t.Run("empty and nil maps", func(t *testing.T) {
+		assert.Empty(t, redactContainerMetadata(nil))
+		assert.Empty(t, redactContainerMetadata(map[string]string{}))
+	})
+}
+
+func TestUserOptionBoolPasswordPolicyBypasses(t *testing.T) {
+	// The bypass flags share one options map with the two already shipped, and
+	// each one exempts the account from a domain-wide password rule.
+	options := map[string]any{
+		"ignore_password_expiry":                true,
+		"ignore_change_password_upon_first_use": true,
+		"ignore_user_inactivity":                false,
+	}
+	assert.True(t, userOptionBool(options, "ignore_password_expiry"))
+	assert.True(t, userOptionBool(options, "ignore_change_password_upon_first_use"))
+	assert.False(t, userOptionBool(options, "ignore_user_inactivity"))
+	// An account that sets no options is subject to every policy.
+	assert.False(t, userOptionBool(map[string]any{}, "ignore_password_expiry"))
+}

--- a/providers/openstack/resources/ironic.go
+++ b/providers/openstack/resources/ironic.go
@@ -104,15 +104,20 @@ func (o *mqlOpenstack) baremetalNodes() ([]any, error) {
 			"conductor":            llx.StringData(n.Conductor),
 			"protected":            llx.BoolData(n.Protected),
 			"protectedReason":      llx.StringData(n.ProtectedReason),
-			"description":          llx.StringData(n.Description),
-			"consoleEnabled":       llx.BoolData(n.ConsoleEnabled),
-			"bootInterface":        llx.StringData(n.BootInterface),
-			"deployInterface":      llx.StringData(n.DeployInterface),
-			"networkInterface":     llx.StringData(n.NetworkInterface),
-			"traits":               stringSliceData(n.Traits),
-			"instanceUuid":         llx.StringData(n.InstanceUUID),
-			"createdAt":            llx.TimeDataPtr(timePtr(n.CreatedAt)),
-			"updatedAt":            llx.TimeDataPtr(timePtr(n.UpdatedAt)),
+			// AutomatedClean is *bool in the API: absent means the node defers to the
+			// conductor default, which is neither on nor off, so it stays null.
+			"automatedClean":   llx.BoolDataPtr(n.AutomatedClean),
+			"retired":          llx.BoolData(n.Retired),
+			"retiredReason":    llx.StringData(n.RetiredReason),
+			"description":      llx.StringData(n.Description),
+			"consoleEnabled":   llx.BoolData(n.ConsoleEnabled),
+			"bootInterface":    llx.StringData(n.BootInterface),
+			"deployInterface":  llx.StringData(n.DeployInterface),
+			"networkInterface": llx.StringData(n.NetworkInterface),
+			"traits":           stringSliceData(n.Traits),
+			"instanceUuid":     llx.StringData(n.InstanceUUID),
+			"createdAt":        llx.TimeDataPtr(timePtr(n.CreatedAt)),
+			"updatedAt":        llx.TimeDataPtr(timePtr(n.UpdatedAt)),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/openstack/resources/keystone.go
+++ b/providers/openstack/resources/keystone.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/roles"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/users"
 	"github.com/gophercloud/gophercloud/v2/pagination"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 )
@@ -193,15 +194,18 @@ func (o *mqlOpenstack) users() ([]any, error) {
 
 func newMqlOpenstackUser(runtime *plugin.Runtime, u *users.User) (*mqlOpenstackUser, error) {
 	res, err := CreateResource(runtime, "openstack.user", map[string]*llx.RawData{
-		"__id":                         llx.StringData("openstack.user/" + u.ID),
-		"id":                           llx.StringData(u.ID),
-		"name":                         llx.StringData(u.Name),
-		"enabled":                      llx.BoolData(u.Enabled),
-		"description":                  llx.StringData(u.Description),
-		"passwordExpiresAt":            llx.TimeDataPtr(timePtr(u.PasswordExpiresAt)),
-		"ignoreLockoutFailureAttempts": llx.BoolData(userOptionBool(u.Options, "ignore_lockout_failure_attempts")),
-		"multiFactorAuthEnabled":       llx.BoolData(userOptionBool(u.Options, "multi_factor_auth_enabled")),
-		"multiFactorAuthRules":         dictSliceData(userMFARules(u.Options)),
+		"__id":                             llx.StringData("openstack.user/" + u.ID),
+		"id":                               llx.StringData(u.ID),
+		"name":                             llx.StringData(u.Name),
+		"enabled":                          llx.BoolData(u.Enabled),
+		"description":                      llx.StringData(u.Description),
+		"passwordExpiresAt":                llx.TimeDataPtr(timePtr(u.PasswordExpiresAt)),
+		"ignoreLockoutFailureAttempts":     llx.BoolData(userOptionBool(u.Options, "ignore_lockout_failure_attempts")),
+		"multiFactorAuthEnabled":           llx.BoolData(userOptionBool(u.Options, "multi_factor_auth_enabled")),
+		"multiFactorAuthRules":             dictSliceData(userMFARules(u.Options)),
+		"ignorePasswordExpiry":             llx.BoolData(userOptionBool(u.Options, "ignore_password_expiry")),
+		"ignoreChangePasswordUponFirstUse": llx.BoolData(userOptionBool(u.Options, "ignore_change_password_upon_first_use")),
+		"ignoreUserInactivity":             llx.BoolData(userOptionBool(u.Options, "ignore_user_inactivity")),
 	})
 	if err != nil {
 		return nil, err
@@ -641,6 +645,11 @@ func resolveAssignedRoles(runtime *plugin.Runtime, items []roles.RoleAssignment)
 type mqlOpenstackApplicationCredentialInternal struct {
 	cacheUserID    string
 	cacheProjectID string
+	cacheRoleIDs   []string
+}
+
+func (r *mqlOpenstackApplicationCredential) roles() ([]any, error) {
+	return rolesByID(r.MqlRuntime, r.cacheRoleIDs)
 }
 
 func (r *mqlOpenstackApplicationCredential) id() (string, error) {
@@ -677,8 +686,12 @@ func (r *mqlOpenstackUser) applicationCredentials() ([]any, error) {
 	out := make([]any, 0, len(items))
 	for _, ac := range items {
 		roleNames := make([]string, 0, len(ac.Roles))
+		roleIDs := make([]string, 0, len(ac.Roles))
 		for _, role := range ac.Roles {
 			roleNames = append(roleNames, role.Name)
+			if role.ID != "" {
+				roleIDs = append(roleIDs, role.ID)
+			}
 		}
 		rules := make([]any, 0, len(ac.AccessRules))
 		for _, rule := range ac.AccessRules {
@@ -705,6 +718,7 @@ func (r *mqlOpenstackUser) applicationCredentials() ([]any, error) {
 		mqlAC := res.(*mqlOpenstackApplicationCredential)
 		mqlAC.cacheUserID = r.Id.Data
 		mqlAC.cacheProjectID = ac.ProjectID
+		mqlAC.cacheRoleIDs = roleIDs
 		out = append(out, mqlAC)
 	}
 	return out, nil
@@ -746,6 +760,43 @@ type mqlOpenstackIdentityRoleAssignmentInternal struct {
 	cacheGroupID        string
 	cacheScopeProjectID string
 	cacheScopeDomainID  string
+}
+
+// rolesByID resolves a set of role IDs against the cached role catalog. Trusts
+// and application credentials each carry a handful of role IDs, and a
+// NewResource per id would run openstack.role's init before the runtime cache
+// is consulted, turning one catalog listing into one lookup per delegated role.
+// Walking the already-fetched list keeps it at a single call for the whole scan.
+//
+// A cloud where the role catalog is not readable (it is admin-only) yields an
+// empty list rather than an error: roleNames still carries the names, so the
+// delegation itself stays visible.
+func rolesByID(runtime *plugin.Runtime, ids []string) ([]any, error) {
+	out := make([]any, 0, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	root, err := CreateResource(runtime, "openstack", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	list := root.(*mqlOpenstack).GetRoles()
+	if list.Error != nil {
+		log.Warn().Err(list.Error).Msg("openstack> role catalog not readable; returning no typed roles")
+		return out, nil
+	}
+	byID := make(map[string]*mqlOpenstackRole, len(list.Data))
+	for _, raw := range list.Data {
+		if role, ok := raw.(*mqlOpenstackRole); ok {
+			byID[role.Id.Data] = role
+		}
+	}
+	for _, id := range ids {
+		if role, ok := byID[id]; ok {
+			out = append(out, role)
+		}
+	}
+	return out, nil
 }
 
 // roleNamesByID builds a role-ID to role-name lookup from the role catalog. It

--- a/providers/openstack/resources/keystone_catalog.go
+++ b/providers/openstack/resources/keystone_catalog.go
@@ -225,6 +225,11 @@ type mqlOpenstackTrustInternal struct {
 	cacheTrustorUserID      string
 	cacheProjectID          string
 	cacheRedelegatedTrustID string
+	cacheRoleIDs            []string
+}
+
+func (r *mqlOpenstackTrust) roles() ([]any, error) {
+	return rolesByID(r.MqlRuntime, r.cacheRoleIDs)
 }
 
 func (o *mqlOpenstack) trusts() ([]any, error) {
@@ -248,8 +253,12 @@ func (o *mqlOpenstack) trusts() ([]any, error) {
 	out := make([]any, 0, len(items))
 	for _, t := range items {
 		roleNames := make([]string, 0, len(t.Roles))
+		roleIDs := make([]string, 0, len(t.Roles))
 		for _, role := range t.Roles {
 			roleNames = append(roleNames, role.Name)
+			if role.ID != "" {
+				roleIDs = append(roleIDs, role.ID)
+			}
 		}
 		res, err := CreateResource(o.MqlRuntime, "openstack.trust", map[string]*llx.RawData{
 			"__id":              llx.StringData("openstack.trust/" + t.ID),
@@ -258,6 +267,7 @@ func (o *mqlOpenstack) trusts() ([]any, error) {
 			"roleNames":         stringSliceData(roleNames),
 			"allowRedelegation": llx.BoolData(t.AllowRedelegation),
 			"remainingUses":     llx.IntData(int64(t.RemainingUses)),
+			"redelegationCount": llx.IntData(int64(t.RedelegationCount)),
 			"expiresAt":         llx.TimeDataPtr(timePtr(t.ExpiresAt)),
 		})
 		if err != nil {
@@ -268,6 +278,7 @@ func (o *mqlOpenstack) trusts() ([]any, error) {
 		mqlTrust.cacheTrustorUserID = t.TrustorUserID
 		mqlTrust.cacheProjectID = t.ProjectID
 		mqlTrust.cacheRedelegatedTrustID = t.RedelegatedTrustID
+		mqlTrust.cacheRoleIDs = roleIDs
 		out = append(out, mqlTrust)
 	}
 	return out, nil

--- a/providers/openstack/resources/network_addressscopes.go
+++ b/providers/openstack/resources/network_addressscopes.go
@@ -1,0 +1,111 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/addressscopes"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+type mqlOpenstackNetworkAddressScopeInternal struct {
+	cacheProjectID string
+}
+
+func (r *mqlOpenstackNetworkAddressScope) id() (string, error) {
+	return "openstack.network.addressScope/" + r.Id.Data, nil
+}
+
+func (o *mqlOpenstack) addressScopes() ([]any, error) {
+	c := conn(o.MqlRuntime)
+	client, err := c.NetworkClient()
+	if err != nil {
+		if serviceMissing(err) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+	pages, err := addressscopes.List(client, addressscopes.ListOpts{}).AllPages(ctx())
+	if err != nil {
+		// A cloud without the address-scope extension (or a token without access
+		// to it) has no address scopes rather than a failed query.
+		if translateOpenstackError(err) == nil {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+	items, err := addressscopes.ExtractAddressScopes(pages)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]any, 0, len(items))
+	for i := range items {
+		res, err := newMqlOpenstackAddressScope(o.MqlRuntime, &items[i])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
+func newMqlOpenstackAddressScope(runtime *plugin.Runtime, s *addressscopes.AddressScope) (*mqlOpenstackNetworkAddressScope, error) {
+	res, err := CreateResource(runtime, "openstack.network.addressScope", map[string]*llx.RawData{
+		"__id":      llx.StringData("openstack.network.addressScope/" + s.ID),
+		"id":        llx.StringData(s.ID),
+		"name":      llx.StringData(s.Name),
+		"ipVersion": llx.IntData(int64(s.IPVersion)),
+		"shared":    llx.BoolData(s.Shared),
+	})
+	if err != nil {
+		return nil, err
+	}
+	mqlS := res.(*mqlOpenstackNetworkAddressScope)
+	// ProjectID is the owner; fall back to the legacy TenantID alias.
+	owner := s.ProjectID
+	if owner == "" {
+		owner = s.TenantID
+	}
+	mqlS.cacheProjectID = owner
+	return mqlS, nil
+}
+
+// initOpenstackNetworkAddressScope resolves a scope out of the cached list
+// rather than fetching it by id. Every subnet pool bound to a scope and every
+// RBAC policy sharing one resolves through here, so a per-id fetch would issue
+// one call per pool and per policy; the list is a single call shared by all.
+func initOpenstackNetworkAddressScope(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		initSyntheticID("openstack.network.addressScope", "id", args)
+		return args, nil, nil
+	}
+	id, ok := stringArg(args, "id")
+	if !ok || id == "" {
+		return args, nil, nil
+	}
+	root, err := CreateResource(runtime, "openstack", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	list := root.(*mqlOpenstack).GetAddressScopes()
+	if list.Error != nil {
+		return nil, nil, list.Error
+	}
+	for _, raw := range list.Data {
+		s, ok := raw.(*mqlOpenstackNetworkAddressScope)
+		if ok && s.Id.Data == id {
+			return args, s, nil
+		}
+	}
+	// A blank scope would report shared as false, which is the reading this
+	// resource exists to make trustworthy, so report the miss instead.
+	return nil, nil, fmt.Errorf("openstack.network.addressScope with id %q not found", id)
+}
+
+func (r *mqlOpenstackNetworkAddressScope) project() (*mqlOpenstackProject, error) {
+	return resolveProject(r.MqlRuntime, r.cacheProjectID, &r.Project)
+}

--- a/providers/openstack/resources/network_extensions.go
+++ b/providers/openstack/resources/network_extensions.go
@@ -17,6 +17,20 @@ type mqlOpenstackSubnetPoolInternal struct {
 	cacheProjectID string
 }
 
+func (r *mqlOpenstackSubnetPool) addressScope() (*mqlOpenstackNetworkAddressScope, error) {
+	if r.AddressScopeId.Data == "" {
+		r.AddressScope.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(r.MqlRuntime, "openstack.network.addressScope", map[string]*llx.RawData{
+		"id": llx.StringData(r.AddressScopeId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOpenstackNetworkAddressScope), nil
+}
+
 func (r *mqlOpenstackSubnetPool) id() (string, error) {
 	return "openstack.subnetPool/" + r.Id.Data, nil
 }

--- a/providers/openstack/resources/network_rbac.go
+++ b/providers/openstack/resources/network_rbac.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"strings"
+
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/rbacpolicies"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
@@ -96,8 +98,23 @@ func initOpenstackNetworkRbacPolicy(runtime *plugin.Runtime, args map[string]*ll
 	return args, res, nil
 }
 
+// normalizeRBACObjectType folds a Neutron RBAC object_type into a single
+// spelling. Neutron reports the multi-word types with either a hyphen or an
+// underscore depending on release ("qos-policy" and "qos_policy" are the same
+// type), so matching on one literal silently drops the other spelling and the
+// policy resolves to nothing.
+func normalizeRBACObjectType(s string) string {
+	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(s), "-", "_"))
+}
+
+// rbacObjectTypeIs reports whether the policy targets the given object type,
+// tolerating either spelling.
+func rbacObjectTypeIs(actual, want string) bool {
+	return normalizeRBACObjectType(actual) == normalizeRBACObjectType(want)
+}
+
 func (r *mqlOpenstackNetworkRbacPolicy) network() (*mqlOpenstackNetwork, error) {
-	if r.ObjectType.Data != "network" || r.ObjectId.Data == "" {
+	if !rbacObjectTypeIs(r.ObjectType.Data, "network") || r.ObjectId.Data == "" {
 		r.Network.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -111,7 +128,7 @@ func (r *mqlOpenstackNetworkRbacPolicy) network() (*mqlOpenstackNetwork, error) 
 }
 
 func (r *mqlOpenstackNetworkRbacPolicy) qosPolicy() (*mqlOpenstackQosPolicy, error) {
-	if r.ObjectType.Data != "qos-policy" || r.ObjectId.Data == "" {
+	if !rbacObjectTypeIs(r.ObjectType.Data, "qos-policy") || r.ObjectId.Data == "" {
 		r.QosPolicy.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -122,6 +139,62 @@ func (r *mqlOpenstackNetworkRbacPolicy) qosPolicy() (*mqlOpenstackQosPolicy, err
 		return nil, err
 	}
 	return res.(*mqlOpenstackQosPolicy), nil
+}
+
+func (r *mqlOpenstackNetworkRbacPolicy) securityGroup() (*mqlOpenstackSecurityGroup, error) {
+	if !rbacObjectTypeIs(r.ObjectType.Data, "security_group") || r.ObjectId.Data == "" {
+		r.SecurityGroup.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(r.MqlRuntime, "openstack.securityGroup", map[string]*llx.RawData{
+		"id": llx.StringData(r.ObjectId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOpenstackSecurityGroup), nil
+}
+
+func (r *mqlOpenstackNetworkRbacPolicy) subnetPool() (*mqlOpenstackSubnetPool, error) {
+	if !rbacObjectTypeIs(r.ObjectType.Data, "subnetpool") || r.ObjectId.Data == "" {
+		r.SubnetPool.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(r.MqlRuntime, "openstack.subnetPool", map[string]*llx.RawData{
+		"id": llx.StringData(r.ObjectId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOpenstackSubnetPool), nil
+}
+
+func (r *mqlOpenstackNetworkRbacPolicy) addressScope() (*mqlOpenstackNetworkAddressScope, error) {
+	if !rbacObjectTypeIs(r.ObjectType.Data, "address_scope") || r.ObjectId.Data == "" {
+		r.AddressScope.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(r.MqlRuntime, "openstack.network.addressScope", map[string]*llx.RawData{
+		"id": llx.StringData(r.ObjectId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOpenstackNetworkAddressScope), nil
+}
+
+func (r *mqlOpenstackNetworkRbacPolicy) addressGroup() (*mqlOpenstackNetworkAddressGroup, error) {
+	if !rbacObjectTypeIs(r.ObjectType.Data, "address_group") || r.ObjectId.Data == "" {
+		r.AddressGroup.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(r.MqlRuntime, "openstack.network.addressGroup", map[string]*llx.RawData{
+		"id": llx.StringData(r.ObjectId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlOpenstackNetworkAddressGroup), nil
 }
 
 func (r *mqlOpenstackNetworkRbacPolicy) project() (*mqlOpenstackProject, error) {

--- a/providers/openstack/resources/octavia.go
+++ b/providers/openstack/resources/octavia.go
@@ -374,6 +374,8 @@ func (o *mqlOpenstack) listeners() ([]any, error) {
 			"timeoutMemberConnect":  llx.IntData(int64(l.TimeoutMemberConnect)),
 			"timeoutTcpInspect":     llx.IntData(int64(l.TimeoutTCPInspect)),
 			"hstsIncludeSubdomains": llx.BoolData(l.HSTSIncludeSubdomains),
+			"hstsMaxAge":            llx.IntData(int64(l.HSTSMaxAge)),
+			"hstsPreload":           llx.BoolData(l.HSTSPreload),
 			"tags":                  stringSliceData(l.Tags),
 		})
 		if err != nil {
@@ -1172,6 +1174,22 @@ func (r *mqlOpenstackOctaviaL7Rule) l7Policy() (*mqlOpenstackOctaviaL7Policy, er
 // resolveProject is a shared helper for the many octavia accessors that
 // resolve a cached project ID into a typed openstack.project. Returns
 // (nil, nil) when the cache is empty after marking the field null.
+// hstsEnabledForMaxAge reports whether an HSTS max-age turns the header on.
+// Octavia emits Strict-Transport-Security only for a positive max-age; the
+// includeSubDomains and preload directives do nothing on their own, so reading
+// either of them as "HSTS is configured" is a false positive.
+func hstsEnabledForMaxAge(maxAge int64) bool {
+	return maxAge > 0
+}
+
+func (r *mqlOpenstackOctaviaListener) hstsEnabled() (bool, error) {
+	maxAge := r.GetHstsMaxAge()
+	if maxAge.Error != nil {
+		return false, maxAge.Error
+	}
+	return hstsEnabledForMaxAge(maxAge.Data), nil
+}
+
 func resolveProject(runtime *plugin.Runtime, id string, field *plugin.TValue[*mqlOpenstackProject]) (*mqlOpenstackProject, error) {
 	if id == "" {
 		field.State = plugin.StateIsSet | plugin.StateIsNull

--- a/providers/openstack/resources/openstack.lr
+++ b/providers/openstack/resources/openstack.lr
@@ -131,9 +131,11 @@ openstack {
   amphorae() []openstack.octavia.amphora
   // Neutron subnet pools (admin-allocated CIDR ranges) visible to the scoped project
   subnetPools() []openstack.subnetPool
+  // Neutron address scopes grouping subnet pools into a single routable address namespace
+  addressScopes() []openstack.network.addressScope
   // Neutron QoS policies in the scoped project
   qosPolicies() []openstack.qosPolicy
-  // Neutron RBAC policies controlling which projects a network or QoS policy is shared with
+  // Neutron RBAC policies controlling which projects a network, QoS policy, security group, subnet pool, address scope, or address group is shared with
   rbacPolicies() []openstack.network.rbacPolicy
   // Neutron agents running the network control plane
   networkAgents() []openstack.network.agent
@@ -254,6 +256,18 @@ private openstack.user @defaults("id name enabled") {
   ignoreLockoutFailureAttempts bool
   // Whether multi-factor authentication is required for this user (Keystone option `multi_factor_auth_enabled`)
   multiFactorAuthEnabled bool
+  // Whether the user is exempt from password expiry (Keystone option `ignore_password_expiry`)
+  //
+  // True when the domain password-expiry policy does not apply to this account, so its
+  // password never ages out no matter what the domain security compliance settings require.
+  ignorePasswordExpiry bool
+  // Whether the user is exempt from the forced password change on first use (Keystone option `ignore_change_password_upon_first_use`)
+  //
+  // True when the account keeps whatever password an administrator set for it instead of
+  // being required to rotate it at first login.
+  ignoreChangePasswordUponFirstUse bool
+  // Whether the user is exempt from automatic disabling after a period of inactivity (Keystone option `ignore_user_inactivity`)
+  ignoreUserInactivity bool
   // Multi-factor authentication rule sets (Keystone option `multi_factor_auth_rules`)
   //
   // Each entry is a list of auth-method names that together satisfy MFA, for example `["password", "totp"]`. Empty when no rules are configured.
@@ -1406,6 +1420,16 @@ private openstack.octavia.listener @defaults("id name protocol protocolPort prov
   timeoutTcpInspect int
   // Whether HSTS includeSubDomains is enabled (microversion 2.27+)
   hstsIncludeSubdomains bool
+  // Value of the HSTS max-age directive in seconds; 0 when HSTS is off (microversion 2.27+)
+  hstsMaxAge int
+  // Whether the HSTS preload directive is added (microversion 2.27+)
+  hstsPreload bool
+  // Whether HSTS is in force on this listener
+  //
+  // True only when hstsMaxAge is greater than zero, which is what turns the
+  // Strict-Transport-Security header on. The includeSubDomains and preload directives are
+  // inert on their own.
+  hstsEnabled() bool
   // Tags
   tags []string
   // Project that owns this listener
@@ -1714,7 +1738,9 @@ private openstack.subnetPool @defaults("id name ipVersion shared isDefault") {
   // Per-project quota in addresses
   defaultQuota int
   // Address scope ID this pool is bound to; empty when not in any address scope
-  addressScopeId string
+  //
+  // Deprecated in favor of addressScope.
+  addressScopeId @maturity("deprecated") string
   // IP version (4 or 6)
   ipVersion int
   // Whether the pool is shared across projects
@@ -1727,7 +1753,33 @@ private openstack.subnetPool @defaults("id name ipVersion shared isDefault") {
   createdAt time
   // Last update timestamp
   updatedAt time
+  // Address scope this pool is bound to; null when the pool is not in any address scope
+  addressScope() openstack.network.addressScope
   // Project that owns this subnet pool
+  project() openstack.project
+}
+
+// OpenStack Neutron address scope
+//
+// Namespace of non-overlapping routable addresses that Neutron subnet pools are
+// bound to, so every subnet carved from those pools can route to every other one
+// without translation. The `id` field selects a scope, for example
+// `openstack.network.addressScope(id: "a1b2c3d4-...")`. The `shared` flag is the
+// one to audit: a shared scope lets subnet pools owned by different projects
+// allocate out of the same routable namespace, which is what allows those
+// projects' address space to reach each other directly instead of through NAT
+// or a floating IP.
+private openstack.network.addressScope @defaults("id name ipVersion shared") {
+  init(id? string)
+  // Address scope ID (UUID)
+  id string
+  // Address scope name
+  name string
+  // IP version (4 or 6)
+  ipVersion int
+  // Whether the address scope is shared with other projects
+  shared bool
+  // Project that owns the address scope
   project() openstack.project
 }
 
@@ -2139,6 +2191,28 @@ private openstack.objectstorage.container @defaults("name objectCount bytes publ
   versionsLocation() string
   // Container that records overwritten/deleted object versions (X-History-Location); empty when history is disabled
   historyLocation() string
+  // Whether object versioning is turned on for the container (X-Versions-Enabled)
+  versioningEnabled() bool
+  // Destination this container replicates to (X-Sync-To); empty when container sync is not configured
+  //
+  // A standing replication edge that copies every object to another container, commonly on
+  // a different Swift cluster, so the data leaves the boundary the container ACLs describe.
+  syncTo() string
+  // Whether a container-sync shared secret is configured (X-Sync-Key)
+  //
+  // Reports presence only. The key itself authenticates the sync peer and is never exposed.
+  hasSyncKey() bool
+  // Whether a temporary-URL signing key is configured (X-Container-Meta-Temp-URL-Key)
+  //
+  // A temp-URL key mints pre-signed URLs that grant unauthenticated access to objects for a
+  // chosen lifetime, bypassing the container read ACL. Reports presence only; the key value
+  // is never exposed.
+  hasTempUrlKey() bool
+  // Whether a second temporary-URL signing key is configured (X-Container-Meta-Temp-URL-Key-2)
+  //
+  // The second slot used while rotating temp-URL keys. URLs signed with it are honoured just
+  // as those signed with the first key are. Reports presence only.
+  hasTempUrlKey2() bool
   // Free-form container metadata (X-Container-Meta-* headers, without the prefix)
   metadata() map[string]string
   // Whether the container's read ACL grants unauthenticated read access (i.e. contains ".r:*")
@@ -2453,6 +2527,11 @@ private openstack.applicationCredential @defaults("id name unrestricted expiresA
   unrestricted bool
   // Role names this credential is allowed to assume (subset of the owning user's roles)
   roleNames []string
+  // Roles this credential is allowed to assume
+  //
+  // The grants a holder of the credential secret can exercise. Empty when the role
+  // catalog is not readable, in which case roleNames still carries the names.
+  roles() []openstack.role
   // API endpoint access rules
   //
   // Restrictions limiting which API calls the credential may make. Each entry
@@ -2526,8 +2605,15 @@ private openstack.trust @defaults("id impersonation") {
   impersonation bool
   // Role names delegated by this trust
   roleNames []string
+  // Roles delegated by this trust
+  //
+  // The grants the trustee can exercise on the trustor's behalf. Empty when the role
+  // catalog is not readable, in which case roleNames still carries the names.
+  roles() []openstack.role
   // Whether the trustee may re-delegate the trust to another user
   allowRedelegation bool
+  // How many further re-delegations the chain still allows; 0 when re-delegation is not permitted
+  redelegationCount int
   // Remaining number of times the trust can be used; 0 when unlimited
   remainingUses int
   // Expiration timestamp; null when the trust never expires
@@ -3172,6 +3258,16 @@ private openstack.baremetal.node @defaults("id name provisionState powerState ma
   protected bool
   // Reason the node is protected; empty when not protected
   protectedReason string
+  // Whether Ironic runs automated cleaning when the node is unprovisioned; null when the node does not report it
+  //
+  // Automated cleaning erases the node's disks between tenants. False leaves the previous
+  // tenant's data on the hardware for whoever is scheduled onto it next. Null means the
+  // node left the setting unset, so the conductor's own default applies.
+  automatedClean bool
+  // Whether the node is marked retired and will not be scheduled again
+  retired bool
+  // Reason the node was retired; empty when not retired
+  retiredReason string
   // Free-form description of the node
   description string
   // Whether serial console access is enabled
@@ -3333,16 +3429,31 @@ private openstack.network.rbacPolicy @defaults("id action objectType targetProje
   id string
   // Action (access_as_shared, access_as_external)
   action string
-  // Type of the shared object (network, qos-policy)
+  // Type of the shared object
+  //
+  // One of `network`, `qos_policy`, `security_group`, `subnetpool`, `address_scope`, or
+  // `address_group`. Some deployments spell the QoS type `qos-policy`; both spellings
+  // resolve to the same object.
   objectType string
-  // ID of the shared object (a network ID or QoS policy ID, per objectType)
+  // ID of the shared object, of whichever kind objectType names
   objectId string
   // Project the share is granted to; the literal "*" means all projects (cloud-wide share)
   targetProjectId string
-  // Shared network; null unless objectType is "network"
+  // Shared network; null unless objectType is a network
   network() openstack.network
-  // Shared QoS policy; null unless objectType is "qos-policy"
+  // Shared QoS policy; null unless objectType is a QoS policy
   qosPolicy() openstack.qosPolicy
+  // Shared security group; null unless objectType is a security group
+  //
+  // A security group shared into another project can be attached to that project's ports,
+  // so its rules govern traffic to instances the owning project does not control.
+  securityGroup() openstack.securityGroup
+  // Shared subnet pool; null unless objectType is a subnet pool
+  subnetPool() openstack.subnetPool
+  // Shared address scope; null unless objectType is an address scope
+  addressScope() openstack.network.addressScope
+  // Shared address group; null unless objectType is an address group
+  addressGroup() openstack.network.addressGroup
   // Project that owns the RBAC policy
   project() openstack.project
 }

--- a/providers/openstack/resources/openstack.lr.go
+++ b/providers/openstack/resources/openstack.lr.go
@@ -52,6 +52,7 @@ const (
 	ResourceOpenstackOctaviaL7Policy                    string = "openstack.octavia.l7Policy"
 	ResourceOpenstackOctaviaL7Rule                      string = "openstack.octavia.l7Rule"
 	ResourceOpenstackSubnetPool                         string = "openstack.subnetPool"
+	ResourceOpenstackNetworkAddressScope                string = "openstack.network.addressScope"
 	ResourceOpenstackQosPolicy                          string = "openstack.qosPolicy"
 	ResourceOpenstackTrunk                              string = "openstack.trunk"
 	ResourceOpenstackFirewallGroup                      string = "openstack.firewall.group"
@@ -264,6 +265,10 @@ func init() {
 		"openstack.subnetPool": {
 			Init:   initOpenstackSubnetPool,
 			Create: createOpenstackSubnetPool,
+		},
+		"openstack.network.addressScope": {
+			Init:   initOpenstackNetworkAddressScope,
+			Create: createOpenstackNetworkAddressScope,
 		},
 		"openstack.qosPolicy": {
 			Init:   initOpenstackQosPolicy,
@@ -750,6 +755,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.subnetPools": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstack).GetSubnetPools()).ToDataRes(types.Array(types.Resource("openstack.subnetPool")))
 	},
+	"openstack.addressScopes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstack).GetAddressScopes()).ToDataRes(types.Array(types.Resource("openstack.network.addressScope")))
+	},
 	"openstack.qosPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstack).GetQosPolicies()).ToDataRes(types.Array(types.Resource("openstack.qosPolicy")))
 	},
@@ -881,6 +889,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"openstack.user.multiFactorAuthEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackUser).GetMultiFactorAuthEnabled()).ToDataRes(types.Bool)
+	},
+	"openstack.user.ignorePasswordExpiry": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackUser).GetIgnorePasswordExpiry()).ToDataRes(types.Bool)
+	},
+	"openstack.user.ignoreChangePasswordUponFirstUse": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackUser).GetIgnoreChangePasswordUponFirstUse()).ToDataRes(types.Bool)
+	},
+	"openstack.user.ignoreUserInactivity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackUser).GetIgnoreUserInactivity()).ToDataRes(types.Bool)
 	},
 	"openstack.user.multiFactorAuthRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackUser).GetMultiFactorAuthRules()).ToDataRes(types.Array(types.Dict))
@@ -2001,6 +2018,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.octavia.listener.hstsIncludeSubdomains": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackOctaviaListener).GetHstsIncludeSubdomains()).ToDataRes(types.Bool)
 	},
+	"openstack.octavia.listener.hstsMaxAge": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOctaviaListener).GetHstsMaxAge()).ToDataRes(types.Int)
+	},
+	"openstack.octavia.listener.hstsPreload": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOctaviaListener).GetHstsPreload()).ToDataRes(types.Bool)
+	},
+	"openstack.octavia.listener.hstsEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackOctaviaListener).GetHstsEnabled()).ToDataRes(types.Bool)
+	},
 	"openstack.octavia.listener.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackOctaviaListener).GetTags()).ToDataRes(types.Array(types.String))
 	},
@@ -2361,8 +2387,26 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.subnetPool.updatedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackSubnetPool).GetUpdatedAt()).ToDataRes(types.Time)
 	},
+	"openstack.subnetPool.addressScope": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackSubnetPool).GetAddressScope()).ToDataRes(types.Resource("openstack.network.addressScope"))
+	},
 	"openstack.subnetPool.project": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackSubnetPool).GetProject()).ToDataRes(types.Resource("openstack.project"))
+	},
+	"openstack.network.addressScope.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackNetworkAddressScope).GetId()).ToDataRes(types.String)
+	},
+	"openstack.network.addressScope.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackNetworkAddressScope).GetName()).ToDataRes(types.String)
+	},
+	"openstack.network.addressScope.ipVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackNetworkAddressScope).GetIpVersion()).ToDataRes(types.Int)
+	},
+	"openstack.network.addressScope.shared": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackNetworkAddressScope).GetShared()).ToDataRes(types.Bool)
+	},
+	"openstack.network.addressScope.project": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackNetworkAddressScope).GetProject()).ToDataRes(types.Resource("openstack.project"))
 	},
 	"openstack.qosPolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackQosPolicy).GetId()).ToDataRes(types.String)
@@ -2754,6 +2798,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.objectstorage.container.historyLocation": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackObjectstorageContainer).GetHistoryLocation()).ToDataRes(types.String)
 	},
+	"openstack.objectstorage.container.versioningEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackObjectstorageContainer).GetVersioningEnabled()).ToDataRes(types.Bool)
+	},
+	"openstack.objectstorage.container.syncTo": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackObjectstorageContainer).GetSyncTo()).ToDataRes(types.String)
+	},
+	"openstack.objectstorage.container.hasSyncKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackObjectstorageContainer).GetHasSyncKey()).ToDataRes(types.Bool)
+	},
+	"openstack.objectstorage.container.hasTempUrlKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackObjectstorageContainer).GetHasTempUrlKey()).ToDataRes(types.Bool)
+	},
+	"openstack.objectstorage.container.hasTempUrlKey2": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackObjectstorageContainer).GetHasTempUrlKey2()).ToDataRes(types.Bool)
+	},
 	"openstack.objectstorage.container.metadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackObjectstorageContainer).GetMetadata()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -3072,6 +3131,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.applicationCredential.roleNames": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackApplicationCredential).GetRoleNames()).ToDataRes(types.Array(types.String))
 	},
+	"openstack.applicationCredential.roles": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackApplicationCredential).GetRoles()).ToDataRes(types.Array(types.Resource("openstack.role")))
+	},
 	"openstack.applicationCredential.accessRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackApplicationCredential).GetAccessRules()).ToDataRes(types.Array(types.Dict))
 	},
@@ -3117,8 +3179,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.trust.roleNames": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackTrust).GetRoleNames()).ToDataRes(types.Array(types.String))
 	},
+	"openstack.trust.roles": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackTrust).GetRoles()).ToDataRes(types.Array(types.Resource("openstack.role")))
+	},
 	"openstack.trust.allowRedelegation": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackTrust).GetAllowRedelegation()).ToDataRes(types.Bool)
+	},
+	"openstack.trust.redelegationCount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackTrust).GetRedelegationCount()).ToDataRes(types.Int)
 	},
 	"openstack.trust.remainingUses": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackTrust).GetRemainingUses()).ToDataRes(types.Int)
@@ -3798,6 +3866,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openstack.baremetal.node.protectedReason": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackBaremetalNode).GetProtectedReason()).ToDataRes(types.String)
 	},
+	"openstack.baremetal.node.automatedClean": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackBaremetalNode).GetAutomatedClean()).ToDataRes(types.Bool)
+	},
+	"openstack.baremetal.node.retired": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackBaremetalNode).GetRetired()).ToDataRes(types.Bool)
+	},
+	"openstack.baremetal.node.retiredReason": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackBaremetalNode).GetRetiredReason()).ToDataRes(types.String)
+	},
 	"openstack.baremetal.node.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackBaremetalNode).GetDescription()).ToDataRes(types.String)
 	},
@@ -3974,6 +4051,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"openstack.network.rbacPolicy.qosPolicy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackNetworkRbacPolicy).GetQosPolicy()).ToDataRes(types.Resource("openstack.qosPolicy"))
+	},
+	"openstack.network.rbacPolicy.securityGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackNetworkRbacPolicy).GetSecurityGroup()).ToDataRes(types.Resource("openstack.securityGroup"))
+	},
+	"openstack.network.rbacPolicy.subnetPool": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackNetworkRbacPolicy).GetSubnetPool()).ToDataRes(types.Resource("openstack.subnetPool"))
+	},
+	"openstack.network.rbacPolicy.addressScope": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackNetworkRbacPolicy).GetAddressScope()).ToDataRes(types.Resource("openstack.network.addressScope"))
+	},
+	"openstack.network.rbacPolicy.addressGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenstackNetworkRbacPolicy).GetAddressGroup()).ToDataRes(types.Resource("openstack.network.addressGroup"))
 	},
 	"openstack.network.rbacPolicy.project": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenstackNetworkRbacPolicy).GetProject()).ToDataRes(types.Resource("openstack.project"))
@@ -4660,6 +4749,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstack).SubnetPools, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"openstack.addressScopes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstack).AddressScopes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"openstack.qosPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstack).QosPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -4842,6 +4935,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openstack.user.multiFactorAuthEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackUser).MultiFactorAuthEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.user.ignorePasswordExpiry": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackUser).IgnorePasswordExpiry, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.user.ignoreChangePasswordUponFirstUse": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackUser).IgnoreChangePasswordUponFirstUse, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.user.ignoreUserInactivity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackUser).IgnoreUserInactivity, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"openstack.user.multiFactorAuthRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6444,6 +6549,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackOctaviaListener).HstsIncludeSubdomains, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"openstack.octavia.listener.hstsMaxAge": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOctaviaListener).HstsMaxAge, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"openstack.octavia.listener.hstsPreload": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOctaviaListener).HstsPreload, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.octavia.listener.hstsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackOctaviaListener).HstsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"openstack.octavia.listener.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackOctaviaListener).Tags, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -6948,8 +7065,36 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackSubnetPool).UpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"openstack.subnetPool.addressScope": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackSubnetPool).AddressScope, ok = plugin.RawToTValue[*mqlOpenstackNetworkAddressScope](v.Value, v.Error)
+		return
+	},
 	"openstack.subnetPool.project": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackSubnetPool).Project, ok = plugin.RawToTValue[*mqlOpenstackProject](v.Value, v.Error)
+		return
+	},
+	"openstack.network.addressScope.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackNetworkAddressScope).__id, ok = v.Value.(string)
+		return
+	},
+	"openstack.network.addressScope.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackNetworkAddressScope).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"openstack.network.addressScope.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackNetworkAddressScope).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"openstack.network.addressScope.ipVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackNetworkAddressScope).IpVersion, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"openstack.network.addressScope.shared": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackNetworkAddressScope).Shared, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.network.addressScope.project": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackNetworkAddressScope).Project, ok = plugin.RawToTValue[*mqlOpenstackProject](v.Value, v.Error)
 		return
 	},
 	"openstack.qosPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7520,6 +7665,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackObjectstorageContainer).HistoryLocation, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"openstack.objectstorage.container.versioningEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackObjectstorageContainer).VersioningEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.objectstorage.container.syncTo": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackObjectstorageContainer).SyncTo, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"openstack.objectstorage.container.hasSyncKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackObjectstorageContainer).HasSyncKey, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.objectstorage.container.hasTempUrlKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackObjectstorageContainer).HasTempUrlKey, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.objectstorage.container.hasTempUrlKey2": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackObjectstorageContainer).HasTempUrlKey2, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"openstack.objectstorage.container.metadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackObjectstorageContainer).Metadata, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -7980,6 +8145,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackApplicationCredential).RoleNames, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"openstack.applicationCredential.roles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackApplicationCredential).Roles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"openstack.applicationCredential.accessRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackApplicationCredential).AccessRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -8052,8 +8221,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackTrust).RoleNames, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"openstack.trust.roles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackTrust).Roles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"openstack.trust.allowRedelegation": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackTrust).AllowRedelegation, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.trust.redelegationCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackTrust).RedelegationCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"openstack.trust.remainingUses": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9028,6 +9205,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenstackBaremetalNode).ProtectedReason, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"openstack.baremetal.node.automatedClean": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackBaremetalNode).AutomatedClean, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.baremetal.node.retired": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackBaremetalNode).Retired, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"openstack.baremetal.node.retiredReason": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackBaremetalNode).RetiredReason, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"openstack.baremetal.node.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackBaremetalNode).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -9278,6 +9467,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openstack.network.rbacPolicy.qosPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenstackNetworkRbacPolicy).QosPolicy, ok = plugin.RawToTValue[*mqlOpenstackQosPolicy](v.Value, v.Error)
+		return
+	},
+	"openstack.network.rbacPolicy.securityGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackNetworkRbacPolicy).SecurityGroup, ok = plugin.RawToTValue[*mqlOpenstackSecurityGroup](v.Value, v.Error)
+		return
+	},
+	"openstack.network.rbacPolicy.subnetPool": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackNetworkRbacPolicy).SubnetPool, ok = plugin.RawToTValue[*mqlOpenstackSubnetPool](v.Value, v.Error)
+		return
+	},
+	"openstack.network.rbacPolicy.addressScope": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackNetworkRbacPolicy).AddressScope, ok = plugin.RawToTValue[*mqlOpenstackNetworkAddressScope](v.Value, v.Error)
+		return
+	},
+	"openstack.network.rbacPolicy.addressGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenstackNetworkRbacPolicy).AddressGroup, ok = plugin.RawToTValue[*mqlOpenstackNetworkAddressGroup](v.Value, v.Error)
 		return
 	},
 	"openstack.network.rbacPolicy.project": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -10039,6 +10244,7 @@ type mqlOpenstack struct {
 	L7Policies                  plugin.TValue[[]any]
 	Amphorae                    plugin.TValue[[]any]
 	SubnetPools                 plugin.TValue[[]any]
+	AddressScopes               plugin.TValue[[]any]
 	QosPolicies                 plugin.TValue[[]any]
 	RbacPolicies                plugin.TValue[[]any]
 	NetworkAgents               plugin.TValue[[]any]
@@ -10947,6 +11153,22 @@ func (c *mqlOpenstack) GetSubnetPools() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlOpenstack) GetAddressScopes() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AddressScopes, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack", c.__id, "addressScopes")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.addressScopes()
+	})
+}
+
 func (c *mqlOpenstack) GetQosPolicies() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.QosPolicies, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -11524,20 +11746,23 @@ type mqlOpenstackUser struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOpenstackUserInternal
-	Id                           plugin.TValue[string]
-	Name                         plugin.TValue[string]
-	Enabled                      plugin.TValue[bool]
-	Description                  plugin.TValue[string]
-	PasswordExpiresAt            plugin.TValue[*time.Time]
-	IgnoreLockoutFailureAttempts plugin.TValue[bool]
-	MultiFactorAuthEnabled       plugin.TValue[bool]
-	MultiFactorAuthRules         plugin.TValue[[]any]
-	Domain                       plugin.TValue[*mqlOpenstackDomain]
-	DefaultProject               plugin.TValue[*mqlOpenstackProject]
-	Roles                        plugin.TValue[[]any]
-	Groups                       plugin.TValue[[]any]
-	ApplicationCredentials       plugin.TValue[[]any]
-	Ec2Credentials               plugin.TValue[[]any]
+	Id                               plugin.TValue[string]
+	Name                             plugin.TValue[string]
+	Enabled                          plugin.TValue[bool]
+	Description                      plugin.TValue[string]
+	PasswordExpiresAt                plugin.TValue[*time.Time]
+	IgnoreLockoutFailureAttempts     plugin.TValue[bool]
+	MultiFactorAuthEnabled           plugin.TValue[bool]
+	IgnorePasswordExpiry             plugin.TValue[bool]
+	IgnoreChangePasswordUponFirstUse plugin.TValue[bool]
+	IgnoreUserInactivity             plugin.TValue[bool]
+	MultiFactorAuthRules             plugin.TValue[[]any]
+	Domain                           plugin.TValue[*mqlOpenstackDomain]
+	DefaultProject                   plugin.TValue[*mqlOpenstackProject]
+	Roles                            plugin.TValue[[]any]
+	Groups                           plugin.TValue[[]any]
+	ApplicationCredentials           plugin.TValue[[]any]
+	Ec2Credentials                   plugin.TValue[[]any]
 }
 
 // createOpenstackUser creates a new instance of this resource
@@ -11603,6 +11828,18 @@ func (c *mqlOpenstackUser) GetIgnoreLockoutFailureAttempts() *plugin.TValue[bool
 
 func (c *mqlOpenstackUser) GetMultiFactorAuthEnabled() *plugin.TValue[bool] {
 	return &c.MultiFactorAuthEnabled
+}
+
+func (c *mqlOpenstackUser) GetIgnorePasswordExpiry() *plugin.TValue[bool] {
+	return &c.IgnorePasswordExpiry
+}
+
+func (c *mqlOpenstackUser) GetIgnoreChangePasswordUponFirstUse() *plugin.TValue[bool] {
+	return &c.IgnoreChangePasswordUponFirstUse
+}
+
+func (c *mqlOpenstackUser) GetIgnoreUserInactivity() *plugin.TValue[bool] {
+	return &c.IgnoreUserInactivity
 }
 
 func (c *mqlOpenstackUser) GetMultiFactorAuthRules() *plugin.TValue[[]any] {
@@ -15630,6 +15867,9 @@ type mqlOpenstackOctaviaListener struct {
 	TimeoutMemberConnect  plugin.TValue[int64]
 	TimeoutTcpInspect     plugin.TValue[int64]
 	HstsIncludeSubdomains plugin.TValue[bool]
+	HstsMaxAge            plugin.TValue[int64]
+	HstsPreload           plugin.TValue[bool]
+	HstsEnabled           plugin.TValue[bool]
 	Tags                  plugin.TValue[[]any]
 	Project               plugin.TValue[*mqlOpenstackProject]
 	LoadBalancer          plugin.TValue[*mqlOpenstackOctaviaLoadBalancer]
@@ -15757,6 +15997,20 @@ func (c *mqlOpenstackOctaviaListener) GetTimeoutTcpInspect() *plugin.TValue[int6
 
 func (c *mqlOpenstackOctaviaListener) GetHstsIncludeSubdomains() *plugin.TValue[bool] {
 	return &c.HstsIncludeSubdomains
+}
+
+func (c *mqlOpenstackOctaviaListener) GetHstsMaxAge() *plugin.TValue[int64] {
+	return &c.HstsMaxAge
+}
+
+func (c *mqlOpenstackOctaviaListener) GetHstsPreload() *plugin.TValue[bool] {
+	return &c.HstsPreload
+}
+
+func (c *mqlOpenstackOctaviaListener) GetHstsEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HstsEnabled, func() (bool, error) {
+		return c.hstsEnabled()
+	})
 }
 
 func (c *mqlOpenstackOctaviaListener) GetTags() *plugin.TValue[[]any] {
@@ -16932,6 +17186,7 @@ type mqlOpenstackSubnetPool struct {
 	Tags             plugin.TValue[[]any]
 	CreatedAt        plugin.TValue[*time.Time]
 	UpdatedAt        plugin.TValue[*time.Time]
+	AddressScope     plugin.TValue[*mqlOpenstackNetworkAddressScope]
 	Project          plugin.TValue[*mqlOpenstackProject]
 }
 
@@ -17032,10 +17287,107 @@ func (c *mqlOpenstackSubnetPool) GetUpdatedAt() *plugin.TValue[*time.Time] {
 	return &c.UpdatedAt
 }
 
+func (c *mqlOpenstackSubnetPool) GetAddressScope() *plugin.TValue[*mqlOpenstackNetworkAddressScope] {
+	return plugin.GetOrCompute[*mqlOpenstackNetworkAddressScope](&c.AddressScope, func() (*mqlOpenstackNetworkAddressScope, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.subnetPool", c.__id, "addressScope")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackNetworkAddressScope), nil
+			}
+		}
+
+		return c.addressScope()
+	})
+}
+
 func (c *mqlOpenstackSubnetPool) GetProject() *plugin.TValue[*mqlOpenstackProject] {
 	return plugin.GetOrCompute[*mqlOpenstackProject](&c.Project, func() (*mqlOpenstackProject, error) {
 		if c.MqlRuntime.HasRecording {
 			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.subnetPool", c.__id, "project")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackProject), nil
+			}
+		}
+
+		return c.project()
+	})
+}
+
+// mqlOpenstackNetworkAddressScope for the openstack.network.addressScope resource
+type mqlOpenstackNetworkAddressScope struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlOpenstackNetworkAddressScopeInternal
+	Id        plugin.TValue[string]
+	Name      plugin.TValue[string]
+	IpVersion plugin.TValue[int64]
+	Shared    plugin.TValue[bool]
+	Project   plugin.TValue[*mqlOpenstackProject]
+}
+
+// createOpenstackNetworkAddressScope creates a new instance of this resource
+func createOpenstackNetworkAddressScope(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlOpenstackNetworkAddressScope{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("openstack.network.addressScope", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlOpenstackNetworkAddressScope) MqlName() string {
+	return "openstack.network.addressScope"
+}
+
+func (c *mqlOpenstackNetworkAddressScope) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlOpenstackNetworkAddressScope) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlOpenstackNetworkAddressScope) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlOpenstackNetworkAddressScope) GetIpVersion() *plugin.TValue[int64] {
+	return &c.IpVersion
+}
+
+func (c *mqlOpenstackNetworkAddressScope) GetShared() *plugin.TValue[bool] {
+	return &c.Shared
+}
+
+func (c *mqlOpenstackNetworkAddressScope) GetProject() *plugin.TValue[*mqlOpenstackProject] {
+	return plugin.GetOrCompute[*mqlOpenstackProject](&c.Project, func() (*mqlOpenstackProject, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.network.addressScope", c.__id, "project")
 			if err != nil {
 				return nil, err
 			}
@@ -18430,18 +18782,23 @@ type mqlOpenstackObjectstorageContainer struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOpenstackObjectstorageContainerInternal
-	Name             plugin.TValue[string]
-	ObjectCount      plugin.TValue[int64]
-	Bytes            plugin.TValue[int64]
-	Created          plugin.TValue[*time.Time]
-	ReadACL          plugin.TValue[[]any]
-	WriteACL         plugin.TValue[[]any]
-	StoragePolicy    plugin.TValue[string]
-	VersionsLocation plugin.TValue[string]
-	HistoryLocation  plugin.TValue[string]
-	Metadata         plugin.TValue[map[string]any]
-	Public           plugin.TValue[bool]
-	Objects          plugin.TValue[[]any]
+	Name              plugin.TValue[string]
+	ObjectCount       plugin.TValue[int64]
+	Bytes             plugin.TValue[int64]
+	Created           plugin.TValue[*time.Time]
+	ReadACL           plugin.TValue[[]any]
+	WriteACL          plugin.TValue[[]any]
+	StoragePolicy     plugin.TValue[string]
+	VersionsLocation  plugin.TValue[string]
+	HistoryLocation   plugin.TValue[string]
+	VersioningEnabled plugin.TValue[bool]
+	SyncTo            plugin.TValue[string]
+	HasSyncKey        plugin.TValue[bool]
+	HasTempUrlKey     plugin.TValue[bool]
+	HasTempUrlKey2    plugin.TValue[bool]
+	Metadata          plugin.TValue[map[string]any]
+	Public            plugin.TValue[bool]
+	Objects           plugin.TValue[[]any]
 }
 
 // createOpenstackObjectstorageContainer creates a new instance of this resource
@@ -18526,6 +18883,36 @@ func (c *mqlOpenstackObjectstorageContainer) GetVersionsLocation() *plugin.TValu
 func (c *mqlOpenstackObjectstorageContainer) GetHistoryLocation() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.HistoryLocation, func() (string, error) {
 		return c.historyLocation()
+	})
+}
+
+func (c *mqlOpenstackObjectstorageContainer) GetVersioningEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.VersioningEnabled, func() (bool, error) {
+		return c.versioningEnabled()
+	})
+}
+
+func (c *mqlOpenstackObjectstorageContainer) GetSyncTo() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.SyncTo, func() (string, error) {
+		return c.syncTo()
+	})
+}
+
+func (c *mqlOpenstackObjectstorageContainer) GetHasSyncKey() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasSyncKey, func() (bool, error) {
+		return c.hasSyncKey()
+	})
+}
+
+func (c *mqlOpenstackObjectstorageContainer) GetHasTempUrlKey() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasTempUrlKey, func() (bool, error) {
+		return c.hasTempUrlKey()
+	})
+}
+
+func (c *mqlOpenstackObjectstorageContainer) GetHasTempUrlKey2() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasTempUrlKey2, func() (bool, error) {
+		return c.hasTempUrlKey2()
 	})
 }
 
@@ -19563,6 +19950,7 @@ type mqlOpenstackApplicationCredential struct {
 	Description  plugin.TValue[string]
 	Unrestricted plugin.TValue[bool]
 	RoleNames    plugin.TValue[[]any]
+	Roles        plugin.TValue[[]any]
 	AccessRules  plugin.TValue[[]any]
 	ExpiresAt    plugin.TValue[*time.Time]
 	User         plugin.TValue[*mqlOpenstackUser]
@@ -19624,6 +20012,22 @@ func (c *mqlOpenstackApplicationCredential) GetUnrestricted() *plugin.TValue[boo
 
 func (c *mqlOpenstackApplicationCredential) GetRoleNames() *plugin.TValue[[]any] {
 	return &c.RoleNames
+}
+
+func (c *mqlOpenstackApplicationCredential) GetRoles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Roles, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.applicationCredential", c.__id, "roles")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.roles()
+	})
 }
 
 func (c *mqlOpenstackApplicationCredential) GetAccessRules() *plugin.TValue[[]any] {
@@ -19862,7 +20266,9 @@ type mqlOpenstackTrust struct {
 	Id                plugin.TValue[string]
 	Impersonation     plugin.TValue[bool]
 	RoleNames         plugin.TValue[[]any]
+	Roles             plugin.TValue[[]any]
 	AllowRedelegation plugin.TValue[bool]
+	RedelegationCount plugin.TValue[int64]
 	RemainingUses     plugin.TValue[int64]
 	ExpiresAt         plugin.TValue[*time.Time]
 	Trustee           plugin.TValue[*mqlOpenstackUser]
@@ -19920,8 +20326,28 @@ func (c *mqlOpenstackTrust) GetRoleNames() *plugin.TValue[[]any] {
 	return &c.RoleNames
 }
 
+func (c *mqlOpenstackTrust) GetRoles() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Roles, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.trust", c.__id, "roles")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.roles()
+	})
+}
+
 func (c *mqlOpenstackTrust) GetAllowRedelegation() *plugin.TValue[bool] {
 	return &c.AllowRedelegation
+}
+
+func (c *mqlOpenstackTrust) GetRedelegationCount() *plugin.TValue[int64] {
+	return &c.RedelegationCount
 }
 
 func (c *mqlOpenstackTrust) GetRemainingUses() *plugin.TValue[int64] {
@@ -22148,6 +22574,9 @@ type mqlOpenstackBaremetalNode struct {
 	Conductor            plugin.TValue[string]
 	Protected            plugin.TValue[bool]
 	ProtectedReason      plugin.TValue[string]
+	AutomatedClean       plugin.TValue[bool]
+	Retired              plugin.TValue[bool]
+	RetiredReason        plugin.TValue[string]
 	Description          plugin.TValue[string]
 	ConsoleEnabled       plugin.TValue[bool]
 	BootInterface        plugin.TValue[string]
@@ -22262,6 +22691,18 @@ func (c *mqlOpenstackBaremetalNode) GetProtected() *plugin.TValue[bool] {
 
 func (c *mqlOpenstackBaremetalNode) GetProtectedReason() *plugin.TValue[string] {
 	return &c.ProtectedReason
+}
+
+func (c *mqlOpenstackBaremetalNode) GetAutomatedClean() *plugin.TValue[bool] {
+	return &c.AutomatedClean
+}
+
+func (c *mqlOpenstackBaremetalNode) GetRetired() *plugin.TValue[bool] {
+	return &c.Retired
+}
+
+func (c *mqlOpenstackBaremetalNode) GetRetiredReason() *plugin.TValue[string] {
+	return &c.RetiredReason
 }
 
 func (c *mqlOpenstackBaremetalNode) GetDescription() *plugin.TValue[string] {
@@ -22742,6 +23183,10 @@ type mqlOpenstackNetworkRbacPolicy struct {
 	TargetProjectId plugin.TValue[string]
 	Network         plugin.TValue[*mqlOpenstackNetwork]
 	QosPolicy       plugin.TValue[*mqlOpenstackQosPolicy]
+	SecurityGroup   plugin.TValue[*mqlOpenstackSecurityGroup]
+	SubnetPool      plugin.TValue[*mqlOpenstackSubnetPool]
+	AddressScope    plugin.TValue[*mqlOpenstackNetworkAddressScope]
+	AddressGroup    plugin.TValue[*mqlOpenstackNetworkAddressGroup]
 	Project         plugin.TValue[*mqlOpenstackProject]
 }
 
@@ -22831,6 +23276,70 @@ func (c *mqlOpenstackNetworkRbacPolicy) GetQosPolicy() *plugin.TValue[*mqlOpenst
 		}
 
 		return c.qosPolicy()
+	})
+}
+
+func (c *mqlOpenstackNetworkRbacPolicy) GetSecurityGroup() *plugin.TValue[*mqlOpenstackSecurityGroup] {
+	return plugin.GetOrCompute[*mqlOpenstackSecurityGroup](&c.SecurityGroup, func() (*mqlOpenstackSecurityGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.network.rbacPolicy", c.__id, "securityGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackSecurityGroup), nil
+			}
+		}
+
+		return c.securityGroup()
+	})
+}
+
+func (c *mqlOpenstackNetworkRbacPolicy) GetSubnetPool() *plugin.TValue[*mqlOpenstackSubnetPool] {
+	return plugin.GetOrCompute[*mqlOpenstackSubnetPool](&c.SubnetPool, func() (*mqlOpenstackSubnetPool, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.network.rbacPolicy", c.__id, "subnetPool")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackSubnetPool), nil
+			}
+		}
+
+		return c.subnetPool()
+	})
+}
+
+func (c *mqlOpenstackNetworkRbacPolicy) GetAddressScope() *plugin.TValue[*mqlOpenstackNetworkAddressScope] {
+	return plugin.GetOrCompute[*mqlOpenstackNetworkAddressScope](&c.AddressScope, func() (*mqlOpenstackNetworkAddressScope, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.network.rbacPolicy", c.__id, "addressScope")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackNetworkAddressScope), nil
+			}
+		}
+
+		return c.addressScope()
+	})
+}
+
+func (c *mqlOpenstackNetworkRbacPolicy) GetAddressGroup() *plugin.TValue[*mqlOpenstackNetworkAddressGroup] {
+	return plugin.GetOrCompute[*mqlOpenstackNetworkAddressGroup](&c.AddressGroup, func() (*mqlOpenstackNetworkAddressGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("openstack.network.rbacPolicy", c.__id, "addressGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOpenstackNetworkAddressGroup), nil
+			}
+		}
+
+		return c.addressGroup()
 	})
 }
 

--- a/providers/openstack/resources/openstack.lr.versions
+++ b/providers/openstack/resources/openstack.lr.versions
@@ -3,6 +3,7 @@
 
 openstack 13.0.1
 openstack.addressGroups 13.7.6
+openstack.addressScopes 13.9.1
 openstack.aggregates 13.0.1
 openstack.amphorae 13.7.6
 openstack.applicationCredential 13.0.1
@@ -13,11 +14,13 @@ openstack.applicationCredential.id 13.0.1
 openstack.applicationCredential.name 13.0.1
 openstack.applicationCredential.project 13.0.1
 openstack.applicationCredential.roleNames 13.0.1
+openstack.applicationCredential.roles 13.9.1
 openstack.applicationCredential.unrestricted 13.0.1
 openstack.applicationCredential.user 13.0.1
 openstack.authUrl 13.0.1
 openstack.backups 13.0.1
 openstack.baremetal.node 13.1.4
+openstack.baremetal.node.automatedClean 13.9.1
 openstack.baremetal.node.bootInterface 13.1.4
 openstack.baremetal.node.conductor 13.1.4
 openstack.baremetal.node.conductorGroup 13.1.4
@@ -43,6 +46,8 @@ openstack.baremetal.node.protected 13.1.4
 openstack.baremetal.node.protectedReason 13.1.4
 openstack.baremetal.node.provisionState 13.1.4
 openstack.baremetal.node.resourceClass 13.1.4
+openstack.baremetal.node.retired 13.9.1
+openstack.baremetal.node.retiredReason 13.9.1
 openstack.baremetal.node.targetPowerState 13.1.4
 openstack.baremetal.node.targetProvisionState 13.1.4
 openstack.baremetal.node.traits 13.1.4
@@ -724,6 +729,12 @@ openstack.network.addressGroup.description 13.7.6
 openstack.network.addressGroup.id 13.7.6
 openstack.network.addressGroup.name 13.7.6
 openstack.network.addressGroup.project 13.7.6
+openstack.network.addressScope 13.9.1
+openstack.network.addressScope.id 13.9.1
+openstack.network.addressScope.ipVersion 13.9.1
+openstack.network.addressScope.name 13.9.1
+openstack.network.addressScope.project 13.9.1
+openstack.network.addressScope.shared 13.9.1
 openstack.network.adminStateUp 13.0.1
 openstack.network.agent 13.7.6
 openstack.network.agent.adminStateUp 13.7.6
@@ -766,12 +777,16 @@ openstack.network.quotaSet.subnetPool 13.0.1
 openstack.network.quotaSet.trunk 13.0.1
 openstack.network.rbacPolicy 13.5.2
 openstack.network.rbacPolicy.action 13.5.2
+openstack.network.rbacPolicy.addressGroup 13.9.1
+openstack.network.rbacPolicy.addressScope 13.9.1
 openstack.network.rbacPolicy.id 13.5.2
 openstack.network.rbacPolicy.network 13.5.2
 openstack.network.rbacPolicy.objectId 13.5.2
 openstack.network.rbacPolicy.objectType 13.5.2
 openstack.network.rbacPolicy.project 13.5.2
 openstack.network.rbacPolicy.qosPolicy 13.5.2
+openstack.network.rbacPolicy.securityGroup 13.9.1
+openstack.network.rbacPolicy.subnetPool 13.9.1
 openstack.network.rbacPolicy.targetProjectId 13.5.2
 openstack.network.shared 13.0.1
 openstack.network.status 13.0.1
@@ -804,6 +819,9 @@ openstack.objectstorage.account.tempUrlKeySet 13.0.1
 openstack.objectstorage.container 13.0.1
 openstack.objectstorage.container.bytes 13.0.1
 openstack.objectstorage.container.created 13.6.1
+openstack.objectstorage.container.hasSyncKey 13.9.1
+openstack.objectstorage.container.hasTempUrlKey 13.9.1
+openstack.objectstorage.container.hasTempUrlKey2 13.9.1
 openstack.objectstorage.container.historyLocation 13.0.1
 openstack.objectstorage.container.metadata 13.0.1
 openstack.objectstorage.container.name 13.0.1
@@ -812,6 +830,8 @@ openstack.objectstorage.container.objects 13.0.1
 openstack.objectstorage.container.public 13.0.1
 openstack.objectstorage.container.readACL 13.0.1
 openstack.objectstorage.container.storagePolicy 13.0.1
+openstack.objectstorage.container.syncTo 13.9.1
+openstack.objectstorage.container.versioningEnabled 13.9.1
 openstack.objectstorage.container.versionsLocation 13.0.1
 openstack.objectstorage.container.writeACL 13.0.1
 openstack.objectstorage.object 13.0.1
@@ -906,7 +926,10 @@ openstack.octavia.listener.defaultPool 13.0.1
 openstack.octavia.listener.defaultTlsContainer 13.0.1
 openstack.octavia.listener.defaultTlsSecret 13.8.2
 openstack.octavia.listener.description 13.0.1
+openstack.octavia.listener.hstsEnabled 13.9.1
 openstack.octavia.listener.hstsIncludeSubdomains 13.0.1
+openstack.octavia.listener.hstsMaxAge 13.9.1
+openstack.octavia.listener.hstsPreload 13.9.1
 openstack.octavia.listener.id 13.0.1
 openstack.octavia.listener.insertHeaders 13.0.1
 openstack.octavia.listener.l7Policies 13.0.1
@@ -1243,6 +1266,7 @@ openstack.subnet.subnetPool 13.0.1
 openstack.subnet.tags 13.0.1
 openstack.subnet.updatedAt 13.0.1
 openstack.subnetPool 13.0.1
+openstack.subnetPool.addressScope 13.9.1
 openstack.subnetPool.addressScopeId 13.0.1
 openstack.subnetPool.createdAt 13.0.1
 openstack.subnetPool.defaultPrefixLen 13.0.1
@@ -1283,8 +1307,10 @@ openstack.trust.id 13.1.4
 openstack.trust.impersonation 13.1.4
 openstack.trust.project 13.1.4
 openstack.trust.redelegated 13.2.2
+openstack.trust.redelegationCount 13.9.1
 openstack.trust.remainingUses 13.1.4
 openstack.trust.roleNames 13.1.4
+openstack.trust.roles 13.9.1
 openstack.trust.trustee 13.1.4
 openstack.trust.trustor 13.1.4
 openstack.trusts 13.1.4
@@ -1297,7 +1323,10 @@ openstack.user.ec2Credentials 13.1.4
 openstack.user.enabled 13.0.1
 openstack.user.groups 13.0.1
 openstack.user.id 13.0.1
+openstack.user.ignoreChangePasswordUponFirstUse 13.9.1
 openstack.user.ignoreLockoutFailureAttempts 13.0.1
+openstack.user.ignorePasswordExpiry 13.9.1
+openstack.user.ignoreUserInactivity 13.9.1
 openstack.user.multiFactorAuthEnabled 13.4.2
 openstack.user.multiFactorAuthRules 13.4.2
 openstack.user.name 13.0.1

--- a/providers/openstack/resources/swift.go
+++ b/providers/openstack/resources/swift.go
@@ -250,12 +250,86 @@ func (r *mqlOpenstackObjectstorageContainer) historyLocation() (string, error) {
 	return h.HistoryLocation, nil
 }
 
+func (r *mqlOpenstackObjectstorageContainer) versioningEnabled() (bool, error) {
+	h, _, err := r.fetchHeader()
+	if err != nil || h == nil {
+		return false, err
+	}
+	return h.VersionsEnabled, nil
+}
+
+func (r *mqlOpenstackObjectstorageContainer) syncTo() (string, error) {
+	h, _, err := r.fetchHeader()
+	if err != nil || h == nil {
+		return "", err
+	}
+	return h.SyncTo, nil
+}
+
+// hasSyncKey reports whether a container-sync secret is set. The key itself is
+// the shared secret that authorizes the peer cluster to write into this
+// container, so only its presence is exposed, never its value.
+func (r *mqlOpenstackObjectstorageContainer) hasSyncKey() (bool, error) {
+	h, _, err := r.fetchHeader()
+	if err != nil || h == nil {
+		return false, err
+	}
+	return strings.TrimSpace(h.SyncKey) != "", nil
+}
+
+// hasTempUrlKey reports whether a temporary-URL signing key is set. Anyone
+// holding the key can mint URLs that read (or write) objects without
+// authenticating at all, so only its presence is exposed, never its value.
+func (r *mqlOpenstackObjectstorageContainer) hasTempUrlKey() (bool, error) {
+	h, _, err := r.fetchHeader()
+	if err != nil || h == nil {
+		return false, err
+	}
+	return strings.TrimSpace(h.TempURLKey) != "", nil
+}
+
+// hasTempUrlKey2 reports whether the second temporary-URL signing key slot is
+// set. Swift honours signatures from either slot, so a stale second key keeps
+// minting valid URLs after the first is rotated. Presence only.
+func (r *mqlOpenstackObjectstorageContainer) hasTempUrlKey2() (bool, error) {
+	h, _, err := r.fetchHeader()
+	if err != nil || h == nil {
+		return false, err
+	}
+	return strings.TrimSpace(h.TempURLKey2) != "", nil
+}
+
+// secretContainerMetaKeys are the container metadata keys whose value is
+// credential material. Swift stores the temporary-URL signing keys as ordinary
+// X-Container-Meta-* headers, so they arrive in the metadata map alongside
+// user-set labels. Anyone holding one can mint pre-signed URLs that read or
+// write objects with no authentication, so the values are dropped from the
+// metadata map; hasTempUrlKey and hasTempUrlKey2 report their presence instead.
+// Keys are compared lower-cased because net/http canonicalizes header casing.
+var secretContainerMetaKeys = map[string]struct{}{
+	"temp-url-key":   {},
+	"temp-url-key-2": {},
+}
+
+// redactContainerMetadata copies the metadata map without the entries whose
+// value is credential material.
+func redactContainerMetadata(meta map[string]string) map[string]string {
+	out := make(map[string]string, len(meta))
+	for k, v := range meta {
+		if _, secret := secretContainerMetaKeys[strings.ToLower(k)]; secret {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
 func (r *mqlOpenstackObjectstorageContainer) metadata() (map[string]any, error) {
 	_, meta, err := r.fetchHeader()
 	if err != nil {
 		return map[string]any{}, err
 	}
-	return stringMap(meta), nil
+	return stringMap(redactContainerMetadata(meta)), nil
 }
 
 func (r *mqlOpenstackObjectstorageContainer) public() (bool, error) {


### PR DESCRIPTION
Seven of the twenty findings from the openstack coverage audit. Each is a field or a reference on an already-shipped resource, and each closes a question the schema could not previously express. The remaining thirteen are deferred with reasons below.

## Implemented

| # | Finding | What ships |
|---|---|---|
| 1 | Per-user password-policy bypass flags | `user.ignorePasswordExpiry`, `ignoreChangePasswordUponFirstUse`, `ignoreUserInactivity` |
| 4 | RBAC policy targets beyond network/QoS | `rbacPolicy.securityGroup`, `subnetPool`, `addressScope`, `addressGroup` |
| 5 | Swift container versioning, temp-URL key, sync | `container.versioningEnabled`, `syncTo`, `hasSyncKey`, `hasTempUrlKey`, `hasTempUrlKey2` |
| 6 | Listener HSTS completeness | `listener.hstsMaxAge`, `hstsPreload`, `hstsEnabled` |
| 8 | Ironic node cleaning and retirement | `baremetal.node.automatedClean`, `retired`, `retiredReason` |
| 16 | Trust and app-credential roles as references | `trust.roles`, `trust.redelegationCount`, `applicationCredential.roles` |
| 20 | Address scopes | new `openstack.network.addressScope`, root `addressScopes`, `subnetPool.addressScope` |

**Finding 1.** The provider already read two keys from the Keystone user options map. The three remaining `ignore_*` options are the same shape and the same class: each exempts one account from a domain-wide password rule, so an exempted user was invisible to any query over the domain's password policy.

**Finding 4.** Only `network` and `qos-policy` resolved, so a policy sharing a security group into another project was a bare `objectId` and dropped out of every cross-project-sharing query. While adding the four missing target types I found the existing match is spelling-sensitive: Neutron reports the multi-word object types with either a hyphen or an underscore depending on release, and the shipped `qosPolicy` reference compares against the literal `"qos-policy"`. On a deployment reporting `qos_policy` it silently resolved to null. Matching now folds the two spellings, which fixes the shipped reference as well as the new ones.

**Finding 5.** All five fields come out of the container header the resource already fetches and caches, so this adds no API call. The two signing keys are exposed as **presence booleans only** — a temp-URL key mints pre-signed URLs that read objects with no authentication at all, and the container-sync key authorizes a peer cluster to write in.

**Finding 6.** HSTS is off unless `max_age` is positive, so with only `hstsIncludeSubdomains` shipped the schema literally could not answer whether HSTS was enabled. `hstsEnabled` is derived from `hstsMaxAge > 0`; `includeSubDomains` and `preload` are inert on their own and neither may stand in for it.

**Finding 8.** `automated_clean` is `*bool` in the API. It is carried through as **null** when the node leaves it unset, so a node deferring to the conductor default is not reported as one that skips disk wiping. `automated_clean: false` — disks not wiped between tenants — reads as an explicit `false`.

**Finding 16.** Both role lists resolve through the already-fetched role catalog rather than `NewResource` per role. `NewResource` runs the target's `init` before the runtime cache is consulted, so a per-role lookup would turn one catalog listing into one lookup per delegated role. `roleNames` is deliberately **kept, not deprecated**: the role catalog is admin-only, so a token that can read its own trusts but not the catalog still gets the names. The references are empty in that case, which the field docs say.

**Finding 20.** `subnetPool.addressScopeId` had nothing to resolve to. The new resource gives it a target and gives finding 4's `addressScope` reference somewhere to land. `addressScopeId` is marked `@maturity("deprecated")` since the reference now carries the same value. The `shared` flag is the audit: a shared scope lets subnet pools owned by different projects allocate from one routable namespace, which is what lets their address space reach each other without NAT.

## Additional fix: a shipped secret leak

Swift stores the temporary-URL signing keys as ordinary `X-Container-Meta-*` headers. gophercloud's `ExtractMetadata` returns every such header, so the **shipped** `openstack.objectstorage.container.metadata` field has been returning `Temp-Url-Key` and `Temp-Url-Key-2` with their values in scan results. Anyone holding one can mint URLs that read objects with no authentication and no trace in the container ACL.

Those two keys are now dropped from the metadata map (case-insensitively — `net/http` canonicalizes header casing), and the new `hasTempUrlKey` / `hasTempUrlKey2` booleans report presence instead. This is a behavior change to a shipped field, but in the direction of not emitting credential material; a similarly-named key such as `Temp-Url-Key-Rotated-At` is kept.

## Optional services

Every service touched here degrades to an empty result rather than an error when the deployment does not run it, using the provider's existing `serviceMissing` / `translateOpenstackError` helpers rather than a second pattern. A cloud without Octavia has no listeners and a cloud without Ironic has no bare-metal nodes; neither is a failed scan. No absent value is turned into a fabricated `false` — see the `automatedClean` note above, which is the one case in this set where the API distinguishes absent from false.

## Verification

**No live OpenStack cloud was available.** Every field below is unverified against a real deployment. This is a blocker on the resource-verification standard, not a disclaimer: the values, and in particular the header names Swift actually returns and the object-type spelling Neutron actually emits, have not been observed on a running cloud.

| What I ran | Result |
|---|---|
| `go build ./...` in `providers/openstack/` | clean |
| `go test ./...` in `providers/openstack/` | pass (connection + resources) |
| `golangci-lint run ./resources/` | 0 issues |
| `go vet ./...` | clean |
| `typos providers/openstack/` | clean |
| `mqlr generate` (twice, for the Internal-struct pass) | clean, `.lr.versions` purely additive |
| `--info` compile gate, 9 queries covering every new field | all pass |
| `--info` negative control, 3 deliberately bogus fields | all rejected, so the gate is real |
| Mutation check on the three new pure-Go predicates | each mutation fails the suite |

The mutation check is what makes the unit tests meaningful rather than decorative. Dropping separator folding from the RBAC matcher, removing the metadata redaction, and relaxing `hstsEnabled` to `>= 0` each turn the suite red.

Unit tests cover: RBAC object-type normalization including the near-miss pair `address_scope` / `address_group`; the HSTS predicate at 0, negative, and positive, plus a listener payload with the HSTS fields absent (pre-microversion-2.27 Octavia, which must read as *not* enabled rather than passing an assertion vacuously); `automated_clean` decoding across explicit true, explicit false, absent, and explicit null; metadata redaction including casing, non-mutation of the cached map, and a similarly-named key that must survive; and the user-option reads.

**Specifically unverified:** every field in the table above. The two I would most want a live cloud for are (a) which spelling of `object_type` Neutron actually returns, since the normalizer is written to tolerate both precisely because I could not confirm it, and (b) whether `X-Container-Meta-Temp-URL-Key` arrives canonicalized as `Temp-Url-Key` in the metadata map as the redaction assumes. The redaction is written case-insensitively so it holds either way, but that is reasoning, not observation.

## Deferred

| # | Finding | Why deferred |
|---|---|---|
| 11 | Discovery targets beyond security groups (L) | Changes the asset model, and per the discovery-filter gate every new target's **lister** must consult `conn.Filters` — which this provider has nowhere wired. Shipping the `case Discovery<Thing>:` branch without the filter wiring gives a service that accepts `--filters` and silently ignores it. Needs its own PR that does both halves. |
| 2 | Effective, scope-carrying role assignments (M) | Reworks how `user.roles` and `roleAssignments` relate; belongs with finding 3 in an identity-focused PR. |
| 3 | OAuth1 delegated credentials (M) | New Keystone surface. Metadata only when it lands — never the token or its secret. |
| 7 | Barbican ACL as typed grantees (M) | New sub-resource shape. When it lands it models the grantees only; the secret payload is never fetched. |
| 9 | What a federation mapping actually grants (M) | Pure-Go rule interpretation over `Mapping.Rules`; a meaningful chunk of parsing and testing on its own. |
| 10, 17 | Manila share types, snapshots and replicas (M) | Two Manila findings that should ship together so share types and snapshots land as one coherent Manila expansion. |
| 12 | BGP VPN interconnections (M) | New optional Neutron extension; belongs with the network-exposure chain rather than this set. |
| 13 | Volume attachment mode (M) | New Cinder resource. |
| 14 | Glance import tasks and enabled methods (M) | New Glance surface. |
| 15 | Storage and bare-metal control-plane health (M) | Two new services (Cinder services, Ironic conductors) that pair naturally as one control-plane PR. |
| 18 | Heat stack change history (M) | New Heat sub-resource. |
| 19 | Zun capsules (M) | Whole unmodelled service. |

Deferred for size and coherence, not because the evidence is wrong. Every one of them is still open work.

## Notes that contradict or extend the audit

- **Finding 4's evidence is understated.** It describes the missing target types. The shipped `qosPolicy` reference is also spelling-sensitive and has been resolving to null on any deployment that reports `qos_policy`, which the audit did not flag.
- **Finding 5 sits on top of a live leak, not just a gap.** The audit frames the temp-URL key as something to expose carefully. In fact its value was already being emitted through the shipped `metadata` field, so the work was redaction as much as addition.
- **Finding 16's premise that `roleNames` should give way to references is only half right.** The role catalog is admin-only, so `roleNames` is the field that survives on a restricted token. Both are kept.
- **Pre-existing pattern not fixed here:** several shipped `init` functions in this provider end in `return args, nil, nil` when their lookup found nothing, which creates a blank resource with unset fields rather than reporting the miss. The two new inits in this PR return an error instead. Sweeping the existing ones is a separate change.
