### PR TITLE
🐛 fix missing `shell --strict` setting propagation

### DIFF
--- a/cli/shell/model.go
+++ b/cli/shell/model.go
@@ -139,6 +139,7 @@ func newShellModel(runtime llx.Runtime, theme *ShellTheme, features mql.Features
 		runtime:     runtime,
 		theme:       theme,
 		features:    features,
+		strict:      strict,
 		keyMap:      DefaultKeyMap(),
 		input:       ta,
 		completer:   completer,

--- a/cli/shell/model_strict_test.go
+++ b/cli/shell/model_strict_test.go
@@ -1,0 +1,30 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package shell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql"
+	"go.mondoo.com/mql/providers-sdk/v1/testutils"
+)
+
+// The interactive prompt compiles every typed query through
+// shellModel.compilerConfig, so `--strict` only takes effect there if the flag
+// reaches the model itself. It used to reach only the completer, which meant
+// autocomplete knew about strict mode while the query the user pressed enter on
+// silently compiled permissive.
+func TestShellModel_strictReachesCompilerConfig(t *testing.T) {
+	runtime := testutils.LinuxMock()
+
+	for _, strict := range []bool{false, true} {
+		m := newShellModel(runtime, DefaultShellTheme, mql.DefaultFeatures, strict, "", nil)
+		assert.Equal(t, strict, m.strict, "strict must be stored on the model")
+		assert.Equal(t, strict, m.compilerConfig().Strict,
+			"strict must reach the config the interactive prompt compiles with")
+		assert.Equal(t, strict, m.completer.compilerConfig().Strict,
+			"completion must compile in the same mode as the query")
+	}
+}

--- a/cli/shell/shell_test.go
+++ b/cli/shell/shell_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/cli/shell"
+	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/testutils"
 )
 
@@ -36,4 +38,33 @@ func TestShell_Centos8(t *testing.T) {
 	assert.NotPanics(t, func() {
 		_, _, _ = sh.RunOnce("platform { title name release arch }")
 	}, "should not panic on partial queries")
+}
+
+// The shell has no content to declare a mode, so `--strict` / the `strict`
+// config key is the only thing that turns strict mode on for a typed query.
+// This covers that wiring: WithStrict has to reach the compiler config the
+// shell compiles with.
+func TestShell_Strict(t *testing.T) {
+	const query = `parse.json("/dummy.json").params.NOPE == "no"`
+
+	lenient := shell.NewShell(testutils.LinuxMock())
+	_, res, err := lenient.RunOnce(query)
+	require.NoError(t, err, "a missing key is silently false without strict mode")
+	require.NotEmpty(t, res)
+	assert.False(t, anyResultErrored(res), "non-strict must not error on a missing key")
+
+	strict := shell.NewShell(testutils.LinuxMock(), shell.WithStrict(true))
+	_, res, err = strict.RunOnce(query)
+	require.NoError(t, err, "the query still compiles; the failure is at runtime")
+	require.NotEmpty(t, res)
+	assert.True(t, anyResultErrored(res), "strict mode must surface the missing key as an error")
+}
+
+func anyResultErrored(res map[string]*llx.RawResult) bool {
+	for _, r := range res {
+		if r != nil && r.Data != nil && r.Data.Error != nil {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Setting it did nothing, now it enables strict-mode