### PR TITLE
✨ gcp: expose key blast radius, service-account key exposure, and federated trust anchors

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1398,6 +1398,19 @@ var gcpPermissionOverrides = map[string]map[string]string{
 		// GetIamPolicy is called on a service account; the real permission is the
 		// resource-scoped form, not the auto-derived "iam.iamPolicy.get".
 		"GetIamPolicy": "iam.serviceAccounts.getIamPolicy",
+		// Service account keys are listed over REST as
+		// Projects.ServiceAccounts.Keys.List, whose resource segment is the bare
+		// "Keys"; the real permission names the parent resource type.
+		"Keys.List": "iam.serviceAccountKeys.list",
+	},
+	"kmsinventory": {
+		// The KMS Inventory API has no IAM permissions of its own. Reading a
+		// key's protected-resources summary is governed by the same permission
+		// as searching protected resources, which is the single permission in
+		// roles/cloudkms.protectedResourcesViewer. The generic derivation
+		// lowercases the whole method name into
+		// "kmsinventory.cryptoKeys.getprotectedresourcessummary".
+		"CryptoKeys.GetProtectedResourcesSummary": "cloudkms.protectedResources.search",
 	},
 	"certificatemanager": {
 		// The Certificate Manager IAM permissions use abbreviated, all-lowercase

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -6803,12 +6803,16 @@ private gcp.project.iamService.workloadIdentityPool @defaults("displayName name 
   // external certificates that can federate in beyond that baseline. Empty
   // when no additional bundle is configured.
   additionalTrustDomains []string
-  // Number of CA certificates trusted across every additional trust bundle
+  // Number of trust anchor certificates across every additional trust bundle
   //
-  // Counts the root and intermediate certificates the pool accepts on top of
-  // its own trust domain. Any certificate chaining to one of them federates
-  // in, so this is the size of the added trust surface. 0 when no additional
-  // bundle is configured.
+  // Counts the trust anchors, the certificates a presented chain may be
+  // validated up to. An anchor is usually a root CA certificate but may itself
+  // be an intermediate one. Certificates held in a bundle's separate
+  // intermediate CA set are not counted, because those only help build a chain
+  // up to an anchor and cannot be validated against on their own. Any
+  // certificate chaining to one of these anchors federates in, so this is the
+  // size of the trust surface added on top of the pool's own trust domain. 0
+  // when no additional bundle is configured.
   additionalTrustAnchorCount int
   // Certificate authority pools that issue mTLS workload certificates, keyed by region
   //

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -5931,6 +5931,52 @@ private gcp.project.kmsService.keyring.cryptokey @defaults("name purpose") {
   // tools apply: "terraform", "config-connector", or "cloud-composer". Empty
   // when the resource carries no management signal.
   managedBy() string
+  // Resources across the organization that this key protects
+  //
+  // Null when the summary cannot be read, which covers the KMS Inventory API
+  // not being enabled on the project, the caller lacking
+  // cloudkms.protectedResources.search, and the KMS organization service agent
+  // not yet holding the org-level role the underlying asset search needs. A key
+  // that genuinely protects nothing is not null: it reports a summary whose
+  // `resourceCount` is 0.
+  protectedResources() gcp.project.kmsService.keyring.cryptokey.protectedResources
+}
+
+// Google Cloud (GCP) KMS key protected-resources summary
+//
+// Count of the Cloud resources a key protects, together with the breakdown
+// by Cloud product, resource type, and region. The counts come from Cloud
+// Asset Inventory rather than from KMS, so they cover resources anywhere in
+// the key's organization and not only its own project. A `resourceCount` of
+// 0 identifies an orphaned key that nothing encrypts, and a `projectCount`
+// above 1 shows the key's blast radius crossing project boundaries. When
+// `partialData` is true the asset search behind the summary was incomplete
+// and every count is a lower bound rather than a total.
+private gcp.project.kmsService.keyring.cryptokey.protectedResources @defaults("resourceCount projectCount partialData") {
+  // Total resources in the key's organization that the key protects
+  resourceCount int
+  // Number of distinct projects in the key's organization holding resources the key protects
+  projectCount int
+  // Resources the key protects, counted per Cloud product
+  cloudProducts map[string]string
+  // Resources the key protects, counted per resource type
+  resourceTypes map[string]string
+  // Resources the key protects, counted per region
+  locations map[string]string
+  // Whether the summary was assembled from incomplete data
+  //
+  // True when the API returned a partial-data warning, which happens when the
+  // KMS organization service agent cannot search every asset, when the project
+  // holds more assets than the analysis covers, or when the key's project sits
+  // outside an organization. The counts are lower bounds while this is true,
+  // so an orphaned key cannot be concluded from `resourceCount` alone.
+  partialData bool
+  // Warning codes the API returned alongside the summary
+  //
+  // Any of INSUFFICIENT_PERMISSIONS_PARTIAL_DATA,
+  // RESOURCE_LIMIT_EXCEEDED_PARTIAL_DATA, ORG_LESS_PROJECT_PARTIAL_DATA, or
+  // WARNING_CODE_UNSPECIFIED. Empty when the summary is complete.
+  warnings []string
 }
 
 // Google Cloud (GCP) KMS crypto key version
@@ -6661,6 +6707,25 @@ private gcp.project.iamService.serviceAccount.key @defaults("name") {
   userManaged bool
   // Whether the key is disabled
   disabled bool
+  // Reason the key was disabled
+  //
+  // Set only while `disabled` is true. One of
+  // SERVICE_ACCOUNT_KEY_DISABLE_REASON_UNSPECIFIED,
+  // SERVICE_ACCOUNT_KEY_DISABLE_REASON_USER_INITIATED (an administrator
+  // disabled it), SERVICE_ACCOUNT_KEY_DISABLE_REASON_EXPOSED (Google found
+  // the private key published, typically in a public code repository), or
+  // SERVICE_ACCOUNT_KEY_DISABLE_REASON_COMPROMISE_DETECTED (the key was seen
+  // in use by an attacker). Empty while the key is enabled.
+  disableReason string
+  // Exposure and compromise detections recorded against the key
+  //
+  // Keyed by SERVICE_ACCOUNT_KEY_EXTENDED_STATUS_KEY_EXPOSED or
+  // SERVICE_ACCOUNT_KEY_EXTENDED_STATUS_KEY_COMPROMISE_DETECTED, with the
+  // detection detail as the value. These entries last for the lifetime of the
+  // key, so they still report a key Google once found published after it has
+  // been re-enabled, which `disableReason` no longer does. Empty when nothing
+  // was ever detected.
+  extendedStatus map[string]string
   // Timestamp when the key was last used to authenticate (from Policy Intelligence)
   lastAuthenticatedTime() time
   // Age of the key in whole days, computed from `validAfterTime` to now (useful for key-rotation audits, e.g. a 90-day threshold)
@@ -6730,6 +6795,34 @@ private gcp.project.iamService.workloadIdentityPool @defaults("displayName name 
   //
   // One of FEDERATION_ONLY, TRUST_DOMAIN, SYSTEM_TRUST_DOMAIN, or empty/MODE_UNSPECIFIED (both unspecified values operate as FEDERATION_ONLY). FEDERATION_ONLY pools accept external workload identities (the audit hot spot); TRUST_DOMAIN and SYSTEM_TRUST_DOMAIN pools (e.g. GKE's `*.svc.id.goog` pools) do not host user-defined providers.
   mode string
+  // Extra trust domains whose certificates are accepted by the pool
+  //
+  // Trust domain names, for example `example.com`, that the pool configuration
+  // maps to an additional bundle of trusted CA certificates. A pool always
+  // trusts its own trust domain, so every entry here widens the set of
+  // external certificates that can federate in beyond that baseline. Empty
+  // when no additional bundle is configured.
+  additionalTrustDomains []string
+  // Number of CA certificates trusted across every additional trust bundle
+  //
+  // Counts the root and intermediate certificates the pool accepts on top of
+  // its own trust domain. Any certificate chaining to one of them federates
+  // in, so this is the size of the added trust surface. 0 when no additional
+  // bundle is configured.
+  additionalTrustAnchorCount int
+  // Certificate authority pools that issue mTLS workload certificates, keyed by region
+  //
+  // Maps each region to the CA pool resource path that mints workload
+  // certificates for workloads in that region. Workloads are only issued
+  // certificates from a CA pool in their own region. Empty when the pool
+  // issues no workload certificates, or issues them from the Google-managed
+  // shared authority instead.
+  certificateIssuanceCaPools map[string]string
+  // Whether workload certificates are issued by the Google-provisioned shared certificate authority
+  //
+  // Mutually exclusive with `certificateIssuanceCaPools`. False when the pool
+  // issues no workload certificates at all, or names its own authorities.
+  certificateIssuanceUsesDefaultSharedCa bool
   // Identity providers attached to this pool. Null for TRUST_DOMAIN and SYSTEM_TRUST_DOMAIN pools, which cannot host user-defined providers.
   providers() []gcp.project.iamService.workloadIdentityPool.provider
 }
@@ -6880,6 +6973,33 @@ private gcp.organization.workforcePool.provider @defaults("displayName providerT
   oidcIssuerUri string
   // For OIDC providers: the OAuth 2.0 client ID registered with the IdP
   oidcClientId string
+  // Whether a client secret is registered for the OIDC provider
+  //
+  // A client secret is what enables the Authorization Code flow for browser
+  // sign-in, so a provider without one can only use the implicit flow. The
+  // secret value is never reported, only whether one is configured.
+  oidcHasClientSecret bool
+  // OAuth 2.0 response type requested for browser sign-in
+  //
+  // Browser sign-in covers both Cloud console sign-in and gcloud sign-in
+  // through a browser. One of RESPONSE_TYPE_UNSPECIFIED, CODE (Authorization
+  // Code flow), or ID_TOKEN (implicit flow, which returns the token in the
+  // browser URL where it is exposed to browser history, referrer headers, and
+  // proxy logs). Empty for SAML providers.
+  oidcWebSsoResponseType string
+  // How OIDC claims reach attribute mapping and the attribute condition
+  //
+  // One of ASSERTION_CLAIMS_BEHAVIOR_UNSPECIFIED, ONLY_ID_TOKEN_CLAIMS, or
+  // MERGE_USER_INFO_OVER_ID_TOKEN_CLAIMS, which merges claims read from the
+  // IdP UserInfo endpoint over the ID token claims, preferring the UserInfo
+  // value where both carry the same claim. Merging is available only with the
+  // Authorization Code flow. Empty for SAML providers.
+  oidcWebSsoAssertionClaimsBehavior string
+  // OAuth 2.0 scopes requested on top of openid, profile, and email
+  //
+  // Up to 10 additional scopes may be configured. Empty when browser sign-in
+  // requests only the default scopes, and for SAML providers.
+  oidcWebSsoAdditionalScopes []string
   // For SAML providers: the SAML 2.0 IdP metadata XML document defining the trust
   samlIdpMetadataXml string
   // Attribute type the provider fetches from an external endpoint to augment group claims

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -157,6 +157,7 @@ const (
 	ResourceGcpProjectKmsService                                                       string = "gcp.project.kmsService"
 	ResourceGcpProjectKmsServiceKeyring                                                string = "gcp.project.kmsService.keyring"
 	ResourceGcpProjectKmsServiceKeyringCryptokey                                       string = "gcp.project.kmsService.keyring.cryptokey"
+	ResourceGcpProjectKmsServiceKeyringCryptokeyProtectedResources                     string = "gcp.project.kmsService.keyring.cryptokey.protectedResources"
 	ResourceGcpProjectKmsServiceKeyringCryptokeyVersion                                string = "gcp.project.kmsService.keyring.cryptokey.version"
 	ResourceGcpProjectKmsServiceKeyringCryptokeyVersionAttestation                     string = "gcp.project.kmsService.keyring.cryptokey.version.attestation"
 	ResourceGcpProjectKmsServiceKeyringCryptokeyVersionAttestationCertificatechains    string = "gcp.project.kmsService.keyring.cryptokey.version.attestation.certificatechains"
@@ -1071,6 +1072,10 @@ func init() {
 		"gcp.project.kmsService.keyring.cryptokey": {
 			Init:   initGcpProjectKmsServiceKeyringCryptokey,
 			Create: createGcpProjectKmsServiceKeyringCryptokey,
+		},
+		"gcp.project.kmsService.keyring.cryptokey.protectedResources": {
+			// to override args, implement: initGcpProjectKmsServiceKeyringCryptokeyProtectedResources(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createGcpProjectKmsServiceKeyringCryptokeyProtectedResources,
 		},
 		"gcp.project.kmsService.keyring.cryptokey.version": {
 			// to override args, implement: initGcpProjectKmsServiceKeyringCryptokeyVersion(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -8007,6 +8012,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.kmsService.keyring.cryptokey.managedBy": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokey).GetManagedBy()).ToDataRes(types.String)
 	},
+	"gcp.project.kmsService.keyring.cryptokey.protectedResources": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokey).GetProtectedResources()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey.protectedResources"))
+	},
+	"gcp.project.kmsService.keyring.cryptokey.protectedResources.resourceCount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources).GetResourceCount()).ToDataRes(types.Int)
+	},
+	"gcp.project.kmsService.keyring.cryptokey.protectedResources.projectCount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources).GetProjectCount()).ToDataRes(types.Int)
+	},
+	"gcp.project.kmsService.keyring.cryptokey.protectedResources.cloudProducts": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources).GetCloudProducts()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"gcp.project.kmsService.keyring.cryptokey.protectedResources.resourceTypes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources).GetResourceTypes()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"gcp.project.kmsService.keyring.cryptokey.protectedResources.locations": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources).GetLocations()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"gcp.project.kmsService.keyring.cryptokey.protectedResources.partialData": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources).GetPartialData()).ToDataRes(types.Bool)
+	},
+	"gcp.project.kmsService.keyring.cryptokey.protectedResources.warnings": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources).GetWarnings()).ToDataRes(types.Array(types.String))
+	},
 	"gcp.project.kmsService.keyring.cryptokey.version.resourcePath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokeyVersion).GetResourcePath()).ToDataRes(types.String)
 	},
@@ -8589,6 +8618,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.iamService.serviceAccount.key.disabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectIamServiceServiceAccountKey).GetDisabled()).ToDataRes(types.Bool)
 	},
+	"gcp.project.iamService.serviceAccount.key.disableReason": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectIamServiceServiceAccountKey).GetDisableReason()).ToDataRes(types.String)
+	},
+	"gcp.project.iamService.serviceAccount.key.extendedStatus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectIamServiceServiceAccountKey).GetExtendedStatus()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"gcp.project.iamService.serviceAccount.key.lastAuthenticatedTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectIamServiceServiceAccountKey).GetLastAuthenticatedTime()).ToDataRes(types.Time)
 	},
@@ -8645,6 +8680,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.iamService.workloadIdentityPool.mode": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectIamServiceWorkloadIdentityPool).GetMode()).ToDataRes(types.String)
+	},
+	"gcp.project.iamService.workloadIdentityPool.additionalTrustDomains": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectIamServiceWorkloadIdentityPool).GetAdditionalTrustDomains()).ToDataRes(types.Array(types.String))
+	},
+	"gcp.project.iamService.workloadIdentityPool.additionalTrustAnchorCount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectIamServiceWorkloadIdentityPool).GetAdditionalTrustAnchorCount()).ToDataRes(types.Int)
+	},
+	"gcp.project.iamService.workloadIdentityPool.certificateIssuanceCaPools": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectIamServiceWorkloadIdentityPool).GetCertificateIssuanceCaPools()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"gcp.project.iamService.workloadIdentityPool.certificateIssuanceUsesDefaultSharedCa": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectIamServiceWorkloadIdentityPool).GetCertificateIssuanceUsesDefaultSharedCa()).ToDataRes(types.Bool)
 	},
 	"gcp.project.iamService.workloadIdentityPool.providers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectIamServiceWorkloadIdentityPool).GetProviders()).ToDataRes(types.Array(types.Resource("gcp.project.iamService.workloadIdentityPool.provider")))
@@ -8783,6 +8830,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.organization.workforcePool.provider.oidcClientId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpOrganizationWorkforcePoolProvider).GetOidcClientId()).ToDataRes(types.String)
+	},
+	"gcp.organization.workforcePool.provider.oidcHasClientSecret": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpOrganizationWorkforcePoolProvider).GetOidcHasClientSecret()).ToDataRes(types.Bool)
+	},
+	"gcp.organization.workforcePool.provider.oidcWebSsoResponseType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpOrganizationWorkforcePoolProvider).GetOidcWebSsoResponseType()).ToDataRes(types.String)
+	},
+	"gcp.organization.workforcePool.provider.oidcWebSsoAssertionClaimsBehavior": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpOrganizationWorkforcePoolProvider).GetOidcWebSsoAssertionClaimsBehavior()).ToDataRes(types.String)
+	},
+	"gcp.organization.workforcePool.provider.oidcWebSsoAdditionalScopes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpOrganizationWorkforcePoolProvider).GetOidcWebSsoAdditionalScopes()).ToDataRes(types.Array(types.String))
 	},
 	"gcp.organization.workforcePool.provider.samlIdpMetadataXml": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpOrganizationWorkforcePoolProvider).GetSamlIdpMetadataXml()).ToDataRes(types.String)
@@ -26623,6 +26682,42 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectKmsServiceKeyringCryptokey).ManagedBy, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.kmsService.keyring.cryptokey.protectedResources": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectKmsServiceKeyringCryptokey).ProtectedResources, ok = plugin.RawToTValue[*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources](v.Value, v.Error)
+		return
+	},
+	"gcp.project.kmsService.keyring.cryptokey.protectedResources.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources).__id, ok = v.Value.(string)
+		return
+	},
+	"gcp.project.kmsService.keyring.cryptokey.protectedResources.resourceCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources).ResourceCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"gcp.project.kmsService.keyring.cryptokey.protectedResources.projectCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources).ProjectCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"gcp.project.kmsService.keyring.cryptokey.protectedResources.cloudProducts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources).CloudProducts, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.kmsService.keyring.cryptokey.protectedResources.resourceTypes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources).ResourceTypes, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.kmsService.keyring.cryptokey.protectedResources.locations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources).Locations, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.kmsService.keyring.cryptokey.protectedResources.partialData": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources).PartialData, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.kmsService.keyring.cryptokey.protectedResources.warnings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources).Warnings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.kmsService.keyring.cryptokey.version.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectKmsServiceKeyringCryptokeyVersion).__id, ok = v.Value.(string)
 		return
@@ -27487,6 +27582,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectIamServiceServiceAccountKey).Disabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gcp.project.iamService.serviceAccount.key.disableReason": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectIamServiceServiceAccountKey).DisableReason, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.iamService.serviceAccount.key.extendedStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectIamServiceServiceAccountKey).ExtendedStatus, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.iamService.serviceAccount.key.lastAuthenticatedTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectIamServiceServiceAccountKey).LastAuthenticatedTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -27569,6 +27672,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.iamService.workloadIdentityPool.mode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectIamServiceWorkloadIdentityPool).Mode, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.iamService.workloadIdentityPool.additionalTrustDomains": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectIamServiceWorkloadIdentityPool).AdditionalTrustDomains, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.iamService.workloadIdentityPool.additionalTrustAnchorCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectIamServiceWorkloadIdentityPool).AdditionalTrustAnchorCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"gcp.project.iamService.workloadIdentityPool.certificateIssuanceCaPools": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectIamServiceWorkloadIdentityPool).CertificateIssuanceCaPools, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.iamService.workloadIdentityPool.certificateIssuanceUsesDefaultSharedCa": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectIamServiceWorkloadIdentityPool).CertificateIssuanceUsesDefaultSharedCa, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"gcp.project.iamService.workloadIdentityPool.providers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27765,6 +27884,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.organization.workforcePool.provider.oidcClientId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpOrganizationWorkforcePoolProvider).OidcClientId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.organization.workforcePool.provider.oidcHasClientSecret": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpOrganizationWorkforcePoolProvider).OidcHasClientSecret, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.organization.workforcePool.provider.oidcWebSsoResponseType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpOrganizationWorkforcePoolProvider).OidcWebSsoResponseType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.organization.workforcePool.provider.oidcWebSsoAssertionClaimsBehavior": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpOrganizationWorkforcePoolProvider).OidcWebSsoAssertionClaimsBehavior, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.organization.workforcePool.provider.oidcWebSsoAdditionalScopes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpOrganizationWorkforcePoolProvider).OidcWebSsoAdditionalScopes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.organization.workforcePool.provider.samlIdpMetadataXml": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -61372,6 +61507,7 @@ type mqlGcpProjectKmsServiceKeyringCryptokey struct {
 	IamPolicy                     plugin.TValue[[]any]
 	Public                        plugin.TValue[bool]
 	ManagedBy                     plugin.TValue[string]
+	ProtectedResources            plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources]
 }
 
 // createGcpProjectKmsServiceKeyringCryptokey creates a new instance of this resource
@@ -61515,6 +61651,96 @@ func (c *mqlGcpProjectKmsServiceKeyringCryptokey) GetManagedBy() *plugin.TValue[
 	return plugin.GetOrCompute[string](&c.ManagedBy, func() (string, error) {
 		return c.managedBy()
 	})
+}
+
+func (c *mqlGcpProjectKmsServiceKeyringCryptokey) GetProtectedResources() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources] {
+	return plugin.GetOrCompute[*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources](&c.ProtectedResources, func() (*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.kmsService.keyring.cryptokey", c.__id, "protectedResources")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources), nil
+			}
+		}
+
+		return c.protectedResources()
+	})
+}
+
+// mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources for the gcp.project.kmsService.keyring.cryptokey.protectedResources resource
+type mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResourcesInternal it will be used here
+	ResourceCount plugin.TValue[int64]
+	ProjectCount  plugin.TValue[int64]
+	CloudProducts plugin.TValue[map[string]any]
+	ResourceTypes plugin.TValue[map[string]any]
+	Locations     plugin.TValue[map[string]any]
+	PartialData   plugin.TValue[bool]
+	Warnings      plugin.TValue[[]any]
+}
+
+// createGcpProjectKmsServiceKeyringCryptokeyProtectedResources creates a new instance of this resource
+func createGcpProjectKmsServiceKeyringCryptokeyProtectedResources(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("gcp.project.kmsService.keyring.cryptokey.protectedResources", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources) MqlName() string {
+	return "gcp.project.kmsService.keyring.cryptokey.protectedResources"
+}
+
+func (c *mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources) GetResourceCount() *plugin.TValue[int64] {
+	return &c.ResourceCount
+}
+
+func (c *mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources) GetProjectCount() *plugin.TValue[int64] {
+	return &c.ProjectCount
+}
+
+func (c *mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources) GetCloudProducts() *plugin.TValue[map[string]any] {
+	return &c.CloudProducts
+}
+
+func (c *mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources) GetResourceTypes() *plugin.TValue[map[string]any] {
+	return &c.ResourceTypes
+}
+
+func (c *mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources) GetLocations() *plugin.TValue[map[string]any] {
+	return &c.Locations
+}
+
+func (c *mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources) GetPartialData() *plugin.TValue[bool] {
+	return &c.PartialData
+}
+
+func (c *mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources) GetWarnings() *plugin.TValue[[]any] {
+	return &c.Warnings
 }
 
 // mqlGcpProjectKmsServiceKeyringCryptokeyVersion for the gcp.project.kmsService.keyring.cryptokey.version resource
@@ -63666,6 +63892,8 @@ type mqlGcpProjectIamServiceServiceAccountKey struct {
 	KeyType               plugin.TValue[string]
 	UserManaged           plugin.TValue[bool]
 	Disabled              plugin.TValue[bool]
+	DisableReason         plugin.TValue[string]
+	ExtendedStatus        plugin.TValue[map[string]any]
 	LastAuthenticatedTime plugin.TValue[*time.Time]
 	AgeInDays             plugin.TValue[int64]
 }
@@ -63737,6 +63965,14 @@ func (c *mqlGcpProjectIamServiceServiceAccountKey) GetUserManaged() *plugin.TVal
 
 func (c *mqlGcpProjectIamServiceServiceAccountKey) GetDisabled() *plugin.TValue[bool] {
 	return &c.Disabled
+}
+
+func (c *mqlGcpProjectIamServiceServiceAccountKey) GetDisableReason() *plugin.TValue[string] {
+	return &c.DisableReason
+}
+
+func (c *mqlGcpProjectIamServiceServiceAccountKey) GetExtendedStatus() *plugin.TValue[map[string]any] {
+	return &c.ExtendedStatus
 }
 
 func (c *mqlGcpProjectIamServiceServiceAccountKey) GetLastAuthenticatedTime() *plugin.TValue[*time.Time] {
@@ -63840,16 +64076,20 @@ type mqlGcpProjectIamServiceWorkloadIdentityPool struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectIamServiceWorkloadIdentityPoolInternal it will be used here
-	ProjectId   plugin.TValue[string]
-	Name        plugin.TValue[string]
-	PoolId      plugin.TValue[string]
-	DisplayName plugin.TValue[string]
-	Description plugin.TValue[string]
-	State       plugin.TValue[string]
-	Disabled    plugin.TValue[bool]
-	ExpireTime  plugin.TValue[*time.Time]
-	Mode        plugin.TValue[string]
-	Providers   plugin.TValue[[]any]
+	ProjectId                              plugin.TValue[string]
+	Name                                   plugin.TValue[string]
+	PoolId                                 plugin.TValue[string]
+	DisplayName                            plugin.TValue[string]
+	Description                            plugin.TValue[string]
+	State                                  plugin.TValue[string]
+	Disabled                               plugin.TValue[bool]
+	ExpireTime                             plugin.TValue[*time.Time]
+	Mode                                   plugin.TValue[string]
+	AdditionalTrustDomains                 plugin.TValue[[]any]
+	AdditionalTrustAnchorCount             plugin.TValue[int64]
+	CertificateIssuanceCaPools             plugin.TValue[map[string]any]
+	CertificateIssuanceUsesDefaultSharedCa plugin.TValue[bool]
+	Providers                              plugin.TValue[[]any]
 }
 
 // createGcpProjectIamServiceWorkloadIdentityPool creates a new instance of this resource
@@ -63923,6 +64163,22 @@ func (c *mqlGcpProjectIamServiceWorkloadIdentityPool) GetExpireTime() *plugin.TV
 
 func (c *mqlGcpProjectIamServiceWorkloadIdentityPool) GetMode() *plugin.TValue[string] {
 	return &c.Mode
+}
+
+func (c *mqlGcpProjectIamServiceWorkloadIdentityPool) GetAdditionalTrustDomains() *plugin.TValue[[]any] {
+	return &c.AdditionalTrustDomains
+}
+
+func (c *mqlGcpProjectIamServiceWorkloadIdentityPool) GetAdditionalTrustAnchorCount() *plugin.TValue[int64] {
+	return &c.AdditionalTrustAnchorCount
+}
+
+func (c *mqlGcpProjectIamServiceWorkloadIdentityPool) GetCertificateIssuanceCaPools() *plugin.TValue[map[string]any] {
+	return &c.CertificateIssuanceCaPools
+}
+
+func (c *mqlGcpProjectIamServiceWorkloadIdentityPool) GetCertificateIssuanceUsesDefaultSharedCa() *plugin.TValue[bool] {
+	return &c.CertificateIssuanceUsesDefaultSharedCa
 }
 
 func (c *mqlGcpProjectIamServiceWorkloadIdentityPool) GetProviders() *plugin.TValue[[]any] {
@@ -64198,24 +64454,28 @@ type mqlGcpOrganizationWorkforcePoolProvider struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpOrganizationWorkforcePoolProviderInternal it will be used here
-	Name                     plugin.TValue[string]
-	ProviderId               plugin.TValue[string]
-	PoolId                   plugin.TValue[string]
-	DisplayName              plugin.TValue[string]
-	Description              plugin.TValue[string]
-	State                    plugin.TValue[string]
-	Disabled                 plugin.TValue[bool]
-	ExpireTime               plugin.TValue[*time.Time]
-	AttributeMapping         plugin.TValue[map[string]any]
-	AttributeCondition       plugin.TValue[string]
-	DetailedAuditLogging     plugin.TValue[bool]
-	ScimUsage                plugin.TValue[string]
-	ProviderType             plugin.TValue[string]
-	OidcIssuerUri            plugin.TValue[string]
-	OidcClientId             plugin.TValue[string]
-	SamlIdpMetadataXml       plugin.TValue[string]
-	ExtraAttributesType      plugin.TValue[string]
-	ExtraAttributesIssuerUri plugin.TValue[string]
+	Name                              plugin.TValue[string]
+	ProviderId                        plugin.TValue[string]
+	PoolId                            plugin.TValue[string]
+	DisplayName                       plugin.TValue[string]
+	Description                       plugin.TValue[string]
+	State                             plugin.TValue[string]
+	Disabled                          plugin.TValue[bool]
+	ExpireTime                        plugin.TValue[*time.Time]
+	AttributeMapping                  plugin.TValue[map[string]any]
+	AttributeCondition                plugin.TValue[string]
+	DetailedAuditLogging              plugin.TValue[bool]
+	ScimUsage                         plugin.TValue[string]
+	ProviderType                      plugin.TValue[string]
+	OidcIssuerUri                     plugin.TValue[string]
+	OidcClientId                      plugin.TValue[string]
+	OidcHasClientSecret               plugin.TValue[bool]
+	OidcWebSsoResponseType            plugin.TValue[string]
+	OidcWebSsoAssertionClaimsBehavior plugin.TValue[string]
+	OidcWebSsoAdditionalScopes        plugin.TValue[[]any]
+	SamlIdpMetadataXml                plugin.TValue[string]
+	ExtraAttributesType               plugin.TValue[string]
+	ExtraAttributesIssuerUri          plugin.TValue[string]
 }
 
 // createGcpOrganizationWorkforcePoolProvider creates a new instance of this resource
@@ -64313,6 +64573,22 @@ func (c *mqlGcpOrganizationWorkforcePoolProvider) GetOidcIssuerUri() *plugin.TVa
 
 func (c *mqlGcpOrganizationWorkforcePoolProvider) GetOidcClientId() *plugin.TValue[string] {
 	return &c.OidcClientId
+}
+
+func (c *mqlGcpOrganizationWorkforcePoolProvider) GetOidcHasClientSecret() *plugin.TValue[bool] {
+	return &c.OidcHasClientSecret
+}
+
+func (c *mqlGcpOrganizationWorkforcePoolProvider) GetOidcWebSsoResponseType() *plugin.TValue[string] {
+	return &c.OidcWebSsoResponseType
+}
+
+func (c *mqlGcpOrganizationWorkforcePoolProvider) GetOidcWebSsoAssertionClaimsBehavior() *plugin.TValue[string] {
+	return &c.OidcWebSsoAssertionClaimsBehavior
+}
+
+func (c *mqlGcpOrganizationWorkforcePoolProvider) GetOidcWebSsoAdditionalScopes() *plugin.TValue[[]any] {
+	return &c.OidcWebSsoAdditionalScopes
 }
 
 func (c *mqlGcpOrganizationWorkforcePoolProvider) GetSamlIdpMetadataXml() *plugin.TValue[string] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -304,7 +304,11 @@ gcp.organization.workforcePool.provider.extraAttributesIssuerUri 13.32.1
 gcp.organization.workforcePool.provider.extraAttributesType 13.32.1
 gcp.organization.workforcePool.provider.name 13.32.1
 gcp.organization.workforcePool.provider.oidcClientId 13.32.1
+gcp.organization.workforcePool.provider.oidcHasClientSecret 13.37.1
 gcp.organization.workforcePool.provider.oidcIssuerUri 13.32.1
+gcp.organization.workforcePool.provider.oidcWebSsoAdditionalScopes 13.37.1
+gcp.organization.workforcePool.provider.oidcWebSsoAssertionClaimsBehavior 13.37.1
+gcp.organization.workforcePool.provider.oidcWebSsoResponseType 13.37.1
 gcp.organization.workforcePool.provider.poolId 13.32.1
 gcp.organization.workforcePool.provider.providerId 13.32.1
 gcp.organization.workforcePool.provider.providerType 13.32.1
@@ -3720,7 +3724,9 @@ gcp.project.iamService.serviceAccount.impersonators 13.34.2
 gcp.project.iamService.serviceAccount.isDefault 13.18.1
 gcp.project.iamService.serviceAccount.key 9.0.0
 gcp.project.iamService.serviceAccount.key.ageInDays 13.18.1
+gcp.project.iamService.serviceAccount.key.disableReason 13.37.1
 gcp.project.iamService.serviceAccount.key.disabled 9.0.0
+gcp.project.iamService.serviceAccount.key.extendedStatus 13.37.1
 gcp.project.iamService.serviceAccount.key.keyAlgorithm 9.0.0
 gcp.project.iamService.serviceAccount.key.keyOrigin 9.0.0
 gcp.project.iamService.serviceAccount.key.keyType 9.0.0
@@ -3738,6 +3744,10 @@ gcp.project.iamService.serviceAccount.projectId 9.0.0
 gcp.project.iamService.serviceAccount.uniqueId 9.0.0
 gcp.project.iamService.serviceAccounts 9.0.0
 gcp.project.iamService.workloadIdentityPool 13.13.4
+gcp.project.iamService.workloadIdentityPool.additionalTrustAnchorCount 13.37.1
+gcp.project.iamService.workloadIdentityPool.additionalTrustDomains 13.37.1
+gcp.project.iamService.workloadIdentityPool.certificateIssuanceCaPools 13.37.1
+gcp.project.iamService.workloadIdentityPool.certificateIssuanceUsesDefaultSharedCa 13.37.1
 gcp.project.iamService.workloadIdentityPool.description 13.13.4
 gcp.project.iamService.workloadIdentityPool.disabled 13.13.4
 gcp.project.iamService.workloadIdentityPool.displayName 13.13.4
@@ -3884,6 +3894,14 @@ gcp.project.kmsService.keyring.cryptokey.name 9.0.0
 gcp.project.kmsService.keyring.cryptokey.nextRotation 9.0.0
 gcp.project.kmsService.keyring.cryptokey.primary 9.0.0
 gcp.project.kmsService.keyring.cryptokey.primaryState 13.18.1
+gcp.project.kmsService.keyring.cryptokey.protectedResources 13.37.1
+gcp.project.kmsService.keyring.cryptokey.protectedResources.cloudProducts 13.37.1
+gcp.project.kmsService.keyring.cryptokey.protectedResources.locations 13.37.1
+gcp.project.kmsService.keyring.cryptokey.protectedResources.partialData 13.37.1
+gcp.project.kmsService.keyring.cryptokey.protectedResources.projectCount 13.37.1
+gcp.project.kmsService.keyring.cryptokey.protectedResources.resourceCount 13.37.1
+gcp.project.kmsService.keyring.cryptokey.protectedResources.resourceTypes 13.37.1
+gcp.project.kmsService.keyring.cryptokey.protectedResources.warnings 13.37.1
 gcp.project.kmsService.keyring.cryptokey.public 13.12.2
 gcp.project.kmsService.keyring.cryptokey.purpose 9.0.0
 gcp.project.kmsService.keyring.cryptokey.resourcePath 9.0.0

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
   "version": "13.37.0",
-  "generated_at": "2026-08-23T13:31:23-07:00",
+  "generated_at": "2026-08-23T20:23:17-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",
@@ -84,6 +84,7 @@
     "cloudkms.importJobs.list",
     "cloudkms.keyRings.list",
     "cloudkms.locations.list",
+    "cloudkms.protectedResources.search",
     "cloudkms.retiredResources.list",
     "cloudscheduler.jobs.list",
     "cloudsql.backupRuns.list",
@@ -790,6 +791,12 @@
       "service": "cloudkms",
       "action": "ListLocations",
       "source_file": "kms.go"
+    },
+    {
+      "permission": "cloudkms.protectedResources.search",
+      "service": "kmsinventory",
+      "action": "CryptoKeys.GetProtectedResourcesSummary",
+      "source_file": "kms_protected_resources.go"
     },
     {
       "permission": "cloudkms.retiredResources.list",
@@ -1514,7 +1521,7 @@
     {
       "permission": "iam.serviceAccountKeys.list",
       "service": "iam",
-      "action": "ListServiceAccountKeys",
+      "action": "Keys.List",
       "source_file": "iam.go"
     },
     {

--- a/providers/gcp/resources/iam.go
+++ b/providers/gcp/resources/iam.go
@@ -24,6 +24,7 @@ import (
 	iamv2 "cloud.google.com/go/iam/apiv2"
 	iamv2pb "cloud.google.com/go/iam/apiv2/iampb"
 	"google.golang.org/api/googleapi"
+	iamrest "google.golang.org/api/iam/v1"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	policyanalyzer "google.golang.org/api/policyanalyzer/v1"
@@ -333,36 +334,40 @@ func (g *mqlGcpProjectIamServiceServiceAccount) keys() ([]any, error) {
 
 	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
 
-	creds, err := conn.Credentials(admin.DefaultAuthScopes()...)
+	client, err := conn.Client(iamrest.CloudPlatformScope)
 	if err != nil {
 		return nil, err
 	}
 
 	ctx := context.Background()
 
-	adminSvc, err := admin.NewIamClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
+	iamSvc, err := iamrest.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return nil, err
 	}
-	defer adminSvc.Close()
 
-	resp, err := adminSvc.ListServiceAccountKeys(ctx, &adminpb.ListServiceAccountKeysRequest{Name: fmt.Sprintf("projects/%s/serviceAccounts/%s", projectId, email)})
+	// The keys are read over REST rather than through the admin gRPC client
+	// because disableReason and extendedStatus exist only on the REST
+	// ServiceAccountKey. The admin protobuf message carries neither, so on the
+	// gRPC path a key Google disabled because it found the private key
+	// published is indistinguishable from one an operator disabled on purpose.
+	//
+	// Both transports are governed by iam.serviceAccountKeys.list and return
+	// the same key set with the same enum spellings. This endpoint reports every
+	// key in one response: ListServiceAccountKeysResponse has no page token, and
+	// a service account is capped well below any page limit.
+	resp, err := iamSvc.Projects.ServiceAccounts.Keys.
+		List(fmt.Sprintf("projects/%s/serviceAccounts/%s", projectId, email)).
+		Context(ctx).Do()
 	if err != nil {
 		return nil, err
 	}
 	mqlKeys := make([]any, 0, len(resp.Keys))
 	for _, k := range resp.Keys {
-		keyType := k.KeyType.String()
-		mqlKey, err := CreateResource(g.MqlRuntime, "gcp.project.iamService.serviceAccount.key", map[string]*llx.RawData{
-			"name":            llx.StringData(k.Name),
-			"keyAlgorithm":    llx.StringData(k.KeyAlgorithm.String()),
-			"validAfterTime":  llx.TimeDataPtr(timestampAsTimePtr(k.ValidAfterTime)),
-			"validBeforeTime": llx.TimeDataPtr(timestampAsTimePtr(k.ValidBeforeTime)),
-			"keyOrigin":       llx.StringData(k.KeyOrigin.String()),
-			"keyType":         llx.StringData(keyType),
-			"userManaged":     llx.BoolData(keyType == "USER_MANAGED"),
-			"disabled":        llx.BoolData(k.Disabled),
-		})
+		if k == nil {
+			continue
+		}
+		mqlKey, err := CreateResource(g.MqlRuntime, "gcp.project.iamService.serviceAccount.key", serviceAccountKeyArgs(k))
 		if err != nil {
 			return nil, err
 		}
@@ -373,6 +378,38 @@ func (g *mqlGcpProjectIamServiceServiceAccount) keys() ([]any, error) {
 		mqlKeys = append(mqlKeys, mqlKey)
 	}
 	return mqlKeys, nil
+}
+
+// serviceAccountKeyArgs maps a service account key onto its MQL resource
+// arguments.
+//
+// extendedStatus is keyed by the detection kind (EXPOSED, COMPROMISE_DETECTED)
+// so a query can ask for one directly. An entry with an empty key is dropped
+// rather than collapsing into a "" bucket, and the first value wins for a
+// repeated key, so the map size is the number of distinct detections reported.
+func serviceAccountKeyArgs(k *iamrest.ServiceAccountKey) map[string]*llx.RawData {
+	extendedStatus := map[string]any{}
+	for _, st := range k.ExtendedStatus {
+		if st == nil || st.Key == "" {
+			continue
+		}
+		if _, seen := extendedStatus[st.Key]; seen {
+			continue
+		}
+		extendedStatus[st.Key] = st.Value
+	}
+	return map[string]*llx.RawData{
+		"name":            llx.StringData(k.Name),
+		"keyAlgorithm":    llx.StringData(k.KeyAlgorithm),
+		"validAfterTime":  llx.TimeDataPtr(parseTime(k.ValidAfterTime)),
+		"validBeforeTime": llx.TimeDataPtr(parseTime(k.ValidBeforeTime)),
+		"keyOrigin":       llx.StringData(k.KeyOrigin),
+		"keyType":         llx.StringData(k.KeyType),
+		"userManaged":     llx.BoolData(k.KeyType == "USER_MANAGED"),
+		"disabled":        llx.BoolData(k.Disabled),
+		"disableReason":   llx.StringData(k.DisableReason),
+		"extendedStatus":  llx.MapData(extendedStatus, types.String),
+	}
 }
 
 // lastAuthActivity matches the JSON shape returned by the Policy Analyzer

--- a/providers/gcp/resources/iam_credentials_test.go
+++ b/providers/gcp/resources/iam_credentials_test.go
@@ -1,0 +1,273 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	iamrest "google.golang.org/api/iam/v1"
+)
+
+// TestServiceAccountKeyArgs pins the REST key mapping. The eight pre-existing
+// fields are pinned too, not just the two new ones: this lister moved from the
+// admin gRPC client to REST to reach disableReason and extendedStatus, and the
+// migration is only safe if the shipped fields keep the same spellings.
+func TestServiceAccountKeyArgs(t *testing.T) {
+	t.Run("a user-managed key maps every field", func(t *testing.T) {
+		args := serviceAccountKeyArgs(&iamrest.ServiceAccountKey{
+			Name:            "projects/p/serviceAccounts/sa@p.iam.gserviceaccount.com/keys/abc",
+			KeyAlgorithm:    "KEY_ALG_RSA_2048",
+			KeyOrigin:       "USER_PROVIDED",
+			KeyType:         "USER_MANAGED",
+			ValidAfterTime:  "2026-07-06T05:53:51Z",
+			ValidBeforeTime: "2027-07-06T05:53:51Z",
+		})
+
+		assert.Equal(t, "projects/p/serviceAccounts/sa@p.iam.gserviceaccount.com/keys/abc", args["name"].Value)
+		assert.Equal(t, "KEY_ALG_RSA_2048", args["keyAlgorithm"].Value)
+		assert.Equal(t, "USER_PROVIDED", args["keyOrigin"].Value)
+		assert.Equal(t, "USER_MANAGED", args["keyType"].Value)
+		assert.Equal(t, true, args["userManaged"].Value, "USER_MANAGED must drive userManaged")
+
+		after, ok := args["validAfterTime"].Value.(*time.Time)
+		require.True(t, ok)
+		require.NotNil(t, after)
+		assert.Equal(t, "2026-07-06T05:53:51Z", after.UTC().Format(time.RFC3339))
+	})
+
+	t.Run("a system-managed key is not user-managed", func(t *testing.T) {
+		args := serviceAccountKeyArgs(&iamrest.ServiceAccountKey{KeyType: "SYSTEM_MANAGED"})
+		assert.Equal(t, false, args["userManaged"].Value)
+	})
+
+	t.Run("an absent validity window stays null rather than the zero time", func(t *testing.T) {
+		args := serviceAccountKeyArgs(&iamrest.ServiceAccountKey{KeyType: "USER_MANAGED"})
+
+		// A zero time here would report 1 January year 1 as a real timestamp and
+		// make every key look long expired to an age-based rotation audit.
+		assert.Nil(t, args["validAfterTime"].Value)
+		assert.Nil(t, args["validBeforeTime"].Value)
+	})
+
+	t.Run("an enabled key reports no disable reason", func(t *testing.T) {
+		args := serviceAccountKeyArgs(&iamrest.ServiceAccountKey{KeyType: "USER_MANAGED"})
+		assert.Equal(t, false, args["disabled"].Value)
+		assert.Equal(t, "", args["disableReason"].Value)
+		assert.Equal(t, map[string]any{}, args["extendedStatus"].Value)
+	})
+
+	t.Run("an exposed key is distinguishable from an operator-disabled one", func(t *testing.T) {
+		exposed := serviceAccountKeyArgs(&iamrest.ServiceAccountKey{
+			KeyType:       "USER_MANAGED",
+			Disabled:      true,
+			DisableReason: "SERVICE_ACCOUNT_KEY_DISABLE_REASON_EXPOSED",
+		})
+		byOperator := serviceAccountKeyArgs(&iamrest.ServiceAccountKey{
+			KeyType:       "USER_MANAGED",
+			Disabled:      true,
+			DisableReason: "SERVICE_ACCOUNT_KEY_DISABLE_REASON_USER_INITIATED",
+		})
+
+		// Both are disabled==true; the reason is the only thing that separates
+		// "Google found this key published" from routine key hygiene.
+		assert.Equal(t, exposed["disabled"].Value, byOperator["disabled"].Value)
+		assert.NotEqual(t, exposed["disableReason"].Value, byOperator["disableReason"].Value)
+	})
+
+	t.Run("extendedStatus survives a key being re-enabled", func(t *testing.T) {
+		args := serviceAccountKeyArgs(&iamrest.ServiceAccountKey{
+			KeyType:  "USER_MANAGED",
+			Disabled: false,
+			ExtendedStatus: []*iamrest.ExtendedStatus{
+				{Key: "SERVICE_ACCOUNT_KEY_EXTENDED_STATUS_KEY_EXPOSED", Value: "public GitHub repo"},
+			},
+		})
+
+		// The key is enabled and carries no disableReason, so extendedStatus is
+		// the only remaining evidence that it was ever found published.
+		assert.Equal(t, false, args["disabled"].Value)
+		assert.Equal(t, "", args["disableReason"].Value)
+		assert.Equal(t, map[string]any{
+			"SERVICE_ACCOUNT_KEY_EXTENDED_STATUS_KEY_EXPOSED": "public GitHub repo",
+		}, args["extendedStatus"].Value)
+	})
+
+	t.Run("extendedStatus drops nil and empty keys and keeps the first duplicate", func(t *testing.T) {
+		args := serviceAccountKeyArgs(&iamrest.ServiceAccountKey{
+			ExtendedStatus: []*iamrest.ExtendedStatus{
+				nil,
+				{Key: "", Value: "orphan"},
+				{Key: "SERVICE_ACCOUNT_KEY_EXTENDED_STATUS_KEY_COMPROMISE_DETECTED", Value: "first"},
+				{Key: "SERVICE_ACCOUNT_KEY_EXTENDED_STATUS_KEY_COMPROMISE_DETECTED", Value: "second"},
+			},
+		})
+
+		assert.Equal(t, map[string]any{
+			"SERVICE_ACCOUNT_KEY_EXTENDED_STATUS_KEY_COMPROMISE_DETECTED": "first",
+		}, args["extendedStatus"].Value)
+	})
+}
+
+func TestWifPoolTrustConfig(t *testing.T) {
+	anchors := func(n int) iamrest.TrustStore {
+		ts := iamrest.TrustStore{}
+		for i := 0; i < n; i++ {
+			ts.TrustAnchors = append(ts.TrustAnchors, &iamrest.TrustAnchor{PemCertificate: "pem"})
+		}
+		return ts
+	}
+
+	t.Run("no inline trust config is an empty set, not an unread value", func(t *testing.T) {
+		got := wifPoolTrustConfig(nil)
+		assert.Equal(t, []any{}, got.domains)
+		assert.Equal(t, int64(0), got.anchorCount)
+	})
+
+	t.Run("domains are sorted and anchors counted across bundles", func(t *testing.T) {
+		got := wifPoolTrustConfig(&iamrest.InlineTrustConfig{
+			AdditionalTrustBundles: map[string]iamrest.TrustStore{
+				"zeta.example":  anchors(1),
+				"alpha.example": anchors(2),
+			},
+		})
+
+		assert.Equal(t, []any{"alpha.example", "zeta.example"}, got.domains,
+			"an unordered field would compare unequal to itself between two reads")
+		assert.Equal(t, int64(3), got.anchorCount)
+	})
+
+	t.Run("intermediate CAs are not counted as anchors", func(t *testing.T) {
+		store := anchors(1)
+		store.IntermediateCas = []*iamrest.IntermediateCA{{PemCertificate: "pem"}, {PemCertificate: "pem"}}
+		got := wifPoolTrustConfig(&iamrest.InlineTrustConfig{
+			AdditionalTrustBundles: map[string]iamrest.TrustStore{"a.example": store},
+		})
+
+		// Intermediates chain up to an anchor; counting them would overstate how
+		// many independent authorities the pool trusts.
+		assert.Equal(t, int64(1), got.anchorCount)
+	})
+
+	t.Run("an empty domain key is dropped", func(t *testing.T) {
+		got := wifPoolTrustConfig(&iamrest.InlineTrustConfig{
+			AdditionalTrustBundles: map[string]iamrest.TrustStore{"": anchors(1)},
+		})
+		assert.Equal(t, []any{}, got.domains)
+	})
+}
+
+func TestWifPoolCertIssuance(t *testing.T) {
+	t.Run("no issuance config names no authority and does not use the shared one", func(t *testing.T) {
+		got := wifPoolCertIssuance(nil)
+		assert.Equal(t, map[string]any{}, got.caPools)
+		assert.Equal(t, false, got.usesDefaultSharedCa)
+	})
+
+	t.Run("regional CA pools are carried through", func(t *testing.T) {
+		got := wifPoolCertIssuance(&iamrest.InlineCertificateIssuanceConfig{
+			CaPools: map[string]string{"us-central1": "projects/p/locations/us-central1/caPools/pool"},
+		})
+		assert.Equal(t, map[string]any{"us-central1": "projects/p/locations/us-central1/caPools/pool"}, got.caPools)
+		assert.Equal(t, false, got.usesDefaultSharedCa)
+	})
+
+	t.Run("the Google-managed shared authority is reported", func(t *testing.T) {
+		got := wifPoolCertIssuance(&iamrest.InlineCertificateIssuanceConfig{UseDefaultSharedCa: true})
+		assert.Equal(t, true, got.usesDefaultSharedCa)
+		assert.Equal(t, map[string]any{}, got.caPools)
+	})
+}
+
+func TestFlattenWorkforceProviderConfig(t *testing.T) {
+	t.Run("the implicit flow is distinguishable from the authorization code flow", func(t *testing.T) {
+		implicit := flattenWorkforceProviderConfig(&iamrest.WorkforcePoolProvider{
+			Oidc: &iamrest.GoogleIamAdminV1WorkforcePoolProviderOidc{
+				IssuerUri: "https://idp.example",
+				ClientId:  "client",
+				WebSsoConfig: &iamrest.GoogleIamAdminV1WorkforcePoolProviderOidcWebSsoConfig{
+					ResponseType:            "ID_TOKEN",
+					AssertionClaimsBehavior: "ONLY_ID_TOKEN_CLAIMS",
+				},
+			},
+		})
+
+		assert.Equal(t, "oidc", implicit.providerType)
+		assert.Equal(t, "ID_TOKEN", implicit.webSsoResponseType)
+		assert.Equal(t, "ONLY_ID_TOKEN_CLAIMS", implicit.webSsoAssertionClaimsBehavior)
+		assert.Equal(t, []any{}, implicit.webSsoAdditionalScopes)
+	})
+
+	t.Run("additional scopes are carried through", func(t *testing.T) {
+		got := flattenWorkforceProviderConfig(&iamrest.WorkforcePoolProvider{
+			Oidc: &iamrest.GoogleIamAdminV1WorkforcePoolProviderOidc{
+				WebSsoConfig: &iamrest.GoogleIamAdminV1WorkforcePoolProviderOidcWebSsoConfig{
+					ResponseType:     "CODE",
+					AdditionalScopes: []string{"groups", "offline_access"},
+				},
+			},
+		})
+
+		assert.Equal(t, "CODE", got.webSsoResponseType)
+		assert.Equal(t, []any{"groups", "offline_access"}, got.webSsoAdditionalScopes)
+	})
+
+	t.Run("a client secret is reported by presence and never by value", func(t *testing.T) {
+		withSecret := flattenWorkforceProviderConfig(&iamrest.WorkforcePoolProvider{
+			Oidc: &iamrest.GoogleIamAdminV1WorkforcePoolProviderOidc{
+				ClientSecret: &iamrest.GoogleIamAdminV1WorkforcePoolProviderOidcClientSecret{
+					Value: &iamrest.GoogleIamAdminV1WorkforcePoolProviderOidcClientSecretValue{
+						Thumbprint: "abc123",
+					},
+				},
+			},
+		})
+		assert.Equal(t, true, withSecret.oidcHasClientSecret)
+
+		// A secret struct with no thumbprint is not a configured secret.
+		empty := flattenWorkforceProviderConfig(&iamrest.WorkforcePoolProvider{
+			Oidc: &iamrest.GoogleIamAdminV1WorkforcePoolProviderOidc{
+				ClientSecret: &iamrest.GoogleIamAdminV1WorkforcePoolProviderOidcClientSecret{
+					Value: &iamrest.GoogleIamAdminV1WorkforcePoolProviderOidcClientSecretValue{},
+				},
+			},
+		})
+		assert.Equal(t, false, empty.oidcHasClientSecret)
+
+		// And a nil Value must not panic.
+		nilValue := flattenWorkforceProviderConfig(&iamrest.WorkforcePoolProvider{
+			Oidc: &iamrest.GoogleIamAdminV1WorkforcePoolProviderOidc{
+				ClientSecret: &iamrest.GoogleIamAdminV1WorkforcePoolProviderOidcClientSecret{},
+			},
+		})
+		assert.Equal(t, false, nilValue.oidcHasClientSecret)
+	})
+
+	t.Run("an OIDC provider with no web SSO config reports no response type", func(t *testing.T) {
+		got := flattenWorkforceProviderConfig(&iamrest.WorkforcePoolProvider{
+			Oidc: &iamrest.GoogleIamAdminV1WorkforcePoolProviderOidc{IssuerUri: "https://idp.example"},
+		})
+		assert.Equal(t, "oidc", got.providerType)
+		assert.Equal(t, "", got.webSsoResponseType)
+	})
+
+	t.Run("a SAML provider carries no OIDC web SSO fields", func(t *testing.T) {
+		got := flattenWorkforceProviderConfig(&iamrest.WorkforcePoolProvider{
+			Saml: &iamrest.GoogleIamAdminV1WorkforcePoolProviderSaml{IdpMetadataXml: "<xml/>"},
+		})
+
+		assert.Equal(t, "saml", got.providerType)
+		assert.Equal(t, "<xml/>", got.samlMetadata)
+		assert.Equal(t, "", got.webSsoResponseType)
+		assert.Equal(t, false, got.oidcHasClientSecret)
+		assert.Equal(t, []any{}, got.webSsoAdditionalScopes)
+	})
+
+	t.Run("a provider with neither protocol set has no type", func(t *testing.T) {
+		got := flattenWorkforceProviderConfig(&iamrest.WorkforcePoolProvider{})
+		assert.Equal(t, "", got.providerType)
+	})
+}

--- a/providers/gcp/resources/iam_workforce.go
+++ b/providers/gcp/resources/iam_workforce.go
@@ -118,7 +118,7 @@ func (g *mqlGcpOrganizationWorkforcePool) providers() ([]any, error) {
 		ShowDeleted(true).
 		Pages(ctx, func(resp *iam.ListWorkforcePoolProvidersResponse) error {
 			for _, p := range resp.WorkforcePoolProviders {
-				providerType, oidcIssuer, oidcClientId, samlMetadata := flattenWorkforceProviderConfig(p)
+				cfg := flattenWorkforceProviderConfig(p)
 
 				var extraAttributesType, extraAttributesIssuerUri string
 				if p.ExtraAttributesOauth2Client != nil {
@@ -128,24 +128,29 @@ func (g *mqlGcpOrganizationWorkforcePool) providers() ([]any, error) {
 
 				mqlProvider, err := CreateResource(g.MqlRuntime, "gcp.organization.workforcePool.provider",
 					map[string]*llx.RawData{
-						"name":                     llx.StringData(p.Name),
-						"providerId":               llx.StringData(lastSegment(p.Name)),
-						"poolId":                   llx.StringData(lastSegment(poolName)),
-						"displayName":              llx.StringData(p.DisplayName),
-						"description":              llx.StringData(p.Description),
-						"state":                    llx.StringData(p.State),
-						"disabled":                 llx.BoolData(p.Disabled),
-						"expireTime":               llx.TimeDataPtr(parseTime(p.ExpireTime)),
-						"attributeMapping":         llx.MapData(convert.MapToInterfaceMap(p.AttributeMapping), types.String),
-						"attributeCondition":       llx.StringData(p.AttributeCondition),
-						"detailedAuditLogging":     llx.BoolData(p.DetailedAuditLogging),
-						"scimUsage":                llx.StringData(p.ScimUsage),
-						"providerType":             llx.StringData(providerType),
-						"oidcIssuerUri":            llx.StringData(oidcIssuer),
-						"oidcClientId":             llx.StringData(oidcClientId),
-						"samlIdpMetadataXml":       llx.StringData(samlMetadata),
-						"extraAttributesType":      llx.StringData(extraAttributesType),
-						"extraAttributesIssuerUri": llx.StringData(extraAttributesIssuerUri),
+						"name":                 llx.StringData(p.Name),
+						"providerId":           llx.StringData(lastSegment(p.Name)),
+						"poolId":               llx.StringData(lastSegment(poolName)),
+						"displayName":          llx.StringData(p.DisplayName),
+						"description":          llx.StringData(p.Description),
+						"state":                llx.StringData(p.State),
+						"disabled":             llx.BoolData(p.Disabled),
+						"expireTime":           llx.TimeDataPtr(parseTime(p.ExpireTime)),
+						"attributeMapping":     llx.MapData(convert.MapToInterfaceMap(p.AttributeMapping), types.String),
+						"attributeCondition":   llx.StringData(p.AttributeCondition),
+						"detailedAuditLogging": llx.BoolData(p.DetailedAuditLogging),
+						"scimUsage":            llx.StringData(p.ScimUsage),
+						"providerType":         llx.StringData(cfg.providerType),
+						"oidcIssuerUri":        llx.StringData(cfg.oidcIssuer),
+						"oidcClientId":         llx.StringData(cfg.oidcClientId),
+						"samlIdpMetadataXml":   llx.StringData(cfg.samlMetadata),
+
+						"oidcHasClientSecret":               llx.BoolData(cfg.oidcHasClientSecret),
+						"oidcWebSsoResponseType":            llx.StringData(cfg.webSsoResponseType),
+						"oidcWebSsoAssertionClaimsBehavior": llx.StringData(cfg.webSsoAssertionClaimsBehavior),
+						"oidcWebSsoAdditionalScopes":        llx.ArrayData(cfg.webSsoAdditionalScopes, types.String),
+						"extraAttributesType":               llx.StringData(extraAttributesType),
+						"extraAttributesIssuerUri":          llx.StringData(extraAttributesIssuerUri),
 					})
 				if err != nil {
 					return err
@@ -164,18 +169,50 @@ func (g *mqlGcpOrganizationWorkforcePoolProvider) id() (string, error) {
 	return g.Name.Data, g.Name.Error
 }
 
+// workforceProviderConfig is the flattened per-protocol trust configuration of
+// a workforce pool provider.
+type workforceProviderConfig struct {
+	providerType                  string
+	oidcIssuer                    string
+	oidcClientId                  string
+	oidcHasClientSecret           bool
+	webSsoResponseType            string
+	webSsoAssertionClaimsBehavior string
+	webSsoAdditionalScopes        []any
+	samlMetadata                  string
+}
+
 // flattenWorkforceProviderConfig extracts the protocol discriminator and the
 // per-protocol trust fields from a WorkforcePoolProvider. Exactly one of Oidc
-// or Saml should be set; the other returns zero values.
-func flattenWorkforceProviderConfig(p *iam.WorkforcePoolProvider) (providerType, oidcIssuer, oidcClientId, samlMetadata string) {
+// or Saml should be set; the other leaves its fields at the zero value.
+//
+// oidcHasClientSecret reports only whether a secret is registered. The API
+// returns the secret as a thumbprint on read and never the plaintext, and
+// neither is exposed here: the secret is a credential, and the posture question
+// is whether one exists at all, because that is what allows the provider to use
+// the Authorization Code flow rather than the implicit flow.
+//
+// A SAML provider has no web SSO config, so its response type stays empty
+// rather than being reported as a value it does not have.
+func flattenWorkforceProviderConfig(p *iam.WorkforcePoolProvider) workforceProviderConfig {
+	var c workforceProviderConfig
+	c.webSsoAdditionalScopes = []any{}
 	switch {
 	case p.Oidc != nil:
-		providerType = "oidc"
-		oidcIssuer = p.Oidc.IssuerUri
-		oidcClientId = p.Oidc.ClientId
+		c.providerType = "oidc"
+		c.oidcIssuer = p.Oidc.IssuerUri
+		c.oidcClientId = p.Oidc.ClientId
+		c.oidcHasClientSecret = p.Oidc.ClientSecret != nil &&
+			p.Oidc.ClientSecret.Value != nil &&
+			p.Oidc.ClientSecret.Value.Thumbprint != ""
+		if ws := p.Oidc.WebSsoConfig; ws != nil {
+			c.webSsoResponseType = ws.ResponseType
+			c.webSsoAssertionClaimsBehavior = ws.AssertionClaimsBehavior
+			c.webSsoAdditionalScopes = convert.SliceAnyToInterface(ws.AdditionalScopes)
+		}
 	case p.Saml != nil:
-		providerType = "saml"
-		samlMetadata = p.Saml.IdpMetadataXml
+		c.providerType = "saml"
+		c.samlMetadata = p.Saml.IdpMetadataXml
 	}
-	return
+	return c
 }

--- a/providers/gcp/resources/iam_workload_identity.go
+++ b/providers/gcp/resources/iam_workload_identity.go
@@ -105,9 +105,13 @@ type wifPoolTrust struct {
 // Domains are sorted because the API returns them in a map, and an unordered
 // field would compare unequal to itself between two reads of the same pool.
 //
-// Only TrustAnchors are counted. Intermediate CAs build a chain up to an
-// anchor, they are not anchors themselves, so counting them would overstate how
-// many independent authorities the pool trusts.
+// Only TrustAnchors are counted. A trust anchor is what a presented chain is
+// validated up to, and the API documents its own IntermediateCas set as
+// material for building a chain to an anchor, so an intermediate is unusable
+// unless some anchor already covers it. Counting both would overstate how many
+// independent authorities the pool trusts. Note the anchor list itself may hold
+// an intermediate certificate being used as an anchor, which is still one
+// independent authority and is counted as one.
 //
 // A nil config means no additional bundle is configured, which is genuinely an
 // empty set rather than an unread value, so it yields an empty list and 0.

--- a/providers/gcp/resources/iam_workload_identity.go
+++ b/providers/gcp/resources/iam_workload_identity.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"go.mondoo.com/mql/llx"
@@ -60,6 +61,8 @@ func (g *mqlGcpProjectIamService) workloadIdentityPools() ([]any, error) {
 		ShowDeleted(true).
 		Pages(ctx, func(resp *iam.ListWorkloadIdentityPoolsResponse) error {
 			for _, p := range resp.WorkloadIdentityPools {
+				trust := wifPoolTrustConfig(p.InlineTrustConfig)
+				issuance := wifPoolCertIssuance(p.InlineCertificateIssuanceConfig)
 				mqlPool, err := CreateResource(g.MqlRuntime, "gcp.project.iamService.workloadIdentityPool",
 					map[string]*llx.RawData{
 						"projectId":   llx.StringData(projectId),
@@ -71,6 +74,11 @@ func (g *mqlGcpProjectIamService) workloadIdentityPools() ([]any, error) {
 						"disabled":    llx.BoolData(p.Disabled),
 						"expireTime":  llx.TimeDataPtr(parseTime(p.ExpireTime)),
 						"mode":        llx.StringData(p.Mode),
+
+						"additionalTrustDomains":                 llx.ArrayData(trust.domains, types.String),
+						"additionalTrustAnchorCount":             llx.IntData(trust.anchorCount),
+						"certificateIssuanceCaPools":             llx.MapData(issuance.caPools, types.String),
+						"certificateIssuanceUsesDefaultSharedCa": llx.BoolData(issuance.usesDefaultSharedCa),
 					})
 				if err != nil {
 					return err
@@ -83,6 +91,66 @@ func (g *mqlGcpProjectIamService) workloadIdentityPools() ([]any, error) {
 		return nil, err
 	}
 	return pools, nil
+}
+
+// wifPoolTrust is the flattened additional-trust configuration of a pool.
+type wifPoolTrust struct {
+	domains     []any
+	anchorCount int64
+}
+
+// wifPoolTrustConfig flattens the additional trust bundles a pool configures on
+// top of its own trust domain.
+//
+// Domains are sorted because the API returns them in a map, and an unordered
+// field would compare unequal to itself between two reads of the same pool.
+//
+// Only TrustAnchors are counted. Intermediate CAs build a chain up to an
+// anchor, they are not anchors themselves, so counting them would overstate how
+// many independent authorities the pool trusts.
+//
+// A nil config means no additional bundle is configured, which is genuinely an
+// empty set rather than an unread value, so it yields an empty list and 0.
+func wifPoolTrustConfig(cfg *iam.InlineTrustConfig) wifPoolTrust {
+	out := wifPoolTrust{domains: []any{}}
+	if cfg == nil {
+		return out
+	}
+	names := make([]string, 0, len(cfg.AdditionalTrustBundles))
+	for domain, store := range cfg.AdditionalTrustBundles {
+		if domain == "" {
+			continue
+		}
+		names = append(names, domain)
+		out.anchorCount += int64(len(store.TrustAnchors))
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		out.domains = append(out.domains, n)
+	}
+	return out
+}
+
+// wifPoolCertIssuance is the flattened mTLS workload-certificate issuance
+// configuration of a pool.
+type wifPoolCertIssuanceConfig struct {
+	caPools             map[string]any
+	usesDefaultSharedCa bool
+}
+
+// wifPoolCertIssuance flattens which certificate authorities may mint mTLS
+// workload certificates for the pool.
+//
+// A nil config means the pool issues no workload certificates, so it names no
+// authorities and does not use the shared one.
+func wifPoolCertIssuance(cfg *iam.InlineCertificateIssuanceConfig) wifPoolCertIssuanceConfig {
+	if cfg == nil {
+		return wifPoolCertIssuanceConfig{caPools: map[string]any{}}
+	}
+	return wifPoolCertIssuanceConfig{
+		caPools:             convert.MapToInterfaceMap(cfg.CaPools),
+		usesDefaultSharedCa: cfg.UseDefaultSharedCa,
+	}
 }
 
 func (g *mqlGcpProjectIamServiceWorkloadIdentityPool) id() (string, error) {

--- a/providers/gcp/resources/kms_protected_resources.go
+++ b/providers/gcp/resources/kms_protected_resources.go
@@ -1,0 +1,175 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
+	"go.mondoo.com/mql/providers/gcp/connection"
+	"go.mondoo.com/mql/types"
+	kmsinventory "google.golang.org/api/kmsinventory/v1"
+	"google.golang.org/api/option"
+)
+
+// partialDataWarningCodes are the KMS Inventory warning codes that mean the
+// asset search behind a protected-resources summary did not see everything.
+//
+// Any of them makes every count a lower bound. That distinction is the whole
+// point of surfacing the warnings: the headline use of this summary is finding
+// orphaned keys, and a resourceCount of 0 that came back with one of these
+// warnings is not evidence that a key protects nothing.
+var partialDataWarningCodes = map[string]struct{}{
+	"INSUFFICIENT_PERMISSIONS_PARTIAL_DATA": {},
+	"RESOURCE_LIMIT_EXCEEDED_PARTIAL_DATA":  {},
+	"ORG_LESS_PROJECT_PARTIAL_DATA":         {},
+}
+
+// protectedResourcesWarnings extracts the warning codes from a summary and
+// reports whether any of them means the data is partial.
+//
+// Codes are sorted so the field does not reorder between two reads of the same
+// key, and repeats are collapsed. An unrecognized code is still reported, but
+// does not set partialData: treating an unknown code as "incomplete" would flip
+// a complete summary to a lower bound on the strength of a string we do not
+// know, and WARNING_CODE_UNSPECIFIED is documented as unused.
+func protectedResourcesWarnings(warnings []*kmsinventory.GoogleCloudKmsInventoryV1Warning) (codes []any, partial bool) {
+	seen := map[string]struct{}{}
+	names := make([]string, 0, len(warnings))
+	for _, w := range warnings {
+		if w == nil || w.WarningCode == "" {
+			continue
+		}
+		if _, dup := seen[w.WarningCode]; dup {
+			continue
+		}
+		seen[w.WarningCode] = struct{}{}
+		names = append(names, w.WarningCode)
+		if _, isPartial := partialDataWarningCodes[w.WarningCode]; isPartial {
+			partial = true
+		}
+	}
+	sort.Strings(names)
+	codes = make([]any, 0, len(names))
+	for _, n := range names {
+		codes = append(codes, n)
+	}
+	return codes, partial
+}
+
+// protectedResourcesArgs maps a protected-resources summary onto its MQL
+// resource arguments.
+//
+// The per-product, per-type and per-region breakdowns are counts the API
+// returns as strings, and they are passed through as strings rather than parsed:
+// a parse failure would have to invent a number, and the map is a breakdown to
+// read rather than a value to compare against.
+func protectedResourcesArgs(keyPath string, summary *kmsinventory.GoogleCloudKmsInventoryV1ProtectedResourcesSummary) map[string]*llx.RawData {
+	warnings, partial := protectedResourcesWarnings(summary.Warnings)
+	return map[string]*llx.RawData{
+		"__id":          llx.StringData(keyPath + "/protectedResourcesSummary"),
+		"resourceCount": llx.IntData(summary.ResourceCount),
+		"projectCount":  llx.IntData(summary.ProjectCount),
+		"cloudProducts": llx.MapData(convert.MapToInterfaceMap(summary.CloudProducts), types.String),
+		"resourceTypes": llx.MapData(convert.MapToInterfaceMap(summary.ResourceTypes), types.String),
+		"locations":     llx.MapData(convert.MapToInterfaceMap(summary.Locations), types.String),
+		"partialData":   llx.BoolData(partial),
+		"warnings":      llx.ArrayData(warnings, types.String),
+	}
+}
+
+// protectedResources reports what this key actually protects.
+//
+// The summary comes from KMS Inventory, which reads Cloud Asset Inventory rather
+// than KMS, so it spans the key's whole organization and answers the two
+// questions the per-resource CMEK references cannot: whether anything uses this
+// key, and whether its blast radius leaves the project.
+//
+// The field is null whenever the summary cannot be read: the API is not enabled
+// on the project, the caller lacks cloudkms.protectedResources.search, or the
+// KMS organization service agent has not been granted the org-level role the
+// asset search behind this API needs. Null rather than a zero-count summary,
+// because a fabricated resourceCount of 0 is exactly the reading an
+// orphaned-key audit acts on, and none of those failures is evidence that a key
+// protects nothing. The distinction that has to survive is null ("not read")
+// against resourceCount 0 ("read, and it protects nothing"), and that one holds:
+// null does not satisfy resourceCount == 0.
+//
+// The reason for degrading rather than returning the error was measured, not
+// assumed. The org service agent grant is a separate manual step, so a project
+// with keys and the API enabled still answers 403 until someone performs it, and
+// returning that error failed the whole cryptokeys collection: a query asking
+// for name alongside this field lost the names too. The error is logged with the
+// message the API supplied, which names the service agent and the grant to make,
+// so the reason a field is null is recoverable from the scan log.
+func (g *mqlGcpProjectKmsServiceKeyringCryptokey) protectedResources() (*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources, error) {
+	if g.ResourcePath.Error != nil {
+		return nil, g.ResourcePath.Error
+	}
+	keyPath := g.ResourcePath.Data
+	if keyPath == "" {
+		return nil, errors.New("crypto key has no resource path")
+	}
+
+	projectId := projectFromResourceName(keyPath)
+	if projectId == "" {
+		return nil, fmt.Errorf("could not extract project id from crypto key path %q", keyPath)
+	}
+
+	enabled, err := serviceEnabledForInit(g.MqlRuntime, projectId, service_kmsinventory)
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		log.Debug().Str("service", service_kmsinventory).Str("project", projectId).
+			Msg("gcp service is not enabled, cannot read protected resources summary")
+		g.ProtectedResources.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	conn, ok := g.MqlRuntime.Connection.(*connection.GcpConnection)
+	if !ok {
+		return nil, errors.New("invalid connection provided, it is not a GCP connection")
+	}
+	client, err := conn.Client(kmsinventory.CloudPlatformScope)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	invSvc, err := kmsinventory.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return nil, err
+	}
+
+	summary, err := invSvc.Projects.Locations.KeyRings.CryptoKeys.
+		GetProtectedResourcesSummary(keyPath).
+		Context(ctx).Do()
+	if err != nil {
+		if isSkippable(err) {
+			// Warn, not debug: unlike most skippable reads this one is usually
+			// fixable, and the API's own message names the service agent and the
+			// role it needs.
+			log.Warn().Err(err).Str("key", keyPath).
+				Msg("could not read the protected resources summary for this key")
+			g.ProtectedResources.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	res, err := CreateResource(g.MqlRuntime,
+		"gcp.project.kmsService.keyring.cryptokey.protectedResources",
+		protectedResourcesArgs(keyPath, summary))
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectKmsServiceKeyringCryptokeyProtectedResources), nil
+}

--- a/providers/gcp/resources/kms_protected_resources_test.go
+++ b/providers/gcp/resources/kms_protected_resources_test.go
@@ -1,0 +1,155 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kmsinventory "google.golang.org/api/kmsinventory/v1"
+)
+
+func TestProtectedResourcesWarnings(t *testing.T) {
+	warn := func(code string) *kmsinventory.GoogleCloudKmsInventoryV1Warning {
+		return &kmsinventory.GoogleCloudKmsInventoryV1Warning{WarningCode: code}
+	}
+
+	tests := []struct {
+		name     string
+		in       []*kmsinventory.GoogleCloudKmsInventoryV1Warning
+		expCodes []any
+		expPart  bool
+	}{
+		{
+			name:     "no warnings is a complete summary",
+			in:       nil,
+			expCodes: []any{},
+			expPart:  false,
+		},
+		{
+			// The failure this guards: the service agent cannot search every
+			// asset, the API answers with a count anyway, and a resourceCount of
+			// 0 reads as an orphaned key.
+			name:     "insufficient permissions is partial",
+			in:       []*kmsinventory.GoogleCloudKmsInventoryV1Warning{warn("INSUFFICIENT_PERMISSIONS_PARTIAL_DATA")},
+			expCodes: []any{"INSUFFICIENT_PERMISSIONS_PARTIAL_DATA"},
+			expPart:  true,
+		},
+		{
+			name:     "resource limit exceeded is partial",
+			in:       []*kmsinventory.GoogleCloudKmsInventoryV1Warning{warn("RESOURCE_LIMIT_EXCEEDED_PARTIAL_DATA")},
+			expCodes: []any{"RESOURCE_LIMIT_EXCEEDED_PARTIAL_DATA"},
+			expPart:  true,
+		},
+		{
+			name:     "org-less project is partial",
+			in:       []*kmsinventory.GoogleCloudKmsInventoryV1Warning{warn("ORG_LESS_PROJECT_PARTIAL_DATA")},
+			expCodes: []any{"ORG_LESS_PROJECT_PARTIAL_DATA"},
+			expPart:  true,
+		},
+		{
+			// WARNING_CODE_UNSPECIFIED is documented as unused, and an
+			// unrecognized code must not flip a complete summary into a lower
+			// bound on the strength of a string we do not know.
+			name:     "unspecified code is reported but not partial",
+			in:       []*kmsinventory.GoogleCloudKmsInventoryV1Warning{warn("WARNING_CODE_UNSPECIFIED")},
+			expCodes: []any{"WARNING_CODE_UNSPECIFIED"},
+			expPart:  false,
+		},
+		{
+			name: "codes are sorted and de-duplicated",
+			in: []*kmsinventory.GoogleCloudKmsInventoryV1Warning{
+				warn("RESOURCE_LIMIT_EXCEEDED_PARTIAL_DATA"),
+				warn("INSUFFICIENT_PERMISSIONS_PARTIAL_DATA"),
+				warn("RESOURCE_LIMIT_EXCEEDED_PARTIAL_DATA"),
+			},
+			expCodes: []any{"INSUFFICIENT_PERMISSIONS_PARTIAL_DATA", "RESOURCE_LIMIT_EXCEEDED_PARTIAL_DATA"},
+			expPart:  true,
+		},
+		{
+			name: "nil and empty entries are dropped",
+			in: []*kmsinventory.GoogleCloudKmsInventoryV1Warning{
+				nil,
+				warn(""),
+				warn("ORG_LESS_PROJECT_PARTIAL_DATA"),
+			},
+			expCodes: []any{"ORG_LESS_PROJECT_PARTIAL_DATA"},
+			expPart:  true,
+		},
+		{
+			name: "one partial code among several sets the flag",
+			in: []*kmsinventory.GoogleCloudKmsInventoryV1Warning{
+				warn("WARNING_CODE_UNSPECIFIED"),
+				warn("INSUFFICIENT_PERMISSIONS_PARTIAL_DATA"),
+			},
+			expCodes: []any{"INSUFFICIENT_PERMISSIONS_PARTIAL_DATA", "WARNING_CODE_UNSPECIFIED"},
+			expPart:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			codes, partial := protectedResourcesWarnings(tc.in)
+			assert.Equal(t, tc.expCodes, codes)
+			assert.Equal(t, tc.expPart, partial)
+		})
+	}
+}
+
+func TestProtectedResourcesArgs(t *testing.T) {
+	const keyPath = "projects/p/locations/global/keyRings/kr/cryptoKeys/k"
+
+	t.Run("a key that protects nothing still reports zero counts", func(t *testing.T) {
+		args := protectedResourcesArgs(keyPath, &kmsinventory.GoogleCloudKmsInventoryV1ProtectedResourcesSummary{})
+
+		require.Contains(t, args, "resourceCount")
+		assert.Equal(t, int64(0), args["resourceCount"].Value)
+		assert.Equal(t, int64(0), args["projectCount"].Value)
+		assert.Equal(t, false, args["partialData"].Value)
+		assert.Equal(t, []any{}, args["warnings"].Value)
+	})
+
+	t.Run("counts and breakdowns are carried through", func(t *testing.T) {
+		args := protectedResourcesArgs(keyPath, &kmsinventory.GoogleCloudKmsInventoryV1ProtectedResourcesSummary{
+			ResourceCount: 42,
+			ProjectCount:  3,
+			CloudProducts: map[string]string{"Compute Engine": "40", "Cloud Storage": "2"},
+			ResourceTypes: map[string]string{"compute.googleapis.com/Disk": "40"},
+			Locations:     map[string]string{"us-central1": "42"},
+		})
+
+		assert.Equal(t, int64(42), args["resourceCount"].Value)
+		// The cross-project blast radius: the reason projectCount is modelled
+		// separately from resourceCount.
+		assert.Equal(t, int64(3), args["projectCount"].Value)
+		assert.Equal(t, map[string]any{"Compute Engine": "40", "Cloud Storage": "2"}, args["cloudProducts"].Value)
+		assert.Equal(t, map[string]any{"compute.googleapis.com/Disk": "40"}, args["resourceTypes"].Value)
+		assert.Equal(t, map[string]any{"us-central1": "42"}, args["locations"].Value)
+	})
+
+	t.Run("__id carries the key path so two keys cannot collide", func(t *testing.T) {
+		a := protectedResourcesArgs("projects/p/locations/global/keyRings/kr/cryptoKeys/one",
+			&kmsinventory.GoogleCloudKmsInventoryV1ProtectedResourcesSummary{})
+		b := protectedResourcesArgs("projects/p/locations/global/keyRings/kr/cryptoKeys/two",
+			&kmsinventory.GoogleCloudKmsInventoryV1ProtectedResourcesSummary{})
+
+		assert.NotEqual(t, a["__id"].Value, b["__id"].Value)
+		assert.Equal(t, keyPath+"/protectedResourcesSummary",
+			protectedResourcesArgs(keyPath, &kmsinventory.GoogleCloudKmsInventoryV1ProtectedResourcesSummary{})["__id"].Value)
+	})
+
+	t.Run("a zero count carrying a partial-data warning is flagged", func(t *testing.T) {
+		args := protectedResourcesArgs(keyPath, &kmsinventory.GoogleCloudKmsInventoryV1ProtectedResourcesSummary{
+			ResourceCount: 0,
+			Warnings: []*kmsinventory.GoogleCloudKmsInventoryV1Warning{
+				{WarningCode: "INSUFFICIENT_PERMISSIONS_PARTIAL_DATA"},
+			},
+		})
+
+		assert.Equal(t, int64(0), args["resourceCount"].Value)
+		assert.Equal(t, true, args["partialData"].Value,
+			"a zero count with a partial-data warning must not read as an orphaned key")
+	})
+}

--- a/providers/gcp/resources/permissions_test.go
+++ b/providers/gcp/resources/permissions_test.go
@@ -119,6 +119,11 @@ var validatedGCPPermissions = []string{
 	"cloudkms.importJobs.list",
 	"cloudkms.keyRings.list",
 	"cloudkms.locations.list",
+	// The KMS Inventory API publishes no permissions of its own; reading a key's
+	// protected-resources summary is governed by this one, the single permission
+	// in roles/cloudkms.protectedResourcesViewer (verified against the live role
+	// definition and present in queryTestablePermissions at project scope).
+	"cloudkms.protectedResources.search",
 	"cloudkms.retiredResources.list",
 	"cloudscheduler.jobs.list",
 	"cloudsql.backupRuns.list",

--- a/providers/gcp/resources/services.go
+++ b/providers/gcp/resources/services.go
@@ -39,6 +39,7 @@ const (
 	service_cloudfunctions      = "cloudfunctions.googleapis.com"
 	service_logging             = "logging.googleapis.com"
 	service_kms                 = "cloudkms.googleapis.com"
+	service_kmsinventory        = "kmsinventory.googleapis.com"
 	service_sqladmin            = "sqladmin.googleapis.com"
 	service_storage             = "storage.googleapis.com"
 	service_iam                 = "iam.googleapis.com"


### PR DESCRIPTION
Four small, high-signal gaps in how credentials, keys, and federated trust are established and controlled in GCP. Picked from a 28-finding coverage audit; the other 24 are listed with reasons at the bottom.

## Implemented

### 1. Service account key exposure — `gcp.project.iamService.serviceAccount.key`

`disableReason` and `extendedStatus`.

Google disables a service account key on its own when it finds the private material published (`SERVICE_ACCOUNT_KEY_DISABLE_REASON_EXPOSED`) or sees the key in use by an attacker (`..._COMPROMISE_DETECTED`). Until now that was indistinguishable from an operator disabling a key as routine hygiene: `disabled` was `true` either way.

`extendedStatus` is the durable half of the same signal. `disableReason` exists only while the key is disabled, so re-enabling a key erases the record; extended status lasts for the life of the key and still reports that Google once found it published.

**This required a transport change.** The audit cited `iam/v1 ServiceAccountKey.DisableReason`, but the lister used the admin gRPC client, whose protobuf message (`cloud.google.com/go/iam/admin/apiv1/adminpb`) carries neither field. The lister now uses the REST client. Both transports are governed by `iam.serviceAccountKeys.list`, return the same key set, and use the same enum spellings; the endpoint returns every key in one response, with no page token. The new tests pin all eight pre-existing fields alongside the two new ones so the migration is provably faithful, and the live A/B below confirms identical values.

### 2. Workforce federation browser flow — `gcp.organization.workforcePool.provider`

`oidcWebSsoResponseType`, `oidcWebSsoAssertionClaimsBehavior`, `oidcWebSsoAdditionalScopes`, `oidcHasClientSecret`.

`responseType: ID_TOKEN` selects the OIDC implicit flow, which returns the token in the browser URL where it reaches browser history, referrer headers, and proxy logs. It is the one workforce-federation setting with an unambiguously insecure value, and it was not reachable.

`oidcHasClientSecret` is a presence flag only. A client secret is what permits the Authorization Code flow, so whether one exists is the posture question; the API returns a thumbprint rather than plaintext on read, and neither is exposed.

### 3. Workload identity federation trust anchors — `gcp.project.iamService.workloadIdentityPool`

`additionalTrustDomains`, `additionalTrustAnchorCount`, `certificateIssuanceCaPools`, `certificateIssuanceUsesDefaultSharedCa`.

A pool always trusts its own trust domain. Every additional trust bundle widens the set of external certificates that can federate in, and any certificate chaining to one of those anchors is accepted. The certificate-issuance fields are the other half: which CA pools may mint mTLS workload certificates into the trust domain.

Only `TrustAnchors` are counted, not `IntermediateCas` — intermediates chain up to an anchor rather than being one, so counting them would overstate how many independent authorities the pool trusts. Domains are sorted, because an unordered field compares unequal to itself across two reads.

### 4. What a KMS key actually protects — `gcp.project.kmsService.keyring.cryptokey.protectedResources`

New sub-resource: `resourceCount`, `projectCount`, `cloudProducts`, `resourceTypes`, `locations`, `partialData`, `warnings`.

The provider has 62 CMEK references pointing from a resource at the key protecting it. None answers the reverse: is this key orphaned, and does its blast radius cross project boundaries. This summary comes from KMS Inventory, which reads Cloud Asset Inventory rather than KMS, so it spans the key's whole organization.

`partialData` and `warnings` are modelled deliberately. The API returns counts even when its asset search was incomplete, and the headline use of this field is finding orphaned keys — so a `resourceCount` of 0 that arrived with `INSUFFICIENT_PERMISSIONS_PARTIAL_DATA` must not read as "nothing uses this key". An unrecognised warning code is reported but does not set `partialData`, so an unknown string cannot flip a complete summary into a lower bound.

**Null vs. empty.** The field is null whenever the summary could not be read — API not enabled, caller lacks the permission, or the KMS organization service agent has not been granted the org-level role the asset search needs. It is never a fabricated zero-count summary. The distinction that has to survive is null ("not read") against `resourceCount` 0 ("read, protects nothing"), and it does: null does not satisfy `resourceCount == 0`.

**The degrade-to-null choice was measured, not assumed.** Returning the error instead failed the entire `cryptokeys` collection — a query asking for `name` alongside this field lost the names too (observed live, see below). The error is logged at warn with the API's own message, which names the service agent and the grant to make, so the reason a field is null stays recoverable from the scan log.

### Permissions manifest

The KMS Inventory API publishes **no IAM permissions of its own** — confirmed against `queryTestablePermissions` (13,502 permissions at project scope, zero `kmsinventory.*`) and against the role definition: `roles/cloudkms.protectedResourcesViewer` contains exactly one permission, `cloudkms.protectedResources.search`. Two extractor overrides were needed:

- `kmsinventory` / `CryptoKeys.GetProtectedResourcesSummary` → `cloudkms.protectedResources.search`. The generic derivation lowercases the whole method name into `kmsinventory.cryptoKeys.getprotectedresourcessummary`.
- `iam` / `Keys.List` → `iam.serviceAccountKeys.list`. The REST call's resource segment is the bare `Keys`; this keeps the permission identical to what the gRPC call derived, so the manifest's permission set is unchanged by the transport switch.

Net manifest change is one added permission (288 → 289) plus one `action` string. `TestGCPPermissionsMatchValidatedList` passes.

## What I ran

| Check | Result |
|---|---|
| `go build ./...` in `providers/gcp/` | clean |
| `go test ./...` in `providers/gcp/` | all packages ok |
| `golangci-lint run ./resources/...` | 0 issues |
| `TestGCPPermissionsMatchValidatedList` | ok (289 permissions, in sync) |
| `go mod tidy` in `providers/gcp/` | no change (both packages ship inside the pinned `google.golang.org/api`) |
| `crate-ci/typos` on changed files | clean |
| Em dashes in new `.lr` lines | 0 |
| `--info` compile gate, all 18 new fields | every field resolves with the expected type |
| `--info` negative control | `cannot find field or resource 'totallyBogusFieldXyz'` — the gate does fail |
| Mutation testing, 4 mutations | each new test fails when its implementation is broken, passes when restored |

New `.lr.versions` entries are all `13.37.1` (provider `Version` is `13.37.0`); `config.go` is untouched.

### Live verification

Run against real projects with the build staged under `PROVIDERS_PATH` so the installed provider was never touched.

| Finding | Live result |
|---|---|
| 1, SA keys | **Verified.** All eight pre-existing fields returned identical values after the transport switch (`keyType: SYSTEM_MANAGED`, `keyAlgorithm: KEY_ALG_RSA_2048`, `keyOrigin: GOOGLE_PROVIDED`, `userManaged: false`, `disabled: false`). New fields correctly absent-as-empty: `disableReason: ""`, `extendedStatus: {}`. |
| 3, WIF pools | **Verified on two pools**, one `SYSTEM_TRUST_DOMAIN` and one federation-only pool with a live GitHub Actions OIDC provider. Both report `additionalTrustDomains: []`, `additionalTrustAnchorCount: 0`, `certificateIssuanceCaPools: {}`, `certificateIssuanceUsesDefaultSharedCa: false` — an empty set for a pool that configures none, not null and not a fabricated value. |
| 4, KMS summary | **Read path verified; populated-summary path not.** The API was enabled temporarily against real keyrings and returns 403 because the KMS organization service agent lacks the org-level grant — a separate manual step I did not perform. That exercised exactly the degrade path: `protectedResources: null` with the sibling `name` intact, and the API's message in the log. The API was returned to `DISABLED` afterwards, leaving the project as found. |

**Unverified against live data, named precisely:** every field of finding 2 (`oidcWebSsoResponseType`, `oidcWebSsoAssertionClaimsBehavior`, `oidcWebSsoAdditionalScopes`, `oidcHasClientSecret`) — the organization has no workforce pools. Finding 3's populated case (`additionalTrustDomains` / `additionalTrustAnchorCount` / `certificateIssuanceCaPools` non-empty) — no pool configures an inline trust or issuance config; only the absent case was exercised, and whether the list response returns those nested objects when they are set is untested. Finding 4's populated case (`resourceCount`, `projectCount`, `cloudProducts`, `resourceTypes`, `locations`, and a true `partialData`) — blocked on the org-level service agent grant. All of these are covered by unit tests against payloads shaped like the documented responses, which is not the same as a live read.

## Where the audit was wrong

- **Two findings had already shipped.** "Conditional org-policy rules are silently discarded" and "dnsSecAlgorithmWeak reads initial-generation config" both landed in #10302, merged the same day the audit was taken. Not reimplemented.
- **Finding 1's effort was understated.** It reads as a one-line field addition against `iam/v1`, but the provider's lister used the admin gRPC client, whose protobuf carries neither `DisableReason` nor `ExtendedStatus`. It needed a transport migration with fidelity tests. The audit also missed `extendedStatus` entirely, which is the more durable of the two signals.
- **"Serverless VPC Access connectors" is not Small.** The audit rates it S. `vpcaccess.googleapis.com` **rejects the wildcard location**: `projects/{p}/locations/-/connectors` answers `400 Location must be us-central1`. So it is a per-location fan-out with a real call cost, not one call — the same shape that forced the per-location walk for `clientTlsPolicies` in #10131. Deferred on that basis rather than on size alone.
- **Finding 4's "in one call" holds per key, but understates the setup.** Beyond the API needing enabling, the summary depends on an org-level grant to a Google-managed service agent. In most environments this field will read null until an org admin performs that grant, which is why the degrade path and its log message got as much attention as the happy path.

## Deferred

Deferred for size, to keep this reviewable — not dropped.

**A coherent network-edge follow-up (4 findings, all Small).** Cloud Armor policies that protect nothing (`securityPolicy.associations`); hierarchical firewall rule `tlsInspect` and `targetType`; load-balancer control-plane typed edges (`targetHttpsProxy.serverTlsPolicy` → the modelled `networkSecurityService.serverTlsPolicy`); transport crypto strength (`vpnTunnel.cipherSuite`, `backendService.tlsSettings`). These belong together and are the natural next PR. Worth noting for whoever takes it: none of them is verifiable in the accessible projects — there are zero security policies, target proxies, VPN tunnels, backend services, and firewall policies across all 22 projects, so that PR needs provisioned infrastructure.

**Other themes, each its own PR.** Log sink `interceptChildren` (logging); Spanner backup `kmsKey()` (CMEK edges); Cloud SQL credential controls (data plane); Private CA chain descriptions and tier (PKI); runtime-identity typed edges on 22 raw service-account emails (cross-cutting, touches many files).

**Serverless VPC Access connectors** — deferred on the fan-out finding above, not size.

**Medium field sets.** SCC finding detail structs (TRACKED); MIG version templates; VPC Service Controls ingress/egress rules; DNS forwarding path and routing policy; BigQuery conditioned grants and remote UDFs; Healthcare FHIR store consent and export posture.

**New areas, Medium to Large.** Cloud NGFW / Secure Web Proxy / L7 authorization policies; GKE Fleet memberships and features (TRACKED); Cloud Workstations configs and instances; Cloud Run revisions and worker pools; SCC attack paths, valued resources and custom modules (TRACKED); Cloud Build source-repository connections.
