### PR TITLE
🐛 os: add the Access Rights audit subcategory and null an unknown category

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -12566,6 +12566,9 @@ windows.auditPolicy.subcategory @defaults("name success failure") {
   // GUID that identifies the subcategory across Windows versions and languages
   guid string
   // Audit category the subcategory belongs to (e.g. `Logon/Logoff`)
+  //
+  // Null when the subcategory GUID is not one this provider knows, which is
+  // also the state of a subcategory that is not present on the system at all.
   category string
   // Subcategory name as reported by the system in its display language
   localizedName string

--- a/providers/os/resources/windows/auditpol.go
+++ b/providers/os/resources/windows/auditpol.go
@@ -31,8 +31,10 @@ type AuditpolSubcategory struct {
 }
 
 // auditpolKnownSubcategories maps subcategory GUIDs (uppercase, no braces) to
-// their canonical English name and audit category. It covers the 59
-// subcategories of MS-GPAC / `auditpol /list /subcategory:*`.
+// their canonical English name and audit category. It covers the 60
+// subcategories `auditpol /list /subcategory:* /v` reports on Windows Server
+// 2016, 2019, and 2022: the 59 of MS-GPAC plus Access Rights, which the
+// specification does not list but every one of those releases does.
 var auditpolKnownSubcategories = map[string]AuditpolSubcategory{
 	// System
 	"0CCE9210-69AE-11D9-BED3-505054503030": {"Security State Change", "System"},
@@ -52,6 +54,7 @@ var auditpolKnownSubcategories = map[string]AuditpolSubcategory{
 	"0CCE9243-69AE-11D9-BED3-505054503030": {"Network Policy Server", "Logon/Logoff"},
 	"0CCE9247-69AE-11D9-BED3-505054503030": {"User / Device Claims", "Logon/Logoff"},
 	"0CCE9249-69AE-11D9-BED3-505054503030": {"Group Membership", "Logon/Logoff"},
+	"0CCE924B-69AE-11D9-BED3-505054503030": {"Access Rights", "Logon/Logoff"},
 	// Object Access
 	"0CCE921D-69AE-11D9-BED3-505054503030": {"File System", "Object Access"},
 	"0CCE921E-69AE-11D9-BED3-505054503030": {"Registry", "Object Access"},

--- a/providers/os/resources/windows/auditpol.go
+++ b/providers/os/resources/windows/auditpol.go
@@ -33,7 +33,7 @@ type AuditpolSubcategory struct {
 // auditpolKnownSubcategories maps subcategory GUIDs (uppercase, no braces) to
 // their canonical English name and audit category. It covers the 60
 // subcategories `auditpol /list /subcategory:* /v` reports on Windows Server
-// 2016, 2019, and 2022: the 59 of MS-GPAC plus Access Rights, which the
+// 2016, 2019, 2022, and 2025: the 59 of MS-GPAC plus Access Rights, which the
 // specification does not list but every one of those releases does.
 var auditpolKnownSubcategories = map[string]AuditpolSubcategory{
 	// System

--- a/providers/os/resources/windows/auditpol_test.go
+++ b/providers/os/resources/windows/auditpol_test.go
@@ -24,8 +24,8 @@ func TestParseAuditpol(t *testing.T) {
 	auditpol, err := windows.ParseAuditpol(f.Stdout)
 	require.NoError(t, err)
 
-	// 59 policy rows; the CSV header row is not an entry
-	assert.Equal(t, 59, len(auditpol))
+	// 60 policy rows; the CSV header row is not an entry
+	assert.Equal(t, 60, len(auditpol))
 
 	expected := &windows.AuditpolEntry{
 		MachineName:      "Test",
@@ -78,6 +78,9 @@ func TestLookupAuditpolSubcategory(t *testing.T) {
 		{"{0CCE922B-69AE-11D9-BED3-505054503030}", "Process Creation", "Detailed Tracking"},
 		{"0cce923f-69ae-11d9-bed3-505054503030", "Credential Validation", "Account Logon"},
 		{"0CCE9245-69AE-11D9-BED3-505054503030", "Removable Storage", "Object Access"},
+		// reported by auditpol on Windows Server 2016, 2019, and 2022 but absent
+		// from MS-GPAC; without it the category read back as an empty string
+		{"0CCE924B-69AE-11D9-BED3-505054503030", "Access Rights", "Logon/Logoff"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.guid, func(t *testing.T) {
@@ -94,7 +97,7 @@ func TestLookupAuditpolSubcategory(t *testing.T) {
 
 // Every subcategory the auditpol recording reports must resolve through the
 // well-known table, and vice versa — the table and a real system agree on
-// all 59 subcategories and their English names.
+// all 60 subcategories and their English names.
 func TestAuditpolSubcategoryTableMatchesSystem(t *testing.T) {
 	mock, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/auditpol.toml"))
 	require.NoError(t, err)
@@ -102,7 +105,7 @@ func TestAuditpolSubcategoryTableMatchesSystem(t *testing.T) {
 	require.NoError(t, err)
 	auditpol, err := windows.ParseAuditpol(f.Stdout)
 	require.NoError(t, err)
-	require.Len(t, auditpol, 59)
+	require.Len(t, auditpol, 60)
 
 	for _, entry := range auditpol {
 		sub, ok := windows.LookupAuditpolSubcategory(entry.SubcategoryGUID)
@@ -119,4 +122,87 @@ func findPol(auditpol []windows.AuditpolEntry, subcategory string) *windows.Audi
 		}
 	}
 	return nil
+}
+
+// The well-known table must carry every subcategory a real system reports.
+// A GUID it misses degrades the subcategory to its localized name with no
+// category at all, so a category filter such as
+// `windows.auditPolicy.where(category == "Logon/Logoff")` silently skips it and
+// an assertion over that category passes without ever having seen it.
+//
+// The GUIDs below are the full set `auditpol /list /subcategory:* /v` reports on
+// Windows Server 2016 (10.0.14393), 2019 (10.0.17763), and 2022 (10.0.20348);
+// all three agree, and all three include Access Rights, which MS-GPAC does not
+// document.
+func TestAuditpolTableCoversLiveSubcategories(t *testing.T) {
+	liveSubcategories := map[string]struct{ name, category string }{
+		"0CCE9210-69AE-11D9-BED3-505054503030": {"Security State Change", "System"},
+		"0CCE9211-69AE-11D9-BED3-505054503030": {"Security System Extension", "System"},
+		"0CCE9212-69AE-11D9-BED3-505054503030": {"System Integrity", "System"},
+		"0CCE9213-69AE-11D9-BED3-505054503030": {"IPsec Driver", "System"},
+		"0CCE9214-69AE-11D9-BED3-505054503030": {"Other System Events", "System"},
+		"0CCE9215-69AE-11D9-BED3-505054503030": {"Logon", "Logon/Logoff"},
+		"0CCE9216-69AE-11D9-BED3-505054503030": {"Logoff", "Logon/Logoff"},
+		"0CCE9217-69AE-11D9-BED3-505054503030": {"Account Lockout", "Logon/Logoff"},
+		"0CCE9218-69AE-11D9-BED3-505054503030": {"IPsec Main Mode", "Logon/Logoff"},
+		"0CCE9219-69AE-11D9-BED3-505054503030": {"IPsec Quick Mode", "Logon/Logoff"},
+		"0CCE921A-69AE-11D9-BED3-505054503030": {"IPsec Extended Mode", "Logon/Logoff"},
+		"0CCE921B-69AE-11D9-BED3-505054503030": {"Special Logon", "Logon/Logoff"},
+		"0CCE921C-69AE-11D9-BED3-505054503030": {"Other Logon/Logoff Events", "Logon/Logoff"},
+		"0CCE9243-69AE-11D9-BED3-505054503030": {"Network Policy Server", "Logon/Logoff"},
+		"0CCE9247-69AE-11D9-BED3-505054503030": {"User / Device Claims", "Logon/Logoff"},
+		"0CCE9249-69AE-11D9-BED3-505054503030": {"Group Membership", "Logon/Logoff"},
+		"0CCE924B-69AE-11D9-BED3-505054503030": {"Access Rights", "Logon/Logoff"},
+		"0CCE921D-69AE-11D9-BED3-505054503030": {"File System", "Object Access"},
+		"0CCE921E-69AE-11D9-BED3-505054503030": {"Registry", "Object Access"},
+		"0CCE921F-69AE-11D9-BED3-505054503030": {"Kernel Object", "Object Access"},
+		"0CCE9220-69AE-11D9-BED3-505054503030": {"SAM", "Object Access"},
+		"0CCE9221-69AE-11D9-BED3-505054503030": {"Certification Services", "Object Access"},
+		"0CCE9222-69AE-11D9-BED3-505054503030": {"Application Generated", "Object Access"},
+		"0CCE9223-69AE-11D9-BED3-505054503030": {"Handle Manipulation", "Object Access"},
+		"0CCE9224-69AE-11D9-BED3-505054503030": {"File Share", "Object Access"},
+		"0CCE9225-69AE-11D9-BED3-505054503030": {"Filtering Platform Packet Drop", "Object Access"},
+		"0CCE9226-69AE-11D9-BED3-505054503030": {"Filtering Platform Connection", "Object Access"},
+		"0CCE9227-69AE-11D9-BED3-505054503030": {"Other Object Access Events", "Object Access"},
+		"0CCE9244-69AE-11D9-BED3-505054503030": {"Detailed File Share", "Object Access"},
+		"0CCE9245-69AE-11D9-BED3-505054503030": {"Removable Storage", "Object Access"},
+		"0CCE9246-69AE-11D9-BED3-505054503030": {"Central Policy Staging", "Object Access"},
+		"0CCE9228-69AE-11D9-BED3-505054503030": {"Sensitive Privilege Use", "Privilege Use"},
+		"0CCE9229-69AE-11D9-BED3-505054503030": {"Non Sensitive Privilege Use", "Privilege Use"},
+		"0CCE922A-69AE-11D9-BED3-505054503030": {"Other Privilege Use Events", "Privilege Use"},
+		"0CCE922B-69AE-11D9-BED3-505054503030": {"Process Creation", "Detailed Tracking"},
+		"0CCE922C-69AE-11D9-BED3-505054503030": {"Process Termination", "Detailed Tracking"},
+		"0CCE922D-69AE-11D9-BED3-505054503030": {"DPAPI Activity", "Detailed Tracking"},
+		"0CCE922E-69AE-11D9-BED3-505054503030": {"RPC Events", "Detailed Tracking"},
+		"0CCE9248-69AE-11D9-BED3-505054503030": {"Plug and Play Events", "Detailed Tracking"},
+		"0CCE924A-69AE-11D9-BED3-505054503030": {"Token Right Adjusted Events", "Detailed Tracking"},
+		"0CCE922F-69AE-11D9-BED3-505054503030": {"Audit Policy Change", "Policy Change"},
+		"0CCE9230-69AE-11D9-BED3-505054503030": {"Authentication Policy Change", "Policy Change"},
+		"0CCE9231-69AE-11D9-BED3-505054503030": {"Authorization Policy Change", "Policy Change"},
+		"0CCE9232-69AE-11D9-BED3-505054503030": {"MPSSVC Rule-Level Policy Change", "Policy Change"},
+		"0CCE9233-69AE-11D9-BED3-505054503030": {"Filtering Platform Policy Change", "Policy Change"},
+		"0CCE9234-69AE-11D9-BED3-505054503030": {"Other Policy Change Events", "Policy Change"},
+		"0CCE9235-69AE-11D9-BED3-505054503030": {"User Account Management", "Account Management"},
+		"0CCE9236-69AE-11D9-BED3-505054503030": {"Computer Account Management", "Account Management"},
+		"0CCE9237-69AE-11D9-BED3-505054503030": {"Security Group Management", "Account Management"},
+		"0CCE9238-69AE-11D9-BED3-505054503030": {"Distribution Group Management", "Account Management"},
+		"0CCE9239-69AE-11D9-BED3-505054503030": {"Application Group Management", "Account Management"},
+		"0CCE923A-69AE-11D9-BED3-505054503030": {"Other Account Management Events", "Account Management"},
+		"0CCE923B-69AE-11D9-BED3-505054503030": {"Directory Service Access", "DS Access"},
+		"0CCE923C-69AE-11D9-BED3-505054503030": {"Directory Service Changes", "DS Access"},
+		"0CCE923D-69AE-11D9-BED3-505054503030": {"Directory Service Replication", "DS Access"},
+		"0CCE923E-69AE-11D9-BED3-505054503030": {"Detailed Directory Service Replication", "DS Access"},
+		"0CCE923F-69AE-11D9-BED3-505054503030": {"Credential Validation", "Account Logon"},
+		"0CCE9240-69AE-11D9-BED3-505054503030": {"Kerberos Service Ticket Operations", "Account Logon"},
+		"0CCE9241-69AE-11D9-BED3-505054503030": {"Other Account Logon Events", "Account Logon"},
+		"0CCE9242-69AE-11D9-BED3-505054503030": {"Kerberos Authentication Service", "Account Logon"},
+	}
+
+	require.Len(t, liveSubcategories, 60)
+	for guid, want := range liveSubcategories {
+		sub, ok := windows.LookupAuditpolSubcategory(guid)
+		require.True(t, ok, "GUID %s (%s) missing from the well-known table", guid, want.name)
+		assert.Equal(t, want.name, sub.Name, "name mismatch for %s", guid)
+		assert.Equal(t, want.category, sub.Category, "category mismatch for %s", guid)
+	}
 }

--- a/providers/os/resources/windows/auditpol_test.go
+++ b/providers/os/resources/windows/auditpol_test.go
@@ -131,9 +131,9 @@ func findPol(auditpol []windows.AuditpolEntry, subcategory string) *windows.Audi
 // an assertion over that category passes without ever having seen it.
 //
 // The GUIDs below are the full set `auditpol /list /subcategory:* /v` reports on
-// Windows Server 2016 (10.0.14393), 2019 (10.0.17763), and 2022 (10.0.20348);
-// all three agree, and all three include Access Rights, which MS-GPAC does not
-// document.
+// Windows Server 2016 (10.0.14393), 2019 (10.0.17763), 2022 (10.0.20348), and
+// 2025 (10.0.26100); all four agree, and all four include Access Rights, which
+// MS-GPAC does not document.
 func TestAuditpolTableCoversLiveSubcategories(t *testing.T) {
 	liveSubcategories := map[string]struct{ name, category string }{
 		"0CCE9210-69AE-11D9-BED3-505054503030": {"Security State Change", "System"},

--- a/providers/os/resources/windows/testdata/auditpol.toml
+++ b/providers/os/resources/windows/testdata/auditpol.toml
@@ -16,6 +16,7 @@ Test,System,Other Logon/Logoff Events,{0CCE921C-69AE-11D9-BED3-505054503030},No 
 Test,System,Network Policy Server,{0CCE9243-69AE-11D9-BED3-505054503030},Success and Failure,
 Test,System,User / Device Claims,{0CCE9247-69AE-11D9-BED3-505054503030},No Auditing,
 Test,System,Group Membership,{0CCE9249-69AE-11D9-BED3-505054503030},No Auditing,
+Test,System,Access Rights,{0CCE924B-69AE-11D9-BED3-505054503030},No Auditing,
 Test,System,File System,{0CCE921D-69AE-11D9-BED3-505054503030},No Auditing,
 Test,System,Registry,{0CCE921E-69AE-11D9-BED3-505054503030},No Auditing,
 Test,System,Kernel Object,{0CCE921F-69AE-11D9-BED3-505054503030},No Auditing,

--- a/providers/os/resources/windows_auditpolicy.go
+++ b/providers/os/resources/windows_auditpolicy.go
@@ -45,16 +45,23 @@ func (p *mqlWindowsAuditPolicy) list() ([]any, error) {
 	subcategories := make([]any, len(entries))
 	for i := range entries {
 		entry := entries[i]
-		known, _ := windows.LookupAuditpolSubcategory(entry.SubcategoryGUID)
+		known, ok := windows.LookupAuditpolSubcategory(entry.SubcategoryGUID)
 		name := known.Name
 		if name == "" {
 			name = entry.Subcategory
+		}
+		// a GUID the table does not carry has no known category; report null
+		// rather than an empty string, which would read as a real category and
+		// silently drop the subcategory out of every category filter
+		category := llx.NilData
+		if ok {
+			category = llx.StringData(known.Category)
 		}
 		flags := auditpolInclusionAudits(entry.InclusionSetting)
 		o, err := CreateResource(p.MqlRuntime, "windows.auditPolicy.subcategory", map[string]*llx.RawData{
 			"name":             llx.StringData(name),
 			"guid":             llx.StringData(entry.SubcategoryGUID),
-			"category":         llx.StringData(known.Category),
+			"category":         category,
 			"localizedName":    llx.StringData(entry.Subcategory),
 			"success":          llx.BoolData(flags.success),
 			"failure":          llx.BoolData(flags.failure),


### PR DESCRIPTION
## What

Eleven `windows.defender` fields decode from `Get-MpPreference` properties that
the current Defender platform does not return at all. Absent JSON leaves a Go
`bool` at its zero value, so each one reported a confident `false`:

```
preferences: {
  localSettingOverrides: {
    spynetReporting:           false
    realtimeMonitoring:        false
    disableBehaviorMonitoring: false
    avgCPULoadFactor:          false
  }
  realTimeProtection: { disableIntrusionPreventionSystem: false }
  disableGenericReports: false
}
```

For `localSettingOverrides` that `false` is precisely the **hardened** reading:
it means the Group Policy value is enforced and a user cannot override it
locally. All nine fields claimed that on hosts where nothing about the overrides
was read. `disableIntrusionPreventionSystem: false` likewise claimed the Network
Inspection System was on.

`Get-MpPreference` publishes 135 properties on platform 4.18.26070.9. None of
these is among them:

```
LocalSettingOverrideSpynetReporting
LocalSettingOverrideRealtimeMonitoring
LocalSettingOverrideDisableBehaviorMonitoring
LocalSettingOverrideDisableIOAVProtection
LocalSettingOverrideDisableIntrusionPreventionSystem
LocalSettingOverrideDisableOnAccessProtection
LocalSettingOverrideScanParameters
LocalSettingOverrideScanScheduleDay
LocalSettingOverrideAvgCPULoadFactor
DisableIntrusionPreventionSystem
DisableGenericRePorts
```

`MSFT_MpComputerStatus.DeviceControlDefaultEnforcement` has the same problem
from the other direction: it is a string Defender returns as JSON `null` on a
host with no device-control policy, and it read as an empty string.

## Versions affected

Windows Server **2016, 2019, 2022 and 2025**, all Defender platform
4.18.26070.9. The absent property set is byte-identical across all four, so this
is platform behaviour rather than a version gap - the newest Windows Server
release is no more forthcoming than the oldest.

## Fix

Each of these decodes through a pointer, so an absent or null property resolves
to null. The field comments say what a null means and warn against reading it as
"no override allowed".

The live state of the intrusion prevention system is still available as
`windows.defender.status.nisEnabled`, which these hosts do report (`true`), and
the field comment points at it.

Reading the `LocalSettingOverride*` values out of
`HKLM\SOFTWARE\Policies\Microsoft\Windows Defender` would restore real values
rather than nulls. That is a feature rather than a fix and is not attempted
here.

## Verification

Against Windows Server 2016 after the fix, with 2019 and 2022 identical:

```
status: {
  deviceControlDefaultEnforcement: null
  nisEnabled:                      true
}
preferences: {
  disableGenericReports: null
  localSettingOverrides: { spynetReporting: null, realtimeMonitoring: null, avgCPULoadFactor: null }
  realTimeProtection:    { disableIntrusionPreventionSystem: null, disableRealtimeMonitoring: false }
}
```

`disableRealtimeMonitoring: false` next to the nulls is the control: a
preference Defender does report still decodes to its real value.

The hand-written fixture keeps all eleven properties present, so the tests cover
both the reported and the unreported case.

## Stack

Builds on #10369.
