### PR TITLE
🐛 os: make windows.lsa.ntlm and secureChannel resolvable by their dotted path

### DIFF
--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -2326,11 +2326,11 @@ func init() {
 			Create: createWindowsLsa,
 		},
 		"windows.lsa.ntlm": {
-			// to override args, implement: initWindowsLsaNtlm(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initWindowsLsaNtlm,
 			Create: createWindowsLsaNtlm,
 		},
 		"windows.lsa.secureChannel": {
-			// to override args, implement: initWindowsLsaSecureChannel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initWindowsLsaSecureChannel,
 			Create: createWindowsLsaSecureChannel,
 		},
 		"windows.schannel": {

--- a/providers/os/resources/windows_dnsserver_test.go
+++ b/providers/os/resources/windows_dnsserver_test.go
@@ -93,8 +93,6 @@ func TestNoNewDottedPathHusks(t *testing.T) {
 		"windows.exploitProtection.dep":   true,
 		"windows.exploitProtection.heap":  true,
 		"windows.exploitProtection.sehop": true,
-		"windows.lsa.ntlm":                true,
-		"windows.lsa.secureChannel":       true,
 		"windows.scheduledTask.principal": true,
 		"windows.scheduledTask.settings":  true,
 		"windows.smartScreen":             true,

--- a/providers/os/resources/windows_lsa.go
+++ b/providers/os/resources/windows_lsa.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"errors"
 	"strings"
 
 	"go.mondoo.com/mql/llx"
@@ -494,4 +495,53 @@ func stringFieldPtr(v *string) plugin.TValue[string] {
 		return plugin.TValue[string]{State: plugin.StateIsSet | plugin.StateIsNull}
 	}
 	return plugin.TValue[string]{Data: *v, State: plugin.StateIsSet}
+}
+
+// initWindowsLsaNtlm resolves a bare windows.lsa.ntlm to the one the parent
+// builds. The resource shares its name with the field path that reaches it, so
+// `windows.lsa.ntlm.useLogonCredential` creates it directly rather than through
+// windows.lsa. Its fields are plain schema fields with no accessor of their own,
+// so without this the dotted form returned null for every field (and logged
+// "provider returned no data and no error for a field") while the block form
+// `windows.lsa { ntlm { useLogonCredential } }` returned the real values.
+func initWindowsLsaNtlm(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	// the parent populates every field through CreateResource, which skips
+	// this init; only a bare creation reaches here
+	if len(args) > 0 {
+		return args, nil, nil
+	}
+
+	o, err := CreateResource(runtime, "windows.lsa", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	ntlm := o.(*mqlWindowsLsa).GetNtlm()
+	if ntlm.Error != nil {
+		return nil, nil, ntlm.Error
+	}
+	if ntlm.Data == nil {
+		return nil, nil, errors.New("could not read the NTLM settings from windows.lsa")
+	}
+	return nil, ntlm.Data, nil
+}
+
+// initWindowsLsaSecureChannel resolves a bare windows.lsa.secureChannel to the
+// one the parent builds, for the same reason as initWindowsLsaNtlm.
+func initWindowsLsaSecureChannel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 0 {
+		return args, nil, nil
+	}
+
+	o, err := CreateResource(runtime, "windows.lsa", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	sc := o.(*mqlWindowsLsa).GetSecureChannel()
+	if sc.Error != nil {
+		return nil, nil, sc.Error
+	}
+	if sc.Data == nil {
+		return nil, nil, errors.New("could not read the Netlogon secure-channel settings from windows.lsa")
+	}
+	return nil, sc.Data, nil
 }


### PR DESCRIPTION
## What

The four Defender schedule preferences are CIM datetime values. Windows
PowerShell 5.1, which is what ships on Windows Server, serializes them as whole
`TimeSpan` objects, and the field passed the raw JSON straight through:

```
scan: {
  scanScheduleTime: "{\"Ticks\":72000000000,\"Days\":0,\"Hours\":2,\"Milliseconds\":0,\"Minutes\":0,\"Seconds\":0,\"TotalDays\":0.083333333333333329,\"TotalHours\":2,\"TotalMilliseconds\":7200000,\"TotalMinutes\":120,\"TotalSeconds\":7200}"
  scanScheduleQuickScanTime: "{\"Ticks\":0,\"Days\":0,\"Hours\":0,...}"
}
signatureUpdates: { signatureScheduleTime: "{\"Ticks\":63000000000,...}" }
remediation:      { remediationScheduleTime: "{\"Ticks\":72000000000,...}" }
```

Nothing can be asserted against a serialized .NET object. Worse, the same
setting serializes four different ways depending on the host, so a policy
written against one host's output would not match another's:

| host | `ScanScheduleTime` for 02:00 |
|---|---|
| Windows PowerShell 5.1 | `{"Ticks":72000000000,...}` |
| PowerShell 7+ | `"PT2H"` |
| some builds | `"/Date(...)/"` |
| already formatted | `"02:00:00"` |

## Fix

All four normalize to `"HH:MM:SS"`. An unrecognized value is passed through
trimmed rather than dropped, so a serialization we have not seen surfaces as
itself instead of as an empty string that would read as "no schedule
configured".

## Versions affected

Windows Server **2016, 2019, 2022 and 2025**, all returning the PowerShell 5.1
`TimeSpan` object form. Windows Server 2025 ships Windows PowerShell 5.1 as its
system shell just as the older releases do, so the newest version is affected
exactly like the oldest.

## Verification

Against Windows Server 2016 after the fix, with 2019 and 2022 identical:

```
scan:             { scanScheduleTime: "02:00:00", scanScheduleQuickScanTime: "00:00:00" }
signatureUpdates: { signatureScheduleTime: "01:45:00" }
remediation:      { remediationScheduleTime: "02:00:00" }
```

which matches the raw preferences: `ScanScheduleTime` 72000000000 ticks = 2h,
`SignatureScheduleTime` 63000000000 ticks = 1h45m.

`TestScheduleTime` covers all four serializations plus the null, empty and
unrecognized cases; `TestLiveScheduleTimes` pins the values read off each of the
four captured hosts.

## Note on shipped behaviour

The string value these fields return changes shape. No consumer can have
depended on the old value, because the whole `preferences` subtree errored
before #10369.

## Stack

Builds on #10370.
