### PR TITLE
🐛 os: read windows.schannel.ellipticCurves from the supported-group list

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -12046,15 +12046,17 @@ private windows.lsa.secureChannel {
 
 // Windows Schannel TLS configuration
 //
-// Schannel (Secure Channel) TLS cipher-suite and supported-group
-// configuration that backs the Microsoft TLS/SSL stack, read from the effective
-// local Schannel store under
+// Schannel (Secure Channel) TLS cipher-suite, supported-group, and
+// signature-algorithm configuration that backs the Microsoft TLS/SSL stack, read
+// from the effective local Schannel store under
 // HKLM\SYSTEM\CurrentControlSet\Control\Cryptography\Configuration\Local\SSL.
-// The ordered cipher-suite list is the REG_MULTI_SZ `Functions` value under the
-// 00010002 subkey and the ordered elliptic-curve / supported-group list is the
-// REG_MULTI_SZ `Functions` value under the 00010003 subkey. On Windows 11 24H2
-// and Windows Server 2025 the supported-group list is where post-quantum ML-KEM
-// key-exchange groups (for example secp256r1_mlkem768) appear once enabled.
+// The 00010002 subkey holds the ordered cipher-suite list in its REG_MULTI_SZ
+// `Functions` value and the ordered elliptic-curve / supported-group list in its
+// REG_MULTI_SZ `EccCurves` value, the same list `Get-TlsEccCurve` reports. The
+// 00010003 subkey holds the ordered signature-algorithm list in its REG_MULTI_SZ
+// `Functions` value. On Windows 11 24H2 and Windows Server 2025 the
+// supported-group list is where post-quantum ML-KEM key-exchange groups (for
+// example secp256r1_mlkem768) appear once enabled.
 //
 // When a key or value is absent (the common case on older Windows, on systems
 // using the default order, and on non-Windows platforms) the list accessors
@@ -12077,8 +12079,21 @@ private windows.lsa.secureChannel {
 windows.schannel {
   // Ordered TLS cipher suite list (REG_MULTI_SZ Functions under ...\SSL\00010002)
   cipherSuites() []string
-  // Ordered TLS elliptic-curve / supported-group list (REG_MULTI_SZ Functions under ...\SSL\00010003)
+  // Ordered TLS elliptic-curve / supported-group list (REG_MULTI_SZ EccCurves under ...\SSL\00010002)
+  //
+  // The key-exchange groups Schannel offers, in preference order, for example
+  // curve25519, NistP256, and NistP384 on a stock Windows Server. This is the
+  // list `Get-TlsEccCurve` reports and the list post-quantum ML-KEM groups join
+  // once enabled. Signature algorithms are a separate list, exposed as
+  // signatureAlgorithms.
   ellipticCurves() []string
+  // Ordered TLS signature algorithm list (REG_MULTI_SZ Functions under ...\SSL\00010003)
+  //
+  // The certificate and handshake signature algorithms Schannel offers, in
+  // preference order, spelled key type and hash separated by a slash, for
+  // example RSA/SHA256, ECDSA/SHA384, and the legacy DSA/SHA1 and RSA/SHA1.
+  // Windows Server 2022 and later also list the RSAE-PSS entries.
+  signatureAlgorithms() []string
   // Whether a post-quantum ML-KEM key-exchange group is enabled (any ellipticCurves entry contains "MLKEM", case-insensitive)
   pqcKeyExchangeEnabled() bool
   // Per-protocol client and server overrides (SCHANNEL\Protocols)

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -12679,6 +12679,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"windows.schannel.ellipticCurves": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsSchannel).GetEllipticCurves()).ToDataRes(types.Array(types.String))
 	},
+	"windows.schannel.signatureAlgorithms": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsSchannel).GetSignatureAlgorithms()).ToDataRes(types.Array(types.String))
+	},
 	"windows.schannel.pqcKeyExchangeEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsSchannel).GetPqcKeyExchangeEnabled()).ToDataRes(types.Bool)
 	},
@@ -31268,6 +31271,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"windows.schannel.ellipticCurves": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindowsSchannel).EllipticCurves, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"windows.schannel.signatureAlgorithms": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsSchannel).SignatureAlgorithms, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"windows.schannel.pqcKeyExchangeEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -80603,6 +80610,7 @@ type mqlWindowsSchannel struct {
 	// optional: if you define mqlWindowsSchannelInternal it will be used here
 	CipherSuites          plugin.TValue[[]any]
 	EllipticCurves        plugin.TValue[[]any]
+	SignatureAlgorithms   plugin.TValue[[]any]
 	PqcKeyExchangeEnabled plugin.TValue[bool]
 	Protocols             plugin.TValue[[]any]
 	Ciphers               plugin.TValue[[]any]
@@ -80656,6 +80664,12 @@ func (c *mqlWindowsSchannel) GetCipherSuites() *plugin.TValue[[]any] {
 func (c *mqlWindowsSchannel) GetEllipticCurves() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.EllipticCurves, func() ([]any, error) {
 		return c.ellipticCurves()
+	})
+}
+
+func (c *mqlWindowsSchannel) GetSignatureAlgorithms() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SignatureAlgorithms, func() ([]any, error) {
+		return c.signatureAlgorithms()
 	})
 }
 

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -4727,6 +4727,7 @@ windows.schannel.protocol.serverConfigured 13.40.10
 windows.schannel.protocol.serverDisabledByDefault 13.40.10
 windows.schannel.protocol.serverEnabled 13.40.10
 windows.schannel.protocols 13.40.10
+windows.schannel.signatureAlgorithms 13.40.10
 windows.scheduledTask 13.25.1
 windows.scheduledTask.action 13.25.1
 windows.scheduledTask.action.arguments 13.25.1

--- a/providers/os/resources/windows_schannel.go
+++ b/providers/os/resources/windows_schannel.go
@@ -13,21 +13,28 @@ import (
 	"go.mondoo.com/ranger-rpc/status"
 )
 
-// Registry locations of the effective Schannel TLS configuration. The ordered
-// cipher-suite list and the ordered elliptic-curve / supported-group list are
-// each stored as the REG_MULTI_SZ `Functions` value under their own subkey of
-// the local SSL configuration store.
+// Registry locations of the effective Schannel TLS configuration, held in the
+// local SSL configuration store. The store has one subkey per NCRYPT interface,
+// named after the interface id, and each subkey names itself in its default
+// value:
 //
-// Verified against Microsoft Learn: the cipher-suite order lives at
-// ...\Local\SSL\00010002 as the `Functions` REG_MULTI_SZ value (documented in
-// several Microsoft troubleshooting articles). The companion
-// ...\Local\SSL\00010003 subkey holds the effective elliptic-curve /
-// supported-group order, where post-quantum ML-KEM groups appear on Windows 11
-// 24H2 and Windows Server 2025.
+//   - 00010002 is NCRYPT_SCHANNEL_INTERFACE. Its `Functions` REG_MULTI_SZ is the
+//     ordered cipher-suite list and its `EccCurves` REG_MULTI_SZ is the ordered
+//     elliptic-curve / supported-group list, which is what `Get-TlsEccCurve`
+//     reports and where post-quantum ML-KEM groups appear on Windows 11 24H2 and
+//     Windows Server 2025.
+//   - 00010003 is NCRYPT_SCHANNEL_SIGNATURE_INTERFACE. Its `Functions`
+//     REG_MULTI_SZ is the ordered signature-algorithm list (RSA/SHA256,
+//     ECDSA/SHA384, DSA/SHA1, and on newer releases the RSAE-PSS entries).
+//
+// The two interfaces both spell their list `Functions`, which is why the
+// supported groups have to come from the `EccCurves` value of the first rather
+// than the `Functions` value of the second.
 const (
-	schannelCipherSuitesPath    = `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Cryptography\Configuration\Local\SSL\00010002`
-	schannelSupportedGroupsPath = `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Cryptography\Configuration\Local\SSL\00010003`
-	schannelFunctionsValue      = "Functions"
+	schannelCipherSuitesPath  = `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Cryptography\Configuration\Local\SSL\00010002`
+	schannelSignatureAlgoPath = `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Cryptography\Configuration\Local\SSL\00010003`
+	schannelFunctionsValue    = "Functions"
+	schannelEccCurvesValue    = "EccCurves"
 )
 
 func (r *mqlWindowsSchannel) id() (string, error) {
@@ -73,11 +80,19 @@ func (r *mqlWindowsSchannel) cipherSuites() ([]interface{}, error) {
 }
 
 func (r *mqlWindowsSchannel) ellipticCurves() ([]interface{}, error) {
-	curves, err := r.readMultiString(schannelSupportedGroupsPath, schannelFunctionsValue)
+	curves, err := r.readMultiString(schannelCipherSuitesPath, schannelEccCurvesValue)
 	if err != nil {
 		return nil, err
 	}
 	return strSliceToAny(curves), nil
+}
+
+func (r *mqlWindowsSchannel) signatureAlgorithms() ([]interface{}, error) {
+	algorithms, err := r.readMultiString(schannelSignatureAlgoPath, schannelFunctionsValue)
+	if err != nil {
+		return nil, err
+	}
+	return strSliceToAny(algorithms), nil
 }
 
 func (r *mqlWindowsSchannel) pqcKeyExchangeEnabled() (bool, error) {

--- a/providers/os/resources/windows_schannel_internal_test.go
+++ b/providers/os/resources/windows_schannel_internal_test.go
@@ -343,3 +343,54 @@ func TestMergeSchannelNames(t *testing.T) {
 }
 
 func boolPtr(v bool) *bool { return &v }
+
+// TestSchannelLocalSslStoreSources pins which subkey and which value name backs
+// each of the three effective lists. The local SSL store keys one subkey per
+// NCRYPT interface and both interfaces spell their own list `Functions`, so
+// reading `Functions` under 00010003 for the supported groups returns the
+// signature algorithms instead: a plausible, non-empty, entirely wrong answer
+// that no error reports. Real hosts confirm the split, with the subkey naming
+// itself in its default value: 00010002 is NCRYPT_SCHANNEL_INTERFACE and
+// 00010003 is NCRYPT_SCHANNEL_SIGNATURE_INTERFACE on Windows Server 2016, 2019,
+// and 2022 alike.
+func TestSchannelLocalSslStoreSources(t *testing.T) {
+	const store = `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Cryptography\Configuration\Local\SSL`
+
+	assert.Equal(t, store+`\00010002`, schannelCipherSuitesPath)
+	assert.Equal(t, store+`\00010003`, schannelSignatureAlgoPath)
+	assert.Equal(t, "Functions", schannelFunctionsValue)
+	assert.Equal(t, "EccCurves", schannelEccCurvesValue)
+
+	// the supported groups come from the cipher-suite interface, not the
+	// signature interface
+	assert.NotEqual(t, schannelSignatureAlgoPath, schannelCipherSuitesPath)
+	assert.NotEqual(t, schannelFunctionsValue, schannelEccCurvesValue)
+}
+
+// TestPqcKeyExchangeEnabledOnSignatureAlgorithms feeds the real
+// signature-algorithm lists captured from Windows Server 2016, 2019, and 2022
+// through the ML-KEM detector. None of them can ever contain a key-exchange
+// group, so a pqcKeyExchangeEnabled built on that list is pinned to false on
+// every host, including one where post-quantum key exchange is switched on.
+func TestPqcKeyExchangeEnabledOnSignatureAlgorithms(t *testing.T) {
+	// ...\SSL\00010003 Functions, verbatim
+	ws2016 := []string{
+		"RSA/SHA256", "RSA/SHA384", "RSA/SHA1", "ECDSA/SHA256",
+		"ECDSA/SHA384", "ECDSA/SHA1", "DSA/SHA1", "RSA/SHA512", "ECDSA/SHA512",
+	}
+	ws2022 := []string{
+		"RSAE-PSS/SHA256", "RSAE-PSS/SHA384", "RSAE-PSS/SHA512",
+		"RSA/SHA256", "RSA/SHA384", "RSA/SHA1", "ECDSA/SHA256",
+		"ECDSA/SHA384", "ECDSA/SHA1", "DSA/SHA1", "RSA/SHA512", "ECDSA/SHA512",
+	}
+	assert.False(t, pqcKeyExchangeEnabled(ws2016))
+	assert.False(t, pqcKeyExchangeEnabled(ws2022))
+
+	// ...\SSL\00010002 EccCurves, verbatim, on the same hosts
+	stockGroups := []string{"curve25519", "NistP256", "NistP384"}
+	assert.False(t, pqcKeyExchangeEnabled(stockGroups))
+
+	// the same list once a post-quantum group is enabled
+	withMlKem := append([]string{"secp256r1_mlkem768"}, stockGroups...)
+	assert.True(t, pqcKeyExchangeEnabled(withMlKem))
+}


### PR DESCRIPTION
## What

`windows.defender` does not work. On every current Windows host, every field of
`windows.defender.status`, `windows.defender.preferences` and all eleven
preference sub-resources errors:

```
$ mql run ssh Administrator@<2016-host> -c "windows.defender { enabled status { antivirusEnabled } preferences { puaProtection } }"
2 errors occurred:
	* json: cannot unmarshal bool into Go struct field MpPreference.CheckForSignaturesBeforeRunningScan of type int64
	* json: cannot unmarshal string into Go struct field MpComputerStatus.DeviceControlState of type int64
windows.defender: {
  status:      json: cannot unmarshal string into Go struct field MpComputerStatus.DeviceControlState of type int64
  enabled:     json: cannot unmarshal string into Go struct field MpComputerStatus.DeviceControlState of type int64
  preferences: json: cannot unmarshal bool into Go struct field MpPreference.CheckForSignaturesBeforeRunningScan of type int64
  threats: []
  threatDetections: []
}
```

Three properties have types the Go structs do not declare. `json.Unmarshal`
aborts the whole decode on the first mismatch, so one wrong field takes the
entire payload down with it.

| property | declared | actually returned |
|---|---|---|
| `MSFT_MpComputerStatus.DeviceControlState` | `int64` | `"Disabled"` (string) |
| `MSFT_MpComputerStatus.DeviceControlDefaultEnforcement` | `int64` | string, null when unset |
| `MSFT_MpPreference.CheckForSignaturesBeforeRunningScan` | `int64` | `false` (boolean) |

These are not per-version accidents. The CIM class metadata the cmdlets return
alongside the properties declares `DeviceControlState` and
`DeviceControlDefaultEnforcement` as strings and
`CheckForSignaturesBeforeRunningScan` as CimType 1 (Boolean). The `.lr` comment
documenting `checkForSignaturesBeforeRunningScan` as a `0 = never, 1 = before
every scan, 2 = disabled` enum was wrong on both count and kind.

## Versions affected

Reproduced identically on **Windows Server 2016, 2019, 2022 and 2025**, all
running Defender platform 4.18.26070.9. Both cmdlets return CIM instance
properties, so their shapes come from the Defender platform rather than the
Windows build, and the platform updates itself independently of the OS. That is
why all four versions agree, property for property.

| version | build | reproduces | `Get-MpComputerStatus` / `Get-MpPreference` property set |
|---|---|---|---|
| Server 2016 | 10.0.14393 | yes | 63 / 135 |
| Server 2019 | 10.0.17763 | yes | 63 / 135 |
| Server 2022 | 10.0.20348 | yes | 63 / 135 |
| Server 2025 | 10.0.26100 | yes | 63 / 135 |

The property sets are byte-identical across all four.

## Why this changes shipped field types

Changing a shipped field's type is normally off-limits. It is safe here because
none of the three has ever produced a value: they have errored on every host
since the family shipped in `13.29.1`, so there is no observed behaviour to
preserve.

## Why the tests did not catch it

The existing fixtures were written by hand from the cmdlet documentation rather
than captured from a host, so they agree with the implementation by
construction. They carried `"DeviceControlState": 0` and
`"CheckForSignaturesBeforeRunningScan": 0`, shapes that no Windows host emits.
They are corrected here.

Alongside them this adds fixtures captured live from Windows Server 2016, 2019,
2022 and 2025, with parser tests that pin the types and a test asserting the
four versions report the same property set, so a future divergence surfaces by
name rather than as a field that quietly reads zero on one version.

Fixtures were sanitized: the machine identifier is replaced with a synthetic
value and the CIM metadata wrappers `ConvertTo-Json` emits alongside the
properties (`CimClass`, `CimInstanceProperties`, `CimSystemProperties`) are
removed. Every reported property is verbatim. There are no hostnames,
addresses, SIDs, serials, MACs or instance IDs in the captures.

## Verification

After the fix, against Windows Server 2016:

```
windows.defender: {
  enabled: true
  status: {
    amProductVersion:                "4.18.26070.9"
    antivirusEnabled:                true
    realTimeProtectionEnabled:       true
    isTamperProtected:               false
    deviceControlState:              "Disabled"
    deviceControlDefaultEnforcement: ""
    fullScanAge:                     4294967295
    smartAppControlState:            "Off"
    tamperProtectionSource:          "N/A"
  }
}
```

`go test ./resources/windows/` passes.

## Stack

This is the first of five Defender PRs; the rest build on it.

## Reproduction on the unfixed provider, Windows Server 2025

```
$ PROVIDERS_PATH=<provider built from main> mql run ssh Administrator@<2025-host> \
    -c "windows.defender { enabled status { antivirusEnabled } preferences { puaProtection } }"
2 errors occurred:
	* json: cannot unmarshal bool into Go struct field MpPreference.CheckForSignaturesBeforeRunningScan of type int64
	* json: cannot unmarshal string into Go struct field MpComputerStatus.DeviceControlState of type int64
windows.defender: {
  enabled:     json: cannot unmarshal string into Go struct field MpComputerStatus.DeviceControlState of type int64
  preferences: json: cannot unmarshal bool into Go struct field MpPreference.CheckForSignaturesBeforeRunningScan of type int64
  status:      json: cannot unmarshal string into Go struct field MpComputerStatus.DeviceControlState of type int64
}
```

Byte-identical to the failure on 2016. The newest Windows Server release is
affected exactly like the oldest.

## Re-confirmed, unchanged by this PR

The same four hosts were used to check the surrounding Schannel behavior that this PR does not touch, since a regression there would look identical to a correct reading:

- **Absent is not disabled.** `SCHANNEL\Protocols` has zero child keys on 2019, 2022 and 2025, and one (`SSL 2.0`) on 2016. On every version all ten well-known protocols are still reported, with `clientConfigured` / `serverConfigured` `false` and `clientEnabled` / `serverEnabled` **null** -- never `false`. Same for all nine ciphers, five hashes and three key-exchange algorithms on all four. A `false` there would report TLS 1.0 as disabled on a host whose OS default leaves it on.
- **Slash-named keys.** `Ciphers\RC4 128/128` and `Ciphers\AES 256/256` were created on 2016, 2019 and 2025 (2022 was covered when #10358 landed) and read back correctly: `configured: true` with `enabled: false` and `true` respectively, alongside `Triple DES 168` and a `KeyExchangeAlgorithms\Diffie-Hellman` carrying only `ServerMinKeyBitLength: 2048`, which `configured` picks up. A name that failed to round-trip would read as unconfigured, which is indistinguishable from the default state, so this is checked rather than assumed. All keys were removed and the baseline verified afterwards.
- **TLS 1.3 and DTLS.** No release in the range creates a protocol subkey for them, so the well-known list is what makes them queryable at all; the merge-with-discovered path is exercised only by 2016's `SSL 2.0`, which merges without displacing the canonical order.
