### PR TITLE
🐛 os: report Defender preferences the platform does not publish as null

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -13975,7 +13975,7 @@ private windows.defender.status @defaults("antivirusEnabled realTimeProtectionEn
   // Default enforcement mode for device control
   //
   // Reported as a name rather than a number, for example "Allow" or "Deny".
-  // An empty string means no device-control enforcement policy is applied.
+  // Null when no device-control enforcement policy is applied.
   deviceControlDefaultEnforcement string
   // Date the device-control policies were last updated
   deviceControlPoliciesLastUpdated time
@@ -14094,6 +14094,8 @@ windows.defender.preferences @defaults("puaProtection") {
   // Whether automatic exclusions for server roles are disabled
   disableAutoExclusions() bool
   // Whether sending Watson (generic) reports to Microsoft is disabled
+  //
+  // Null when the Defender platform does not report this preference.
   disableGenericReports() bool
 }
 
@@ -14162,6 +14164,10 @@ windows.defender.realTimeSettings @defaults("disableRealtimeMonitoring") {
   // Whether script scanning is disabled
   disableScriptScanning bool
   // Whether the Network Inspection System (intrusion prevention) is disabled
+  //
+  // Null when the Defender platform does not report this preference. Recent
+  // platform releases dropped it from Get-MpPreference, in which case the
+  // live state is available as nisEnabled on windows.defender.status.
   disableIntrusionPreventionSystem bool
   // Direction in which real-time scanning inspects files
   //
@@ -14347,8 +14353,13 @@ windows.defender.behavioralNetworkBlockSettings @defaults("bruteForceProtectionC
 //
 // Whether a locally configured preference is allowed to override the
 // corresponding Group Policy setting. When an override is disabled (false)
-// the policy value is enforced and users cannot change it locally; CIS
-// benchmarks generally require these overrides to be disabled.
+// the policy value is enforced and users cannot change it locally, which is
+// the hardened configuration.
+//
+// Every field here is null on a host whose Defender platform does not report
+// the preference. Recent platform releases dropped the LocalSettingOverride
+// properties from Get-MpPreference, so on those hosts nothing about the
+// overrides is known and a null must not be read as "no override allowed".
 windows.defender.localSettingOverrides @defaults("spynetReporting realtimeMonitoring") {
   // Whether a local setting may override MAPS (SpyNet) reporting
   spynetReporting bool

--- a/providers/os/resources/windows/defender.go
+++ b/providers/os/resources/windows/defender.go
@@ -248,7 +248,7 @@ type MpComputerStatus struct {
 	ComputerID                       string
 	ComputerState                    int64
 	DefenderSignaturesOutOfDate      bool
-	DeviceControlDefaultEnforcement  string
+	DeviceControlDefaultEnforcement  *string
 	DeviceControlPoliciesLastUpdated string
 	DeviceControlState               string
 	FullScanAge                      int64
@@ -309,7 +309,7 @@ type MpPreference struct {
 	DisableBehaviorMonitoring        bool
 	DisableIOAVProtection            bool
 	DisableScriptScanning            bool
-	DisableIntrusionPreventionSystem bool
+	DisableIntrusionPreventionSystem *bool
 	RealTimeScanDirection            int64
 	EnableFileHashComputation        bool
 
@@ -365,15 +365,15 @@ type MpPreference struct {
 	RemoteEncryptionProtectionMaxBlockTime    int64
 
 	// local setting overrides (whether a local preference may override policy)
-	LocalSettingOverrideSpynetReporting                  bool
-	LocalSettingOverrideRealtimeMonitoring               bool
-	LocalSettingOverrideDisableBehaviorMonitoring        bool
-	LocalSettingOverrideDisableIOAVProtection            bool
-	LocalSettingOverrideDisableIntrusionPreventionSystem bool
-	LocalSettingOverrideDisableOnAccessProtection        bool
-	LocalSettingOverrideScanParameters                   bool
-	LocalSettingOverrideScanScheduleDay                  bool
-	LocalSettingOverrideAvgCPULoadFactor                 bool
+	LocalSettingOverrideSpynetReporting                  *bool
+	LocalSettingOverrideRealtimeMonitoring               *bool
+	LocalSettingOverrideDisableBehaviorMonitoring        *bool
+	LocalSettingOverrideDisableIOAVProtection            *bool
+	LocalSettingOverrideDisableIntrusionPreventionSystem *bool
+	LocalSettingOverrideDisableOnAccessProtection        *bool
+	LocalSettingOverrideScanParameters                   *bool
+	LocalSettingOverrideScanScheduleDay                  *bool
+	LocalSettingOverrideAvgCPULoadFactor                 *bool
 
 	// remediation
 	RemediationScheduleDay         int64
@@ -399,7 +399,7 @@ type MpPreference struct {
 	// Defender uses the historical "RePorts" casing for this preference; the
 	// json tag matches it explicitly so the field is populated regardless of how
 	// the cmdlet serializes it.
-	DisableGenericReports bool `json:"DisableGenericRePorts"`
+	DisableGenericReports *bool `json:"DisableGenericRePorts"`
 }
 
 // ScanScheduleTimeString returns the raw scheduled-scan time value.

--- a/providers/os/resources/windows/defender_live_test.go
+++ b/providers/os/resources/windows/defender_live_test.go
@@ -63,7 +63,7 @@ func TestMpComputerStatusLiveDecodes(t *testing.T) {
 			// default enforcement unset on a host with no device-control
 			// policy, so it must not read as a number either.
 			assert.Equal(t, "Disabled", status.DeviceControlState)
-			assert.Empty(t, status.DeviceControlDefaultEnforcement)
+			assert.Nil(t, status.DeviceControlDefaultEnforcement)
 
 			// A host that has never run a scan reports uint32 max for the scan
 			// age and leaves the scan times null.
@@ -113,6 +113,22 @@ func TestMpPreferenceLiveDecodes(t *testing.T) {
 			assert.Empty(t, pref.ThreatIDDefaultAction_Actions)
 			assert.Empty(t, pref.ControlledFolderAccessAllowedApplications)
 			assert.Empty(t, pref.ControlledFolderAccessProtectedFolders)
+
+			// The Defender platform on these hosts does not report these
+			// preferences at all. They must stay nil rather than decoding to
+			// false, which would claim a hardened configuration that nothing
+			// verified.
+			assert.Nil(t, pref.DisableIntrusionPreventionSystem)
+			assert.Nil(t, pref.DisableGenericReports)
+			assert.Nil(t, pref.LocalSettingOverrideSpynetReporting)
+			assert.Nil(t, pref.LocalSettingOverrideRealtimeMonitoring)
+			assert.Nil(t, pref.LocalSettingOverrideDisableBehaviorMonitoring)
+			assert.Nil(t, pref.LocalSettingOverrideDisableIOAVProtection)
+			assert.Nil(t, pref.LocalSettingOverrideDisableIntrusionPreventionSystem)
+			assert.Nil(t, pref.LocalSettingOverrideDisableOnAccessProtection)
+			assert.Nil(t, pref.LocalSettingOverrideScanParameters)
+			assert.Nil(t, pref.LocalSettingOverrideScanScheduleDay)
+			assert.Nil(t, pref.LocalSettingOverrideAvgCPULoadFactor)
 		})
 	}
 }

--- a/providers/os/resources/windows/defender_test.go
+++ b/providers/os/resources/windows/defender_test.go
@@ -100,14 +100,17 @@ func TestParseMpPreference(t *testing.T) {
 	assert.Equal(t, int64(1), pref.RemoteEncryptionProtectionConfiguredState)
 
 	// local setting overrides
-	assert.False(t, pref.LocalSettingOverrideSpynetReporting)
-	assert.False(t, pref.LocalSettingOverrideRealtimeMonitoring)
+	require.NotNil(t, pref.LocalSettingOverrideSpynetReporting)
+	assert.False(t, *pref.LocalSettingOverrideSpynetReporting)
+	require.NotNil(t, pref.LocalSettingOverrideRealtimeMonitoring)
+	assert.False(t, *pref.LocalSettingOverrideRealtimeMonitoring)
 
 	// misc
 	assert.Equal(t, int64(1), pref.PUAProtection)
 	assert.True(t, pref.RandomizeScheduleTaskTimes)
 	// the "RePorts" casing is matched via the explicit json tag
-	assert.True(t, pref.DisableGenericReports)
+	require.NotNil(t, pref.DisableGenericReports)
+	assert.True(t, *pref.DisableGenericReports)
 }
 
 func TestParseMpThreats(t *testing.T) {

--- a/providers/os/resources/windows_defender.go
+++ b/providers/os/resources/windows_defender.go
@@ -64,7 +64,7 @@ func (d *mqlWindowsDefender) status() (*mqlWindowsDefenderStatus, error) {
 		"computerID":                       llx.StringData(status.ComputerID),
 		"computerState":                    llx.IntData(status.ComputerState),
 		"defenderSignaturesOutOfDate":      llx.BoolData(status.DefenderSignaturesOutOfDate),
-		"deviceControlDefaultEnforcement":  llx.StringData(status.DeviceControlDefaultEnforcement),
+		"deviceControlDefaultEnforcement":  llx.StringDataPtr(status.DeviceControlDefaultEnforcement),
 		"deviceControlPoliciesLastUpdated": llx.TimeDataPtr(windows.DefenderTime(status.DeviceControlPoliciesLastUpdated)),
 		"deviceControlState":               llx.StringData(status.DeviceControlState),
 		"fullScanAge":                      llx.IntData(status.FullScanAge),
@@ -269,7 +269,7 @@ func (p *mqlWindowsDefenderPreferences) realTimeProtection() (*mqlWindowsDefende
 		"disableBehaviorMonitoring":        llx.BoolData(prefs.DisableBehaviorMonitoring),
 		"disableIOAVProtection":            llx.BoolData(prefs.DisableIOAVProtection),
 		"disableScriptScanning":            llx.BoolData(prefs.DisableScriptScanning),
-		"disableIntrusionPreventionSystem": llx.BoolData(prefs.DisableIntrusionPreventionSystem),
+		"disableIntrusionPreventionSystem": llx.BoolDataPtr(prefs.DisableIntrusionPreventionSystem),
 		"realTimeScanDirection":            llx.IntData(prefs.RealTimeScanDirection),
 		"enableFileHashComputation":        llx.BoolData(prefs.EnableFileHashComputation),
 	})
@@ -410,15 +410,15 @@ func (p *mqlWindowsDefenderPreferences) localSettingOverrides() (*mqlWindowsDefe
 	}
 	res, err := CreateResource(p.MqlRuntime, "windows.defender.localSettingOverrides", map[string]*llx.RawData{
 		"__id":                             llx.StringData("windows.defender.localSettingOverrides"),
-		"spynetReporting":                  llx.BoolData(prefs.LocalSettingOverrideSpynetReporting),
-		"realtimeMonitoring":               llx.BoolData(prefs.LocalSettingOverrideRealtimeMonitoring),
-		"disableBehaviorMonitoring":        llx.BoolData(prefs.LocalSettingOverrideDisableBehaviorMonitoring),
-		"disableIOAVProtection":            llx.BoolData(prefs.LocalSettingOverrideDisableIOAVProtection),
-		"disableIntrusionPreventionSystem": llx.BoolData(prefs.LocalSettingOverrideDisableIntrusionPreventionSystem),
-		"disableOnAccessProtection":        llx.BoolData(prefs.LocalSettingOverrideDisableOnAccessProtection),
-		"scanParameters":                   llx.BoolData(prefs.LocalSettingOverrideScanParameters),
-		"scanScheduleDay":                  llx.BoolData(prefs.LocalSettingOverrideScanScheduleDay),
-		"avgCPULoadFactor":                 llx.BoolData(prefs.LocalSettingOverrideAvgCPULoadFactor),
+		"spynetReporting":                  llx.BoolDataPtr(prefs.LocalSettingOverrideSpynetReporting),
+		"realtimeMonitoring":               llx.BoolDataPtr(prefs.LocalSettingOverrideRealtimeMonitoring),
+		"disableBehaviorMonitoring":        llx.BoolDataPtr(prefs.LocalSettingOverrideDisableBehaviorMonitoring),
+		"disableIOAVProtection":            llx.BoolDataPtr(prefs.LocalSettingOverrideDisableIOAVProtection),
+		"disableIntrusionPreventionSystem": llx.BoolDataPtr(prefs.LocalSettingOverrideDisableIntrusionPreventionSystem),
+		"disableOnAccessProtection":        llx.BoolDataPtr(prefs.LocalSettingOverrideDisableOnAccessProtection),
+		"scanParameters":                   llx.BoolDataPtr(prefs.LocalSettingOverrideScanParameters),
+		"scanScheduleDay":                  llx.BoolDataPtr(prefs.LocalSettingOverrideScanScheduleDay),
+		"avgCPULoadFactor":                 llx.BoolDataPtr(prefs.LocalSettingOverrideAvgCPULoadFactor),
 	})
 	if err != nil {
 		return nil, err
@@ -528,7 +528,11 @@ func (p *mqlWindowsDefenderPreferences) disableGenericReports() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return prefs.DisableGenericReports, nil
+	if prefs.DisableGenericReports == nil {
+		p.DisableGenericReports.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
+	return *prefs.DisableGenericReports, nil
 }
 
 // mqlWindowsDefenderThreatActionSettingsInternal caches the per-threat-ID


### PR DESCRIPTION
## What

Eleven `windows.defender` fields decode from `Get-MpPreference` properties that
the current Defender platform does not return at all. Absent JSON leaves a Go
`bool` at its zero value, so each one reported a confident `false`:

```
preferences: {
  localSettingOverrides: {
    spynetReporting:           false
    realtimeMonitoring:        false
    disableBehaviorMonitoring: false
    avgCPULoadFactor:          false
  }
  realTimeProtection: { disableIntrusionPreventionSystem: false }
  disableGenericReports: false
}
```

For `localSettingOverrides` that `false` is precisely the **hardened** reading:
it means the Group Policy value is enforced and a user cannot override it
locally. All nine fields claimed that on hosts where nothing about the overrides
was read. `disableIntrusionPreventionSystem: false` likewise claimed the Network
Inspection System was on.

`Get-MpPreference` publishes 135 properties on platform 4.18.26070.9. None of
these is among them:

```
LocalSettingOverrideSpynetReporting
LocalSettingOverrideRealtimeMonitoring
LocalSettingOverrideDisableBehaviorMonitoring
LocalSettingOverrideDisableIOAVProtection
LocalSettingOverrideDisableIntrusionPreventionSystem
LocalSettingOverrideDisableOnAccessProtection
LocalSettingOverrideScanParameters
LocalSettingOverrideScanScheduleDay
LocalSettingOverrideAvgCPULoadFactor
DisableIntrusionPreventionSystem
DisableGenericRePorts
```

`MSFT_MpComputerStatus.DeviceControlDefaultEnforcement` has the same problem
from the other direction: it is a string Defender returns as JSON `null` on a
host with no device-control policy, and it read as an empty string.

## Versions affected

Windows Server **2016, 2019, 2022 and 2025**, all Defender platform
4.18.26070.9. The absent property set is byte-identical across all four, so this
is platform behaviour rather than a version gap - the newest Windows Server
release is no more forthcoming than the oldest.

## Fix

Each of these decodes through a pointer, so an absent or null property resolves
to null. The field comments say what a null means and warn against reading it as
"no override allowed".

The live state of the intrusion prevention system is still available as
`windows.defender.status.nisEnabled`, which these hosts do report (`true`), and
the field comment points at it.

Reading the `LocalSettingOverride*` values out of
`HKLM\SOFTWARE\Policies\Microsoft\Windows Defender` would restore real values
rather than nulls. That is a feature rather than a fix and is not attempted
here.

## Verification

Against Windows Server 2016 after the fix, with 2019 and 2022 identical:

```
status: {
  deviceControlDefaultEnforcement: null
  nisEnabled:                      true
}
preferences: {
  disableGenericReports: null
  localSettingOverrides: { spynetReporting: null, realtimeMonitoring: null, avgCPULoadFactor: null }
  realTimeProtection:    { disableIntrusionPreventionSystem: null, disableRealtimeMonitoring: false }
}
```

`disableRealtimeMonitoring: false` next to the nulls is the control: a
preference Defender does report still decodes to its real value.

The hand-written fixture keeps all eleven properties present, so the tests cover
both the reported and the unreported case.

## Stack

Builds on #10369.
