### PR TITLE
🛑 mainline the terraform variable resolution

### DIFF
--- a/discovery/asset_explorer.go
+++ b/discovery/asset_explorer.go
@@ -110,9 +110,9 @@ func NewAssetExplorer(ctx context.Context, cfg AssetExplorerConfig) (*AssetExplo
 		upstream:  cfg.Upstream,
 		recording: cfg.Recording,
 		// Carry the context's mql features (which include platform/server-activated
-		// ones like TerraformResolveVars) into every asset connection, unioned with
-		// the local cli/config.Features global. Without this, connection-level
-		// features present only on the context never reach the provider.
+		// ones) into every asset connection, unioned with the local
+		// cli/config.Features global. Without this, connection-level features
+		// present only on the context never reach the provider.
 		features:        []byte(mql.GetFeatures(ctx)),
 		runtimeLabels:   runtimeLabels,
 		seenPlatformIDs: make(map[string]struct{}),

--- a/discovery/asset_explorer_test.go
+++ b/discovery/asset_explorer_test.go
@@ -14,15 +14,16 @@ import (
 
 // TestMergeConnectionFeatures verifies that connection features are the union of
 // the local cli/config.Features global and caller-supplied (server-activated)
-// features — so a feature present only on the context (e.g. TerraformResolveVars
-// from GetScanParameters) still reaches the provider connection.
+// features — so a feature present only on the context (e.g. one activated
+// upstream and returned by GetScanParameters) still reaches the provider
+// connection.
 func TestMergeConnectionFeatures(t *testing.T) {
 	saved := config.Features
 	t.Cleanup(func() { config.Features = saved })
 	config.Features = []byte{7, 9} // local config features
 
 	t.Run("adds server features on top of local ones", func(t *testing.T) {
-		got := mergeConnectionFeatures([]byte{17}) // TerraformResolveVars from server
+		got := mergeConnectionFeatures([]byte{17}) // server-activated feature
 		assert.ElementsMatch(t, []byte{7, 9, 17}, got)
 	})
 

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -28,9 +28,8 @@ type AssetWithError struct {
 // mergeConnectionFeatures unions the process-global CLI features
 // (cli/config.Features, populated from local config/MONDOO_FEATURES) with any
 // caller-supplied features (e.g. platform/server-activated ones). Both must
-// reach the provider connection: connection-level features like
-// TerraformResolveVars are read at Connect time, and the global alone never
-// carries server-activated features.
+// reach the provider connection: connection-level features are read at Connect
+// time, and the global alone never carries server-activated features.
 func mergeConnectionFeatures(extra []byte) []byte {
 	out := make([]byte, 0, len(config.Features)+len(extra))
 	seen := make(map[byte]bool, len(config.Features)+len(extra))

--- a/features.go
+++ b/features.go
@@ -94,7 +94,8 @@ const (
 
 	// Resolve var.* and local.* references in Terraform HCL block arguments to their effective values (variable defaults overridden by .tfvars, locals evaluated from those). Unresolvable references fall back to their reference string; the unresolved view stays available via terraform.block.argumentReferences.
 	// start:  v13.x
-	// status: new
+	// end: v13.x => this is the default now, no need to set it anymore
+	// status: builtin
 	TerraformResolveVars Feature = 17
 
 	// Compute a checksum for every row while writing the scan database, so an unchanged scan is detectable. Nothing else changes - every scan still uploads and is processed in full.
@@ -161,7 +162,6 @@ var AvailableFeatures = Features{
 	byte(UploadResultsV2),
 	byte(BiosUUIDAsID),
 	byte(ExchangeTokenForToken),
-	byte(TerraformResolveVars),
 	byte(ScanContentModeShadow),
 	byte(ScanContentModeServerCompare),
 	byte(ScanContentModeClientCompare),

--- a/features.yaml
+++ b/features.yaml
@@ -95,9 +95,10 @@ Features:
   status: new
 - id: TerraformResolveVars
   desc: "Resolve var.* and local.* references in Terraform HCL block arguments to their effective values (variable defaults overridden by .tfvars, locals evaluated from those). Unresolvable references fall back to their reference string; the unresolved view stays available via terraform.block.argumentReferences."
+  end: v13.x => this is the default now, no need to set it anymore
   idx: 17
   start: v13.x
-  status: new
+  status: builtin
 - id: ScanContentModeShadow
   desc: "Compute a checksum for every row while writing the scan database, so an unchanged scan is detectable. Nothing else changes - every scan still uploads and is processed in full."
   idx: 18

--- a/providers/terraform/connection/connection.go
+++ b/providers/terraform/connection/connection.go
@@ -33,7 +33,7 @@ type Connection struct {
 	closer          func()
 
 	// features carries the active MQL feature flags (encoded bitset) for this
-	// connection. Used to gate behaviors like Terraform variable resolution.
+	// connection, as sent by the client at Connect time.
 	features []byte
 
 	// varCtx memoizes the resolved var.*/local.* evaluation context so it is

--- a/providers/terraform/go.mod
+++ b/providers/terraform/go.mod
@@ -59,7 +59,6 @@ require (
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
-	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/kevinburke/ssh_config v1.6.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.4.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
@@ -79,7 +78,6 @@ require (
 	github.com/segmentio/ksuid v1.0.4 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect
-	github.com/smarty/assertions v1.16.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/providers/terraform/go.sum
+++ b/providers/terraform/go.sum
@@ -440,8 +440,6 @@ github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7 h1:4RpHzZRqq3RwB9Oa6kp6p8QjIHBGeAQ0cNKv/BfUCP0=
 go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
-go.mondoo.com/mql/v13 v13.35.2 h1:oii5mnKHpUo3ol9mRTM++Ai4Zh7uKsCMODBmt42/35A=
-go.mondoo.com/mql/v13 v13.35.2/go.mod h1:NRCnjBSiOoAOdBTBlRpD6tAPDKrZttVRzDPI4W2HQoY=
 go.mondoo.com/ranger-rpc v0.8.1 h1:DynUWByDnxI4wMHbFpXUMw+lndYJ21BAHOxrhGyVCD4=
 go.mondoo.com/ranger-rpc v0.8.1/go.mod h1:HP3hjWjgRFxCFAnY86YLMiY0bU7eqhKuP8Qm+QlFBbI=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -17,7 +17,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
-	mql "go.mondoo.com/mql"
 	"go.mondoo.com/mql/checksums"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
@@ -568,16 +567,13 @@ func (t *mqlTerraformBlock) attributes() (map[string]any, error) {
 }
 
 // evalContext returns the HCL evaluation context used to resolve this block's
-// argument expressions. When the TerraformResolveVars feature flag is
-// active, it returns the connection's context that resolves var.*/local.*
-// references; otherwise it returns nil, preserving the historical behavior of
-// surfacing those references as strings.
+// argument expressions: the connection's context that resolves var.*/local.*
+// references to their effective values. It returns nil for connections that
+// carry no such context (plan and state assets, which have no HCL parser), in
+// which case references are surfaced as strings.
 func (t *mqlTerraformBlock) evalContext() *hcl.EvalContext {
 	conn, ok := t.MqlRuntime.Connection.(*connection.Connection)
 	if !ok || conn == nil {
-		return nil
-	}
-	if !mql.Features(conn.Features()).IsActive(mql.TerraformResolveVars) {
 		return nil
 	}
 	return conn.VariableEvalContext()
@@ -600,9 +596,9 @@ func (t *mqlTerraformBlock) arguments() (map[string]any, error) {
 }
 
 // argumentReferences returns the block's arguments with variable and local
-// references left unresolved (e.g. "var.bucket_acl"), regardless of the
-// TerraformResolveVars feature flag. Use it to inspect that a value is
-// parameterized even when arguments() resolves to the effective value.
+// references left unresolved (e.g. "var.bucket_acl"). Use it to inspect that a
+// value is parameterized even though arguments() resolves it to the effective
+// value.
 func (t *mqlTerraformBlock) argumentReferences() (map[string]any, error) {
 	var hclBlock *hcl.Block
 	if t.block.State == plugin.StateIsSet {
@@ -680,8 +676,8 @@ func (t *mqlTerraformBlock) values() (map[string]any, error) {
 }
 
 // hclEvalContextOrDefault returns ctx when it carries resolved variable/local
-// values, or a functions-only context (the historical, no-resolution behavior)
-// when ctx is nil.
+// values, or a functions-only context (no var.*/local.* resolution, as used by
+// argumentReferences and by plan/state assets) when ctx is nil.
 func hclEvalContextOrDefault(ctx *hcl.EvalContext) *hcl.EvalContext {
 	if ctx != nil {
 		return ctx
@@ -786,11 +782,10 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		}
 		return results
 	case *hclsyntax.ScopeTraversalExpr:
-		// When the eval context carries resolved var.*/local.* values (the
-		// TerraformResolveVars feature flag), resolve the traversal to its
-		// effective value. If it can't be resolved (no such variable/local,
-		// data/resource references, …), fall back to surfacing the reference as
-		// a dotted string below.
+		// When the eval context carries resolved var.*/local.* values, resolve
+		// the traversal to its effective value. If it can't be resolved (no
+		// such variable/local, data/resource references, …), fall back to
+		// surfacing the reference as a dotted string below.
 		if ctx != nil && len(ctx.Variables) > 0 {
 			if val, diags := t.Value(ctx); !diags.HasErrors() {
 				return ctyValueToGo(val)

--- a/providers/terraform/resources/hcl_dynamic_test.go
+++ b/providers/terraform/resources/hcl_dynamic_test.go
@@ -32,7 +32,7 @@ resource "aws_security_group" "ex" {
   }
 }
 `), 0o600))
-	rt := newRuntimeForDir(t, dir, nil)
+	rt := newRuntimeForDir(t, dir)
 
 	args, _, err := initTerraformResources(rt, map[string]*llx.RawData{})
 	require.NoError(t, err)
@@ -75,7 +75,7 @@ resource "aws_security_group" "ex" {
   }
 }
 `), 0o600))
-	rt := newRuntimeForDir(t, dir, nil)
+	rt := newRuntimeForDir(t, dir)
 
 	args, _, err := initTerraformResources(rt, map[string]*llx.RawData{})
 	require.NoError(t, err)

--- a/providers/terraform/resources/hcl_test.go
+++ b/providers/terraform/resources/hcl_test.go
@@ -251,8 +251,7 @@ func TestGetCtyValue_UnaryOp_UnboundOperand(t *testing.T) {
 }
 
 // resolvingCtx builds an eval context with resolved var.*/local.* values,
-// mimicking what Connection.VariableEvalContext produces when the
-// TerraformResolveVars feature flag is active.
+// mimicking what Connection.VariableEvalContext produces for an HCL asset.
 func resolvingCtx(vars, locals map[string]cty.Value) *hcl.EvalContext {
 	ctx := &hcl.EvalContext{Functions: hclFunctions(), Variables: map[string]cty.Value{}}
 	if len(vars) > 0 {

--- a/providers/terraform/resources/hcl_vars_e2e_test.go
+++ b/providers/terraform/resources/hcl_vars_e2e_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	mql "go.mondoo.com/mql"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
@@ -34,7 +33,7 @@ func writeVarFixture(t *testing.T) string {
 	return dir
 }
 
-func newRuntimeForDir(t *testing.T, dir string, features []byte) *plugin.Runtime {
+func newRuntimeForDir(t *testing.T, dir string) *plugin.Runtime {
 	t.Helper()
 	asset := &inventory.Asset{
 		Connections: []*inventory.Config{
@@ -43,7 +42,6 @@ func newRuntimeForDir(t *testing.T, dir string, features []byte) *plugin.Runtime
 	}
 	conn, err := connection.NewHclConnection(1, asset)
 	require.NoError(t, err)
-	conn.SetFeatures(features)
 	return &plugin.Runtime{
 		Connection: conn,
 		Resources:  &syncx.Map[plugin.Resource]{},
@@ -52,12 +50,12 @@ func newRuntimeForDir(t *testing.T, dir string, features []byte) *plugin.Runtime
 
 // TestTerraformResources_VarResolution exercises the full reported scenario end
 // to end: terraform.resources must return the resource block (the fix for the
-// intermittently-empty list, mondoohq/mql#8966), and with the
-// TerraformResolveVars feature active arguments() must resolve var.ingress_cidr
-// to the .tfvars override 0.0.0.0/0 — so the security check is non-vacuous.
+// intermittently-empty list, mondoohq/mql#8966), and arguments() must resolve
+// var.ingress_cidr to the .tfvars override 0.0.0.0/0 — so the security check is
+// non-vacuous.
 func TestTerraformResources_VarResolution(t *testing.T) {
 	dir := writeVarFixture(t)
-	rt := newRuntimeForDir(t, dir, []byte{byte(mql.TerraformResolveVars)})
+	rt := newRuntimeForDir(t, dir)
 
 	// terraform.resources init -> the list must contain the resource block.
 	args, _, err := initTerraformResources(rt, map[string]*llx.RawData{})
@@ -77,12 +75,13 @@ func TestTerraformResources_VarResolution(t *testing.T) {
 		"var.ingress_cidr must resolve to the .tfvars override")
 }
 
-// TestTerraformResources_VarResolutionDisabled documents the opt-out: with the
-// feature inactive, arguments() surfaces the raw reference string instead of the
-// resolved value, but the resources list is still populated.
-func TestTerraformResources_VarResolutionDisabled(t *testing.T) {
+// TestTerraformResources_ArgumentReferences documents the unresolved view:
+// argumentReferences() surfaces the raw reference string even though
+// arguments() resolves it, so a policy can still tell that a value is
+// parameterized.
+func TestTerraformResources_ArgumentReferences(t *testing.T) {
 	dir := writeVarFixture(t)
-	rt := newRuntimeForDir(t, dir, nil)
+	rt := newRuntimeForDir(t, dir)
 
 	args, _, err := initTerraformResources(rt, map[string]*llx.RawData{})
 	require.NoError(t, err)
@@ -90,8 +89,8 @@ func TestTerraformResources_VarResolutionDisabled(t *testing.T) {
 	require.Len(t, list, 1, "terraform.resources must not be empty")
 
 	block := list[0].(*mqlTerraformBlock)
-	arguments, err := block.arguments()
+	refs, err := block.argumentReferences()
 	require.NoError(t, err)
-	require.Equal(t, []any{"var.ingress_cidr"}, arguments["cidr_blocks"],
-		"with the feature off, the reference string is surfaced verbatim")
+	require.Equal(t, []any{"var.ingress_cidr"}, refs["cidr_blocks"],
+		"argumentReferences must surface the reference string verbatim")
 }

--- a/providers/terraform/resources/terraform.lr
+++ b/providers/terraform/resources/terraform.lr
@@ -104,9 +104,10 @@ private terraform.context @defaults("path range content") {
 // field carries the block kind and `labels` holds its identifying
 // labels; for resource and data blocks, `resourceType` and
 // `resourceName` expose the two labels separately. Argument values
-// are available raw, with variable and local references left intact,
-// or folded into the plan/state shape, so one audit can run across
-// HCL, plan, and state assets.
+// are available resolved, with variable and local references replaced
+// by their effective values, unresolved via `argumentReferences`, or
+// folded into the plan/state shape, so one audit can run across HCL,
+// plan, and state assets.
 private terraform.block @defaults("type labels") @context("terraform.context") {
   // Block type
   type string
@@ -123,8 +124,15 @@ private terraform.block @defaults("type labels") @context("terraform.context") {
   // Block end position
   end terraform.fileposition
   // Block arguments
+  //
+  // Argument values with `var.*` and `local.*` references resolved to
+  // their effective values (variable defaults overridden by .tfvars,
+  // locals evaluated from those). References that cannot be resolved
+  // statically, such as data sources and resource attributes, fall back
+  // to their reference string. For the unresolved view, use
+  // `argumentReferences`.
   arguments() dict
-  // Block arguments with variable and local references left unresolved (e.g. "var.bucket_acl"), regardless of the TerraformResolveVars feature flag
+  // Block arguments with variable and local references left unresolved (e.g. "var.bucket_acl")
   argumentReferences() dict
   // Arguments with child blocks folded in as lists-of-maps, mirroring the plan (change.after) and state (values) shape
   values() dict


### PR DESCRIPTION
This was introduced in v13 as a feature and is now the default for v14, i.e. we resolve terraform variables. This is far closer to how users interact with the system and what they want from these policies, thus becoming the new default.