### PR TITLE
🐛 mqlc: reach private sub-resources through the owner's accessor

### DIFF
--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -1108,6 +1108,35 @@ func (c *compiler) compileBoundIdentifierWithMqlCtx(id string, binding *variable
 	return false, types.Nil, nil
 }
 
+// prefersFieldOverResource reports whether the dotted path `owner`.`field`
+// should be compiled as a field read on owner instead of being extended into the
+// resource of the same name.
+//
+// The path extension is greedy, so a resource name always used to win over a
+// field of the same name. That is wrong for private resources: private means the
+// resource cannot stand on its own, and a bare instance skips the owner's
+// accessor. For resources whose fields are only filled by that accessor every
+// field then reads null, which combined with MQL's asymmetric null comparisons
+// turns a check into a confidently wrong verdict rather than an error. See
+// windows.deviceGuard, windows.lsa.ntlm, aws.emr.cluster.encryptionConfiguration
+// and friends.
+//
+// Only redirect when the owner really does expose the value under that name and
+// with exactly that type, so nothing that used to compile becomes unreachable.
+// Implicit fields are excluded: those are the singular accessors lr generates for
+// every `x.y` resource, they are not backed by an accessor on the owner, so
+// routing through them would break paths that work today.
+func (c *compiler) prefersFieldOverResource(owner *resources.ResourceInfo, target *resources.ResourceInfo, field string) bool {
+	if !target.GetPrivate() {
+		return false
+	}
+	_, f := c.Schema.LookupField(owner.Name, field)
+	if f == nil || f.GetIsImplicitResource() {
+		return false
+	}
+	return types.Type(f.Type) == types.Resource(target.Name)
+}
+
 // compile a resource from an identifier, trying to find the longest matching resource
 // and execute all call functions if there are any
 func (c *compiler) compileResource(id string, calls []*parser.Call) (bool, []*parser.Call, types.Type, error) {
@@ -1117,9 +1146,13 @@ func (c *compiler) compileResource(id string, calls []*parser.Call) (bool, []*pa
 	}
 
 	for len(calls) > 0 && calls[0].Ident != nil {
-		nuID := id + "." + (*calls[0].Ident)
+		field := *calls[0].Ident
+		nuID := id + "." + field
 		nuResource := c.Schema.Lookup(nuID)
 		if nuResource == nil {
+			break
+		}
+		if c.prefersFieldOverResource(resource, nuResource, field) {
 			break
 		}
 		resource, id = nuResource, nuID

--- a/mqlc/mqlc_test.go
+++ b/mqlc/mqlc_test.go
@@ -2606,3 +2606,40 @@ func allCodepoints(code *llx.CodeV2) ([]uint64, []uint64) {
 	}
 	return entrypoints, datapoints
 }
+
+func TestCompiler_PrivateResourcePathPrefersField(t *testing.T) {
+	// A dotted path whose full name is also a resource used to always compile to
+	// that resource, skipping the owner's accessor. For private resources with
+	// data-only fields that left every field null. Private resources must instead
+	// be reached through the owner's accessor, while everything else keeps
+	// resolving to the longest matching resource name.
+	data := []struct {
+		code   string
+		chunks []string
+	}{
+		// private sub-resources: routed through the owner's accessor
+		{"windows.deviceGuard.credentialGuardConfig", []string{"windows", "deviceGuard", "credentialGuardConfig"}},
+		{"windows.lsa.ntlm.useLogonCredential", []string{"windows.lsa", "ntlm", "useLogonCredential"}},
+		{"windows.smb.serverConfiguration.requireSecuritySignature", []string{"windows.smb", "serverConfiguration", "requireSecuritySignature"}},
+		{"windows.winrm.service.allowBasic", []string{"windows.winrm", "service", "allowBasic"}},
+		{"windows.defender.status.amEngineVersion", []string{"windows.defender", "status", "amEngineVersion"}},
+		// public resources are untouched, even when they shadow a field
+		{"windows.lsa.forceGuest", []string{"windows.lsa", "forceGuest"}},
+		{"sshd.config.params", []string{"sshd.config", "params"}},
+		// the singular accessors lr generates for list resources are implicit and
+		// not backed by the owner, so those paths keep resolving to the resource
+		{"windows.printerDriver.name", []string{"windows.printerDriver", "name"}},
+	}
+
+	for _, v := range data {
+		t.Run(v.code, func(t *testing.T) {
+			compileT(t, v.code, func(res *llx.CodeBundle) {
+				ids := []string{}
+				for _, c := range res.CodeV2.Blocks[0].Chunks {
+					ids = append(ids, c.Id)
+				}
+				assert.Equal(t, v.chunks, ids)
+			})
+		})
+	}
+}

--- a/providers/alicloud/resources/alicloud.lr
+++ b/providers/alicloud/resources/alicloud.lr
@@ -321,7 +321,7 @@ alicloud.ram.policy.statement @defaults("effect action resource") {
 // Account-wide password requirements for RAM users. Exposes the minimum
 // length, character-class requirements, expiration and reuse rules, and the
 // failed-login lockout threshold.
-alicloud.ram.passwordPolicy {
+private alicloud.ram.passwordPolicy {
   // Minimum number of characters required in a password
   minimumPasswordLength int
   // Whether passwords must contain a lowercase letter
@@ -5585,7 +5585,7 @@ alicloud.sas {
 // fingerprints are collected. A machine can sit in the inventory reporting no
 // findings because a scan it needed was never scheduled, which the machine
 // inventory alone does not show.
-alicloud.sas.config {
+private alicloud.sas.config {
   // Whether the scheduled antivirus scan is switched on
   //
   // This is the scheduled scan, not real-time protection. Reports false when

--- a/providers/ansible/resources/ansible.lr
+++ b/providers/ansible/resources/ansible.lr
@@ -330,7 +330,7 @@ ansible.role @defaults("name") {
 // Contents of a role's meta/main.yml: the minimum Ansible version it declares,
 // the galaxy_info block describing authorship and platform support, and the
 // names of the roles it depends on.
-ansible.role.meta @defaults("minAnsibleVersion") {
+private ansible.role.meta @defaults("minAnsibleVersion") {
   // Minimum Ansible version the role supports
   minAnsibleVersion string
   // Galaxy metadata block (author, description, license, platforms)

--- a/providers/arista/resources/arista.lr
+++ b/providers/arista/resources/arista.lr
@@ -1030,7 +1030,7 @@ private arista.eos.hardware.inventoryItem @defaults("name description serialNumb
 // can authenticate against the switch's local account database alone with no
 // remote AAA source, a common hardening finding where policy requires
 // TACACS+ or RADIUS.
-arista.eos.aaa {
+private arista.eos.aaa {
   // Authentication login method lists (key = list name, e.g. "default")
   authenticationLogin map[string][]string
   // Authentication enable method lists
@@ -1173,7 +1173,7 @@ private arista.eos.aaa.serverGroup @defaults("name protocol") {
 // whether FIPS restrictions are enforced. This is the surface auditors
 // compare against SSH hardening benchmarks for weak algorithms, missing
 // idle timeouts, and non-standard ports.
-arista.eos.sshSettings {
+private arista.eos.sshSettings {
   // Whether the SSH service is enabled (no shutdown)
   enabled bool
   // Configured SSH protocol version (typically "2")
@@ -1221,7 +1221,7 @@ private arista.eos.snmpCommunity @defaults("name access acl") {
 // exists and is actually enabled, the idle timeout, session limits (global
 // and per-host), and any access-list restricting connections. Telnet is a
 // plaintext protocol, so benchmarks generally require it to be disabled.
-arista.eos.telnetService {
+private arista.eos.telnetService {
   // Whether a `management telnet` block exists in the running-config
   configured bool
   // Whether the telnet service is enabled (configured AND not shutdown)
@@ -1244,7 +1244,7 @@ arista.eos.telnetService {
 // may log in remotely, login-event logging, and the minimum-character and
 // maximum-repetition rules from the `password policy` block. Audit these to
 // confirm brute-force protection is enabled and complexity meets policy.
-arista.eos.passwordPolicy {
+private arista.eos.passwordPolicy {
   // Failures allowed before account lockout (0 = lockout not configured)
   lockoutFailure int
   // Rolling window during which failures count, in seconds
@@ -1345,7 +1345,7 @@ private arista.eos.portSecurity @defaults("interface enabled violationAction") {
 // which transports are actually listening. Common compliance audits
 // check that `httpServerConfigured` is false (no plaintext HTTP) while
 // `httpsServerConfigured` and `httpsServerRunning` are both true.
-arista.eos.eapi @defaults("enabled httpsServerRunning httpServerRunning") {
+private arista.eos.eapi @defaults("enabled httpsServerRunning httpServerRunning") {
   // Whether eAPI is enabled on the device
   enabled bool
   // Whether the plaintext HTTP eAPI server is configured
@@ -1437,7 +1437,7 @@ private arista.eos.vrrp.group @defaults("interface groupId state priority") {
 // it off, per-interface `dot1x port-control auto` lines are configured but
 // inert, so a device can carry a complete-looking 802.1X configuration and
 // enforce nothing.
-arista.eos.dot1x {
+private arista.eos.dot1x {
   // Whether 802.1X authentication is globally active (`dot1x system-auth-control`)
   systemAuthControl bool
   // Whether a RADIUS server may change or revoke an authorized session
@@ -1504,7 +1504,7 @@ private arista.eos.dot1x.interface @defaults("interface portControl hostMode") {
 //
 // `trustedInterfaces` is the field to audit: an uplink toward the real DHCP
 // server has to be trusted, and an access port facing users must not be.
-arista.eos.dhcpSnooping {
+private arista.eos.dhcpSnooping {
   // Whether DHCP snooping is globally enabled
   enabled bool
   // VLANs snooping is enabled on
@@ -1532,7 +1532,7 @@ arista.eos.dhcpSnooping {
 //
 // DAI has no device-wide on switch. It is enabled per VLAN, so `enabled` is
 // derived from whether any VLAN is covered.
-arista.eos.arpInspection {
+private arista.eos.arpInspection {
   // Whether Dynamic ARP Inspection covers at least one VLAN
   enabled bool
   // VLANs inspection is enabled on
@@ -1598,7 +1598,7 @@ private arista.eos.monitorSession.source @defaults("interface direction") {
 //
 // Collectors can be configured while sampling is off, so `enabled` and
 // `destinations` answer different questions and both are worth reading.
-arista.eos.sflow {
+private arista.eos.sflow {
   // Whether sFlow sampling is running
   enabled bool
   // One-in-N packet sampling rate (0 = unset)
@@ -1716,7 +1716,7 @@ private arista.eos.extension @defaults("name version status") {
 // and the console speed it comes up with. The image path is what a device
 // actually runs after a reload, so it is worth confirming it points at the
 // image that was reviewed rather than one staged beside it.
-arista.eos.bootConfig {
+private arista.eos.bootConfig {
   // Path to the software image loaded on next boot
   softwareImage string
   // Console baud rate
@@ -1750,7 +1750,7 @@ arista.eos.startupConfig {
 // `errors`, `disabled`, or a numeric level. An empty severity means the
 // running-config did not set that destination and the release default
 // applies, which is reported as unset rather than filled in with a guess.
-arista.eos.logging {
+private arista.eos.logging {
   // Whether system logging is enabled
   //
   // True unless `no logging on` is configured. EOS logs by default, so an

--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -3331,7 +3331,7 @@ digitalocean.partnerAttachment @defaults("id name state") {
 // crypto-mining droplets), so this is useful for spend-anomaly auditing.
 // Amounts are USD strings as returned by the API to preserve exact
 // formatting.
-digitalocean.billing @defaults("monthToDateBalance monthToDateUsage") {
+private digitalocean.billing @defaults("monthToDateBalance monthToDateUsage") {
   // Total balance carried over at the start of the period (USD)
   accountBalance string
   // Usage accrued so far this billing period (USD)

--- a/providers/mikrotik/resources/mikrotik.lr
+++ b/providers/mikrotik/resources/mikrotik.lr
@@ -68,7 +68,7 @@ mikrotik {
 // runtime resources such as CPU, memory, storage, and uptime. The values
 // are read from `/system/identity`, `/system/resource`, and
 // `/system/routerboard`.
-mikrotik.system @defaults("identity version boardName") {
+private mikrotik.system @defaults("identity version boardName") {
   // System identity name
   identity string
   // Running RouterOS version
@@ -195,7 +195,7 @@ mikrotik.system.ntp.client @defaults("enabled status") {
 // trap configuration (community, protocol version, generators, and source
 // address). Useful for confirming that SNMP is disabled where it isn't needed
 // and that any enabled SNMP exposure is scoped and attributed.
-mikrotik.snmp @defaults("enabled contact location") {
+private mikrotik.snmp @defaults("enabled contact location") {
   // Whether the SNMP service is enabled
   enabled bool
   // Configured SNMP contact string

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -12132,7 +12132,7 @@ windows.defender @defaults("enabled") {
 // and whether a reboot or signature update is pending. This is the "is
 // Defender actually protecting the host right now" view, complementing the
 // policy in windows.defender.preferences.
-windows.defender.status @defaults("antivirusEnabled realTimeProtectionEnabled isTamperProtected") {
+private windows.defender.status @defaults("antivirusEnabled realTimeProtectionEnabled isTamperProtected") {
   // Antimalware engine version
   amEngineVersion string
   // Antimalware client (product) version

--- a/providers/proxmox/resources/proxmox.lr
+++ b/providers/proxmox/resources/proxmox.lr
@@ -2006,7 +2006,7 @@ proxmox.node.disk @defaults("devPath model size health") {
 // when it is `text` the device only returns unstructured output via
 // the `text` field. Structured `attributes` are available for ATA and
 // SAS drives.
-proxmox.node.disk.smart @defaults("health type") {
+private proxmox.node.disk.smart @defaults("health type") {
   // Overall device health verdict
   health string
   // SMART report flavor (ata, nvme, sas, text)


### PR DESCRIPTION
Fixes #10348

## Problem

A dotted path whose full name is also a resource name always compiled to that resource: `compileResource` extends the path greedily and `Schema.Lookup` doesn't filter `private`. So `windows.deviceGuard.credentialGuardConfig` built a **bare** `windows.deviceGuard`, and the `deviceGuard()` accessor on `windows` — the only thing that fills the resource's fields — never ran.

Every field then read `null`. With MQL's asymmetric null comparisons (`null == 1` is false, `null != 1` is true) the affected checks returned **confidently wrong verdicts** rather than failing, and the runtime logged an error per field access — which on Windows service installs lands in the Application event log.

```
windows.deviceGuard.credentialGuardConfig   [1] id="windows.deviceGuard" binding=0 hasArgs=false   # accessor bypassed
                                            [2] id="credentialGuardConfig" binding=<chunk 1>
```

`windows.lsa` was unaffected only because it declares its fields lazily (`forceGuest() bool` + a `populate()` delegate), so a bare instance self-populates. That contrast is the whole bug.

## Fix

**`mqlc/mqlc.go`** — stop extending the path into a `private` resource when the owner declares a field of that name and exactly that type. Private means the resource cannot stand on its own, so the accessor is the correct route.

Two guards keep it safe:
- the field must exist with a matching type, so **nothing that compiles today becomes uncompilable**;
- implicit fields are excluded — lr's generated singular accessors aren't backed by the owner, so routing through them would break paths that work now.

**Seven `.lr` files** — 19 public singleton config/status blocks with the identical shape marked `private`, since they're filled by their owner's accessor and can't be instantiated standalone either: `windows.defender.status`, `arista.eos.{aaa,arpInspection,bootConfig,dhcpSnooping,dot1x,eapi,logging,passwordPolicy,sflow,sshSettings,telnetService}`, `alicloud.{ram.passwordPolicy,sas.config}`, `mikrotik.{snmp,system}`, `ansible.role.meta`, `digitalocean.billing`, `proxmox.node.disk.smart`.

No generated Go changed — `private` only affects the schema, and `.resources.json` is gitignored.

## Verification

The reported path now routes through the accessor:

```
windows.deviceGuard.credentialGuardConfig   ->  windows -> deviceGuard -> credentialGuardConfig
```

I swept **every** data-only, init-less resource across all 74 providers, compiled its path, and counted any still landing on a bare resource whose fields only the owner can fill:

| | private | public | total |
| --- | --- | --- | --- |
| before | 233 | 19 | **252** |
| after | 0 | 0 | **0** |

The 252 broken paths spanned 15 providers — `aws` 65, `gcp` 54, `azure` 33, `os` 25, `ms365` 20, `cloudflare` 14, `vsphere` 9, `gitlab` 4, `network` 3, `openstack` 2, and one each in `stackit`, `ollama`, `oci`, `google-workspace`, `artifactory`. So `windows.deviceGuard` was one instance of a class that reaches well beyond the os provider; the compiler change closes all 233 private ones at once and the `.lr` markings close the remaining 19.

Baseline measured by running the same sweep against the pre-fix tree in a git worktree, not estimated.

Also confirmed each new redirect target (`windows`, `windows.lsa`, `windows.smb`, `windows.winrm`, `windows.defender`) is public and its accessor reads from the connection directly, so a bare owner is fine.

Tests: `mqlc`, `mqlc/parser`, and `providers/os/resources` pass. `gofmt` clean. Two pre-existing failures, both confirmed failing on a clean tree and unrelated: `llx.TestRawDataJson_Umlauts` and `providers/os/connection/device/linux` (missing generated mock). The three `go vet` "copies lock" warnings in `mqlc` are pre-existing and not in the new code.

Regression test in `mqlc/mqlc_test.go` covers the redirected private paths plus the cases that must stay unchanged (public resources, resources with `init`, implicit list-element accessors).

## Deliberately not in scope

- **`windows.printerDriver.name`-style paths** — list-element resources reached through lr's implicit singular accessor still compile bare. Different problem (that's the documented empty-`id=` trap); asserted as unchanged in the test.
- **The lr-generator guardrail** (option 3 in the issue) — a lint rejecting data-only, init-less resources that shadow a declared accessor. It's what stops recurrence, and the count is now 0 so it'd be enforceable immediately. Left out to keep this diff reviewable; happy to add it here or as a follow-up.

## Note for reviewers

Marking a resource `private` removes it from resource suggestions/listings. Nothing that works today breaks: a bare instance of any of these 19 returned all-null, so the only reachable-and-correct path was already through the accessor.

Worth flagging separately: `windows.deviceGuard.id()` (and `windows.defender.status`) return a hardcoded constant, so a bare instance still gets a plausible-looking id. The usual diagnostic for this class — an **empty** `id=` in the log line — does not hold for singletons with static IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
