### PR TITLE
⚡ deduplicate concurrent resource resolution in the provider SDK

### DIFF
--- a/providers-sdk/v1/mqlr/lrcore/go.go
+++ b/providers-sdk/v1/mqlr/lrcore/go.go
@@ -184,38 +184,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -227,19 +196,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 `
 }

--- a/providers-sdk/v1/plugin/resource_factory.go
+++ b/providers-sdk/v1/plugin/resource_factory.go
@@ -1,0 +1,165 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package plugin
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.mondoo.com/mql/llx"
+)
+
+// ResolveResource turns a set of user-provided arguments into a resource,
+// running the factory's init function when it has one. It is the shared body of
+// the generated NewResource in every provider.
+//
+// Two concurrent calls that ask for the same resource with the same arguments
+// run the init function once and share its result. Without that, both callers
+// enter init, both spend the API call, and the loser's freshly built resource is
+// thrown away on the way out -- the cache cannot prevent it, because the cache
+// key is the resolved resource's MqlID, which is not knowable until init has
+// already done the work. The argument set is knowable up front, and two calls
+// with identical arguments must by definition produce the same resource, so it
+// is a sound key to collapse on.
+//
+// Failures are shared with everyone waiting on that flight but are never
+// cached: the flight is forgotten as soon as it completes, so the next caller
+// tries again.
+func ResolveResource(runtime *Runtime, name string, args map[string]*llx.RawData, f ResourceFactory) (Resource, error) {
+	if f.Init == nil {
+		return InstantiateResource(runtime, name, args, f)
+	}
+
+	key, ok := initFlightKey(name, args)
+	if !ok {
+		// The arguments do not reduce to a key we can compare safely, so we
+		// resolve without deduplicating. Missing a chance to share work is
+		// harmless; merging two different resources would not be.
+		return initResource(runtime, name, args, f)
+	}
+
+	v, err, _ := runtime.flights().Do(key, func() (any, error) {
+		return initResource(runtime, name, args, f)
+	})
+	// Comma-ok rather than a bare assertion: on the error path the factory may
+	// hand back a nil resource, which arrives here as an untyped nil.
+	res, _ := v.(Resource)
+	return res, err
+}
+
+// InstantiateResource creates a resource from arguments that are already
+// complete, skipping the factory's init function. It is the shared body of the
+// generated CreateResource in every provider, used for resources built from
+// lists and from recordings.
+func InstantiateResource(runtime *Runtime, name string, args map[string]*llx.RawData, f ResourceFactory) (Resource, error) {
+	res, err := f.Create(runtime, args)
+	if err != nil {
+		return nil, err
+	}
+	return cacheResource(runtime, name, res), nil
+}
+
+func initResource(runtime *Runtime, name string, args map[string]*llx.RawData, f ResourceFactory) (Resource, error) {
+	cargs, res, err := f.Init(runtime, args)
+	if err != nil {
+		// The resource is returned alongside the error on purpose: some inits
+		// report a partially resolved resource with a failure attached.
+		return res, err
+	}
+
+	if res != nil {
+		return cacheResource(runtime, name, res), nil
+	}
+
+	return InstantiateResource(runtime, name, cargs, f)
+}
+
+// cacheResource registers the resource under its id and returns whichever
+// instance is canonical for that id. When another caller got there first, its
+// instance wins and ours is dropped, so every reference in the graph points at
+// one object and the fields memoized on it are visible to everyone.
+func cacheResource(runtime *Runtime, name string, res Resource) Resource {
+	id := name + "\x00" + res.MqlID()
+	canonical, _ := runtime.Resources.GetOrSet(id, res)
+	return canonical
+}
+
+// initFlightKey builds a comparison key for a resource name and its init
+// arguments, reporting false when the arguments cannot be reduced to one.
+//
+// The key is only ever used to decide that two calls are asking for the same
+// thing, so the two failure modes are not symmetric: refusing a key we could
+// have built merely costs us a deduplication, while accepting a key that two
+// different argument sets share would hand back the wrong resource. Every part
+// is therefore length-prefixed, so no value can forge a separator, and any
+// argument that is not a plain scalar refuses outright rather than guessing at
+// a serialization.
+func initFlightKey(name string, args map[string]*llx.RawData) (string, bool) {
+	var b strings.Builder
+	writeChunk(&b, name)
+
+	if len(args) == 0 {
+		return b.String(), true
+	}
+
+	keys := make([]string, 0, len(args))
+	for k := range args {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		arg := args[k]
+		if arg == nil || arg.Error != nil {
+			return "", false
+		}
+		scalar, ok := scalarKey(arg.Value)
+		if !ok {
+			return "", false
+		}
+		writeChunk(&b, k)
+		// The type travels with the value so that the string "1" and the
+		// integer 1 cannot collapse onto one key.
+		writeChunk(&b, string(arg.Type))
+		writeChunk(&b, scalar)
+	}
+
+	return b.String(), true
+}
+
+func writeChunk(b *strings.Builder, s string) {
+	b.WriteString(strconv.Itoa(len(s)))
+	b.WriteByte(':')
+	b.WriteString(s)
+}
+
+// scalarKey renders the values that llx uses for scalar types. Anything else --
+// resources, arrays, maps, dicts -- returns false, because comparing them means
+// a deep walk whose cost and correctness are not worth the deduplication.
+func scalarKey(v any) (string, bool) {
+	switch x := v.(type) {
+	case nil:
+		return "", true
+	case string:
+		return x, true
+	case bool:
+		if x {
+			return "true", true
+		}
+		return "false", true
+	case int64:
+		return strconv.FormatInt(x, 10), true
+	case float64:
+		return strconv.FormatFloat(x, 'g', -1, 64), true
+	case *time.Time:
+		if x == nil {
+			return "", true
+		}
+		return strconv.FormatInt(x.UnixNano(), 10), true
+	default:
+		return "", false
+	}
+}

--- a/providers-sdk/v1/plugin/resource_factory_test.go
+++ b/providers-sdk/v1/plugin/resource_factory_test.go
@@ -1,0 +1,549 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package plugin
+
+import (
+	"errors"
+	goruntime "runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/types"
+	"go.mondoo.com/mql/utils/syncx"
+)
+
+type fakeResource struct {
+	id string
+}
+
+func (f *fakeResource) MqlID() string   { return f.id }
+func (f *fakeResource) MqlName() string { return "fake" }
+
+func testRuntime() *Runtime {
+	return &Runtime{Resources: &syncx.Map[Resource]{}}
+}
+
+// countingFactory builds a factory whose init resolves every argument set to the
+// same resource id, and records how many times init actually ran.
+func countingFactory(id string, calls *atomic.Int64, hook func()) ResourceFactory {
+	return ResourceFactory{
+		Init: func(runtime *Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, Resource, error) {
+			calls.Add(1)
+			if hook != nil {
+				hook()
+			}
+			return args, &fakeResource{id: id}, nil
+		},
+		Create: func(runtime *Runtime, args map[string]*llx.RawData) (Resource, error) {
+			return &fakeResource{id: id}, nil
+		},
+	}
+}
+
+// TestResolveResourceRunsInitOnceForConcurrentCallers is the core of the
+// change: the second caller must wait on the first flight rather than spend a
+// second API call whose result is then discarded.
+//
+// It is written as a two-goroutine handoff rather than a stress loop so that the
+// call count is a deterministic assertion: the first init is held open until we
+// have confirmed the second caller is parked, so a second init can only appear
+// if the deduplication is genuinely absent.
+func TestResolveResourceRunsInitOnceForConcurrentCallers(t *testing.T) {
+	runtime := testRuntime()
+
+	var calls atomic.Int64
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+
+	factory := countingFactory("vol-1", &calls, func() {
+		once.Do(func() { close(started) })
+		<-release
+	})
+
+	args := func() map[string]*llx.RawData {
+		return map[string]*llx.RawData{"id": llx.StringData("vol-1")}
+	}
+
+	type result struct {
+		res Resource
+		err error
+	}
+	firstDone := make(chan result, 1)
+	go func() {
+		res, err := ResolveResource(runtime, "fake", args(), factory)
+		firstDone <- result{res, err}
+	}()
+
+	// The first caller is now inside init and owns the flight.
+	<-started
+
+	secondDone := make(chan result, 1)
+	go func() {
+		res, err := ResolveResource(runtime, "fake", args(), factory)
+		secondDone <- result{res, err}
+	}()
+
+	select {
+	case <-secondDone:
+		t.Fatal("the second caller resolved while the first was still in init; it ran its own init instead of joining the flight")
+	case <-time.After(500 * time.Millisecond):
+		// Expected: parked behind the first caller.
+	}
+
+	close(release)
+	first := <-firstDone
+	second := <-secondDone
+
+	require.NoError(t, first.err)
+	require.NoError(t, second.err)
+	assert.Equal(t, int64(1), calls.Load(), "init must run exactly once for two identical concurrent calls")
+	assert.Same(t, first.res, second.res, "both callers must receive the same resource instance")
+}
+
+// TestResolveResourceDoesNotMergeDifferentArguments guards the other direction:
+// deduplication must never hand one caller another caller's resource.
+func TestResolveResourceDoesNotMergeDifferentArguments(t *testing.T) {
+	runtime := testRuntime()
+
+	var calls atomic.Int64
+	factory := ResourceFactory{
+		Init: func(runtime *Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, Resource, error) {
+			calls.Add(1)
+			return args, &fakeResource{id: args["id"].Value.(string)}, nil
+		},
+		Create: func(runtime *Runtime, args map[string]*llx.RawData) (Resource, error) {
+			return nil, errors.New("unexpected create")
+		},
+	}
+
+	a, err := ResolveResource(runtime, "fake", map[string]*llx.RawData{"id": llx.StringData("vol-1")}, factory)
+	require.NoError(t, err)
+	b, err := ResolveResource(runtime, "fake", map[string]*llx.RawData{"id": llx.StringData("vol-2")}, factory)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2), calls.Load())
+	assert.Equal(t, "vol-1", a.MqlID())
+	assert.Equal(t, "vol-2", b.MqlID())
+}
+
+// TestResolveResourceSharesFailuresButDoesNotCacheThem pins the error policy:
+// everyone waiting on a flight sees the failure, and the next caller gets a
+// fresh attempt rather than a memoized error.
+func TestResolveResourceSharesFailuresButDoesNotCacheThem(t *testing.T) {
+	runtime := testRuntime()
+
+	var calls atomic.Int64
+	boom := errors.New("api is down")
+	factory := ResourceFactory{
+		Init: func(runtime *Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, Resource, error) {
+			if calls.Add(1) == 1 {
+				return nil, nil, boom
+			}
+			return args, &fakeResource{id: "vol-1"}, nil
+		},
+		Create: func(runtime *Runtime, args map[string]*llx.RawData) (Resource, error) {
+			return nil, errors.New("unexpected create")
+		},
+	}
+
+	args := map[string]*llx.RawData{"id": llx.StringData("vol-1")}
+
+	res, err := ResolveResource(runtime, "fake", args, factory)
+	require.ErrorIs(t, err, boom)
+	assert.Nil(t, res)
+
+	// The flight is forgotten when it completes, so the retry runs init again.
+	res, err = ResolveResource(runtime, "fake", args, factory)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, "vol-1", res.MqlID())
+	assert.Equal(t, int64(2), calls.Load())
+}
+
+// TestResolveResourceKeepsThePartialResourceOnError preserves a behavior the
+// generated code had: some inits report a resource alongside a failure.
+func TestResolveResourceKeepsThePartialResourceOnError(t *testing.T) {
+	runtime := testRuntime()
+
+	boom := errors.New("partial")
+	partial := &fakeResource{id: "vol-1"}
+	factory := ResourceFactory{
+		Init: func(runtime *Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, Resource, error) {
+			return nil, partial, boom
+		},
+	}
+
+	res, err := ResolveResource(runtime, "fake", map[string]*llx.RawData{"id": llx.StringData("vol-1")}, factory)
+	require.ErrorIs(t, err, boom)
+	assert.Same(t, partial, res)
+}
+
+// TestResolveResourceFallsThroughToCreate covers the init path that returns no
+// resource, only rewritten arguments.
+func TestResolveResourceFallsThroughToCreate(t *testing.T) {
+	runtime := testRuntime()
+
+	factory := ResourceFactory{
+		Init: func(runtime *Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, Resource, error) {
+			args["id"] = llx.StringData("rewritten")
+			return args, nil, nil
+		},
+		Create: func(runtime *Runtime, args map[string]*llx.RawData) (Resource, error) {
+			return &fakeResource{id: args["id"].Value.(string)}, nil
+		},
+	}
+
+	res, err := ResolveResource(runtime, "fake", map[string]*llx.RawData{"id": llx.StringData("original")}, factory)
+	require.NoError(t, err)
+	assert.Equal(t, "rewritten", res.MqlID())
+}
+
+// TestResolveResourceWithoutInitSkipsTheFlight makes sure resources that have no
+// init still resolve, and are not routed through the deduplication path.
+func TestResolveResourceWithoutInitSkipsTheFlight(t *testing.T) {
+	runtime := testRuntime()
+
+	var calls atomic.Int64
+	factory := ResourceFactory{
+		Create: func(runtime *Runtime, args map[string]*llx.RawData) (Resource, error) {
+			calls.Add(1)
+			return &fakeResource{id: "vol-1"}, nil
+		},
+	}
+
+	a, err := ResolveResource(runtime, "fake", nil, factory)
+	require.NoError(t, err)
+	b, err := ResolveResource(runtime, "fake", nil, factory)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2), calls.Load())
+	assert.Same(t, a, b, "the cache must still collapse both onto one instance")
+}
+
+// TestResolveResourceWithUnkeyableArgumentsStillResolves is the safety valve: an
+// argument set we cannot compare must fall back to resolving without
+// deduplication rather than fail or guess at a key.
+func TestResolveResourceWithUnkeyableArgumentsStillResolves(t *testing.T) {
+	runtime := testRuntime()
+
+	var calls atomic.Int64
+	factory := countingFactory("vol-1", &calls, nil)
+	args := map[string]*llx.RawData{
+		"filters": llx.ArrayData([]any{"a", "b"}, types.String),
+	}
+
+	a, err := ResolveResource(runtime, "fake", args, factory)
+	require.NoError(t, err)
+	b, err := ResolveResource(runtime, "fake", args, factory)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2), calls.Load(), "unkeyable arguments must not be deduplicated")
+	assert.Same(t, a, b, "the cache must still collapse both onto one instance")
+}
+
+// TestResolveResourceNestedResolutionDoesNotDeadlock covers the pattern every
+// typed accessor uses: an init that resolves another resource while it runs.
+// Distinct flights must never block each other.
+func TestResolveResourceNestedResolutionDoesNotDeadlock(t *testing.T) {
+	runtime := testRuntime()
+
+	inner := ResourceFactory{
+		Init: func(runtime *Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, Resource, error) {
+			return args, &fakeResource{id: "vpc-1"}, nil
+		},
+	}
+	outer := ResourceFactory{
+		Init: func(runtime *Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, Resource, error) {
+			_, err := ResolveResource(runtime, "fake.vpc", map[string]*llx.RawData{"id": llx.StringData("vpc-1")}, inner)
+			if err != nil {
+				return nil, nil, err
+			}
+			return args, &fakeResource{id: "vol-1"}, nil
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, err := ResolveResource(runtime, "fake", map[string]*llx.RawData{"id": llx.StringData("vol-1")}, outer)
+		assert.NoError(t, err)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a nested resolution of a different resource deadlocked")
+	}
+}
+
+// TestInstantiateResourceConvergesOnOneInstance is the regression test for the
+// check-then-act race the generated code used to carry. A Get followed by a Set
+// lets two callers that both miss the Get hand out two different objects for one
+// id, which makes every field memoized on the loser invisible to the rest of the
+// graph. All callers must end up with the same pointer.
+func TestInstantiateResourceConvergesOnOneInstance(t *testing.T) {
+	// Sized to the cores actually available so that every caller can be running
+	// at the same instant, and repeated because the window a check-then-act pair
+	// leaves open is a handful of instructions wide. A single round of this
+	// missed the regression roughly nine times out of ten.
+	callers := goruntime.GOMAXPROCS(0)
+	if callers < 4 {
+		callers = 4
+	}
+	const rounds = 100
+
+	for round := 0; round < rounds; round++ {
+		runtime := testRuntime()
+
+		// Each caller announces itself and then spins until all of them have,
+		// so they leave Create together rather than being woken one at a time.
+		var arrived atomic.Int64
+		factory := ResourceFactory{
+			Create: func(runtime *Runtime, args map[string]*llx.RawData) (Resource, error) {
+				arrived.Add(1)
+				for arrived.Load() < int64(callers) {
+					goruntime.Gosched()
+				}
+				// A fresh instance every time, exactly like a real Create.
+				return &fakeResource{id: "vol-1"}, nil
+			},
+		}
+
+		results := make([]Resource, callers)
+		var wg sync.WaitGroup
+		for i := 0; i < callers; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				res, err := InstantiateResource(runtime, "fake", nil, factory)
+				assert.NoError(t, err)
+				results[i] = res
+			}(i)
+		}
+		wg.Wait()
+
+		for i := 1; i < callers; i++ {
+			if results[0] != results[i] {
+				t.Fatalf("round %d: caller %d received a different instance for the same id; "+
+					"two objects for one cache key means fields memoized on one are invisible to the other", round, i)
+			}
+		}
+	}
+}
+
+func TestInitFlightKey(t *testing.T) {
+	t.Run("no arguments still yields a key", func(t *testing.T) {
+		key, ok := initFlightKey("aws.vpc", nil)
+		require.True(t, ok)
+		assert.NotEmpty(t, key)
+	})
+
+	t.Run("argument order does not matter", func(t *testing.T) {
+		a, ok := initFlightKey("aws.vpc", map[string]*llx.RawData{
+			"id":     llx.StringData("vpc-1"),
+			"region": llx.StringData("us-east-1"),
+		})
+		require.True(t, ok)
+		b, ok := initFlightKey("aws.vpc", map[string]*llx.RawData{
+			"region": llx.StringData("us-east-1"),
+			"id":     llx.StringData("vpc-1"),
+		})
+		require.True(t, ok)
+		assert.Equal(t, a, b)
+	})
+
+	t.Run("distinguishes values that would concatenate alike", func(t *testing.T) {
+		// Without length prefixes both of these serialize to "abc".
+		a, ok := initFlightKey("fake", map[string]*llx.RawData{"ab": llx.StringData("c")})
+		require.True(t, ok)
+		b, ok := initFlightKey("fake", map[string]*llx.RawData{"a": llx.StringData("bc")})
+		require.True(t, ok)
+		assert.NotEqual(t, a, b)
+	})
+
+	t.Run("a value cannot forge a separator", func(t *testing.T) {
+		a, ok := initFlightKey("fake", map[string]*llx.RawData{"a": llx.StringData("x\x00b\x00y")})
+		require.True(t, ok)
+		b, ok := initFlightKey("fake", map[string]*llx.RawData{
+			"a": llx.StringData("x"),
+			"b": llx.StringData("y"),
+		})
+		require.True(t, ok)
+		assert.NotEqual(t, a, b)
+	})
+
+	t.Run("the type is part of the key", func(t *testing.T) {
+		a, ok := initFlightKey("fake", map[string]*llx.RawData{"v": llx.StringData("1")})
+		require.True(t, ok)
+		b, ok := initFlightKey("fake", map[string]*llx.RawData{"v": llx.IntData(1)})
+		require.True(t, ok)
+		assert.NotEqual(t, a, b)
+	})
+
+	t.Run("the resource name is part of the key", func(t *testing.T) {
+		a, ok := initFlightKey("aws.vpc", map[string]*llx.RawData{"id": llx.StringData("x")})
+		require.True(t, ok)
+		b, ok := initFlightKey("aws.subnet", map[string]*llx.RawData{"id": llx.StringData("x")})
+		require.True(t, ok)
+		assert.NotEqual(t, a, b)
+	})
+
+	t.Run("null and empty string are distinct", func(t *testing.T) {
+		a, ok := initFlightKey("fake", map[string]*llx.RawData{"id": llx.StringData("")})
+		require.True(t, ok)
+		b, ok := initFlightKey("fake", map[string]*llx.RawData{"id": llx.NilData})
+		require.True(t, ok)
+		assert.NotEqual(t, a, b)
+	})
+
+	t.Run("scalars are keyable", func(t *testing.T) {
+		now := time.Now()
+		for name, arg := range map[string]*llx.RawData{
+			"string": llx.StringData("x"),
+			"int":    llx.IntData(7),
+			"float":  llx.FloatData(1.5),
+			"bool":   llx.BoolData(true),
+			"time":   llx.TimeData(now),
+			"nil":    llx.NilData,
+		} {
+			_, ok := initFlightKey("fake", map[string]*llx.RawData{"v": arg})
+			assert.Truef(t, ok, "%s should be keyable", name)
+		}
+	})
+
+	t.Run("non-scalars refuse rather than guess", func(t *testing.T) {
+		for name, arg := range map[string]*llx.RawData{
+			"array":    llx.ArrayData([]any{"a"}, types.String),
+			"map":      llx.MapData(map[string]any{"a": "b"}, types.String),
+			"resource": llx.ResourceData(&fakeResource{id: "x"}, "fake"),
+		} {
+			_, ok := initFlightKey("fake", map[string]*llx.RawData{"v": arg})
+			assert.Falsef(t, ok, "%s should not be keyable", name)
+		}
+	})
+
+	t.Run("an argument carrying an error refuses", func(t *testing.T) {
+		_, ok := initFlightKey("fake", map[string]*llx.RawData{
+			"v": {Type: types.String, Error: errors.New("broken")},
+		})
+		assert.False(t, ok)
+	})
+
+	t.Run("a nil argument refuses", func(t *testing.T) {
+		_, ok := initFlightKey("fake", map[string]*llx.RawData{"v": nil})
+		assert.False(t, ok)
+	})
+}
+
+// TestInheritedRuntimesShareOneFlight covers the child-connection case. A child
+// runtime that inherits its parent's resource cache must resolve through the
+// same flights, because the two scopes have to agree: sibling assets scanned in
+// parallel share one cache, so without shared flights they each run the same
+// init and then race to publish into it.
+func TestInheritedRuntimesShareOneFlight(t *testing.T) {
+	parent := testRuntime()
+	child := testRuntime()
+	child.InheritResourceCacheFrom(parent)
+
+	var calls atomic.Int64
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	factory := countingFactory("vpc-1", &calls, func() {
+		once.Do(func() { close(started) })
+		<-release
+	})
+
+	args := func() map[string]*llx.RawData {
+		return map[string]*llx.RawData{"id": llx.StringData("vpc-1")}
+	}
+
+	type result struct {
+		res Resource
+		err error
+	}
+	parentDone := make(chan result, 1)
+	go func() {
+		res, err := ResolveResource(parent, "fake", args(), factory)
+		parentDone <- result{res, err}
+	}()
+	<-started
+
+	childDone := make(chan result, 1)
+	go func() {
+		res, err := ResolveResource(child, "fake", args(), factory)
+		childDone <- result{res, err}
+	}()
+
+	select {
+	case <-childDone:
+		t.Fatal("the child resolved while the parent was still in init; the two are not sharing flights")
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	close(release)
+	p := <-parentDone
+	c := <-childDone
+
+	require.NoError(t, p.err)
+	require.NoError(t, c.err)
+	assert.Equal(t, int64(1), calls.Load(), "a parent and its child must run init once between them")
+	assert.Same(t, p.res, c.res)
+}
+
+// TestUnrelatedRuntimesDoNotShareFlights is the other half: two connections that
+// do not share a resource cache must not deduplicate against each other. They
+// may be pointed at different accounts, where the same arguments mean different
+// resources.
+func TestUnrelatedRuntimesDoNotShareFlights(t *testing.T) {
+	a := testRuntime()
+	b := testRuntime()
+
+	var calls atomic.Int64
+	started := make(chan struct{})
+	release := make(chan struct{})
+	// Only the first init parks. A second one must be free to finish, which is
+	// exactly what we are asserting can happen.
+	var first atomic.Bool
+	factory := countingFactory("vpc-1", &calls, func() {
+		if first.CompareAndSwap(false, true) {
+			close(started)
+			<-release
+		}
+	})
+
+	args := func() map[string]*llx.RawData {
+		return map[string]*llx.RawData{"id": llx.StringData("vpc-1")}
+	}
+
+	aDone := make(chan struct{})
+	go func() {
+		defer close(aDone)
+		_, _ = ResolveResource(a, "fake", args(), factory)
+	}()
+	<-started
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, err := ResolveResource(b, "fake", args(), factory)
+		assert.NoError(t, err)
+	}()
+
+	select {
+	case <-done:
+		// Expected: b runs its own init rather than waiting on a's.
+	case <-time.After(2 * time.Second):
+		t.Fatal("an unrelated runtime waited on another connection's flight")
+	}
+	close(release)
+	<-aDone
+	assert.Equal(t, int64(2), calls.Load())
+}

--- a/providers-sdk/v1/plugin/resources.go
+++ b/providers-sdk/v1/plugin/resources.go
@@ -5,4 +5,8 @@ package plugin
 type Resources[T any] interface {
 	Get(key string) (T, bool)
 	Set(key string, value T)
+	// GetOrSet stores the value only if the key is still free and returns
+	// whichever value is canonical for that key, so that concurrent callers
+	// converge on one instance instead of racing a Get/Set pair.
+	GetOrSet(key string, value T) (T, bool)
 }

--- a/providers-sdk/v1/plugin/runtime.go
+++ b/providers-sdk/v1/plugin/runtime.go
@@ -10,6 +10,7 @@ import (
 	"go.mondoo.com/mql/providers-sdk/v1/upstream"
 	"go.mondoo.com/mql/types"
 	"go.mondoo.com/mql/utils/syncx"
+	"golang.org/x/sync/singleflight"
 )
 
 type Runtime struct {
@@ -22,6 +23,37 @@ type Runtime struct {
 	GetData        GetData
 	SetData        SetData
 	Upstream       *upstream.UpstreamClient
+
+	// initFlights collapses concurrent resolutions of the same resource into a
+	// single run of its init function. See ResolveResource. Its zero value is
+	// ready to use, so runtimes built as struct literals get it for free.
+	initFlights singleflight.Group
+
+	// sharedFlights points at the group of the runtime this one inherited its
+	// resource cache from, so that a family of connections deduplicates against
+	// each other exactly as far as it shares results. Nil means this runtime
+	// owns its flights; see flights.
+	sharedFlights *singleflight.Group
+}
+
+// flights returns the group this runtime resolves through. A child connection
+// that inherited a parent's Resources must also inherit its flights: the two
+// have to agree on scope, or sibling assets scanned in parallel would each run
+// the same init and then race to publish into the one cache they share.
+func (r *Runtime) flights() *singleflight.Group {
+	if r.sharedFlights != nil {
+		return r.sharedFlights
+	}
+	return &r.initFlights
+}
+
+// InheritResourceCacheFrom points this runtime at another runtime's resource
+// cache, and at the flights that keep that cache consistent. Used when a child
+// connection is opened under a parent that has already resolved resources the
+// child would otherwise fetch again.
+func (r *Runtime) InheritResourceCacheFrom(parent *Runtime) {
+	r.Resources = parent.Resources
+	r.sharedFlights = parent.flights()
 }
 
 func NewRuntime(

--- a/providers-sdk/v1/plugin/service.go
+++ b/providers-sdk/v1/plugin/service.go
@@ -120,7 +120,7 @@ func (s *Service) AddRuntime(conf *inventory.Config, createRuntime func(connId u
 				log.Warn().Uint32("parent", parentId).Uint32("child", conf.Id).
 					Msg("parent connection not found, proceeding without shared resource cache")
 			} else {
-				runtime.Resources = parentRuntime.Resources
+				runtime.InheritResourceCacheFrom(parentRuntime)
 			}
 		}
 	}
@@ -157,7 +157,7 @@ func (s *Service) deprecatedAddRuntime(createRuntime func(connId uint32) (*Runti
 				log.Warn().Uint32("parent", parentId).Uint32("child", s.lastConnectionID).
 					Msg("parent connection not found, proceeding without shared resource cache")
 			} else {
-				runtime.Resources = parentRuntime.Resources
+				runtime.InheritResourceCacheFrom(parentRuntime)
 			}
 		}
 	}

--- a/providers-sdk/v1/testutils/mockprovider/resources/mockprovider.lr.go
+++ b/providers-sdk/v1/testutils/mockprovider/resources/mockprovider.lr.go
@@ -63,38 +63,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -106,19 +75,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/activedirectory/resources/activedirectory.lr.go
+++ b/providers/activedirectory/resources/activedirectory.lr.go
@@ -119,38 +119,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -162,19 +131,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/alicloud/resources/alicloud.lr.go
+++ b/providers/alicloud/resources/alicloud.lr.go
@@ -849,38 +849,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -892,19 +861,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/ansible/resources/ansible.lr.go
+++ b/providers/ansible/resources/ansible.lr.go
@@ -143,38 +143,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -186,19 +155,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/arista/resources/arista.lr.go
+++ b/providers/arista/resources/arista.lr.go
@@ -368,38 +368,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -411,19 +380,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/artifactory/resources/artifactory.lr.go
+++ b/providers/artifactory/resources/artifactory.lr.go
@@ -174,38 +174,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -217,19 +186,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/atlassian/resources/atlassian.lr.go
+++ b/providers/atlassian/resources/atlassian.lr.go
@@ -209,38 +209,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -252,19 +221,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/auth0/resources/auth0.lr.go
+++ b/providers/auth0/resources/auth0.lr.go
@@ -99,38 +99,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -142,19 +111,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -5179,38 +5179,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -5222,19 +5191,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -2924,38 +2924,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -2967,19 +2936,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/bicep/resources/bicep.lr.go
+++ b/providers/bicep/resources/bicep.lr.go
@@ -133,38 +133,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -176,19 +145,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/bicep/resources/resolver_test.go
+++ b/providers/bicep/resources/resolver_test.go
@@ -28,6 +28,14 @@ func (r *mapResources) Set(key string, value plugin.Resource) {
 	r.m[key] = value
 }
 
+func (r *mapResources) GetOrSet(key string, value plugin.Resource) (plugin.Resource, bool) {
+	if existing, ok := r.m[key]; ok {
+		return existing, true
+	}
+	r.m[key] = value
+	return value, false
+}
+
 func testRuntime() *plugin.Runtime {
 	return &plugin.Runtime{Resources: &mapResources{m: map[string]plugin.Resource{}}}
 }

--- a/providers/bitwarden/resources/bitwarden.lr.go
+++ b/providers/bitwarden/resources/bitwarden.lr.go
@@ -68,38 +68,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -111,19 +80,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/cassandra/resources/cassandra.lr.go
+++ b/providers/cassandra/resources/cassandra.lr.go
@@ -68,38 +68,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -111,19 +80,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/claude/resources/claude.lr.go
+++ b/providers/claude/resources/claude.lr.go
@@ -179,38 +179,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -222,19 +191,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/clickhousecloud/resources/clickhousecloud.lr.go
+++ b/providers/clickhousecloud/resources/clickhousecloud.lr.go
@@ -69,38 +69,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -112,19 +81,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/clickhousedb/resources/clickhousedb.lr.go
+++ b/providers/clickhousedb/resources/clickhousedb.lr.go
@@ -73,38 +73,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -116,19 +85,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/cloudflare/resources/cloudflare.lr.go
+++ b/providers/cloudflare/resources/cloudflare.lr.go
@@ -469,38 +469,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -512,19 +481,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/cloudformation/resources/cloudformation.lr.go
+++ b/providers/cloudformation/resources/cloudformation.lr.go
@@ -58,38 +58,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -101,19 +70,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/core/resources/core.lr.go
+++ b/providers/core/resources/core.lr.go
@@ -104,38 +104,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -147,19 +116,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/databricks/resources/databricks.lr.go
+++ b/providers/databricks/resources/databricks.lr.go
@@ -319,38 +319,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -362,19 +331,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/datadog/resources/datadog.lr.go
+++ b/providers/datadog/resources/datadog.lr.go
@@ -254,38 +254,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -297,19 +266,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/depsdev/resources/depsdev.lr.go
+++ b/providers/depsdev/resources/depsdev.lr.go
@@ -69,38 +69,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -112,19 +81,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -484,38 +484,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -527,19 +496,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/dropbox/resources/dropbox.lr.go
+++ b/providers/dropbox/resources/dropbox.lr.go
@@ -64,38 +64,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -107,19 +76,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/elasticsearch/resources/elasticsearch.lr.go
+++ b/providers/elasticsearch/resources/elasticsearch.lr.go
@@ -74,38 +74,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -117,19 +86,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -2684,38 +2684,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -2727,19 +2696,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/github/resources/github.lr.go
+++ b/providers/github/resources/github.lr.go
@@ -394,38 +394,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -437,19 +406,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/gitlab/resources/gitlab.lr.go
+++ b/providers/gitlab/resources/gitlab.lr.go
@@ -394,38 +394,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -437,19 +406,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/google-workspace/resources/google-workspace.lr.go
+++ b/providers/google-workspace/resources/google-workspace.lr.go
@@ -189,38 +189,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -232,19 +201,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/grafana/resources/grafana.lr.go
+++ b/providers/grafana/resources/grafana.lr.go
@@ -89,38 +89,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -132,19 +101,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/hcp/resources/hcp.lr.go
+++ b/providers/hcp/resources/hcp.lr.go
@@ -89,38 +89,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -132,19 +101,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/helm/resources/helm.lr.go
+++ b/providers/helm/resources/helm.lr.go
@@ -99,38 +99,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -142,19 +111,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/hetzner/resources/hetzner.lr.go
+++ b/providers/hetzner/resources/hetzner.lr.go
@@ -199,38 +199,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -242,19 +211,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/huggingface/resources/huggingface.lr.go
+++ b/providers/huggingface/resources/huggingface.lr.go
@@ -84,38 +84,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -127,19 +96,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/ipinfo/resources/ipinfo.lr.go
+++ b/providers/ipinfo/resources/ipinfo.lr.go
@@ -38,38 +38,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -81,19 +50,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/ipmi/resources/ipmi.lr.go
+++ b/providers/ipmi/resources/ipmi.lr.go
@@ -74,38 +74,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -117,19 +86,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/iru/resources/iru.lr.go
+++ b/providers/iru/resources/iru.lr.go
@@ -69,38 +69,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -112,19 +81,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/jamf/resources/jamf.lr.go
+++ b/providers/jamf/resources/jamf.lr.go
@@ -99,38 +99,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -142,19 +111,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/jumpcloud/resources/jumpcloud.lr.go
+++ b/providers/jumpcloud/resources/jumpcloud.lr.go
@@ -84,38 +84,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -127,19 +96,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/k8s/resources/k8s.lr.go
+++ b/providers/k8s/resources/k8s.lr.go
@@ -439,38 +439,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -482,19 +451,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/keycloak/resources/keycloak.lr.go
+++ b/providers/keycloak/resources/keycloak.lr.go
@@ -124,38 +124,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -167,19 +136,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/kustomize/resources/kustomize.lr.go
+++ b/providers/kustomize/resources/kustomize.lr.go
@@ -78,38 +78,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -121,19 +90,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/mikrotik/resources/mikrotik.lr.go
+++ b/providers/mikrotik/resources/mikrotik.lr.go
@@ -314,38 +314,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -357,19 +326,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/mistral/resources/mistral.lr.go
+++ b/providers/mistral/resources/mistral.lr.go
@@ -59,38 +59,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -102,19 +71,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/mondoo/resources/mondoo.lr.go
+++ b/providers/mondoo/resources/mondoo.lr.go
@@ -59,38 +59,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -102,19 +71,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/mongo/resources/mongo.lr.go
+++ b/providers/mongo/resources/mongo.lr.go
@@ -68,38 +68,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -111,19 +80,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/mongodbatlas/resources/mongodbatlas.lr.go
+++ b/providers/mongodbatlas/resources/mongodbatlas.lr.go
@@ -269,38 +269,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -312,19 +281,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -1024,38 +1024,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -1067,19 +1036,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/mssql/resources/mssql.lr.go
+++ b/providers/mssql/resources/mssql.lr.go
@@ -139,38 +139,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -182,19 +151,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/mysqldb/resources/mysqldb.lr.go
+++ b/providers/mysqldb/resources/mysqldb.lr.go
@@ -89,38 +89,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -132,19 +101,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/neon/resources/neon.lr.go
+++ b/providers/neon/resources/neon.lr.go
@@ -159,38 +159,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -202,19 +171,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/netlify/resources/netlify.lr.go
+++ b/providers/netlify/resources/netlify.lr.go
@@ -139,38 +139,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -182,19 +151,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/network/resources/network.lr.go
+++ b/providers/network/resources/network.lr.go
@@ -204,38 +204,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -247,19 +216,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/nextdns/resources/nextdns.lr.go
+++ b/providers/nextdns/resources/nextdns.lr.go
@@ -104,38 +104,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -147,19 +116,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/nmap/resources/nmap.lr.go
+++ b/providers/nmap/resources/nmap.lr.go
@@ -59,38 +59,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -102,19 +71,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/nutanix/resources/nutanix.lr.go
+++ b/providers/nutanix/resources/nutanix.lr.go
@@ -174,38 +174,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -217,19 +186,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -1574,38 +1574,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -1617,19 +1586,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/okta/resources/okta.lr.go
+++ b/providers/okta/resources/okta.lr.go
@@ -344,38 +344,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -387,19 +356,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/ollama/resources/ollama.lr.go
+++ b/providers/ollama/resources/ollama.lr.go
@@ -59,38 +59,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -102,19 +71,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/opcua/resources/opcua.lr.go
+++ b/providers/opcua/resources/opcua.lr.go
@@ -54,38 +54,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -97,19 +66,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/openai/resources/openai.lr.go
+++ b/providers/openai/resources/openai.lr.go
@@ -164,38 +164,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -207,19 +176,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/opensearch/resources/opensearch.lr.go
+++ b/providers/opensearch/resources/opensearch.lr.go
@@ -68,38 +68,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -111,19 +80,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/openstack/resources/openstack.lr.go
+++ b/providers/openstack/resources/openstack.lr.go
@@ -534,38 +534,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -577,19 +546,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -3114,38 +3114,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -3157,19 +3126,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/portainer/resources/portainer.lr.go
+++ b/providers/portainer/resources/portainer.lr.go
@@ -129,38 +129,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -172,19 +141,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/postgresdb/resources/postgresdb.lr.go
+++ b/providers/postgresdb/resources/postgresdb.lr.go
@@ -124,38 +124,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -167,19 +136,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/proxmox/resources/proxmox.lr.go
+++ b/providers/proxmox/resources/proxmox.lr.go
@@ -419,38 +419,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -462,19 +431,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/redfish/resources/redfish.lr.go
+++ b/providers/redfish/resources/redfish.lr.go
@@ -119,38 +119,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -162,19 +131,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/redisdb/resources/redisdb.lr.go
+++ b/providers/redisdb/resources/redisdb.lr.go
@@ -53,38 +53,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -96,19 +65,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/shodan/resources/shodan.lr.go
+++ b/providers/shodan/resources/shodan.lr.go
@@ -84,38 +84,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -127,19 +96,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/slack/resources/slack.lr.go
+++ b/providers/slack/resources/slack.lr.go
@@ -79,38 +79,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -122,19 +91,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/snowflake/resources/snowflake.lr.go
+++ b/providers/snowflake/resources/snowflake.lr.go
@@ -294,38 +294,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -337,19 +306,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/stackit/resources/stackit.lr.go
+++ b/providers/stackit/resources/stackit.lr.go
@@ -634,38 +634,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -677,19 +646,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/tailscale/resources/tailscale.lr.go
+++ b/providers/tailscale/resources/tailscale.lr.go
@@ -74,38 +74,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -117,19 +86,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/terraform/resources/terraform.lr.go
+++ b/providers/terraform/resources/terraform.lr.go
@@ -123,38 +123,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -166,19 +135,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/together/resources/together.lr.go
+++ b/providers/together/resources/together.lr.go
@@ -94,38 +94,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -137,19 +106,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/vcd/resources/vcd.lr.go
+++ b/providers/vcd/resources/vcd.lr.go
@@ -93,38 +93,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -136,19 +105,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/vercel/resources/vercel.lr.go
+++ b/providers/vercel/resources/vercel.lr.go
@@ -199,38 +199,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -242,19 +211,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/vllm/resources/vllm.lr.go
+++ b/providers/vllm/resources/vllm.lr.go
@@ -74,38 +74,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -117,19 +86,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/vsphere/resources/vsphere.lr.go
+++ b/providers/vsphere/resources/vsphere.lr.go
@@ -434,38 +434,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -477,19 +446,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/weaviate/resources/weaviate.lr.go
+++ b/providers/weaviate/resources/weaviate.lr.go
@@ -63,38 +63,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -106,19 +75,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/providers/zoom/resources/zoom.lr.go
+++ b/providers/zoom/resources/zoom.lr.go
@@ -59,38 +59,7 @@ func NewResource(runtime *plugin.Runtime, name string, args map[string]*llx.RawD
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	if f.Init != nil {
-		cargs, res, err := f.Init(runtime, args)
-		if err != nil {
-			return res, err
-		}
-
-		if res != nil {
-			mqlId := res.MqlID()
-			id := name + "\x00" + mqlId
-			if x, ok := runtime.Resources.Get(id); ok {
-				return x, nil
-			}
-			runtime.Resources.Set(id, res)
-			return res, nil
-		}
-
-		args = cargs
-	}
-
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.ResolveResource(runtime, name, args, f)
 }
 
 // CreateResource is used by the runtime of this plugin to create resources.
@@ -102,19 +71,7 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 		return nil, errors.New("cannot find resource " + name + " in this provider")
 	}
 
-	res, err := f.Create(runtime, args)
-	if err != nil {
-		return nil, err
-	}
-
-	mqlId := res.MqlID()
-	id := name + "\x00" + mqlId
-	if x, ok := runtime.Resources.Get(id); ok {
-		return x, nil
-	}
-
-	runtime.Resources.Set(id, res)
-	return res, nil
+	return plugin.InstantiateResource(runtime, name, args, f)
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{

--- a/utils/syncx/map.go
+++ b/utils/syncx/map.go
@@ -21,3 +21,17 @@ func (r *Map[T]) Get(key string) (T, bool) {
 func (r *Map[T]) Set(key string, value T) {
 	r.Store(key, value)
 }
+
+// GetOrSet returns the value already stored under the key, if there is one.
+// Otherwise it stores the given value and returns that. The second return
+// value reports whether the key was already present.
+//
+// Use this instead of a Get followed by a Set whenever the value is a shared
+// object with an identity: the Get/Set pair is a check-then-act race, so two
+// callers that both miss the Get will both Set and hand out two different
+// objects for one key. GetOrSet is atomic, so every caller converges on the
+// same instance.
+func (r *Map[T]) GetOrSet(key string, value T) (T, bool) {
+	res, loaded := r.LoadOrStore(key, value)
+	return res.(T), loaded
+}


### PR DESCRIPTION
Closes mondoohq/server#18630 (the `NewResource` half; see [Not in scope](#not-in-scope) for the rest).

## The defect

Two concurrent resolutions of the same resource both entered its `init`, both spent the API call, and the loser's freshly built resource was discarded on the way out. The cache cannot prevent this: the cache key is the *resolved* resource's `MqlID()`, which is not knowable until `init` has already done the work.

The argument set **is** knowable up front, and two calls with identical arguments must by definition produce the same resource. `ResolveResource` collapses them onto one flight.

Two related fixes came with it:

**Child connections now inherit flights along with the cache.** `service.go` gives a child runtime its parent's `Resources` map. Scoping flights per-runtime would have left sibling assets sharing a cache while duplicating the work that fills it — the two scopes have to agree.

**The generated code had a check-then-act race.** It did `Get` → miss → `Set`. Two callers that both miss the `Get` both `Set`, so **two objects escape for one cache key**, and every field memoized on the loser is invisible to the rest of the graph. `syncx.Map.GetOrSet` (atomic `LoadOrStore`) makes the cache converge.

## Measurement

A/B against a **neutered** build — the same binary with the deduplication bypassed — so the probe is proven to reach the changed code. 16 assets, `cnspec scan aws --parallelism 8`, three runs each:

| | no dedup | with dedup |
|---|---|---|
| `DescribeVpcs` (20 distinct VPCs) | 97 | **20** — exactly 1.00× |
| `DescribeVolumes` | 10 | **2** |
| targeted init calls, 3 runs | 108 / 108 / 107 | **22 / 22 / 22** |
| init executions | 399–440 of 399–440 asked | 450–501 of 670–781 asked |
| wall time (mean of 3) | 10.0s | 10.6s |
| check results | — | **identical on all 16 assets** |

~80% fewer targeted calls, and the deduplicating build does **more** traversal work (643 VPC resolutions vs 407) while making a fifth of the calls. The only difference in the JSON reports is the per-run random incognito asset MRN.

**Wall time does not move**, and the table says so deliberately. These are single-item `Describe` calls running alongside the region-fanout list calls that dominate the critical path. The win is API quota and rate-limit headroom, not latency.

**This only pays off above `--parallelism 1`.** At parallelism 1 both builds are identical — 108 calls each, max observed init concurrency 1 — because `llx` executes a single asset strictly serially. It is worth doing now because parallelism defaults to 8 for aws.

## Design notes

- **`sync.Once` was the obvious idea and is wrong twice over.** It would seal `NotReady`, which must stay retryable (`providers/os/resources/command.go:27` depends on it), and there is nowhere to put it: `TValue[T]` is assigned by value at 1,048 hand-written sites, so a lock inside it is a copylocks violation *and* a proactive assignment would replace the lock while another goroutine holds it.
- **Key canonicalisation refuses rather than guesses.** Every part is length-prefixed so no value can forge a separator, the type travels with the value so `"1"` and `1` cannot collapse, and any argument that is not a plain scalar declines a key outright. A missed deduplication is free; a collision returns the wrong resource.
- **Errors are shared within a flight and never cached.** `singleflight` forgets the key when the flight completes, so the next caller retries. Covered by a test.
- **Nested resolution.** Distinct flights never block each other, which is what every typed accessor relies on. Same-key re-entry from inside an `init` would deadlock — but that is infinite recursion today, so it is not a new broken program. Tested.

## Diff shape

+932 / −3,737 across 89 files. The generated `NewResource` / `CreateResource` bodies collapse to one SDK call each, which is where the deletions come from and why the logic is now unit-testable in `providers-sdk/v1/plugin` instead of duplicated into 82 providers.

## Tests

New `resource_factory_test.go`. Both halves are mutation-verified — removing the single-flight fails the concurrency test, reverting `GetOrSet` fails the convergence test.

The convergence test needed real work to be load-bearing: a plain stress loop caught the regression 1 run in 10, and a channel gate made it *worse* (Go wakes goroutines serially, so the first one finishes its `Get`/`Set` before the others are scheduled). A spin barrier sized to `GOMAXPROCS` over 100 rounds gets it to **10/10**, while the correct implementation passes 20 consecutive runs in 0.5s.

## Verification

- all 82 providers build
- 243 packages pass; `-race` clean on `providers-sdk/v1/plugin`
- `golangci-lint` v2: 0 issues on the changed packages
- codegen reproducible — regenerating every `.lr` produces no further diff
- one pre-existing failure in `llx` (`TestRawDataJson_Umlauts`, a UTF-8 replacement-char assertion); `llx` is untouched by this PR

## Not in scope

The issue's `GetOrCompute` half is left alone. It is unmeasured by the issue's own admission, and the pervasive provider idiom is *one compute populating several fields* — a per-field lock does not deduplicate that at all, which is why `mqlCommand` hand-rolls its own. Worth measuring before paying for it.

Same for a single-flight on the client at `providers/runtime.go:582`, which would also save the gRPC round-trip — but it would hand one `*llx.RawData` to all waiters where each gets its own today, so it wants a measurement rather than an assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)