### PR TITLE
✨ os: add FIPS, Kerberos encryption type, and LDAP signing to windows.lsa

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -11657,16 +11657,103 @@ private windows.deviceGuard @defaults("virtualizationBasedSecurityEnabled hyperv
 // are exposed as booleans and graded settings (such as the LAN Manager
 // authentication level) as integers. NTLM (MSV1_0 and WDigest) settings are
 // grouped under `ntlm` and the Netlogon secure-channel settings under
-// `secureChannel`. Values are nullable: an absent value resolves to null so it
-// is distinguishable from an explicit false or 0, letting checks assert on
-// configured-vs-default precisely.
+// `secureChannel`. The FIPS algorithm policy, the Kerberos supported
+// encryption types, and the LDAP signing and channel-binding requirements are
+// read from their own keys and exposed directly on this resource. Values are
+// nullable: an absent value resolves to null so it is distinguishable from an
+// explicit false or 0, letting checks assert on configured-vs-default
+// precisely.
 windows.lsa {
   // Whether storing network authentication credentials is disabled (Lsa\DisableDomainCreds)
   disableDomainCreds() bool
   // Whether the Everyone permissions apply to anonymous users (Lsa\EveryoneIncludesAnonymous)
   everyoneIncludesAnonymous() bool
+  // Whether FIPS compliant algorithms are required for encryption, hashing, and signing (Lsa\FipsAlgorithmPolicy\Enabled)
+  //
+  // Backs the "System cryptography: Use FIPS compliant algorithms for
+  // encryption, hashing, and signing" security option. When enabled, Windows
+  // components restrict themselves to FIPS 140 validated algorithms. Null when
+  // the value is absent, in which case the Windows default of FIPS mode off
+  // applies rather than a configured false.
+  fipsAlgorithmPolicyEnabled() bool
   // Whether the guest-only sharing and security model is used for local accounts (Lsa\ForceGuest)
   forceGuest() bool
+  // Whether Kerberos may negotiate AES128-CTS-HMAC-SHA1-96 (bit 0x8 of SupportedEncryptionTypes)
+  //
+  // Decoded from kerberosSupportedEncryptionTypes. Null when that value is
+  // absent, in which case Windows uses its built-in default set rather than a
+  // configured one.
+  kerberosAllowsAes128() bool
+  // Whether Kerberos may negotiate AES256-CTS-HMAC-SHA1-96 (bit 0x10 of SupportedEncryptionTypes)
+  //
+  // Decoded from kerberosSupportedEncryptionTypes. Null when that value is
+  // absent, in which case Windows uses its built-in default set rather than a
+  // configured one.
+  kerberosAllowsAes256() bool
+  // Whether Kerberos may negotiate the legacy DES-CBC-CRC cipher (bit 0x1 of SupportedEncryptionTypes)
+  //
+  // DES is broken and a hardened system leaves this bit clear. Decoded from
+  // kerberosSupportedEncryptionTypes. Null when that value is absent, in which
+  // case Windows uses its built-in default set rather than a configured one.
+  kerberosAllowsDesCbcCrc() bool
+  // Whether Kerberos may negotiate the legacy DES-CBC-MD5 cipher (bit 0x2 of SupportedEncryptionTypes)
+  //
+  // DES is broken and a hardened system leaves this bit clear. Decoded from
+  // kerberosSupportedEncryptionTypes. Null when that value is absent, in which
+  // case Windows uses its built-in default set rather than a configured one.
+  kerberosAllowsDesCbcMd5() bool
+  // Whether Kerberos may negotiate the legacy RC4-HMAC-MD5 cipher (bit 0x4 of SupportedEncryptionTypes)
+  //
+  // RC4 is retained only as a transition fallback and is the cipher targeted by
+  // Kerberoasting. A hardened system leaves this bit clear. Decoded from
+  // kerberosSupportedEncryptionTypes. Null when that value is absent, in which
+  // case Windows uses its built-in default set rather than a configured one.
+  kerberosAllowsRc4Hmac() bool
+  // Kerberos encryption types the computer is allowed to negotiate (SupportedEncryptionTypes bitmask)
+  //
+  // Bitmask behind the "Network security: Configure encryption types allowed
+  // for Kerberos" security option. The defined bits are 0x1 DES_CBC_CRC,
+  // 0x2 DES_CBC_MD5, 0x4 RC4_HMAC_MD5, 0x8 AES128_CTS_HMAC_SHA1_96,
+  // 0x10 AES256_CTS_HMAC_SHA1_96, and 0x20 AES256_CTS_HMAC_SHA1_96_SK, with the
+  // remaining high bits reserved for future encryption types. A common hardened
+  // value is 0x7FFFFFF8, which clears the three legacy bits and leaves the rest
+  // set.
+  //
+  // Read from the policy location
+  // SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Kerberos\Parameters,
+  // falling back to the legacy location Lsa\Kerberos\Parameters that Windows
+  // Server 2025 no longer honors. Null when neither location carries the value,
+  // in which case Windows uses its built-in default set rather than a
+  // configured 0. The kerberosAllows fields decode the well-known bits, since
+  // MQL has no bitwise operators to test them with.
+  kerberosSupportedEncryptionTypes() int
+  // LDAP client signing requirement (Services\LDAP\LDAPClientIntegrity)
+  //
+  // Backs the "Network security: LDAP client signing requirements" security
+  // option, which controls whether this computer requests or requires signing
+  // when it binds to an LDAP server: 0 none, 1 negotiate signing, 2 require
+  // signing. Null when the value is absent, in which case the Windows default
+  // applies rather than a configured 0.
+  ldapClientIntegrity() int
+  // LDAP server channel binding token requirement (Services\NTDS\Parameters\LdapEnforceChannelBinding)
+  //
+  // Extended Protection for Authentication enforcement on LDAP over TLS binds,
+  // introduced by ADV190023: 0 never, 1 when supported, 2 always required. The
+  // NTDS key exists only on domain controllers, so this resolves to null on a
+  // member server or a standalone host where the setting does not apply, and
+  // also on a domain controller that never configured the value. Null therefore
+  // means the Windows default is in force, not that channel binding is off.
+  ldapEnforceChannelBinding() int
+  // LDAP server signing requirement (Services\NTDS\Parameters\LDAPServerIntegrity)
+  //
+  // Backs the "Domain controller: LDAP server signing requirements" security
+  // option, which controls whether the directory rejects unsigned LDAP binds:
+  // 0 and 1 both leave unsigned binds acceptable, 2 requires signing. The NTDS
+  // key exists only on domain controllers, so this resolves to null on a member
+  // server or a standalone host where the setting does not apply, and also on a
+  // domain controller that never configured the value. Null therefore means the
+  // Windows default is in force, not that signing is not required.
+  ldapServerIntegrity() int
   // Whether local accounts with blank passwords are limited to console logon (Lsa\LimitBlankPasswordUse)
   limitBlankPasswordUse() bool
   // LAN Manager authentication level (Lsa\LmCompatibilityLevel; 0-5, higher is stronger)

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -12453,8 +12453,38 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"windows.lsa.everyoneIncludesAnonymous": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsLsa).GetEveryoneIncludesAnonymous()).ToDataRes(types.Bool)
 	},
+	"windows.lsa.fipsAlgorithmPolicyEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLsa).GetFipsAlgorithmPolicyEnabled()).ToDataRes(types.Bool)
+	},
 	"windows.lsa.forceGuest": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsLsa).GetForceGuest()).ToDataRes(types.Bool)
+	},
+	"windows.lsa.kerberosAllowsAes128": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLsa).GetKerberosAllowsAes128()).ToDataRes(types.Bool)
+	},
+	"windows.lsa.kerberosAllowsAes256": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLsa).GetKerberosAllowsAes256()).ToDataRes(types.Bool)
+	},
+	"windows.lsa.kerberosAllowsDesCbcCrc": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLsa).GetKerberosAllowsDesCbcCrc()).ToDataRes(types.Bool)
+	},
+	"windows.lsa.kerberosAllowsDesCbcMd5": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLsa).GetKerberosAllowsDesCbcMd5()).ToDataRes(types.Bool)
+	},
+	"windows.lsa.kerberosAllowsRc4Hmac": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLsa).GetKerberosAllowsRc4Hmac()).ToDataRes(types.Bool)
+	},
+	"windows.lsa.kerberosSupportedEncryptionTypes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLsa).GetKerberosSupportedEncryptionTypes()).ToDataRes(types.Int)
+	},
+	"windows.lsa.ldapClientIntegrity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLsa).GetLdapClientIntegrity()).ToDataRes(types.Int)
+	},
+	"windows.lsa.ldapEnforceChannelBinding": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLsa).GetLdapEnforceChannelBinding()).ToDataRes(types.Int)
+	},
+	"windows.lsa.ldapServerIntegrity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLsa).GetLdapServerIntegrity()).ToDataRes(types.Int)
 	},
 	"windows.lsa.limitBlankPasswordUse": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsLsa).GetLimitBlankPasswordUse()).ToDataRes(types.Bool)
@@ -30684,8 +30714,48 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlWindowsLsa).EveryoneIncludesAnonymous, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"windows.lsa.fipsAlgorithmPolicyEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLsa).FipsAlgorithmPolicyEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"windows.lsa.forceGuest": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindowsLsa).ForceGuest, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.lsa.kerberosAllowsAes128": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLsa).KerberosAllowsAes128, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.lsa.kerberosAllowsAes256": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLsa).KerberosAllowsAes256, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.lsa.kerberosAllowsDesCbcCrc": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLsa).KerberosAllowsDesCbcCrc, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.lsa.kerberosAllowsDesCbcMd5": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLsa).KerberosAllowsDesCbcMd5, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.lsa.kerberosAllowsRc4Hmac": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLsa).KerberosAllowsRc4Hmac, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.lsa.kerberosSupportedEncryptionTypes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLsa).KerberosSupportedEncryptionTypes, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"windows.lsa.ldapClientIntegrity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLsa).LdapClientIntegrity, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"windows.lsa.ldapEnforceChannelBinding": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLsa).LdapEnforceChannelBinding, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"windows.lsa.ldapServerIntegrity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLsa).LdapServerIntegrity, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"windows.lsa.limitBlankPasswordUse": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -79270,21 +79340,31 @@ type mqlWindowsLsa struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlWindowsLsaInternal it will be used here
-	DisableDomainCreds          plugin.TValue[bool]
-	EveryoneIncludesAnonymous   plugin.TValue[bool]
-	ForceGuest                  plugin.TValue[bool]
-	LimitBlankPasswordUse       plugin.TValue[bool]
-	LmCompatibilityLevel        plugin.TValue[int64]
-	NoLmHash                    plugin.TValue[bool]
-	RestrictAnonymous           plugin.TValue[int64]
-	RestrictAnonymousSam        plugin.TValue[bool]
-	RestrictRemoteSam           plugin.TValue[string]
-	RunAsPpl                    plugin.TValue[int64]
-	SceNoApplyLegacyAuditPolicy plugin.TValue[bool]
-	SubmitControl               plugin.TValue[bool]
-	UseMachineId                plugin.TValue[bool]
-	Ntlm                        plugin.TValue[*mqlWindowsLsaNtlm]
-	SecureChannel               plugin.TValue[*mqlWindowsLsaSecureChannel]
+	DisableDomainCreds               plugin.TValue[bool]
+	EveryoneIncludesAnonymous        plugin.TValue[bool]
+	FipsAlgorithmPolicyEnabled       plugin.TValue[bool]
+	ForceGuest                       plugin.TValue[bool]
+	KerberosAllowsAes128             plugin.TValue[bool]
+	KerberosAllowsAes256             plugin.TValue[bool]
+	KerberosAllowsDesCbcCrc          plugin.TValue[bool]
+	KerberosAllowsDesCbcMd5          plugin.TValue[bool]
+	KerberosAllowsRc4Hmac            plugin.TValue[bool]
+	KerberosSupportedEncryptionTypes plugin.TValue[int64]
+	LdapClientIntegrity              plugin.TValue[int64]
+	LdapEnforceChannelBinding        plugin.TValue[int64]
+	LdapServerIntegrity              plugin.TValue[int64]
+	LimitBlankPasswordUse            plugin.TValue[bool]
+	LmCompatibilityLevel             plugin.TValue[int64]
+	NoLmHash                         plugin.TValue[bool]
+	RestrictAnonymous                plugin.TValue[int64]
+	RestrictAnonymousSam             plugin.TValue[bool]
+	RestrictRemoteSam                plugin.TValue[string]
+	RunAsPpl                         plugin.TValue[int64]
+	SceNoApplyLegacyAuditPolicy      plugin.TValue[bool]
+	SubmitControl                    plugin.TValue[bool]
+	UseMachineId                     plugin.TValue[bool]
+	Ntlm                             plugin.TValue[*mqlWindowsLsaNtlm]
+	SecureChannel                    plugin.TValue[*mqlWindowsLsaSecureChannel]
 }
 
 // createWindowsLsa creates a new instance of this resource
@@ -79336,9 +79416,69 @@ func (c *mqlWindowsLsa) GetEveryoneIncludesAnonymous() *plugin.TValue[bool] {
 	})
 }
 
+func (c *mqlWindowsLsa) GetFipsAlgorithmPolicyEnabled() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.FipsAlgorithmPolicyEnabled, func() (bool, error) {
+		return c.fipsAlgorithmPolicyEnabled()
+	})
+}
+
 func (c *mqlWindowsLsa) GetForceGuest() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.ForceGuest, func() (bool, error) {
 		return c.forceGuest()
+	})
+}
+
+func (c *mqlWindowsLsa) GetKerberosAllowsAes128() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.KerberosAllowsAes128, func() (bool, error) {
+		return c.kerberosAllowsAes128()
+	})
+}
+
+func (c *mqlWindowsLsa) GetKerberosAllowsAes256() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.KerberosAllowsAes256, func() (bool, error) {
+		return c.kerberosAllowsAes256()
+	})
+}
+
+func (c *mqlWindowsLsa) GetKerberosAllowsDesCbcCrc() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.KerberosAllowsDesCbcCrc, func() (bool, error) {
+		return c.kerberosAllowsDesCbcCrc()
+	})
+}
+
+func (c *mqlWindowsLsa) GetKerberosAllowsDesCbcMd5() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.KerberosAllowsDesCbcMd5, func() (bool, error) {
+		return c.kerberosAllowsDesCbcMd5()
+	})
+}
+
+func (c *mqlWindowsLsa) GetKerberosAllowsRc4Hmac() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.KerberosAllowsRc4Hmac, func() (bool, error) {
+		return c.kerberosAllowsRc4Hmac()
+	})
+}
+
+func (c *mqlWindowsLsa) GetKerberosSupportedEncryptionTypes() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.KerberosSupportedEncryptionTypes, func() (int64, error) {
+		return c.kerberosSupportedEncryptionTypes()
+	})
+}
+
+func (c *mqlWindowsLsa) GetLdapClientIntegrity() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.LdapClientIntegrity, func() (int64, error) {
+		return c.ldapClientIntegrity()
+	})
+}
+
+func (c *mqlWindowsLsa) GetLdapEnforceChannelBinding() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.LdapEnforceChannelBinding, func() (int64, error) {
+		return c.ldapEnforceChannelBinding()
+	})
+}
+
+func (c *mqlWindowsLsa) GetLdapServerIntegrity() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.LdapServerIntegrity, func() (int64, error) {
+		return c.ldapServerIntegrity()
 	})
 }
 

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -4557,7 +4557,17 @@ windows.hotfixes 9.0.1
 windows.lsa 13.29.1
 windows.lsa.disableDomainCreds 13.29.1
 windows.lsa.everyoneIncludesAnonymous 13.29.1
+windows.lsa.fipsAlgorithmPolicyEnabled 13.40.10
 windows.lsa.forceGuest 13.29.1
+windows.lsa.kerberosAllowsAes128 13.40.10
+windows.lsa.kerberosAllowsAes256 13.40.10
+windows.lsa.kerberosAllowsDesCbcCrc 13.40.10
+windows.lsa.kerberosAllowsDesCbcMd5 13.40.10
+windows.lsa.kerberosAllowsRc4Hmac 13.40.10
+windows.lsa.kerberosSupportedEncryptionTypes 13.40.10
+windows.lsa.ldapClientIntegrity 13.40.10
+windows.lsa.ldapEnforceChannelBinding 13.40.10
+windows.lsa.ldapServerIntegrity 13.40.10
 windows.lsa.limitBlankPasswordUse 13.29.1
 windows.lsa.lmCompatibilityLevel 13.29.1
 windows.lsa.noLmHash 13.29.1

--- a/providers/os/resources/windows_lsa.go
+++ b/providers/os/resources/windows_lsa.go
@@ -28,6 +28,44 @@ const (
 	lsaNetlogonPolicyPath = `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Netlogon\Parameters`
 )
 
+// Registry locations of the hardening controls that live outside the Lsa key
+// itself.
+//
+// FipsAlgorithmPolicy is a subkey of Lsa holding a single Enabled DWORD.
+//
+// The Kerberos supported encryption types are written by the "Network
+// security: Configure encryption types allowed for Kerberos" policy to the
+// Policies hive, which is the location Windows honors. The identically named
+// value under Lsa\Kerberos\Parameters is the legacy location: Windows Server
+// 2025 no longer reads it, but it is still effective on earlier releases, so it
+// is consulted as a fallback when the policy value is absent.
+//
+// The two LDAP server settings live under the NTDS service, which is installed
+// only on a domain controller. On a member server or a standalone host the key
+// does not exist at all, which is why an absent value has to resolve to null
+// rather than to 0: the setting does not apply, it is not turned off. The LDAP
+// client signing requirement is a separate service key present on every host.
+const (
+	lsaFipsPath           = `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy`
+	lsaKerberosPath       = `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa\Kerberos\Parameters`
+	lsaKerberosPolicyPath = `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Kerberos\Parameters`
+	lsaNtdsPath           = `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NTDS\Parameters`
+	lsaLdapClientPath     = `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LDAP`
+)
+
+// Bits of the Kerberos SupportedEncryptionTypes bitmask. Only the well-known
+// encryption types are decoded; the remaining high bits are reserved for future
+// encryption types and are deliberately ignored, so a value that sets them
+// (0x7FFFFFF8 is a common hardened setting) still decodes the known bits
+// correctly.
+const (
+	kerberosEtypeDesCbcCrc int64 = 0x1
+	kerberosEtypeDesCbcMd5 int64 = 0x2
+	kerberosEtypeRc4Hmac   int64 = 0x4
+	kerberosEtypeAes128    int64 = 0x8
+	kerberosEtypeAes256    int64 = 0x10
+)
+
 func (r *mqlWindowsLsa) id() (string, error) {
 	return "windows.lsa", nil
 }
@@ -290,6 +328,144 @@ func (r *mqlWindowsLsa) secureChannel() (*mqlWindowsLsaSecureChannel, error) {
 		return nil, err
 	}
 	return o.(*mqlWindowsLsaSecureChannel), nil
+}
+
+// lsaKerberosValues holds the Kerberos encryption-type settings: the raw
+// bitmask plus the decoded well-known bits, all nullable.
+type lsaKerberosValues struct {
+	SupportedEncryptionTypes *int64
+	AllowsDesCbcCrc          *bool
+	AllowsDesCbcMd5          *bool
+	AllowsRc4Hmac            *bool
+	AllowsAes128             *bool
+	AllowsAes256             *bool
+}
+
+// computeLsaKerberos extracts the Kerberos supported encryption types and
+// decodes the well-known bits. The policy hive wins over the legacy
+// Lsa\Kerberos\Parameters location, matching how Windows resolves the setting.
+// When neither location carries the value every field stays null: an absent
+// value means Windows uses its built-in default set, which is not the same as a
+// configured mask of 0. Pure function for unit testing.
+func computeLsaKerberos(policy, legacy map[string]registry.RegistryKeyItem) lsaKerberosValues {
+	mask := regIntPtr(policy, "SupportedEncryptionTypes")
+	if mask == nil {
+		mask = regIntPtr(legacy, "SupportedEncryptionTypes")
+	}
+	if mask == nil {
+		return lsaKerberosValues{}
+	}
+
+	// bit reports whether one encryption type is permitted. Masking a single bit
+	// keeps unknown high bits from leaking into any of the answers.
+	bit := func(b int64) *bool {
+		v := *mask&b != 0
+		return &v
+	}
+
+	return lsaKerberosValues{
+		SupportedEncryptionTypes: mask,
+		AllowsDesCbcCrc:          bit(kerberosEtypeDesCbcCrc),
+		AllowsDesCbcMd5:          bit(kerberosEtypeDesCbcMd5),
+		AllowsRc4Hmac:            bit(kerberosEtypeRc4Hmac),
+		AllowsAes128:             bit(kerberosEtypeAes128),
+		AllowsAes256:             bit(kerberosEtypeAes256),
+	}
+}
+
+// lsaLdapValues holds the LDAP signing and channel-binding requirements as
+// nullable pointers.
+type lsaLdapValues struct {
+	ClientIntegrity       *int64
+	EnforceChannelBinding *int64
+	ServerIntegrity       *int64
+}
+
+// computeLsaLdap extracts the LDAP settings. The two server-side values come
+// from the NTDS service key, which exists only on a domain controller, and the
+// client-side value from the LDAP service key. Pure function for unit testing.
+func computeLsaLdap(ntds, ldapClient map[string]registry.RegistryKeyItem) lsaLdapValues {
+	return lsaLdapValues{
+		ClientIntegrity:       regIntPtr(ldapClient, "LDAPClientIntegrity"),
+		EnforceChannelBinding: regIntPtr(ntds, "LdapEnforceChannelBinding"),
+		ServerIntegrity:       regIntPtr(ntds, "LDAPServerIntegrity"),
+	}
+}
+
+// computeLsaFips extracts the FIPS algorithm policy from the
+// Lsa\FipsAlgorithmPolicy key. Nil when the Enabled value is absent, which is
+// the state of a host that never configured FIPS mode. Pure function for unit
+// testing.
+func computeLsaFips(fips map[string]registry.RegistryKeyItem) *bool {
+	return regBoolPtr(fips, "Enabled")
+}
+
+func (r *mqlWindowsLsa) fipsAlgorithmPolicyEnabled() (bool, error) {
+	items, err := r.readLsaKey(lsaFipsPath)
+	if err != nil {
+		return false, err
+	}
+	r.FipsAlgorithmPolicyEnabled = boolFieldPtr(computeLsaFips(items))
+	return false, nil
+}
+
+func (r *mqlWindowsLsa) kerberosAllowsAes128() (bool, error)    { return false, r.populateKerberos() }
+func (r *mqlWindowsLsa) kerberosAllowsAes256() (bool, error)    { return false, r.populateKerberos() }
+func (r *mqlWindowsLsa) kerberosAllowsDesCbcCrc() (bool, error) { return false, r.populateKerberos() }
+func (r *mqlWindowsLsa) kerberosAllowsDesCbcMd5() (bool, error) { return false, r.populateKerberos() }
+func (r *mqlWindowsLsa) kerberosAllowsRc4Hmac() (bool, error)   { return false, r.populateKerberos() }
+
+func (r *mqlWindowsLsa) kerberosSupportedEncryptionTypes() (int64, error) {
+	return 0, r.populateKerberos()
+}
+
+// populateKerberos reads the Kerberos encryption-type setting once and fills
+// the raw bitmask together with every decoded field, so a query touching
+// several of them reads the registry a single time and the answers cannot
+// disagree with the mask they came from.
+func (r *mqlWindowsLsa) populateKerberos() error {
+	policy, err := r.readLsaKey(lsaKerberosPolicyPath)
+	if err != nil {
+		return err
+	}
+	legacy, err := r.readLsaKey(lsaKerberosPath)
+	if err != nil {
+		return err
+	}
+	v := computeLsaKerberos(policy, legacy)
+
+	r.KerberosSupportedEncryptionTypes = intFieldPtr(v.SupportedEncryptionTypes)
+	r.KerberosAllowsAes128 = boolFieldPtr(v.AllowsAes128)
+	r.KerberosAllowsAes256 = boolFieldPtr(v.AllowsAes256)
+	r.KerberosAllowsDesCbcCrc = boolFieldPtr(v.AllowsDesCbcCrc)
+	r.KerberosAllowsDesCbcMd5 = boolFieldPtr(v.AllowsDesCbcMd5)
+	r.KerberosAllowsRc4Hmac = boolFieldPtr(v.AllowsRc4Hmac)
+	return nil
+}
+
+func (r *mqlWindowsLsa) ldapClientIntegrity() (int64, error)       { return 0, r.populateLdap() }
+func (r *mqlWindowsLsa) ldapEnforceChannelBinding() (int64, error) { return 0, r.populateLdap() }
+func (r *mqlWindowsLsa) ldapServerIntegrity() (int64, error)       { return 0, r.populateLdap() }
+
+// populateLdap reads the NTDS and LDAP service keys once and fills all three
+// LDAP fields. On a host that is not a domain controller the NTDS key is
+// missing, which readLsaKey turns into an empty map, leaving the two
+// server-side fields null.
+func (r *mqlWindowsLsa) populateLdap() error {
+	ntds, err := r.readLsaKey(lsaNtdsPath)
+	if err != nil {
+		return err
+	}
+	ldapClient, err := r.readLsaKey(lsaLdapClientPath)
+	if err != nil {
+		return err
+	}
+	v := computeLsaLdap(ntds, ldapClient)
+
+	r.LdapClientIntegrity = intFieldPtr(v.ClientIntegrity)
+	r.LdapEnforceChannelBinding = intFieldPtr(v.EnforceChannelBinding)
+	r.LdapServerIntegrity = intFieldPtr(v.ServerIntegrity)
+	return nil
 }
 
 // intFieldPtr converts a nullable *int64 into the generated plugin.TValue[int64]

--- a/providers/os/resources/windows_lsa_internal_test.go
+++ b/providers/os/resources/windows_lsa_internal_test.go
@@ -440,9 +440,9 @@ func TestComputeLsaKerberos(t *testing.T) {
 	})
 
 	tests := []struct {
-		name                                         string
-		mask                                         int64
-		desCbcCrc, desCbcMd5, rc4Hmac, aes128, ae256 bool
+		name                                          string
+		mask                                          int64
+		desCbcCrc, desCbcMd5, rc4Hmac, aes128, aes256 bool
 	}{
 		{"legacy only (0x7)", 0x7, true, true, true, false, false},
 		{"AES only (0x18)", 0x18, false, false, false, true, true},
@@ -479,7 +479,7 @@ func TestComputeLsaKerberos(t *testing.T) {
 				{"desCbcMd5", v.AllowsDesCbcMd5, tc.desCbcMd5},
 				{"rc4Hmac", v.AllowsRc4Hmac, tc.rc4Hmac},
 				{"aes128", v.AllowsAes128, tc.aes128},
-				{"aes256", v.AllowsAes256, tc.ae256},
+				{"aes256", v.AllowsAes256, tc.aes256},
 			} {
 				require.NotNil(t, f.got, f.name)
 				assert.Equal(t, f.want, *f.got, f.name)

--- a/providers/os/resources/windows_lsa_internal_test.go
+++ b/providers/os/resources/windows_lsa_internal_test.go
@@ -364,3 +364,185 @@ func TestLsaStringFieldPtr(t *testing.T) {
 		assert.Equal(t, "", f.Data)
 	})
 }
+
+// isNullBool and isNullInt report whether the generated field representation of
+// a nullable source pointer lands in the null state, which is how an absent
+// registry value has to surface to MQL. The TValue is bound to a local first
+// because IsNull has a pointer receiver.
+func isNullBool(p *bool) bool {
+	f := boolFieldPtr(p)
+	return f.IsSet() && f.IsNull()
+}
+
+func isNullInt(p *int64) bool {
+	f := intFieldPtr(p)
+	return f.IsSet() && f.IsNull()
+}
+
+func TestComputeLsaFips(t *testing.T) {
+	t.Run("absent value yields null, not a fabricated false", func(t *testing.T) {
+		assert.Nil(t, computeLsaFips(map[string]registry.RegistryKeyItem{}))
+		assert.Nil(t, computeLsaFips(items(d("SomethingElse", 1))))
+		assert.True(t, isNullBool(computeLsaFips(map[string]registry.RegistryKeyItem{})))
+	})
+
+	t.Run("explicit 0 is false and distinguishable from absent", func(t *testing.T) {
+		p := computeLsaFips(items(d("Enabled", 0)))
+		require.NotNil(t, p)
+		assert.False(t, *p)
+		assert.False(t, isNullBool(p))
+	})
+
+	t.Run("enabled reads true", func(t *testing.T) {
+		p := computeLsaFips(items(d("Enabled", 1)))
+		require.NotNil(t, p)
+		assert.True(t, *p)
+	})
+}
+
+func TestComputeLsaKerberos(t *testing.T) {
+	empty := map[string]registry.RegistryKeyItem{}
+
+	t.Run("absent in both locations yields null everywhere", func(t *testing.T) {
+		v := computeLsaKerberos(empty, empty)
+		assert.Nil(t, v.SupportedEncryptionTypes)
+		assert.Nil(t, v.AllowsDesCbcCrc)
+		assert.Nil(t, v.AllowsDesCbcMd5)
+		assert.Nil(t, v.AllowsRc4Hmac)
+		assert.Nil(t, v.AllowsAes128)
+		assert.Nil(t, v.AllowsAes256)
+
+		// an absent mask must not decode to "every type denied": that would
+		// report DES and RC4 as blocked on a host that never configured the
+		// policy and is in fact using the Windows default set
+		assert.True(t, isNullInt(v.SupportedEncryptionTypes))
+		assert.True(t, isNullBool(v.AllowsRc4Hmac))
+		assert.True(t, isNullBool(v.AllowsAes256))
+	})
+
+	t.Run("the policy location wins over the legacy location", func(t *testing.T) {
+		v := computeLsaKerberos(
+			items(d("SupportedEncryptionTypes", 0x18)),
+			items(d("SupportedEncryptionTypes", 0x4)),
+		)
+		require.NotNil(t, v.SupportedEncryptionTypes)
+		assert.Equal(t, int64(0x18), *v.SupportedEncryptionTypes)
+		require.NotNil(t, v.AllowsRc4Hmac)
+		assert.False(t, *v.AllowsRc4Hmac)
+	})
+
+	t.Run("the legacy location is used when the policy value is absent", func(t *testing.T) {
+		v := computeLsaKerberos(empty, items(d("SupportedEncryptionTypes", 0x4)))
+		require.NotNil(t, v.SupportedEncryptionTypes)
+		assert.Equal(t, int64(0x4), *v.SupportedEncryptionTypes)
+		require.NotNil(t, v.AllowsRc4Hmac)
+		assert.True(t, *v.AllowsRc4Hmac)
+	})
+
+	tests := []struct {
+		name                                         string
+		mask                                         int64
+		desCbcCrc, desCbcMd5, rc4Hmac, aes128, ae256 bool
+	}{
+		{"legacy only (0x7)", 0x7, true, true, true, false, false},
+		{"AES only (0x18)", 0x18, false, false, false, true, true},
+		{"transitional RC4 plus AES (0x1C)", 0x1C, false, false, true, true, true},
+		{"explicit zero denies every known type", 0x0, false, false, false, false, false},
+		{"single legacy bit (0x1)", 0x1, true, false, false, false, false},
+		{"AES256 alone (0x10)", 0x10, false, false, false, false, true},
+		// 0x7FFFFFF8 is the hardened value the Windows baseline expects: every
+		// reserved future-type bit is set alongside AES, and the three legacy
+		// bits are clear. The unknown high bits must not bleed into any answer.
+		{"future-type bits set with AES (0x7FFFFFF8)", 0x7FFFFFF8, false, false, false, true, true},
+		// the same shape with a legacy bit deliberately left on, so a bug that
+		// widened the mask would show up as DES reading false
+		{"future-type bits set with DES still on (0x7FFFFFF9)", 0x7FFFFFF9, true, false, false, true, true},
+		// 0x80000000 is documented as "use Windows default values"; it is an
+		// unknown bit as far as the decode is concerned and must be ignored
+		{"top bit set alongside AES (0x80000018)", 0x80000018, false, false, false, true, true},
+		{"top bit alone (0x80000000)", 0x80000000, false, false, false, false, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := computeLsaKerberos(items(d("SupportedEncryptionTypes", tc.mask)), empty)
+
+			require.NotNil(t, v.SupportedEncryptionTypes)
+			assert.Equal(t, tc.mask, *v.SupportedEncryptionTypes, "the raw mask is reported unchanged")
+
+			for _, f := range []struct {
+				name string
+				got  *bool
+				want bool
+			}{
+				{"desCbcCrc", v.AllowsDesCbcCrc, tc.desCbcCrc},
+				{"desCbcMd5", v.AllowsDesCbcMd5, tc.desCbcMd5},
+				{"rc4Hmac", v.AllowsRc4Hmac, tc.rc4Hmac},
+				{"aes128", v.AllowsAes128, tc.aes128},
+				{"aes256", v.AllowsAes256, tc.ae256},
+			} {
+				require.NotNil(t, f.got, f.name)
+				assert.Equal(t, f.want, *f.got, f.name)
+			}
+		})
+	}
+}
+
+func TestComputeLsaLdap(t *testing.T) {
+	empty := map[string]registry.RegistryKeyItem{}
+
+	t.Run("no NTDS key leaves the server settings null, not zero", func(t *testing.T) {
+		// the shape of a member server or standalone host: the NTDS service is
+		// not installed, so the key is missing entirely. Reporting 0 here would
+		// claim "LDAP signing not required" about a setting that does not apply.
+		v := computeLsaLdap(empty, empty)
+		assert.Nil(t, v.ServerIntegrity)
+		assert.Nil(t, v.EnforceChannelBinding)
+		assert.Nil(t, v.ClientIntegrity)
+
+		assert.True(t, isNullInt(v.ServerIntegrity))
+		assert.True(t, isNullInt(v.EnforceChannelBinding))
+		assert.True(t, isNullInt(v.ClientIntegrity))
+	})
+
+	t.Run("client setting resolves while the server settings stay null", func(t *testing.T) {
+		v := computeLsaLdap(empty, items(d("LDAPClientIntegrity", 1)))
+		require.NotNil(t, v.ClientIntegrity)
+		assert.Equal(t, int64(1), *v.ClientIntegrity)
+		assert.Nil(t, v.ServerIntegrity)
+		assert.Nil(t, v.EnforceChannelBinding)
+	})
+
+	t.Run("a domain controller resolves every value", func(t *testing.T) {
+		v := computeLsaLdap(
+			items(d("LDAPServerIntegrity", 2), d("LdapEnforceChannelBinding", 2)),
+			items(d("LDAPClientIntegrity", 2)),
+		)
+		require.NotNil(t, v.ServerIntegrity)
+		assert.Equal(t, int64(2), *v.ServerIntegrity)
+		require.NotNil(t, v.EnforceChannelBinding)
+		assert.Equal(t, int64(2), *v.EnforceChannelBinding)
+		require.NotNil(t, v.ClientIntegrity)
+		assert.Equal(t, int64(2), *v.ClientIntegrity)
+	})
+
+	t.Run("explicit 0 is reported as 0, not as null", func(t *testing.T) {
+		v := computeLsaLdap(
+			items(d("LDAPServerIntegrity", 0), d("LdapEnforceChannelBinding", 0)),
+			items(d("LDAPClientIntegrity", 0)),
+		)
+		require.NotNil(t, v.ServerIntegrity)
+		assert.Equal(t, int64(0), *v.ServerIntegrity)
+		assert.False(t, isNullInt(v.ServerIntegrity))
+		require.NotNil(t, v.EnforceChannelBinding)
+		assert.False(t, isNullInt(v.EnforceChannelBinding))
+		require.NotNil(t, v.ClientIntegrity)
+		assert.False(t, isNullInt(v.ClientIntegrity))
+	})
+
+	t.Run("the server settings are read from NTDS, not from the client key", func(t *testing.T) {
+		// a value planted on the wrong key must not satisfy the field
+		v := computeLsaLdap(empty, items(d("LDAPServerIntegrity", 2)))
+		assert.Nil(t, v.ServerIntegrity)
+	})
+}


### PR DESCRIPTION
## What

`windows.lsa` is the deepest resource of the Windows set, and four well-known hardening
controls had no typed home anywhere in the provider. SMB signing is covered elsewhere;
LDAP signing was not covered at all. All four are LSA-adjacent registry settings, so this
resource is where they belong.

Ten new fields:

| field | source |
|---|---|
| `fipsAlgorithmPolicyEnabled` | `Lsa\FipsAlgorithmPolicy\Enabled` |
| `kerberosSupportedEncryptionTypes` | `SupportedEncryptionTypes` (raw bitmask) |
| `kerberosAllowsDesCbcCrc` | bit `0x1` |
| `kerberosAllowsDesCbcMd5` | bit `0x2` |
| `kerberosAllowsRc4Hmac` | bit `0x4` |
| `kerberosAllowsAes128` | bit `0x8` |
| `kerberosAllowsAes256` | bit `0x10` |
| `ldapServerIntegrity` | `Services\NTDS\Parameters\LDAPServerIntegrity` |
| `ldapEnforceChannelBinding` | `Services\NTDS\Parameters\LdapEnforceChannelBinding` |
| `ldapClientIntegrity` | `Services\LDAP\LDAPClientIntegrity` |

## Absent is not disabled

The NTDS key exists only on a domain controller. On a member server or a standalone host
it is missing entirely, and missing means the OS default applies, not `0`. Modelling these
as plain ints would report "LDAP signing not required" on a host where the setting does not
apply at all. Every field resolves to **null** (`plugin.StateIsSet | plugin.StateIsNull`)
when its value is absent, following the nullable pattern the rest of `windows.lsa` already
uses.

Verified below that this holds in both directions: an absent value reads null, and an
explicit `0` reads `0`.

## Why the Kerberos booleans exist

MQL has no bitwise operators. The operator table in `mqlc/parser/operators.go` is
`= && || == =~ != !~ < <= > >= + - * / %` — there is no `&`. So a raw bitmask is only
testable by exact equality against a whole mask value, which breaks the moment a reserved
future-type bit is set. `0x7FFFFFF8` is the hardened value the Windows baseline expects,
and it sets 27 bits the schema knows nothing about.

Decoding the five well-known bits is therefore the only way to express "RC4 is still
permitted" in a policy. The decode masks one bit at a time, so unknown high bits cannot
corrupt a known-bit answer — proven against a real registry round trip in state B below.

(For context: the shipped `ntlmMinClientSec` / `ntlmMinServerSec` are documented bitmasks
with no decode, so they have this gap today. Not addressed here.)

## Registry location correction

The Kerberos setting is read from the **policy** location
`SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Kerberos\Parameters`, falling
back to the legacy `Lsa\Kerberos\Parameters`.

Per Microsoft Learn (Kerberos authentication overview): "Beginning with Windows Server 2025,
Kerberos no longer honors the legacy registry key `SupportedEncryptionTypes` found in the
path `HKLM\CurrentControlSet\Control\Lsa\Kerberos\Parameters`." The policy location is also
the one the Windows security baseline names. The legacy location is still effective on
earlier releases, so it is kept as a fallback rather than dropped.

There is precedent for reading a GPO hive here: `secureChannel.blockNetbiosDiscovery`
already does it while its siblings read from Services.

## Schema shape: flattened, not `ldap()` / `kerberos()` sub-resources

`windows.lsa` already has `ntlm` and `secureChannel` sub-resources, so grouping would have
been the locally consistent move. I flattened instead, following CLAUDE.md's sub-resource
bar:

1. **Neither group clears the bar.** No clear ID (both would need a synthetic
   `windows.lsa.ldap`), and no nested typed reference. The bar says flatten with a
   disambiguating prefix in exactly this case.
2. **The prefix is the vendor's own, not invented.** The registry value names already read
   `LDAPServerIntegrity`, `LdapEnforceChannelBinding`, `LDAPClientIntegrity`.
3. **`ntlm` / `secureChannel` earn their containers on mass** — 7 and 10 fields, each a
   whole registry subsystem. Three LDAP scalars do not reach that, and CLAUDE.md is explicit
   that an existing sibling which deviates is "a pre-existing deviation, not precedent".
4. **Smaller diff on a hot file** — no new resources, no new `__id`s, no resource-level
   `.lr.versions` entries, which matters with several PRs touching `os.lr` in parallel.

Laziness is preserved without the sub-resources: each key group has its own
`populateKerberos()` / `populateLdap()`, so querying one LSA field does not read five extra
registry keys.

## Verification

Live host: standalone EC2 Windows Server 2022, build 20348, AMD64, over SSH.
Confirmed standalone rather than assumed — `PartOfDomain=False`, `DomainRole=2`
(Standalone Server), `Domain=WORKGROUP`.

Each state was written to the registry with PowerShell, then read back through
`mql run ssh ... -c "windows.lsa { ... }"`. Every reading below is observed output, not
expected output.

Two findings about the stock image worth recording: `FipsAlgorithmPolicy\Enabled` ships
**present as `0`**, and `Services\LDAP\LDAPClientIntegrity` ships **present as `1`**. Only
the NTDS values and the Kerberos mask are genuinely absent by default.

### State A — stock host (baseline, and restored afterwards)

| field | registry | mql |
|---|---|---|
| `fipsAlgorithmPolicyEnabled` | `Enabled=0` present | `false` |
| `kerberosSupportedEncryptionTypes` | absent in both locations | `null` |
| `kerberosAllows*` (all five) | derived, no mask | `null` |
| `ldapServerIntegrity` | NTDS key absent | `null` |
| `ldapEnforceChannelBinding` | NTDS key absent | `null` |
| `ldapClientIntegrity` | `=1` present | `1` |

This is the central result: the two NTDS-backed fields read **null, not 0**, on a host where
the setting does not apply. FIPS reading `false` rather than `null` in the same run shows
set-`0` and absent are genuinely distinguished rather than collapsed.

### State B — FIPS on, hardened Kerberos mask, synthesized NTDS key

Registry: `Enabled=1`; policy `SupportedEncryptionTypes=0x7FFFFFF8`; NTDS key created with
`LDAPServerIntegrity=2`, `LdapEnforceChannelBinding=2`; `LDAPClientIntegrity=2`.

| field | mql |
|---|---|
| `fipsAlgorithmPolicyEnabled` | `true` |
| `kerberosSupportedEncryptionTypes` | `2147483640` (`0x7FFFFFF8`) |
| `kerberosAllowsDesCbcCrc` | `false` |
| `kerberosAllowsDesCbcMd5` | `false` |
| `kerberosAllowsRc4Hmac` | `false` |
| `kerberosAllowsAes128` | `true` |
| `kerberosAllowsAes256` | `true` |
| `ldapServerIntegrity` | `2` |
| `ldapEnforceChannelBinding` | `2` |
| `ldapClientIntegrity` | `2` |

**The high-bits case, proven on real data.** 27 reserved bits are set and every known-bit
answer is still correct.

### State C — decode flip, precedence conflict, FIPS null

Registry: `Enabled` **deleted**; policy `=0x1C` while legacy `Lsa` `=0x7FFFFFF8`, the two
deliberately disagreeing about RC4; NTDS `LDAPServerIntegrity=1`,
`LdapEnforceChannelBinding=0`; `LDAPClientIntegrity=0`.

| field | mql | shows |
|---|---|---|
| `fipsAlgorithmPolicyEnabled` | `null` | deleted value reads null, not `false` |
| `kerberosSupportedEncryptionTypes` | `28` | **policy hive won over legacy** (`0x1C`, not `2147483640`) |
| `kerberosAllowsRc4Hmac` | `true` | flipped from state B |
| `kerberosAllowsDesCbcCrc` / `DesCbcMd5` | `false` / `false` | |
| `kerberosAllowsAes128` / `Aes256` | `true` / `true` | |
| `ldapServerIntegrity` | `1` | |
| `ldapEnforceChannelBinding` | `0` | **explicit 0 reads 0, not null** |
| `ldapClientIntegrity` | `0` | |

The RC4 disagreement is the discriminator: had the legacy location won, the mask would have
read `2147483640` and RC4 `false`.

### State D — legacy fallback in isolation

Registry: policy Kerberos key **removed**, legacy `Lsa` left at `0x7FFFFFF8`; NTDS key
removed; `Enabled` restored to `0`; `LDAPClientIntegrity` restored to `1`.

| field | mql | shows |
|---|---|---|
| `kerberosSupportedEncryptionTypes` | `2147483640` | **legacy fallback works** with the policy key gone |
| `kerberosAllowsRc4Hmac` | `false` | |
| `kerberosAllowsAes128` / `Aes256` | `true` / `true` | |
| `ldapServerIntegrity` | `null` | returns to null once NTDS is removed |
| `ldapEnforceChannelBinding` | `null` | |
| `fipsAlgorithmPolicyEnabled` | `false` | |

### Teardown

Every value and key I created was removed and the registry compared field by field against
the recorded baseline. `Services\NTDS` and the policy `System\Kerberos` key are gone
(neither existed before); `Lsa\Kerberos\Parameters` still exists with no
`SupportedEncryptionTypes` value, exactly as found. A final mql read returned output
identical to state A.

### Null cannot pass vacuously

Since these fields are the kind a policy asserts on, I checked that an absent value fails a
check rather than satisfying it:

```
windows.lsa { ldapServerIntegrity == 2  kerberosAllowsRc4Hmac == false
              fipsAlgorithmPolicyEnabled == true  ldapClientIntegrity == 1 }
```
```
ldapServerIntegrity == 2          false     (field is null)
kerberosAllowsRc4Hmac == false    false     (field is null)
fipsAlgorithmPolicyEnabled == true false    (field is 0)
ldapClientIntegrity == 1          true
```

Equality against null returns false, so "RC4 is not permitted" does **not** pass on a host
that never configured the mask. That is the fail-safe direction.

## What is still unverified

`ldapServerIntegrity` and `ldapEnforceChannelBinding` were exercised on a **synthesized**
NTDS key, not a real domain controller. That proves the read path is correct — right key,
right value names, right type, correct null-on-absence — but it does not prove the values a
live AD DS installation would produce. Worth a follow-up against a real DC if one becomes
available.

## Tests

Pure-Go decode and null handling in `windows_lsa_internal_test.go`:

- `TestComputeLsaKerberos` — 16 cases including `0x7FFFFFF8`, `0x7FFFFFF9` (high bits set
  *with* a legacy bit still on, so a widened mask would show up as DES reading false),
  `0x80000018`, `0x80000000`, policy-wins-over-legacy, and the legacy fallback.
- `TestComputeLsaLdap` — 5 cases including the no-NTDS-key shape and a value planted on the
  wrong key.
- `TestComputeLsaFips` — absent vs explicit `0` vs `1`.

I mutation-checked the bitmask decode: replacing the single-bit mask with a comparison
produced 35 assertion failures, so the tests pin the behaviour rather than passing by
construction.

## Checks

```
gofmt -l providers/os/resources/     clean
go vet ./resources/                  clean
go build ./... (root + providers/os) clean
go test ./resources/                 ok (full suite)
codegen idempotent                   md5 identical across a repeat generate
typos                                clean
em dashes in new .lr lines           0
make providers/build/os              ok, no other generated files changed
```

`.lr.versions` entries at `13.40.10` (os provider is `13.40.9`); `config.go` not bumped.
