### PR TITLE
✨ lr: reject public resources only their owner can fill

### DIFF
--- a/providers-sdk/v1/mqlr/lrcore/go.go
+++ b/providers-sdk/v1/mqlr/lrcore/go.go
@@ -34,6 +34,8 @@ func Go(packageName string, ast *LR, collector *Collector, licenseHeaderTpl *tem
 		o.providerName = "provider"
 	}
 
+	o.checkOwnerFilledResourcesArePrivate(ast.Resources)
+
 	o.goCreateResource(ast.Resources)
 	o.goGetData(ast.Resources)
 	o.goSetData(ast.Resources)
@@ -568,6 +570,80 @@ func capitalizeDot(in []byte) []byte {
 
 func (r *Resource) interfaceName(b *goBuilder) string {
 	return resource2goname(r.ID, b)
+}
+
+// checkOwnerFilledResourcesArePrivate rejects a public resource that only its
+// owner's accessor can populate. A dotted path resolves to the longest matching
+// resource name, so while it is public `owner.name.field` builds a bare instance
+// that skips the accessor and reads null for every field. Marking it private
+// makes the compiler use the accessor instead; see mqlc.prefersFieldOverResource.
+func (b *goBuilder) checkOwnerFilledResourcesArePrivate(all []*Resource) {
+	byID := make(map[string]*Resource, len(all))
+	for _, r := range all {
+		byID[r.ID] = r
+	}
+
+	for _, r := range all {
+		if r.IsPrivate || !b.onlyOwnerCanFill(r) {
+			continue
+		}
+
+		dot := strings.LastIndex(r.ID, ".")
+		if dot == -1 {
+			continue
+		}
+		owner, ok := byID[r.ID[:dot]]
+		if !ok {
+			continue
+		}
+		if !b.declaresAccessorFor(owner, r.ID[dot+1:], r.ID) {
+			continue
+		}
+
+		b.errors.Add(fmt.Errorf(
+			"resource %s is public, but only the `%s` accessor on %s can fill it. "+
+				"A path like `%s.<field>` therefore compiles to a bare %s and every field reads null. Mark the resource `private`",
+			r.ID, r.ID[dot+1:], owner.ID, r.ID, r.ID))
+	}
+}
+
+// onlyOwnerCanFill reports whether a resource has no way to populate itself:
+// every field is data-only and there is no init to build it from args.
+func (b *goBuilder) onlyOwnerCanFill(r *Resource) bool {
+	if r.Body == nil || r.ListType != nil {
+		return false
+	}
+	if len(r.GetInitFields()) > 0 || b.collector.HasInit(r.interfaceName(b)) {
+		return false
+	}
+
+	fields := 0
+	for _, f := range r.Body.Fields {
+		if f.BasicField == nil || f.BasicField.ID == "" {
+			continue
+		}
+		if !f.BasicField.isStatic() {
+			return false
+		}
+		fields++
+	}
+	return fields > 0
+}
+
+// declaresAccessorFor reports whether owner declares `name` as an accessor for
+// resourceID. Only fields spelled out in the .lr count: the singular accessors lr
+// synthesizes for every `x.y` resource reach nothing.
+func (b *goBuilder) declaresAccessorFor(owner *Resource, name string, resourceID string) bool {
+	if owner.Body == nil {
+		return false
+	}
+	for _, f := range owner.Body.Fields {
+		if f.BasicField == nil || f.BasicField.ID != name {
+			continue
+		}
+		return f.BasicField.Type.Type(b.ast) == types.Resource(resourceID)
+	}
+	return false
 }
 
 var caser = cases.Title(language.English, cases.NoLower)

--- a/providers-sdk/v1/mqlr/lrcore/guard_test.go
+++ b/providers-sdk/v1/mqlr/lrcore/guard_test.go
@@ -1,0 +1,90 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package lrcore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckOwnerFilledResourcesArePrivate(t *testing.T) {
+	tests := []struct {
+		name    string
+		lr      string
+		wantErr string
+	}{
+		{
+			name: "public, data-only, shadows its accessor",
+			lr: `windows {
+  deviceGuard() windows.deviceGuard
+}
+windows.deviceGuard {
+  credentialGuardConfig int
+}`,
+			wantErr: "resource windows.deviceGuard is public",
+		},
+		{
+			name: "same but private",
+			lr: `windows {
+  deviceGuard() windows.deviceGuard
+}
+private windows.deviceGuard {
+  credentialGuardConfig int
+}`,
+		},
+		{
+			name: "one lazy field is enough to fill itself",
+			lr: `windows {
+  lsa() windows.lsa
+}
+windows.lsa {
+  forceGuest() bool
+  noLmHash bool
+}`,
+		},
+		{
+			name: "accessor has a different name, so the path is not shadowed",
+			lr: `windows.defender.preferences {
+  cloudProtection() windows.defender.cloudSettings
+}
+windows.defender.cloudSettings {
+  mapsReporting int
+}`,
+		},
+		{
+			name: "reached as a list entry, not a singleton accessor",
+			lr: `windows {
+  printerDrivers() []windows.printerDriver
+}
+windows.printerDriver {
+  name string
+}`,
+		},
+		{
+			name: "owner is synthesized, so there is no accessor to route through",
+			lr: `container.repository {
+  registry string
+}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ast := parse(t, test.lr)
+			b := goBuilder{ast: ast, collector: &Collector{}}
+			b.checkOwnerFilledResourcesArePrivate(ast.Resources)
+			err := b.errors.Deduplicate()
+
+			if test.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.wantErr)
+			assert.Contains(t, err.Error(), "Mark the resource `private`")
+		})
+	}
+}


### PR DESCRIPTION
Fixes #10350. Follow-up to #10349 (merged), now rebased straight onto `main`.

## What

A resource whose every field is data-only and that has no `init` cannot populate itself — the generated getters just hand back the stored `TValue`, so the owner's accessor is the only thing that ever sets them. While such a resource is **public**, MQL's longest-resource-name resolution turns `owner.name.field` into a bare instance that skips the accessor and reads `null` for every field, which with asymmetric null comparisons yields a confidently wrong verdict rather than an error.

Generation now fails for that combination and names the fix:

```
resource windows.defender.status is public, but only the `status` accessor on windows.defender
can fill it. A path like `windows.defender.status.<field>` therefore compiles to a bare
windows.defender.status and every field reads null. Mark the resource `private`
```

## Scope — a ratchet, not a fix

- **#10349 is what stops the `windows.deviceGuard` class from recurring**, structurally and for every provider. This guardrail would *not* have caught that bug — `windows.deviceGuard` was already private.
- **This covers the narrower leftover**: a new *public* singleton config block that shadows its own accessor, i.e. the 19 resources #10349 marked private. Nothing otherwise stops that count drifting back up from 0.

## Precision

The check only fires when the owner **actually declares** the accessor, so these are left alone:

| case | why it's fine |
| --- | --- |
| owner's field is `[]resource` | reached as a list entry, not a singleton path |
| accessor has a different name (`preferences.cloudProtection` → `…cloudSettings`) | the real path isn't a resource name, so nothing is shadowed |
| owner is synthesized by lr (`container` for `container.repository`) | no declared accessor to route through |
| resource has ≥1 lazy field, or an `init` | it can fill itself |

## Implementation note

It lives in the **go builder**, not `Schema()` as the issue proposed: init detection needs `collector.HasInit`, and the collector scans the provider's Go source — it's a field on `goBuilder` and isn't reachable from `Schema(ast *LR)`. The builder also already carries the `multierr` accumulator, so all violations report at once instead of failing on the first.

`isStatic()` is read off the AST rather than the emitted schema because the `Field` proto has `IsMandatory` and `IsImplicitResource` but no computed-vs-data-only flag.

## Verification

- **All 81 `.lr` files pass** — no provider trips the check, re-confirmed on top of merged `main`.
- **Regenerating every provider produces no diff**, so the change emits nothing new.
- **Negative test**: reverting one `private` marking makes generation fail with the new error. Worth confirming explicitly — a check that never fires is worthless.
- Unit test covers all six cases above. Full `lrcore` suite passes, including `TestParseLR`, which runs `Go()` over the real provider `.lr` files, so the guard is exercised against production schemas in-test. `gofmt` clean.

## Error vs warning

Erroring is enforceable today precisely because the count is verified at 0. It fails the build for anyone mid-flight with such a resource, but the fix is a one-word `private`. Happy to downgrade to a warning if you'd rather not have a hard gate — my read is a warning gets ignored and the count drifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
