### PR TITLE
🐛 azure: give the root asset an identity, fetching the subscription once

### DIFF
--- a/providers/azure/connection/connection.go
+++ b/providers/azure/connection/connection.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
@@ -43,6 +44,11 @@ type AzureConnection struct {
 	clientOptions  policy.ClientOptions
 	// Filters holds the parsed discovery filters (from inventory.Discovery.Filter).
 	Filters DiscoveryFilters
+
+	// The ARM record of the subscription this connection is scoped to, fetched
+	// once and shared through Subscription.
+	subMu     sync.Mutex
+	subRecord *subscriptions.Subscription
 }
 
 // The credentials this process has built, by the identity each signs in as.
@@ -170,6 +176,32 @@ func (p *AzureConnection) Asset() *inventory.Asset {
 
 func (p *AzureConnection) SubId() string {
 	return p.subscriptionId
+}
+
+// Subscription returns the ARM record of the subscription this connection is
+// scoped to, fetched once and cached for the connection's lifetime. Asset
+// detection, discovery, and the azure.subscription resource all read the same
+// record; without the cache each of them pays its own GET.
+//
+// A failed fetch is not cached: the next caller gets its own try, the same way
+// credentialCache treats a failed credential build.
+func (p *AzureConnection) Subscription() (subscriptions.Subscription, error) {
+	if p.subscriptionId == "" {
+		return subscriptions.Subscription{}, errors.New("connection is not scoped to a subscription")
+	}
+
+	p.subMu.Lock()
+	defer p.subMu.Unlock()
+	if p.subRecord != nil {
+		return *p.subRecord, nil
+	}
+
+	record, err := NewSubscriptionsClient(p.token, p.clientOptions).GetSubscription(p.subscriptionId)
+	if err != nil {
+		return subscriptions.Subscription{}, err
+	}
+	p.subRecord = &record
+	return record, nil
 }
 
 func (p *AzureConnection) Token() azcore.TokenCredential {

--- a/providers/azure/connection/connection_test.go
+++ b/providers/azure/connection/connection_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/providers-sdk/v1/vault"
@@ -345,4 +346,27 @@ func TestSelectAzureCredential_RejectsBadAuthMethodEvenWhenCached(t *testing.T) 
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "service-principal")
+}
+
+// A connection with no subscription has no record to fetch: the caller named
+// several subscriptions or none, and discovery enumerates them instead.
+func TestSubscriptionRequiresAScopedConnection(t *testing.T) {
+	conn := &AzureConnection{}
+	_, err := conn.Subscription()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not scoped to a subscription")
+}
+
+// A cached record is served without a client round-trip: a pre-seeded record
+// comes straight back even though the connection has no credentials to fetch
+// anything with.
+func TestSubscriptionServesTheCachedRecord(t *testing.T) {
+	name := "Production"
+	conn := &AzureConnection{
+		subscriptionId: "sub",
+		subRecord:      &subscriptions.Subscription{DisplayName: &name},
+	}
+	record, err := conn.Subscription()
+	require.NoError(t, err)
+	require.Equal(t, "Production", *record.DisplayName)
 }

--- a/providers/azure/provider/detect_test.go
+++ b/providers/azure/provider/detect_test.go
@@ -1,0 +1,132 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/azure/resources"
+)
+
+const (
+	testSubID      = "00000000-0000-0000-0000-000000000000"
+	testTenantID   = "11111111-1111-1111-1111-111111111111"
+	testPlatformID = "//platformid.api.mondoo.app/runtime/azure/subscriptions/" + testSubID
+)
+
+// detect used to be a bare `return nil`, so the root asset -- the one the caller
+// connected as, before any discovery -- reached the client with no platform, no
+// name, and no platform id. Every Azure scan carried one blank entry, and
+// `--discover none` produced nothing but the blank entry.
+func TestApplyAzureSubscriptionIdentity(t *testing.T) {
+	asset := &inventory.Asset{}
+	applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformID, "Production")
+
+	require.NotNil(t, asset.Platform, "a blank platform is the defect")
+	assert.Equal(t, "azure", asset.Platform.Name)
+	assert.Equal(t, []string{"azure", testTenantID, testSubID, "account"},
+		asset.Platform.TechnologyUrlSegments)
+
+	assert.Equal(t, []string{testPlatformID}, asset.PlatformIds)
+	assert.Equal(t, testPlatformID, asset.Id)
+	assert.Equal(t, "Azure subscription Production", asset.Name)
+	assert.Equal(t, testSubID, asset.Labels[resources.SubscriptionLabel])
+}
+
+// The whole point is that the same subscription reads the same whether it arrived
+// as the root asset or as one discovery found, so the shape has to match
+// subToAsset's: the same platform id, the same name prefix, the same label. The
+// client recognizes the discovered duplicate by this platform id and skips it,
+// which is what removes the second entry from the scan.
+func TestApplyAzureSubscriptionIdentityMatchesDiscoveryShape(t *testing.T) {
+	asset := &inventory.Asset{}
+	applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformID, "Production")
+
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/azure/subscriptions/"+testSubID, asset.Id,
+		"the platform id format discovery uses")
+	assert.Equal(t, asset.Id, asset.PlatformIds[0], "id and platform id agree")
+	assert.Equal(t, "azure.mondoo.com/subscription", resources.SubscriptionLabel,
+		"the label key discovery sets")
+}
+
+func TestApplyAzureSubscriptionIdentityFallbacks(t *testing.T) {
+	t.Run("no display name falls back to the id", func(t *testing.T) {
+		// Reached when the subscription lookup fails, or when ARM omits
+		// displayName -- which it does for deleted, disabled, and cross-tenant
+		// subscriptions. A scan must not fail over a display name.
+		asset := &inventory.Asset{}
+		applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformID, "")
+		assert.Equal(t, "Azure subscription "+testSubID, asset.Name)
+	})
+
+	t.Run("no tenant id is reported as unknown", func(t *testing.T) {
+		// Reached only when the caller passed no --tenant-id AND the ARM
+		// record could not be read; detect otherwise takes the tenant from
+		// the record, the same field subToAsset reads for a discovered
+		// subscription.
+		asset := &inventory.Asset{}
+		applyAzureSubscriptionIdentity(asset, testSubID, "", testPlatformID, "Production")
+		assert.Equal(t, []string{"azure", "unknown", testSubID, "account"},
+			asset.Platform.TechnologyUrlSegments)
+	})
+}
+
+// An asset that already carries an id or a label keeps them: those came from
+// whoever built the asset, and this only fills in what is missing.
+func TestApplyAzureSubscriptionIdentityDoesNotOverwriteExistingIdentity(t *testing.T) {
+	asset := &inventory.Asset{
+		Id:     "//some/other/id",
+		Labels: map[string]string{resources.SubscriptionLabel: "someone-elses-sub", "env": "prod"},
+	}
+	applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformID, "Production")
+
+	assert.Equal(t, "//some/other/id", asset.Id, "an id already set is left alone")
+	assert.Equal(t, "someone-elses-sub", asset.Labels[resources.SubscriptionLabel])
+	assert.Equal(t, "prod", asset.Labels["env"], "unrelated labels survive")
+}
+
+// Platform ids that arrived with the asset are the key an integration may
+// resolve it by, so they survive; the connection's own id is appended so the
+// client can still recognize the discovered duplicate of this subscription.
+func TestApplyAzureSubscriptionIdentityKeepsExistingPlatformIds(t *testing.T) {
+	asset := &inventory.Asset{PlatformIds: []string{"//integration/key/for/this/asset"}}
+	applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformID, "Production")
+
+	assert.Equal(t, []string{"//integration/key/for/this/asset", testPlatformID}, asset.PlatformIds)
+
+	// And appending is idempotent: a second detect pass adds nothing.
+	applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformID, "Production")
+	assert.Equal(t, []string{"//integration/key/for/this/asset", testPlatformID}, asset.PlatformIds)
+}
+
+// A name the caller supplied via --asset-name survives detect. Naming the root
+// asset here runs after cnspec has already applied --asset-name, so an
+// unconditional write makes that flag a no-op for every Azure scan.
+func TestApplyAzureSubscriptionIdentityKeepsARequestedName(t *testing.T) {
+	asset := &inventory.Asset{Name: "prod-billing-account"}
+	applyAzureSubscriptionIdentity(asset, testSubID, testTenantID, testPlatformID, "Production")
+
+	assert.Equal(t, "prod-billing-account", asset.Name, "a name already set is left alone")
+
+	// The rest of the identity is still stamped on.
+	assert.Equal(t, []string{testPlatformID}, asset.PlatformIds)
+	assert.Equal(t, testSubID, asset.Labels[resources.SubscriptionLabel])
+}
+
+// detect returns without touching the asset when there is no single subscription
+// to be: the caller named several, or none, and discovery enumerates them.
+func TestDetectLeavesAMultiSubscriptionConnectionAlone(t *testing.T) {
+	s := &Service{}
+	asset := &inventory.Asset{}
+
+	// A nil connection is not an *AzureConnection, which is the same branch a
+	// snapshot connection takes -- those are detected by the os provider.
+	require.NoError(t, s.detect(asset, nil))
+	assert.Nil(t, asset.Platform)
+	assert.Empty(t, asset.Name)
+	assert.Empty(t, asset.PlatformIds)
+}

--- a/providers/azure/provider/provider.go
+++ b/providers/azure/provider/provider.go
@@ -6,8 +6,10 @@ package provider
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
@@ -300,8 +302,101 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 	return runtime.Connection.(shared.AzureConnection), nil
 }
 
+// detect gives the root asset -- the one the caller connected as, before any
+// discovery -- the identity a discovered subscription gets from subToAsset.
+//
+// It used to be a bare `return nil`, so that asset reached the client with no
+// platform, no name, and no platform id: every Azure scan carried one blank
+// entry, and `--discover none` produced nothing but the blank entry. The
+// resources were queryable the whole time, because the connection knows which
+// subscription it is on; only the asset's own identity was missing.
+//
+// A connection with no subscription is left alone deliberately. That is the
+// caller who named several subscriptions or none, where discovery enumerates
+// them and there is no single subscription for the root asset to be.
 func (s *Service) detect(asset *inventory.Asset, conn shared.AzureConnection) error {
+	azureConn, ok := conn.(*connection.AzureConnection)
+	if !ok {
+		// A snapshot connection is handed to the os provider, which detects it.
+		return nil
+	}
+
+	subID := azureConn.SubId()
+	if subID == "" {
+		return nil
+	}
+
+	var tenantID string
+	if conf := azureConn.Config(); conf != nil {
+		tenantID = conf.Options[connection.OptionTenantID]
+	}
+
+	// The record is cached on the connection, so discovery and the
+	// azure.subscription resource reuse this fetch rather than paying their
+	// own GET. Logged rather than returned on failure: ARM omits parts of the
+	// record for deleted, disabled, and cross-tenant subscriptions, and a scan
+	// must not fail because the asset could only be named by its id.
+	var displayName string
+	if sub, err := azureConn.Subscription(); err == nil {
+		if sub.DisplayName != nil {
+			displayName = *sub.DisplayName
+		}
+		if tenantID == "" && sub.TenantID != nil {
+			tenantID = *sub.TenantID
+		}
+	} else {
+		log.Debug().Err(err).Msg("could not read the subscription to name the asset")
+	}
+
+	applyAzureSubscriptionIdentity(asset, subID, tenantID, azureConn.PlatformId(), displayName)
 	return nil
+}
+
+// applyAzureSubscriptionIdentity stamps a subscription's identity onto an asset,
+// in the shape subToAsset gives a discovered subscription, so the same
+// subscription reads the same whichever way it arrived.
+//
+// displayName may be empty, in which case the id names the asset. That is also
+// what subToAsset does for a subscription whose displayName ARM omits, and it is
+// the right outcome here too: a scan should not fail because the asset could only
+// be named by its id.
+func applyAzureSubscriptionIdentity(asset *inventory.Asset, subID, tenantID, platformID, displayName string) {
+	if tenantID == "" {
+		tenantID = "unknown"
+	}
+
+	platform := &inventory.Platform{
+		TechnologyUrlSegments: []string{"azure", tenantID, subID, "account"},
+	}
+	resources.PlatformByName("azure").Apply(platform)
+
+	asset.Platform = platform
+	// Platform ids that arrived with the asset came from whoever built it,
+	// often the key an integration resolves the asset by, so they are kept.
+	// The connection's own id still has to be present for the client to
+	// recognize the discovered duplicate of this subscription.
+	if !slices.Contains(asset.PlatformIds, platformID) {
+		asset.PlatformIds = append(asset.PlatformIds, platformID)
+	}
+	if asset.Id == "" {
+		asset.Id = platformID
+	}
+	if asset.Labels == nil {
+		asset.Labels = map[string]string{}
+	}
+	if _, ok := asset.Labels[resources.SubscriptionLabel]; !ok {
+		asset.Labels[resources.SubscriptionLabel] = subID
+	}
+
+	// Only name an asset that has no name. A caller who passed --asset-name
+	// has already named this asset, and detect running afterwards must not
+	// take that back; the sibling fields above guard for the same reason.
+	if asset.Name == "" {
+		if displayName == "" {
+			displayName = subID
+		}
+		asset.Name = "Azure subscription " + displayName
+	}
 }
 
 func (s *Service) discover(conn shared.AzureConnection) (*inventory.Inventory, error) {

--- a/providers/azure/resources/discovery.go
+++ b/providers/azure/resources/discovery.go
@@ -560,13 +560,24 @@ func subscriptionRecord(conn *connection.AzureConnection, invConfig *inventory.C
 		return sub
 	}
 
-	record, err := connection.NewSubscriptionsClient(conn.Token(), conn.ClientOptions()).GetSubscription(subId)
+	record, err := fetchSubscriptionRecord(conn, subId)
 	if err != nil {
 		log.Warn().Err(err).Str("subscription", subId).
 			Msg("could not read the subscription record, discovering without its name and tags")
 		return sub
 	}
 	return record
+}
+
+// fetchSubscriptionRecord reads one subscription's ARM record, through the
+// connection's cache when the connection is scoped to that same subscription --
+// which is every stage-2 call today, so asset detection's fetch is reused
+// rather than repeated.
+func fetchSubscriptionRecord(conn *connection.AzureConnection, subId string) (subscriptions.Subscription, error) {
+	if conn.SubId() == subId {
+		return conn.Subscription()
+	}
+	return connection.NewSubscriptionsClient(conn.Token(), conn.ClientOptions()).GetSubscription(subId)
 }
 
 // discoverResources lists the assets inside the given subscriptions for every

--- a/providers/azure/resources/subscription.go
+++ b/providers/azure/resources/subscription.go
@@ -4,11 +4,8 @@
 package resources
 
 import (
-	"context"
 	"errors"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
@@ -34,14 +31,9 @@ func initAzureSubscription(runtime *plugin.Runtime, args map[string]*llx.RawData
 		return nil, az.sub, nil
 	}
 
-	subscriptionsC, err := subscriptions.NewClient(conn.Token(), &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	ctx := context.Background()
-	resp, err := subscriptionsC.Get(ctx, conn.SubId(), &subscriptions.ClientGetOptions{})
+	// Cached on the connection: asset detection already fetched this record
+	// when it named the root asset, so the common case costs no API call.
+	resp, err := conn.Subscription()
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Alternative to #10096, for comparison. Same defect, same identity shape, different plumbing: the subscription record is fetched **once per connection** and shared, instead of each consumer paying its own ARM `GET`.

## The defect (same as #10096)

`detect` was a bare `return nil`, so the root asset reached the client with no platform, no name, and no platform ids. Every Azure scan carried one blank entry, and `--discover none` produced nothing but the blank entry.

## What this PR does differently

### 1. The subscription record is memoized on the connection

`AzureConnection.Subscription()` fetches the ARM record once and caches it for the connection's lifetime. Everyone who needs the record goes through it:

| consumer | #10096 | this PR |
|---|---|---|
| `detect` (asset name, tenant) | own `GET` | shared fetch |
| staged discovery `subscriptionRecord` (name, tags) | own `GET` | shared fetch (when scoped to the same sub) |
| `initAzureSubscription` (`azure.subscription` resource) | own `GET` | shared fetch |

A single-subscription staged scan that touches `azure.subscription` pays **one** `GET` where #10096 pays three. Failures are not cached (mirroring `credentialCache`): a transient error on one caller must not deny the record to the next.

The provider layer no longer builds its own ARM client; `detect` reads through the connection, which was already the seam `client_subscriptions.go` provides.

### 2. The tenant comes from the ARM record, not only from `--tenant-id`

#10096 reports the tenant segment as `unknown` unless the caller passed `--tenant-id`. The cached record carries `TenantID` — the same field `subToAsset` reads for a discovered subscription — so the root asset's `TechnologyUrlSegments` now match discovery's even without the flag. `unknown` remains only for the case where the record could not be read at all.

### 3. Pre-existing platform ids survive

#10096 overwrites `asset.PlatformIds` unconditionally. Platform ids that arrived with the asset are often the key an integration resolves it by, so this PR keeps them and **appends** the connection's own id when missing (idempotently). The connection's id still has to be present: it is what lets the client recognize the discovered duplicate of this subscription and skip it.

## Unchanged from #10096 (deliberately)

- The identity shape is `subToAsset`'s: same platform id format, same `Azure subscription <name>` prefix, same `azure.mondoo.com/subscription` label. `TestApplyAzureSubscriptionIdentityMatchesDiscoveryShape` pins the agreement.
- An asset that already has an id, name, or that label keeps them; `--asset-name` survives.
- A connection with no subscription is left alone (multi-sub / tenant scans; discovery enumerates them). A snapshot connection is left alone (the os provider detects it).
- A failed record read degrades to naming the asset by its id — a scan must not fail over a display name.

## Tests

- `TestApplyAzureSubscriptionIdentity` — the full shape, including that `Platform` is not nil, which is the defect.
- `TestApplyAzureSubscriptionIdentityMatchesDiscoveryShape` — pins the platform-id format and label key against discovery's.
- `TestApplyAzureSubscriptionIdentityFallbacks` — no display name falls back to the id; no tenant (flag absent and record unreadable) reports `unknown`.
- `TestApplyAzureSubscriptionIdentityDoesNotOverwriteExistingIdentity` / `...KeepsARequestedName` — existing id, labels, and `--asset-name` survive.
- `TestApplyAzureSubscriptionIdentityKeepsExistingPlatformIds` — integration-supplied platform ids survive; the connection's id is appended idempotently.
- `TestDetectLeavesAMultiSubscriptionConnectionAlone` — the non-`*AzureConnection` branch touches nothing.
- `TestSubscriptionRequiresAScopedConnection` / `TestSubscriptionServesTheCachedRecord` — the cache's guard and hit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
