### PR TITLE
🐛 mongodbatlas: keep unreported project settings flags null

### DIFF
--- a/providers/mongodbatlas/resources/settings.go
+++ b/providers/mongodbatlas/resources/settings.go
@@ -9,6 +9,7 @@ import (
 
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mongodb.org/atlas-sdk/v20250312023/admin"
 )
 
 // isAccessDenied reports whether the API response indicates the credential is
@@ -16,6 +17,33 @@ import (
 // endpoint). Such resources degrade to null rather than failing the scan.
 func isAccessDenied(resp *http.Response) bool {
 	return resp != nil && (resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden)
+}
+
+// projectConfigFields maps the project settings payload onto the
+// mongodbatlas.projectConfig fields.
+//
+// Every flag is read from its pointer field rather than the SDK's Get accessor.
+// The accessors dereference a *bool and return the zero value when the pointer
+// is nil, so a flag the API did not report would become a fabricated false. In
+// MQL `null && null` evaluates to true, so a fabricated false on a flag whose
+// secure reading is false (isDataExplorerEnabled and the generative AI flags)
+// makes a "must be disabled" assertion pass on a project where the flag was
+// never read at all.
+func projectConfigFields(pid string, s *admin.GroupSettings) map[string]*llx.RawData {
+	return map[string]*llx.RawData{
+		"__id":                                            llx.StringData("mongodbatlas.projectConfig/" + pid),
+		"isDataExplorerEnabled":                           llx.BoolDataPtr(s.IsDataExplorerEnabled),
+		"isDataExplorerGenAIFeaturesEnabled":              llx.BoolDataPtr(s.IsDataExplorerGenAIFeaturesEnabled),
+		"isExtendedStorageSizesEnabled":                   llx.BoolDataPtr(s.IsExtendedStorageSizesEnabled),
+		"isPerformanceAdvisorEnabled":                     llx.BoolDataPtr(s.IsPerformanceAdvisorEnabled),
+		"isRealtimePerformancePanelEnabled":               llx.BoolDataPtr(s.IsRealtimePerformancePanelEnabled),
+		"isSchemaAdvisorEnabled":                          llx.BoolDataPtr(s.IsSchemaAdvisorEnabled),
+		"isCollectDatabaseSpecificsStatisticsEnabled":     llx.BoolDataPtr(s.IsCollectDatabaseSpecificsStatisticsEnabled),
+		"isDataExplorerGenAISampleDocumentPassingEnabled": llx.BoolDataPtr(s.IsDataExplorerGenAISampleDocumentPassingEnabled),
+		"isClusterAiAssistantEnabled":                     llx.BoolDataPtr(s.IsClusterAiAssistantEnabled),
+		"isNativeRerankingEnabled":                        llx.BoolDataPtr(s.IsNativeRerankingEnabled),
+		"isDataValidationEnabled":                         llx.BoolDataPtr(s.IsDataValidationEnabled),
+	}
 }
 
 func (r *mqlMongodbatlas) projectSettings() (*mqlMongodbatlasProjectConfig, error) {
@@ -27,24 +55,7 @@ func (r *mqlMongodbatlas) projectSettings() (*mqlMongodbatlasProjectConfig, erro
 	if err != nil {
 		return nil, err
 	}
-	res, err := CreateResource(r.MqlRuntime, "mongodbatlas.projectConfig", map[string]*llx.RawData{
-		"__id":                                        llx.StringData("mongodbatlas.projectConfig/" + pid),
-		"isDataExplorerEnabled":                       llx.BoolData(s.GetIsDataExplorerEnabled()),
-		"isDataExplorerGenAIFeaturesEnabled":          llx.BoolData(s.GetIsDataExplorerGenAIFeaturesEnabled()),
-		"isExtendedStorageSizesEnabled":               llx.BoolData(s.GetIsExtendedStorageSizesEnabled()),
-		"isPerformanceAdvisorEnabled":                 llx.BoolData(s.GetIsPerformanceAdvisorEnabled()),
-		"isRealtimePerformancePanelEnabled":           llx.BoolData(s.GetIsRealtimePerformancePanelEnabled()),
-		"isSchemaAdvisorEnabled":                      llx.BoolData(s.GetIsSchemaAdvisorEnabled()),
-		"isCollectDatabaseSpecificsStatisticsEnabled": llx.BoolData(s.GetIsCollectDatabaseSpecificsStatisticsEnabled()),
-		// The four flags below are read as pointers so a setting the API did
-		// not report stays null. A fabricated false on
-		// isDataExplorerGenAISampleDocumentPassingEnabled would report "sample
-		// documents are not sent" as fact on a project where it was never read.
-		"isDataExplorerGenAISampleDocumentPassingEnabled": llx.BoolDataPtr(s.IsDataExplorerGenAISampleDocumentPassingEnabled),
-		"isClusterAiAssistantEnabled":                     llx.BoolDataPtr(s.IsClusterAiAssistantEnabled),
-		"isNativeRerankingEnabled":                        llx.BoolDataPtr(s.IsNativeRerankingEnabled),
-		"isDataValidationEnabled":                         llx.BoolDataPtr(s.IsDataValidationEnabled),
-	})
+	res, err := CreateResource(r.MqlRuntime, "mongodbatlas.projectConfig", projectConfigFields(pid, s))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/mongodbatlas/resources/settings_test.go
+++ b/providers/mongodbatlas/resources/settings_test.go
@@ -1,0 +1,98 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/types"
+	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+)
+
+// projectConfigFlags lists every boolean field of mongodbatlas.projectConfig
+// alongside the GroupSettings pointer it is read from.
+var projectConfigFlags = []struct {
+	field string
+	set   func(s *admin.GroupSettings, v *bool)
+}{
+	{"isDataExplorerEnabled", func(s *admin.GroupSettings, v *bool) { s.IsDataExplorerEnabled = v }},
+	{"isDataExplorerGenAIFeaturesEnabled", func(s *admin.GroupSettings, v *bool) { s.IsDataExplorerGenAIFeaturesEnabled = v }},
+	{"isExtendedStorageSizesEnabled", func(s *admin.GroupSettings, v *bool) { s.IsExtendedStorageSizesEnabled = v }},
+	{"isPerformanceAdvisorEnabled", func(s *admin.GroupSettings, v *bool) { s.IsPerformanceAdvisorEnabled = v }},
+	{"isRealtimePerformancePanelEnabled", func(s *admin.GroupSettings, v *bool) { s.IsRealtimePerformancePanelEnabled = v }},
+	{"isSchemaAdvisorEnabled", func(s *admin.GroupSettings, v *bool) { s.IsSchemaAdvisorEnabled = v }},
+	{"isCollectDatabaseSpecificsStatisticsEnabled", func(s *admin.GroupSettings, v *bool) {
+		s.IsCollectDatabaseSpecificsStatisticsEnabled = v
+	}},
+	{"isDataExplorerGenAISampleDocumentPassingEnabled", func(s *admin.GroupSettings, v *bool) {
+		s.IsDataExplorerGenAISampleDocumentPassingEnabled = v
+	}},
+	{"isClusterAiAssistantEnabled", func(s *admin.GroupSettings, v *bool) { s.IsClusterAiAssistantEnabled = v }},
+	{"isNativeRerankingEnabled", func(s *admin.GroupSettings, v *bool) { s.IsNativeRerankingEnabled = v }},
+	{"isDataValidationEnabled", func(s *admin.GroupSettings, v *bool) { s.IsDataValidationEnabled = v }},
+}
+
+func TestProjectConfigFieldsID(t *testing.T) {
+	got := projectConfigFields("p1", &admin.GroupSettings{})
+	require.Contains(t, got, "__id")
+	assert.Equal(t, "mongodbatlas.projectConfig/p1", got["__id"].Value)
+}
+
+// TestProjectConfigFieldsUnreported pins the behaviour that a flag Atlas did not
+// report stays null instead of becoming a fabricated false. Reading the flags
+// through the SDK's Get accessors instead of the pointer fields regresses this:
+// the accessors dereference a *bool and return the zero value when it is nil, so
+// an unreported flag would read as false. Because `null && null` evaluates to
+// true in MQL, a fabricated false on a flag whose secure reading is false makes
+// a "must be disabled" assertion pass on a project where nothing was read.
+func TestProjectConfigFieldsUnreported(t *testing.T) {
+	// An empty payload: the API reported none of the flags.
+	got := projectConfigFields("p1", &admin.GroupSettings{})
+
+	for _, f := range projectConfigFlags {
+		t.Run(f.field, func(t *testing.T) {
+			raw, ok := got[f.field]
+			require.True(t, ok, "field is mapped")
+			assert.Equal(t, types.Nil, raw.Type, "an unreported flag stays null, never a fabricated false")
+			assert.Nil(t, raw.Value)
+			assert.NotEqual(t, llx.BoolData(false), raw, "must not report false for a flag the API did not return")
+		})
+	}
+}
+
+func TestProjectConfigFieldsReported(t *testing.T) {
+	for _, want := range []bool{false, true} {
+		for _, f := range projectConfigFlags {
+			t.Run(f.field, func(t *testing.T) {
+				s := &admin.GroupSettings{}
+				f.set(s, admin.PtrBool(want))
+
+				raw, ok := projectConfigFields("p1", s)[f.field]
+				require.True(t, ok, "field is mapped")
+				assert.Equal(t, types.Bool, raw.Type)
+				assert.Equal(t, want, raw.Value, "a reported flag keeps its value")
+			})
+		}
+	}
+}
+
+// TestProjectConfigFieldsPartial covers the mixed payload: the flags Atlas
+// reported keep their values while the rest stay null. Atlas gates several of
+// these settings on the cluster tier and the organization's feature flags, so a
+// partial payload is the normal case, not an edge case.
+func TestProjectConfigFieldsPartial(t *testing.T) {
+	got := projectConfigFields("p1", &admin.GroupSettings{
+		IsDataExplorerEnabled:       admin.PtrBool(true),
+		IsPerformanceAdvisorEnabled: admin.PtrBool(false),
+	})
+
+	assert.Equal(t, true, got["isDataExplorerEnabled"].Value)
+	assert.Equal(t, false, got["isPerformanceAdvisorEnabled"].Value)
+	assert.Equal(t, types.Nil, got["isDataExplorerGenAIFeaturesEnabled"].Type)
+	assert.Equal(t, types.Nil, got["isSchemaAdvisorEnabled"].Type)
+	assert.Equal(t, types.Nil, got["isDataValidationEnabled"].Type)
+}


### PR DESCRIPTION
Found while implementing #10317 and deliberately left out of it, because unlike the new fields in that PR this one **changes what shipped fields report**.

## The bug

`providers/mongodbatlas/resources/settings.go` built seven `mongodbatlas.projectConfig` flags from the Atlas SDK's `Get*` accessors:

```go
"isDataExplorerEnabled": llx.BoolData(s.GetIsDataExplorerEnabled()),
```

Every one of these settings is `*bool` with `omitempty` in `admin.GroupSettings`, and the generated accessor is:

```go
func (o *GroupSettings) GetIsDataExplorerEnabled() bool {
	if o == nil || IsNil(o.IsDataExplorerEnabled) {
		var ret bool
		return ret   // false
	}
	return *o.IsDataExplorerEnabled
}
```

So a flag Atlas did not report came back as `false` — indistinguishable from a flag Atlas reported as off. Atlas gates several of these settings on cluster tier and org feature flags, so a partial payload is the normal case rather than an edge case.

`llx.BoolDataPtr(s.IsDataExplorerEnabled)` reads the pointer field directly and yields null when it is nil. This is not a schema change: the fields stay `bool`, and `BoolDataPtr` on a `bool` field produces null when the pointer is nil.

## Why it matters, per flag

`null && null` evaluates to `true` in MQL, so the direction of the damage depends on which value is the hardened one for each flag:

| Flag | Hardened value | Effect of a fabricated `false` |
|---|---|---|
| `isDataExplorerEnabled` | `false` — browsing live documents from the console is a data-exposure surface | **Vacuous pass.** A "data explorer must be off" check passes on a project where the flag was never read. Dangerous. |
| `isDataExplorerGenAIFeaturesEnabled` | `false` — sends queries and schema to a third-party model | **Vacuous pass.** Same shape, and the same reasoning #10317 used for `isDataExplorerGenAISampleDocumentPassingEnabled`. Dangerous. |
| `isCollectDatabaseSpecificsStatisticsEnabled` | depends on the policy | Under a data-minimization policy (do not collect namespace-level detail) the hardened value is `false`, so a fabricated `false` is a **vacuous pass**. Under an observability policy the hardened value is `true` and it is a false alarm instead. Ambiguous, and dangerous under the first reading. |
| `isExtendedStorageSizesEnabled` | `false` is the more restrictive state | Vacuous-pass direction, but this is a capacity setting, not a security control. Low stakes. |
| `isPerformanceAdvisorEnabled` | `true` | False alarm. A "must be enabled" check fails on a project that never reported the flag. Noisy, not dangerous. |
| `isRealtimePerformancePanelEnabled` | `true` | False alarm. Noisy. |
| `isSchemaAdvisorEnabled` | `true` | False alarm. Noisy. |

Two flags are unambiguously in the dangerous direction, one is dangerous under a data-minimization reading, and three only cost noise. The fix is the same for all of them.

## How it was noticed

The four flags added in #10317 in the same map already used `BoolDataPtr` — `isDataExplorerGenAISampleDocumentPassingEnabled`, `isClusterAiAssistantEnabled`, `isNativeRerankingEnabled`, `isDataValidationEnabled`. Eleven flags read from the same payload, four of them one way and seven the other, is what made the older seven stand out. This makes the whole map consistent rather than introducing a new pattern.

## Blast radius

**This changes observable behaviour on shipped fields.** A query that previously read `false` for any of those seven now reads null when Atlas did not report the flag. Anything downstream that treats "not `true`" as "off" keeps working; anything comparing `== false` will stop matching those projects, and a `&&` over several of these flags can now short-circuit to a null-tolerant `true`. That is the point of the change — the previous `false` was not a reading, it was a default — but it is worth seeing before merge.

Fields whose value Atlas *did* report are untouched: `false` still reports `false` and `true` still reports `true`.

No `.lr` change. The seven field descriptions are one-line "Whether X is enabled" summaries; none of them asserts anything about the absent case, so there is nothing that became wrong. Nothing was regenerated.

## Proving the test bites

The mapping moved into a pure `projectConfigFields(pid, *admin.GroupSettings)` so it can be exercised without a connection. `resources/settings_test.go` covers all three states for every one of the eleven flags: pointer nil reports null, pointer `false` reports `false`, pointer `true` reports `true`, plus a mixed payload where reported and unreported flags coexist.

The fix was reverted locally to confirm the test actually catches the regression. With the seven `Get*` accessors restored, exactly the seven regressed subtests fail and the four from #10317 stay green:

```
--- FAIL: TestProjectConfigFieldsUnreported/isDataExplorerEnabled
--- FAIL: TestProjectConfigFieldsUnreported/isDataExplorerGenAIFeaturesEnabled
--- FAIL: TestProjectConfigFieldsUnreported/isExtendedStorageSizesEnabled
--- FAIL: TestProjectConfigFieldsUnreported/isPerformanceAdvisorEnabled
--- FAIL: TestProjectConfigFieldsUnreported/isRealtimePerformancePanelEnabled
--- FAIL: TestProjectConfigFieldsUnreported/isSchemaAdvisorEnabled
--- FAIL: TestProjectConfigFieldsUnreported/isCollectDatabaseSpecificsStatisticsEnabled
--- FAIL: TestProjectConfigFieldsPartial
```

## Same bug class elsewhere in the provider — not fixed here

Sweeping the provider for `llx.BoolData(x.Get*())` turns up 26 more sites backed by `*bool` SDK fields, so the same fabricated-`false` applies to them. They are left for a follow-up rather than folded in here, because each needs its own hardened-value call and the combined blast radius across eight resources is a much larger review than this one.

The one in the same dangerous direction is worth calling out now:

- `resources/federation.go:65` — `ssoDebugEnabled` on `mongodbatlas.identityProvider`. The hardened value is `false`, so an unreported flag currently passes an "SSO debug must be off" check vacuously.

The rest, all fabricating `false` for an unreported flag: `resources/settings.go:69,70` (`auditConfig.enabled`, `auditAuthorizationSuccess`), `settings.go:98-104` (the six KMS `enabled`/`valid` pairs and `enabledForSearchNodes`), `resources/backup_compliance.go:36-38`, `resources/cluster.go:100-108,127`, `resources/backup.go:99,101,202`, `resources/flex.go:70`, `resources/federation.go:40`, `resources/search.go:67`.

One site in that sweep is **not** a bug and should stay as it is: `resources/federation_orgs.go:75` reads `ConnectedOrgConfig.DomainRestrictionEnabled`, which is a plain `bool` with `json:"domainRestrictionEnabled"` and no `omitempty` — a required field with nothing to fabricate.
