### PR TITLE
🐛 proxmox: stop reporting fabricated values for reads that failed

### DIFF
--- a/providers/proxmox/resources/config_error_test.go
+++ b/providers/proxmox/resources/config_error_test.go
@@ -1,0 +1,188 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/proxmox/connection"
+)
+
+// configRuntime spins up a PVE API whose guest `config` endpoints answer with
+// the given status, and returns a runtime wired to it. A 403 stands in for the
+// case that matters: a token that can list guests but cannot read their
+// configuration.
+func configRuntime(t *testing.T, status int, body map[string]any) *plugin.Runtime {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/config") {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		if status >= 400 {
+			http.Error(w, "Permission check failed", status)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": body})
+	}))
+	t.Cleanup(srv.Close)
+	return &plugin.Runtime{Connection: connection.NewConnection(1, srv.URL, "token", true)}
+}
+
+func testContainer(runtime *plugin.Runtime) *mqlProxmoxContainer {
+	ct := &mqlProxmoxContainer{MqlRuntime: runtime}
+	ct.Id.Data = 100
+	ct.Node.Data = "pve"
+	return ct
+}
+
+func testVM(runtime *plugin.Runtime) *mqlProxmoxVm {
+	vm := &mqlProxmoxVm{MqlRuntime: runtime}
+	vm.Id.Data = 100
+	vm.Node.Data = "pve"
+	return vm
+}
+
+// TestContainerConfigReadFailureIsNotAValue proves that a denied config read
+// reports an error instead of a fabricated value. Before this was fixed every
+// field below answered with the zero value, so a container whose config could
+// not be read looked exactly like a container running privileged, unprotected
+// and with no features enabled.
+func TestContainerConfigReadFailureIsNotAValue(t *testing.T) {
+	runtime := configRuntime(t, http.StatusForbidden, nil)
+	ct := testContainer(runtime)
+
+	fields := map[string]func() (any, error){
+		"osType":       func() (any, error) { return ct.osType() },
+		"hostname":     func() (any, error) { return ct.hostname() },
+		"unprivileged": func() (any, error) { return ct.unprivileged() },
+		"protection":   func() (any, error) { return ct.protection() },
+		"onboot":       func() (any, error) { return ct.onboot() },
+		"description":  func() (any, error) { return ct.description() },
+		"cmode":        func() (any, error) { return ct.cmode() },
+		"searchDomain": func() (any, error) { return ct.searchDomain() },
+		"nameserver":   func() (any, error) { return ct.nameserver() },
+		"swap":         func() (any, error) { return ct.swap() },
+		"cpuLimit":     func() (any, error) { return ct.cpuLimit() },
+		"cpuUnits":     func() (any, error) { return ct.cpuUnits() },
+		"rawLxc":       func() (any, error) { return ct.rawLxc() },
+		"features":     func() (any, error) { return ct.features() },
+		"tags":         func() (any, error) { return ct.tags() },
+		"pool":         func() (any, error) { return ct.pool() },
+		"networks":     func() (any, error) { return ct.networks() },
+		"mountPoints":  func() (any, error) { return ct.mountPoints() },
+		"config":       func() (any, error) { return ct.config() },
+	}
+	for name, read := range fields {
+		t.Run(name, func(t *testing.T) {
+			got, err := read()
+			if err == nil {
+				t.Fatalf("%s() reported %#v with a nil error, but the config read failed", name, got)
+			}
+			if !strings.Contains(err.Error(), "403") {
+				t.Errorf("%s() error %q does not carry the API failure", name, err)
+			}
+		})
+	}
+}
+
+// TestVMConfigReadFailureIsNotAValue is the VM half of the same guarantee.
+// bios() is the loudest of these: it used to answer "seabios" for a VM whose
+// config was never read, which reads as a real, confirmed BIOS setting.
+func TestVMConfigReadFailureIsNotAValue(t *testing.T) {
+	runtime := configRuntime(t, http.StatusForbidden, nil)
+	vm := testVM(runtime)
+
+	fields := map[string]func() (any, error){
+		"osType":        func() (any, error) { return vm.osType() },
+		"machine":       func() (any, error) { return vm.machine() },
+		"bios":          func() (any, error) { return vm.bios() },
+		"bootOrder":     func() (any, error) { return vm.bootOrder() },
+		"agent":         func() (any, error) { return vm.agent() },
+		"protection":    func() (any, error) { return vm.protection() },
+		"description":   func() (any, error) { return vm.description() },
+		"lock":          func() (any, error) { return vm.lock() },
+		"hookscript":    func() (any, error) { return vm.hookscript() },
+		"args":          func() (any, error) { return vm.args() },
+		"vga":           func() (any, error) { return vm.vga() },
+		"ciuser":        func() (any, error) { return vm.ciuser() },
+		"sshkeys":       func() (any, error) { return vm.sshkeys() },
+		"searchDomain":  func() (any, error) { return vm.searchDomain() },
+		"nameserver":    func() (any, error) { return vm.nameserver() },
+		"cipasswordSet": func() (any, error) { return vm.cipasswordSet() },
+		"ciCustom":      func() (any, error) { return vm.ciCustom() },
+		"tags":          func() (any, error) { return vm.tags() },
+		"pool":          func() (any, error) { return vm.pool() },
+		"serialPorts":   func() (any, error) { return vm.serialPorts() },
+		"networks":      func() (any, error) { return vm.networks() },
+		"disks":         func() (any, error) { return vm.disks() },
+		"pciDevices":    func() (any, error) { return vm.pciDevices() },
+		"usbDevices":    func() (any, error) { return vm.usbDevices() },
+		"config":        func() (any, error) { return vm.config() },
+	}
+	for name, read := range fields {
+		t.Run(name, func(t *testing.T) {
+			got, err := read()
+			if err == nil {
+				t.Fatalf("%s() reported %#v with a nil error, but the config read failed", name, got)
+			}
+			if !strings.Contains(err.Error(), "403") {
+				t.Errorf("%s() error %q does not carry the API failure", name, err)
+			}
+		})
+	}
+}
+
+// TestContainerAbsentKeysKeepTheirDefaults pins the state the fix must leave
+// alone: the config was read successfully and simply does not carry the key.
+// An absent PVE flag means the flag is off, and that is a real answer.
+func TestContainerAbsentKeysKeepTheirDefaults(t *testing.T) {
+	runtime := configRuntime(t, http.StatusOK, map[string]any{"ostype": "debian"})
+	ct := testContainer(runtime)
+
+	if got, err := ct.osType(); err != nil || got != "debian" {
+		t.Errorf("osType() = %q, %v; want debian, nil", got, err)
+	}
+	if got, err := ct.unprivileged(); err != nil || got {
+		t.Errorf("unprivileged() = %v, %v; want false, nil for an absent key", got, err)
+	}
+	if got, err := ct.protection(); err != nil || got {
+		t.Errorf("protection() = %v, %v; want false, nil for an absent key", got, err)
+	}
+	if got, err := ct.hostname(); err != nil || got != "" {
+		t.Errorf("hostname() = %q, %v; want empty, nil for an absent key", got, err)
+	}
+	if got, err := ct.swap(); err != nil || got != 0 {
+		t.Errorf("swap() = %d, %v; want 0, nil for an absent key", got, err)
+	}
+}
+
+// TestVMAbsentKeysKeepTheirDefaults is the VM counterpart, including the
+// documented seabios fallback that only applies to a config we did read.
+func TestVMAbsentKeysKeepTheirDefaults(t *testing.T) {
+	runtime := configRuntime(t, http.StatusOK, map[string]any{"protection": 1})
+	vm := testVM(runtime)
+
+	if got, err := vm.bios(); err != nil || got != "seabios" {
+		t.Errorf("bios() = %q, %v; want seabios, nil for an absent key", got, err)
+	}
+	if got, err := vm.protection(); err != nil || !got {
+		t.Errorf("protection() = %v, %v; want true, nil", got, err)
+	}
+	if got, err := vm.agent(); err != nil || got {
+		t.Errorf("agent() = %v, %v; want false, nil for an absent key", got, err)
+	}
+	if got, err := vm.cipasswordSet(); err != nil || got {
+		t.Errorf("cipasswordSet() = %v, %v; want false, nil for an absent key", got, err)
+	}
+	if got, err := vm.osType(); err != nil || got != "" {
+		t.Errorf("osType() = %q, %v; want empty, nil for an absent key", got, err)
+	}
+}

--- a/providers/proxmox/resources/container.go
+++ b/providers/proxmox/resources/container.go
@@ -81,35 +81,42 @@ func (r *mqlProxmoxContainer) ensureConfig() {
 	})
 }
 
-func (r *mqlProxmoxContainer) cfgStr(key string) string {
+// cfgStr reads a key out of the container config. A failed config read is
+// reported as an error rather than an empty value: "the key is absent" and
+// "we never got to see the config" are different answers and an audit has to
+// be able to tell them apart.
+func (r *mqlProxmoxContainer) cfgStr(key string) (string, error) {
 	r.ensureConfig()
-	if r.ctConfig == nil {
-		return ""
+	if r.configErr != nil {
+		return "", r.configErr
 	}
 	if v, ok := r.ctConfig[key]; ok {
-		return fmt.Sprintf("%v", v)
+		return fmt.Sprintf("%v", v), nil
 	}
-	return ""
+	return "", nil
 }
 
-func (r *mqlProxmoxContainer) cfgBool(key string) bool {
+// cfgBool reads a boolean-ish key out of the container config. PVE writes
+// flags as 1/0, so an absent key means the flag is off. A failed config read
+// is an error, not an off flag.
+func (r *mqlProxmoxContainer) cfgBool(key string) (bool, error) {
 	r.ensureConfig()
-	if r.ctConfig == nil {
-		return false
+	if r.configErr != nil {
+		return false, r.configErr
 	}
 	v, ok := r.ctConfig[key]
 	if !ok {
-		return false
+		return false, nil
 	}
 	switch val := v.(type) {
 	case bool:
-		return val
+		return val, nil
 	case float64:
-		return val == 1
+		return val == 1, nil
 	case string:
-		return val == "1" || val == "true"
+		return val == "1" || val == "true", nil
 	}
-	return false
+	return false, nil
 }
 
 func (r *mqlProxmoxContainer) config() (any, error) {
@@ -117,20 +124,23 @@ func (r *mqlProxmoxContainer) config() (any, error) {
 	return r.ctConfig, r.configErr
 }
 
-func (r *mqlProxmoxContainer) osType() (string, error)       { return r.cfgStr("ostype"), nil }
-func (r *mqlProxmoxContainer) hostname() (string, error)     { return r.cfgStr("hostname"), nil }
-func (r *mqlProxmoxContainer) unprivileged() (bool, error)   { return r.cfgBool("unprivileged"), nil }
-func (r *mqlProxmoxContainer) protection() (bool, error)     { return r.cfgBool("protection"), nil }
-func (r *mqlProxmoxContainer) onboot() (bool, error)         { return r.cfgBool("onboot"), nil }
-func (r *mqlProxmoxContainer) description() (string, error)  { return r.cfgStr("description"), nil }
-func (r *mqlProxmoxContainer) cmode() (string, error)        { return r.cfgStr("cmode"), nil }
-func (r *mqlProxmoxContainer) searchDomain() (string, error) { return r.cfgStr("searchdomain"), nil }
-func (r *mqlProxmoxContainer) nameserver() (string, error)   { return r.cfgStr("nameserver"), nil }
+func (r *mqlProxmoxContainer) osType() (string, error)       { return r.cfgStr("ostype") }
+func (r *mqlProxmoxContainer) hostname() (string, error)     { return r.cfgStr("hostname") }
+func (r *mqlProxmoxContainer) unprivileged() (bool, error)   { return r.cfgBool("unprivileged") }
+func (r *mqlProxmoxContainer) protection() (bool, error)     { return r.cfgBool("protection") }
+func (r *mqlProxmoxContainer) onboot() (bool, error)         { return r.cfgBool("onboot") }
+func (r *mqlProxmoxContainer) description() (string, error)  { return r.cfgStr("description") }
+func (r *mqlProxmoxContainer) cmode() (string, error)        { return r.cfgStr("cmode") }
+func (r *mqlProxmoxContainer) searchDomain() (string, error) { return r.cfgStr("searchdomain") }
+func (r *mqlProxmoxContainer) nameserver() (string, error)   { return r.cfgStr("nameserver") }
 
 // swap is configured in MB; convert to bytes for consistency with the
 // other size fields on the resource.
 func (r *mqlProxmoxContainer) swap() (int64, error) {
-	val := r.cfgStr("swap")
+	val, err := r.cfgStr("swap")
+	if err != nil {
+		return 0, err
+	}
 	if val == "" {
 		return 0, nil
 	}
@@ -142,7 +152,10 @@ func (r *mqlProxmoxContainer) swap() (int64, error) {
 }
 
 func (r *mqlProxmoxContainer) cpuLimit() (float64, error) {
-	val := r.cfgStr("cpulimit")
+	val, err := r.cfgStr("cpulimit")
+	if err != nil {
+		return 0, err
+	}
 	if val == "" {
 		return 0, nil
 	}
@@ -154,7 +167,10 @@ func (r *mqlProxmoxContainer) cpuLimit() (float64, error) {
 }
 
 func (r *mqlProxmoxContainer) cpuUnits() (int64, error) {
-	val := r.cfgStr("cpuunits")
+	val, err := r.cfgStr("cpuunits")
+	if err != nil {
+		return 0, err
+	}
 	if val == "" {
 		return 0, nil
 	}
@@ -169,7 +185,10 @@ func (r *mqlProxmoxContainer) cpuUnits() (int64, error) {
 // stores the field as one logical newline-delimited string; split it
 // and trim so audits can iterate one override at a time.
 func (r *mqlProxmoxContainer) rawLxc() ([]any, error) {
-	val := r.cfgStr("lxc")
+	val, err := r.cfgStr("lxc")
+	if err != nil {
+		return nil, err
+	}
 	if val == "" {
 		return []any{}, nil
 	}
@@ -201,7 +220,10 @@ func parseRawLxcLines(raw string) []string {
 }
 
 func (r *mqlProxmoxContainer) features() ([]any, error) {
-	val := r.cfgStr("features")
+	val, err := r.cfgStr("features")
+	if err != nil {
+		return nil, err
+	}
 	if val == "" {
 		return []any{}, nil
 	}
@@ -226,7 +248,10 @@ func (r *mqlProxmoxContainer) features() ([]any, error) {
 }
 
 func (r *mqlProxmoxContainer) tags() ([]any, error) {
-	tagStr := r.cfgStr("tags")
+	tagStr, err := r.cfgStr("tags")
+	if err != nil {
+		return nil, err
+	}
 	if tagStr == "" {
 		return []any{}, nil
 	}
@@ -239,7 +264,10 @@ func (r *mqlProxmoxContainer) tags() ([]any, error) {
 }
 
 func (r *mqlProxmoxContainer) pool() (*mqlProxmoxPool, error) {
-	id := r.cfgStr("pool")
+	id, err := r.cfgStr("pool")
+	if err != nil {
+		return nil, err
+	}
 	if id == "" {
 		r.Pool.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil

--- a/providers/proxmox/resources/init.go
+++ b/providers/proxmox/resources/init.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -15,14 +16,22 @@ import (
 
 // init functions populate a resource when it was looked up by id only —
 // e.g. an ACL entry resolving its target user, group, role, or token.
+//
+// A lookup that finds nothing must return an error, never `args, nil, nil`.
+// Handing back no resource and no error tells the runtime to build the
+// resource out of the partial args it already has, which leaves every field
+// the lookup would have filled in *unset* rather than null. Reading one of
+// those fields then crosses the plugin boundary as an empty result and
+// surfaces client-side as "primitive with no type information", with nothing
+// naming the guest, user, or storage that could not be found.
 
 func initProxmoxUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 1 || args["id"] == nil {
 		return args, nil, nil
 	}
-	userID := args["id"].Value.(string)
-	if userID == "" {
-		return args, nil, nil
+	userID, ok := args["id"].Value.(string)
+	if !ok || userID == "" {
+		return nil, nil, errors.New("proxmox.user lookup requires a non-empty id")
 	}
 	conn := runtime.Connection.(*connection.PveConnection)
 	users, err := conn.GetUsers()
@@ -56,18 +65,19 @@ func initProxmoxUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		mqlUser.cachedGroups = splitProxmoxGroups(u.Groups)
 		return nil, res, nil
 	}
-	// User referenced by ACL no longer exists — return the bare resource
-	// so audits can still see the dangling reference rather than erroring.
-	return args, nil, nil
+	// A user referenced by an ACL that no longer exists is a real finding,
+	// but a husk resource is the wrong way to report it: `enable` would read
+	// false and `email` empty on a user nobody ever looked at.
+	return nil, nil, fmt.Errorf("proxmox.user %q not found", userID)
 }
 
 func initProxmoxGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 1 || args["id"] == nil {
 		return args, nil, nil
 	}
-	groupID := args["id"].Value.(string)
-	if groupID == "" {
-		return args, nil, nil
+	groupID, ok := args["id"].Value.(string)
+	if !ok || groupID == "" {
+		return nil, nil, errors.New("proxmox.group lookup requires a non-empty id")
 	}
 	conn := runtime.Connection.(*connection.PveConnection)
 	groups, err := conn.GetGroups()
@@ -90,16 +100,16 @@ func initProxmoxGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 		args["memberIds"] = llx.ArrayData(memberIds, "\x02")
 		return args, nil, nil
 	}
-	return args, nil, nil
+	return nil, nil, fmt.Errorf("proxmox.group %q not found", groupID)
 }
 
 func initProxmoxRole(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 1 || args["id"] == nil {
 		return args, nil, nil
 	}
-	roleID := args["id"].Value.(string)
-	if roleID == "" {
-		return args, nil, nil
+	roleID, ok := args["id"].Value.(string)
+	if !ok || roleID == "" {
+		return nil, nil, errors.New("proxmox.role lookup requires a non-empty id")
 	}
 	conn := runtime.Connection.(*connection.PveConnection)
 	roles, err := conn.GetRoles()
@@ -120,16 +130,16 @@ func initProxmoxRole(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		args["special"] = llx.BoolData(r.Special == 1)
 		return args, nil, nil
 	}
-	return args, nil, nil
+	return nil, nil, fmt.Errorf("proxmox.role %q not found", roleID)
 }
 
 func initProxmoxStorage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 1 || args["id"] == nil {
 		return args, nil, nil
 	}
-	storageID := args["id"].Value.(string)
-	if storageID == "" {
-		return args, nil, nil
+	storageID, ok := args["id"].Value.(string)
+	if !ok || storageID == "" {
+		return nil, nil, errors.New("proxmox.storage lookup requires a non-empty id")
 	}
 	conn := runtime.Connection.(*connection.PveConnection)
 	s, found, err := conn.LookupStorage(storageID)
@@ -137,7 +147,7 @@ func initProxmoxStorage(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		return nil, nil, err
 	}
 	if !found {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("proxmox.storage %q not found", storageID)
 	}
 	var usagePct float64
 	if s.UsedFrac > 0 {
@@ -164,22 +174,22 @@ func initProxmoxToken(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 	if len(args) > 1 || args["id"] == nil {
 		return args, nil, nil
 	}
-	tokenID := args["id"].Value.(string)
-	if tokenID == "" {
-		return args, nil, nil
+	tokenID, ok := args["id"].Value.(string)
+	if !ok || tokenID == "" {
+		return nil, nil, errors.New("proxmox.token lookup requires a non-empty id")
 	}
 	// Token IDs are user@realm!tokenid — derive the owner to call the
 	// per-user endpoint instead of paging through every user.
 	bangIdx := strings.LastIndex(tokenID, "!")
 	if bangIdx <= 0 {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("proxmox.token id %q is malformed, expected user@realm!tokenid", tokenID)
 	}
 	owner := tokenID[:bangIdx]
 	leaf := tokenID[bangIdx+1:]
 	conn := runtime.Connection.(*connection.PveConnection)
 	tokens, err := conn.GetUserTokens(owner)
 	if err != nil {
-		return args, nil, nil
+		return nil, nil, err
 	}
 	for _, t := range tokens {
 		if t.TokenID != leaf {
@@ -190,16 +200,16 @@ func initProxmoxToken(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 		args["privsep"] = llx.BoolData(t.Privsep == 1)
 		return args, nil, nil
 	}
-	return args, nil, nil
+	return nil, nil, fmt.Errorf("proxmox.token %q not found for user %q", leaf, owner)
 }
 
 func initProxmoxNode(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 1 || args["name"] == nil {
 		return args, nil, nil
 	}
-	name := args["name"].Value.(string)
-	if name == "" {
-		return args, nil, nil
+	name, ok := args["name"].Value.(string)
+	if !ok || name == "" {
+		return nil, nil, errors.New("proxmox.node lookup requires a non-empty name")
 	}
 	conn := runtime.Connection.(*connection.PveConnection)
 	n, found, err := conn.LookupNode(name)
@@ -207,7 +217,7 @@ func initProxmoxNode(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		return nil, nil, err
 	}
 	if !found {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("proxmox.node %q not found", name)
 	}
 	args["status"] = llx.StringData(n.Status)
 	// The address comes from the cluster status, which a standalone host
@@ -222,9 +232,9 @@ func initProxmoxClusterHaGroup(runtime *plugin.Runtime, args map[string]*llx.Raw
 	if len(args) > 1 || args["id"] == nil {
 		return args, nil, nil
 	}
-	groupID := args["id"].Value.(string)
-	if groupID == "" {
-		return args, nil, nil
+	groupID, ok := args["id"].Value.(string)
+	if !ok || groupID == "" {
+		return nil, nil, errors.New("proxmox.cluster.haGroup lookup requires a non-empty id")
 	}
 	conn := runtime.Connection.(*connection.PveConnection)
 	groups, err := conn.GetHAGroups()
@@ -241,16 +251,16 @@ func initProxmoxClusterHaGroup(runtime *plugin.Runtime, args map[string]*llx.Raw
 		args["comment"] = llx.StringData(g.Comment)
 		return args, nil, nil
 	}
-	return args, nil, nil
+	return nil, nil, fmt.Errorf("proxmox.cluster.haGroup %q not found", groupID)
 }
 
 func initProxmoxSdnZone(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 1 || args["zone"] == nil {
 		return args, nil, nil
 	}
-	zoneID := args["zone"].Value.(string)
-	if zoneID == "" {
-		return args, nil, nil
+	zoneID, ok := args["zone"].Value.(string)
+	if !ok || zoneID == "" {
+		return nil, nil, errors.New("proxmox.sdn.zone lookup requires a non-empty zone")
 	}
 	conn := runtime.Connection.(*connection.PveConnection)
 	zones, err := conn.GetSDNZones()
@@ -272,16 +282,16 @@ func initProxmoxSdnZone(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		args["state"] = llx.StringData(z.State)
 		return args, nil, nil
 	}
-	return args, nil, nil
+	return nil, nil, fmt.Errorf("proxmox.sdn.zone %q not found", zoneID)
 }
 
 func initProxmoxSdnVnet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 1 || args["vnet"] == nil {
 		return args, nil, nil
 	}
-	vnetID := args["vnet"].Value.(string)
-	if vnetID == "" {
-		return args, nil, nil
+	vnetID, ok := args["vnet"].Value.(string)
+	if !ok || vnetID == "" {
+		return nil, nil, errors.New("proxmox.sdn.vnet lookup requires a non-empty vnet")
 	}
 	conn := runtime.Connection.(*connection.PveConnection)
 	vnets, err := conn.GetSDNVNets()
@@ -299,16 +309,16 @@ func initProxmoxSdnVnet(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		args["type"] = llx.StringData(v.Type)
 		return args, nil, nil
 	}
-	return args, nil, nil
+	return nil, nil, fmt.Errorf("proxmox.sdn.vnet %q not found", vnetID)
 }
 
 func initProxmoxVm(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 1 || args["id"] == nil {
 		return args, nil, nil
 	}
-	want := args["id"].Value.(int64)
-	if want == 0 {
-		return args, nil, nil
+	want, ok := args["id"].Value.(int64)
+	if !ok || want == 0 {
+		return nil, nil, errors.New("proxmox.vm lookup requires a non-zero vmid")
 	}
 	conn := runtime.Connection.(*connection.PveConnection)
 	vms, err := conn.GetAllVMs()
@@ -336,16 +346,20 @@ func initProxmoxVm(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[s
 		args["template"] = llx.BoolData(vm.Template == 1)
 		return args, nil, nil
 	}
-	return args, nil, nil
+	// cluster.haResources reaches this path whenever an HA entry names a
+	// guest that has been destroyed. Reporting it as a blank VM would leave
+	// `node`, `status`, and `template` unset, which is indistinguishable
+	// from a stopped guest nobody has data for.
+	return nil, nil, fmt.Errorf("proxmox.vm with vmid %d not found", want)
 }
 
 func initProxmoxContainer(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 1 || args["id"] == nil {
 		return args, nil, nil
 	}
-	want := args["id"].Value.(int64)
-	if want == 0 {
-		return args, nil, nil
+	want, ok := args["id"].Value.(int64)
+	if !ok || want == 0 {
+		return nil, nil, errors.New("proxmox.container lookup requires a non-zero vmid")
 	}
 	conn := runtime.Connection.(*connection.PveConnection)
 	cts, err := conn.GetAllContainers()
@@ -373,7 +387,7 @@ func initProxmoxContainer(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		args["template"] = llx.BoolData(ct.Template == 1)
 		return args, nil, nil
 	}
-	return args, nil, nil
+	return nil, nil, fmt.Errorf("proxmox.container with vmid %d not found", want)
 }
 
 func initProxmoxCephFilesystem(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -382,7 +396,7 @@ func initProxmoxCephFilesystem(runtime *plugin.Runtime, args map[string]*llx.Raw
 	}
 	name, ok := args["name"].Value.(string)
 	if !ok || name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New("proxmox.ceph.filesystem lookup requires a non-empty name")
 	}
 	conn := runtime.Connection.(*connection.PveConnection)
 	systems, err := conn.GetCephFileSystems()

--- a/providers/proxmox/resources/init_notfound_test.go
+++ b/providers/proxmox/resources/init_notfound_test.go
@@ -1,0 +1,173 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/proxmox/connection"
+)
+
+// emptyClusterRuntime answers every list endpoint with an empty collection, so
+// any lookup by id misses. That is the shape of a cluster where the object an
+// ACL entry, HA entry, or storage reference names has since been deleted.
+func emptyClusterRuntime(t *testing.T) *plugin.Runtime {
+	t.Helper()
+	return listRuntime(t, map[string]any{})
+}
+
+// listRuntime serves the given path-to-body routes, defaulting to an empty
+// list for anything not registered.
+func listRuntime(t *testing.T, routes map[string]any) *plugin.Runtime {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/api2/json")
+		if r.URL.RawQuery != "" {
+			path += "?" + r.URL.RawQuery
+		}
+		body, ok := routes[path]
+		if !ok {
+			body = []any{}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": body})
+	}))
+	t.Cleanup(srv.Close)
+	return &plugin.Runtime{Connection: connection.NewConnection(1, srv.URL, "token", true)}
+}
+
+type initFunc func(*plugin.Runtime, map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+
+// TestInitLookupMissReturnsError proves every init reports a miss as an error.
+// Returning `args, nil, nil` instead would have the runtime build the resource
+// out of the id alone, leaving every other field unset; reading one of those
+// then surfaces as "primitive with no type information" with nothing naming
+// the object that could not be found.
+func TestInitLookupMissReturnsError(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		fn   initFunc
+		args map[string]*llx.RawData
+		want string
+	}{
+		{"user", initProxmoxUser, map[string]*llx.RawData{"id": llx.StringData("ghost@pam")}, `proxmox.user "ghost@pam" not found`},
+		{"group", initProxmoxGroup, map[string]*llx.RawData{"id": llx.StringData("ghosts")}, `proxmox.group "ghosts" not found`},
+		{"role", initProxmoxRole, map[string]*llx.RawData{"id": llx.StringData("Ghost")}, `proxmox.role "Ghost" not found`},
+		{"storage", initProxmoxStorage, map[string]*llx.RawData{"id": llx.StringData("ghost-nfs")}, `proxmox.storage "ghost-nfs" not found`},
+		{"token", initProxmoxToken, map[string]*llx.RawData{"id": llx.StringData("root@pam!ghost")}, `proxmox.token "ghost" not found`},
+		{"node", initProxmoxNode, map[string]*llx.RawData{"name": llx.StringData("ghost-node")}, `proxmox.node "ghost-node" not found`},
+		{"haGroup", initProxmoxClusterHaGroup, map[string]*llx.RawData{"id": llx.StringData("ghost-ha")}, `proxmox.cluster.haGroup "ghost-ha" not found`},
+		{"sdnZone", initProxmoxSdnZone, map[string]*llx.RawData{"zone": llx.StringData("ghostzone")}, `proxmox.sdn.zone "ghostzone" not found`},
+		{"sdnVnet", initProxmoxSdnVnet, map[string]*llx.RawData{"vnet": llx.StringData("ghostvnet")}, `proxmox.sdn.vnet "ghostvnet" not found`},
+		{"vm", initProxmoxVm, map[string]*llx.RawData{"id": llx.IntData(404)}, "proxmox.vm with vmid 404 not found"},
+		{"container", initProxmoxContainer, map[string]*llx.RawData{"id": llx.IntData(405)}, "proxmox.container with vmid 405 not found"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runtime := emptyClusterRuntime(t)
+			args, res, err := tc.fn(runtime, tc.args)
+			if err == nil {
+				t.Fatalf("lookup miss returned no error (args=%v, resource=%v); a blank resource leaves every field unset", args, res)
+			}
+			if res != nil {
+				t.Errorf("lookup miss returned a resource %v alongside the error", res)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not name what was not found (want it to contain %q)", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestInitRejectsUnusableLookupKey covers the intermediate failures that also
+// used to fall through to blank-resource creation: an empty id, a wrong-typed
+// id, and a token id that is not in user@realm!tokenid form.
+func TestInitRejectsUnusableLookupKey(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		fn   initFunc
+		args map[string]*llx.RawData
+		want string
+	}{
+		{"emptyUserID", initProxmoxUser, map[string]*llx.RawData{"id": llx.StringData("")}, "non-empty id"},
+		{"emptyGroupID", initProxmoxGroup, map[string]*llx.RawData{"id": llx.StringData("")}, "non-empty id"},
+		{"emptyRoleID", initProxmoxRole, map[string]*llx.RawData{"id": llx.StringData("")}, "non-empty id"},
+		{"emptyStorageID", initProxmoxStorage, map[string]*llx.RawData{"id": llx.StringData("")}, "non-empty id"},
+		{"emptyNodeName", initProxmoxNode, map[string]*llx.RawData{"name": llx.StringData("")}, "non-empty name"},
+		{"emptyHaGroupID", initProxmoxClusterHaGroup, map[string]*llx.RawData{"id": llx.StringData("")}, "non-empty id"},
+		{"emptyZone", initProxmoxSdnZone, map[string]*llx.RawData{"zone": llx.StringData("")}, "non-empty zone"},
+		{"emptyVnet", initProxmoxSdnVnet, map[string]*llx.RawData{"vnet": llx.StringData("")}, "non-empty vnet"},
+		{"emptyCephFsName", initProxmoxCephFilesystem, map[string]*llx.RawData{"name": llx.StringData("")}, "non-empty name"},
+		{"zeroVmid", initProxmoxVm, map[string]*llx.RawData{"id": llx.IntData(0)}, "non-zero vmid"},
+		{"zeroCtVmid", initProxmoxContainer, map[string]*llx.RawData{"id": llx.IntData(0)}, "non-zero vmid"},
+		{"emptyTokenID", initProxmoxToken, map[string]*llx.RawData{"id": llx.StringData("")}, "non-empty id"},
+		{"tokenIDWithoutBang", initProxmoxToken, map[string]*llx.RawData{"id": llx.StringData("root@pam")}, "malformed"},
+		{"vmidWrongType", initProxmoxVm, map[string]*llx.RawData{"id": llx.StringData("100")}, "non-zero vmid"},
+		{"userIDWrongType", initProxmoxUser, map[string]*llx.RawData{"id": llx.IntData(1)}, "non-empty id"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runtime := emptyClusterRuntime(t)
+			args, res, err := tc.fn(runtime, tc.args)
+			if err == nil {
+				t.Fatalf("unusable lookup key returned no error (args=%v, resource=%v)", args, res)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not explain the rejected key (want it to contain %q)", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestInitCompleteArgsFastPathIntact guards the legitimate early return: when
+// the caller already supplied the fields, the init must hand the args straight
+// back without an API call and without erroring.
+func TestInitCompleteArgsFastPathIntact(t *testing.T) {
+	runtime := emptyClusterRuntime(t)
+	args := map[string]*llx.RawData{
+		"id":   llx.IntData(100),
+		"name": llx.StringData("web"),
+		"node": llx.StringData("pve"),
+	}
+	got, res, err := initProxmoxVm(runtime, args)
+	if err != nil {
+		t.Fatalf("fast path returned an error: %v", err)
+	}
+	if res != nil {
+		t.Errorf("fast path built a resource %v; it should hand back args", res)
+	}
+	if len(got) != len(args) {
+		t.Errorf("fast path changed the args: got %v", got)
+	}
+}
+
+// TestInitVmHitStillPopulates keeps the fix honest: a guest that does exist
+// still resolves, with the listing fields filled in.
+func TestInitVmHitStillPopulates(t *testing.T) {
+	runtime := listRuntime(t, map[string]any{
+		"/cluster/resources?type=vm": []any{
+			map[string]any{"vmid": 100, "name": "web", "node": "pve", "status": "running", "type": "qemu", "template": 0},
+		},
+	})
+	got, res, err := initProxmoxVm(runtime, map[string]*llx.RawData{"id": llx.IntData(100)})
+	if err != nil {
+		t.Fatalf("existing vm 100 failed to resolve: %v", err)
+	}
+	if res != nil {
+		t.Fatalf("expected populated args, got resource %v", res)
+	}
+	if got["name"] == nil || got["name"].Value.(string) != "web" {
+		t.Errorf("name not populated: %v", got["name"])
+	}
+	if got["node"] == nil || got["node"].Value.(string) != "pve" {
+		t.Errorf("node not populated: %v", got["node"])
+	}
+	if got["status"] == nil || got["status"].Value.(string) != "running" {
+		t.Errorf("status not populated: %v", got["status"])
+	}
+}

--- a/providers/proxmox/resources/vm.go
+++ b/providers/proxmox/resources/vm.go
@@ -38,35 +38,42 @@ func (r *mqlProxmoxVm) ensureConfig() {
 	})
 }
 
-func (r *mqlProxmoxVm) cfgStr(key string) string {
+// cfgStr reads a key out of the VM config. A failed config read is reported
+// as an error rather than an empty value: "the key is absent" and "we never
+// got to see the config" are different answers and an audit has to be able to
+// tell them apart.
+func (r *mqlProxmoxVm) cfgStr(key string) (string, error) {
 	r.ensureConfig()
-	if r.vmConfig == nil {
-		return ""
+	if r.configErr != nil {
+		return "", r.configErr
 	}
 	if v, ok := r.vmConfig[key]; ok {
-		return fmt.Sprintf("%v", v)
+		return fmt.Sprintf("%v", v), nil
 	}
-	return ""
+	return "", nil
 }
 
-func (r *mqlProxmoxVm) cfgBool(key string) bool {
+// cfgBool reads a boolean-ish key out of the VM config. PVE writes flags as
+// 1/0, so an absent key means the flag is off. A failed config read is an
+// error, not an off flag.
+func (r *mqlProxmoxVm) cfgBool(key string) (bool, error) {
 	r.ensureConfig()
-	if r.vmConfig == nil {
-		return false
+	if r.configErr != nil {
+		return false, r.configErr
 	}
 	v, ok := r.vmConfig[key]
 	if !ok {
-		return false
+		return false, nil
 	}
 	switch val := v.(type) {
 	case bool:
-		return val
+		return val, nil
 	case float64:
-		return val == 1
+		return val == 1, nil
 	case string:
-		return val == "1" || val == "true"
+		return val == "1" || val == "true", nil
 	}
-	return false
+	return false, nil
 }
 
 func (r *mqlProxmoxVm) config() (any, error) {
@@ -74,32 +81,38 @@ func (r *mqlProxmoxVm) config() (any, error) {
 	return r.vmConfig, r.configErr
 }
 
-func (r *mqlProxmoxVm) osType() (string, error)  { return r.cfgStr("ostype"), nil }
-func (r *mqlProxmoxVm) machine() (string, error) { return r.cfgStr("machine"), nil }
+func (r *mqlProxmoxVm) osType() (string, error)  { return r.cfgStr("ostype") }
+func (r *mqlProxmoxVm) machine() (string, error) { return r.cfgStr("machine") }
 
+// bios falls back to seabios, which is what PVE boots a VM with when the key
+// is absent from the config. That default only holds for a config we actually
+// read; a failed read is reported as an error instead.
 func (r *mqlProxmoxVm) bios() (string, error) {
-	b := r.cfgStr("bios")
+	b, err := r.cfgStr("bios")
+	if err != nil {
+		return "", err
+	}
 	if b == "" {
 		b = "seabios"
 	}
 	return b, nil
 }
 
-func (r *mqlProxmoxVm) bootOrder() (string, error)   { return r.cfgStr("boot"), nil }
-func (r *mqlProxmoxVm) agent() (bool, error)         { return r.cfgBool("agent"), nil }
-func (r *mqlProxmoxVm) protection() (bool, error)    { return r.cfgBool("protection"), nil }
-func (r *mqlProxmoxVm) description() (string, error) { return r.cfgStr("description"), nil }
-func (r *mqlProxmoxVm) lock() (string, error)        { return r.cfgStr("lock"), nil }
-func (r *mqlProxmoxVm) hookscript() (string, error)  { return r.cfgStr("hookscript"), nil }
-func (r *mqlProxmoxVm) args() (string, error)        { return r.cfgStr("args"), nil }
-func (r *mqlProxmoxVm) vga() (string, error)         { return r.cfgStr("vga"), nil }
+func (r *mqlProxmoxVm) bootOrder() (string, error)   { return r.cfgStr("boot") }
+func (r *mqlProxmoxVm) agent() (bool, error)         { return r.cfgBool("agent") }
+func (r *mqlProxmoxVm) protection() (bool, error)    { return r.cfgBool("protection") }
+func (r *mqlProxmoxVm) description() (string, error) { return r.cfgStr("description") }
+func (r *mqlProxmoxVm) lock() (string, error)        { return r.cfgStr("lock") }
+func (r *mqlProxmoxVm) hookscript() (string, error)  { return r.cfgStr("hookscript") }
+func (r *mqlProxmoxVm) args() (string, error)        { return r.cfgStr("args") }
+func (r *mqlProxmoxVm) vga() (string, error)         { return r.cfgStr("vga") }
 
 // --- Cloud-init ---
 
-func (r *mqlProxmoxVm) ciuser() (string, error)       { return r.cfgStr("ciuser"), nil }
-func (r *mqlProxmoxVm) sshkeys() (string, error)      { return r.cfgStr("sshkeys"), nil }
-func (r *mqlProxmoxVm) searchDomain() (string, error) { return r.cfgStr("searchdomain"), nil }
-func (r *mqlProxmoxVm) nameserver() (string, error)   { return r.cfgStr("nameserver"), nil }
+func (r *mqlProxmoxVm) ciuser() (string, error)       { return r.cfgStr("ciuser") }
+func (r *mqlProxmoxVm) sshkeys() (string, error)      { return r.cfgStr("sshkeys") }
+func (r *mqlProxmoxVm) searchDomain() (string, error) { return r.cfgStr("searchdomain") }
+func (r *mqlProxmoxVm) nameserver() (string, error)   { return r.cfgStr("nameserver") }
 
 // cipasswordSet only reports whether the key is present in the VM
 // config; the password value itself is intentionally never read or
@@ -107,8 +120,8 @@ func (r *mqlProxmoxVm) nameserver() (string, error)   { return r.cfgStr("nameser
 // password is configured, not on what it is.
 func (r *mqlProxmoxVm) cipasswordSet() (bool, error) {
 	r.ensureConfig()
-	if r.vmConfig == nil {
-		return false, nil
+	if r.configErr != nil {
+		return false, r.configErr
 	}
 	v, ok := r.vmConfig["cipassword"]
 	if !ok {
@@ -126,7 +139,10 @@ func (r *mqlProxmoxVm) cipasswordSet() (bool, error) {
 func (r *mqlProxmoxVm) ciCustom() (any, error) {
 	// `cicustom` is serialized as comma-delimited key=storage:snippets/file
 	// pairs (e.g. `user=local:snippets/u.yaml,network=local:snippets/n.yaml`).
-	val := r.cfgStr("cicustom")
+	val, err := r.cfgStr("cicustom")
+	if err != nil {
+		return nil, err
+	}
 	out := map[string]any{}
 	if val == "" {
 		return out, nil
@@ -180,7 +196,10 @@ func isSerialPortKey(key string) bool {
 }
 
 func (r *mqlProxmoxVm) tags() ([]any, error) {
-	tagStr := r.cfgStr("tags")
+	tagStr, err := r.cfgStr("tags")
+	if err != nil {
+		return nil, err
+	}
 	if tagStr == "" {
 		return []any{}, nil
 	}
@@ -193,7 +212,10 @@ func (r *mqlProxmoxVm) tags() ([]any, error) {
 }
 
 func (r *mqlProxmoxVm) pool() (*mqlProxmoxPool, error) {
-	id := r.cfgStr("pool")
+	id, err := r.cfgStr("pool")
+	if err != nil {
+		return nil, err
+	}
 	if id == "" {
 		r.Pool.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil


### PR DESCRIPTION
Two shipped-code bugs in the proxmox provider where a **read that failed** was reported as a confident answer. Found while implementing #10331 and deliberately left out of it because both change what shipped fields report.

## Bug 1 — a failed config read reported a fabricated value

`ensureConfig` memoizes the guest config *and* its error, but `cfgBool`/`cfgStr` only ever looked at the nil map:

```go
func (r *mqlProxmoxContainer) cfgBool(key string) bool {
	r.ensureConfig()
	if r.ctConfig == nil {   // configErr is right there, never consulted
		return false
	}
```

So a denied or failed `/nodes/<node>/{lxc,qemu}/<vmid>/config` fetch was indistinguishable from "the key is absent", and every config-derived field answered with its zero value.

### Which direction each field failed

Direction matters more than the count here:

| failing **loudly** (false alarm) | failing **silently** (audit passes on nothing) |
|---|---|
| `container.unprivileged` → `false` reads as "runs privileged" | `container.protection` → `false` reads as "delete protection off"… which is also the finding, so loud |
| | `vm.protection`, `container.onboot` → `false` |
| | `vm.agent` → `false` reads as "guest agent not configured" |
| | `vm.bios` → `"seabios"` reads as a **confirmed** BIOS setting, so a "must be OVMF/UEFI" check reports a definite fail on a VM nobody read |
| | `vm.cipasswordSet` → `false` reads as "no cloud-init password set" — a set password goes unreported |
| | `container.features`, `container.rawLxc` → `[]` reads as "no privileged features, no raw lxc overrides" — the exact opposite of the risky state |
| | `container.swap`/`cpuLimit`/`cpuUnits` → `0` reads as "unlimited" |
| | `tags`, `pool` → empty, so tag- and pool-scoped exemptions silently apply |

The loud ones are noise. The silent ones are the urgent half: `features`, `rawLxc`, `cipasswordSet` and `agent` all fabricate the *safe-looking* answer, so a policy passes on a guest whose configuration was never read. `bios` is the worst of both — it invents a value that is neither absent nor read.

### Decision: return the error, do not report null

The three states are now distinct:

- **read succeeded, key absent** → unchanged. PVE writes flags as `1`/`0`, so an absent flag genuinely means off, and `bios` genuinely defaults to `seabios`. Pinned by new tests so the fix can't drift into erroring here.
- **read succeeded, key present** → unchanged.
- **read failed** → the error propagates.

Error rather than null, for three reasons:

1. **The plumbing already exists and the neighbours already use it.** Every accessor is `func() (T, error)` and was returning `nil`. `config()`, `networks()`, `disks()`, `mountPoints()`, `serialPorts()`, `pciDevices()`, `usbDevices()` and `passthroughDevices()` on these same two resources *already* return `r.configErr`. The scalar accessors were the inconsistent ones.
2. **An error is attributable, a null is not.** The error carries `failed to get config for container 100: proxmox API error 403 …`, which names the guest, the call and the cause. A null says only "no value", and the operator cannot tell a missing key from a missing permission.
3. **Null is unsafe for exactly these fields.** In MQL `null && null` is `true`, and a denylist-shaped check passes on null. Swapping a fabricated `false` for a null would turn a false alarm into a silent pass on `features`/`rawLxc`/`agent` — the same class of bug, quieter. No field's declared type changes.

## Bug 2 — init functions built blank resources on a lookup miss

Every init ended with `return args, nil, nil` when its lookup found nothing. That tells the runtime to build the resource out of the partial args, leaving every field the lookup would have filled in **unset** — not null, unset. Reading one crosses the plugin boundary as an empty `DataRes` and surfaces client-side as `llx: encountered a primitive with no type information, coercing to null`, with nothing naming the cause. CLAUDE.md prohibits this shape explicitly.

`cluster.haResource.vm` and `.container` reach this whenever an HA entry names a destroyed guest, so it is live rather than theoretical. Each init now returns a not-found error naming what it looked for:

```go
return nil, nil, fmt.Errorf("proxmox.vm with vmid %d not found", want)
```

Also fixed in the same pass:

- **Unusable lookup keys.** An empty id / name / zone / vnet, or a zero vmid, fell through to blank-resource creation. They are now rejected with an error saying which key was unusable.
- **A malformed token id.** `initProxmoxToken` returned a husk when the id had no `!` separator; it now says so.
- **A swallowed API error.** `initProxmoxToken` did `if err != nil { return args, nil, nil }` on the `GetUserTokens` call, converting a failed API call into a blank token resource. It returns the error now.
- **A panic that took down the scan.** The arg assertions were bare `args["id"].Value.(string)`. A wrong-typed arg panicked *inside* the init, which is unrecoverable and kills the whole scan, not just the query. All of them are comma-ok now. (Confirmed against the pre-fix code: `panic: interface conversion: interface {} is int64, not string`.)

The legitimate `if len(args) > 1` fast path is untouched, and a test guards it.

`initProxmoxCephFilesystem` already handled its miss correctly (it was written after the rest); only its empty-name path needed the same treatment.

## Observable behaviour change

**This is a deliberate change to what shipped fields report.** For a guest whose config cannot be read — most commonly a token with `VM.Audit` but not `VM.Config.*`, or a guest deleted mid-scan:

- `proxmox.vms { bios }` previously returned `"seabios"`; it now errors with the 403.
- `proxmox.containers { unprivileged protection onboot }` previously returned `false false false`; they now error.
- `features`, `rawLxc`, `tags` previously returned `[]`; they now error.
- `pool` previously resolved to null; it now errors.
- `swap`, `cpuLimit`, `cpuUnits` previously returned `0`; they now error.

For a reference that resolves to nothing:

- `cluster.haResources { vm { … } }` previously returned a husk VM whose fields decoded as null with no explanation; it now errors with `proxmox.vm with vmid 123 not found`.
- The same for a dangling ACL user / group / role / token, a missing node or storage, and a missing SDN zone / vnet.

Nothing changes for a guest whose config reads fine, or for a reference that resolves.

One trade worth naming: `initProxmoxUser` previously carried a comment saying the husk was intentional, so "audits can still see the dangling reference rather than erroring". The intent is reasonable but the mechanism was not — a husk cannot be read, since every field on it is unset. An init has no way to report "this resource is null"; it can only return a resource or an error. If reporting a dangling reference as *null* is wanted, that needs a sentinel error the xref accessor catches before setting `StateIsNull`, which is a design change rather than a bug fix and is not in this PR.

## Tests

`resources/config_error_test.go` and `resources/init_notfound_test.go`, both driven by an `httptest` PVE API.

Each fix was reverted to `origin/main`'s code to confirm the tests go red, then restored:

- **Bug 1 reverted** — 35 subtests fail, each reporting the fabricated value (`bios() reported "seabios" with a nil error, but the config read failed`). The accessors that already propagated `configErr` on `main` (`networks`, `mountPoints`, `config`, `serialPorts`, `disks`, `pciDevices`, `usbDevices`) stayed green, which is what identifies the scalar helpers as the actual gap. The absent-key tests also stayed green, confirming they pin unchanged behaviour rather than the fix.
- **Bug 2 reverted** — 26 subtests fail, 11 on the miss path and 15 on unusable keys, plus the wrong-typed-arg case which panics rather than failing cleanly.

`go build ./...`, `go vet ./...` and `go test ./...` are clean inside `providers/proxmox/`. `gofmt` clean. No `.lr` or schema change, so no codegen and no `Version` bump. `go mod tidy` wanted to drop two unrelated indirect deps (`jtolds/gls`, `smarty/assertions`) — pre-existing drift, reverted.
