### PR TITLE
🐛 os: fix Defender schedule times and the two dotted-path husks

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -14113,9 +14113,9 @@ windows.defender.scanSettings @defaults("scanParameters scanScheduleDay") {
   //
   // 0 = every day, 1 = Sunday through 7 = Saturday, 8 = never.
   scanScheduleDay int
-  // Time of day a scheduled scan runs (raw schedule value)
+  // Time of day a scheduled scan runs, as "HH:MM:SS"
   scanScheduleTime string
-  // Time of day a scheduled quick scan runs (raw schedule value)
+  // Time of day a scheduled quick scan runs, as "HH:MM:SS"
   scanScheduleQuickScanTime string
   // Number of minutes after midnight to offset the scheduled scan
   scanScheduleOffset int
@@ -14214,7 +14214,7 @@ windows.defender.cloudSettings @defaults("mapsReporting cloudBlockLevel") {
 windows.defender.signatureSettings @defaults("signatureUpdateInterval") {
   // Day of the week scheduled signature updates run
   signatureScheduleDay int
-  // Time of day scheduled signature updates run (raw schedule value)
+  // Time of day scheduled signature updates run, as "HH:MM:SS"
   signatureScheduleTime string
   // Hours between signature update checks
   signatureUpdateInterval int
@@ -14389,7 +14389,7 @@ windows.defender.localSettingOverrides @defaults("spynetReporting realtimeMonito
 windows.defender.remediationSettings @defaults("quarantinePurgeItemsAfterDelay") {
   // Day of the week scheduled remediation runs
   remediationScheduleDay int
-  // Time of day scheduled remediation runs (raw schedule value)
+  // Time of day scheduled remediation runs, as "HH:MM:SS"
   remediationScheduleTime string
   // Number of days quarantined items are kept before purging
   quarantinePurgeItemsAfterDelay int

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -13975,7 +13975,7 @@ private windows.defender.status @defaults("antivirusEnabled realTimeProtectionEn
   // Default enforcement mode for device control
   //
   // Reported as a name rather than a number, for example "Allow" or "Deny".
-  // An empty string means no device-control enforcement policy is applied.
+  // Null when no device-control enforcement policy is applied.
   deviceControlDefaultEnforcement string
   // Date the device-control policies were last updated
   deviceControlPoliciesLastUpdated time
@@ -14094,6 +14094,8 @@ windows.defender.preferences @defaults("puaProtection") {
   // Whether automatic exclusions for server roles are disabled
   disableAutoExclusions() bool
   // Whether sending Watson (generic) reports to Microsoft is disabled
+  //
+  // Null when the Defender platform does not report this preference.
   disableGenericReports() bool
 }
 
@@ -14162,6 +14164,10 @@ windows.defender.realTimeSettings @defaults("disableRealtimeMonitoring") {
   // Whether script scanning is disabled
   disableScriptScanning bool
   // Whether the Network Inspection System (intrusion prevention) is disabled
+  //
+  // Null when the Defender platform does not report this preference. Recent
+  // platform releases dropped it from Get-MpPreference, in which case the
+  // live state is available as nisEnabled on windows.defender.status.
   disableIntrusionPreventionSystem bool
   // Direction in which real-time scanning inspects files
   //
@@ -14347,8 +14353,13 @@ windows.defender.behavioralNetworkBlockSettings @defaults("bruteForceProtectionC
 //
 // Whether a locally configured preference is allowed to override the
 // corresponding Group Policy setting. When an override is disabled (false)
-// the policy value is enforced and users cannot change it locally; CIS
-// benchmarks generally require these overrides to be disabled.
+// the policy value is enforced and users cannot change it locally, which is
+// the hardened configuration.
+//
+// Every field here is null on a host whose Defender platform does not report
+// the preference. Recent platform releases dropped the LocalSettingOverride
+// properties from Get-MpPreference, so on those hosts nothing about the
+// overrides is known and a null must not be read as "no override allowed".
 windows.defender.localSettingOverrides @defaults("spynetReporting realtimeMonitoring") {
   // Whether a local setting may override MAPS (SpyNet) reporting
   spynetReporting bool

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -2542,11 +2542,11 @@ func init() {
 			Create: createWindowsDefender,
 		},
 		"windows.defender.status": {
-			// to override args, implement: initWindowsDefenderStatus(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initWindowsDefenderStatus,
 			Create: createWindowsDefenderStatus,
 		},
 		"windows.defender.preferences": {
-			// to override args, implement: initWindowsDefenderPreferences(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initWindowsDefenderPreferences,
 			Create: createWindowsDefenderPreferences,
 		},
 		"windows.defender.scanSettings": {

--- a/providers/os/resources/windows/defender.go
+++ b/providers/os/resources/windows/defender.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -212,22 +213,111 @@ func (f *flexNumStrings) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// rawString renders a json.RawMessage as a trimmed string, stripping the
-// surrounding quotes when the value is a JSON string. It is used for schedule
-// time fields whose serialization differs across PowerShell versions (a
-// TimeSpan object in 5.1, an ISO duration string in 7+).
-func rawString(raw json.RawMessage) string {
+// ScheduleTime normalizes a Defender schedule preference to a "HH:MM:SS"
+// time of day.
+//
+// These preferences are CIM datetime values, and how PowerShell serializes
+// them depends on the host. Windows PowerShell 5.1 emits a whole TimeSpan
+// object, so the field arrives as
+// {"Ticks":72000000000,"Days":0,"Hours":2,...}; PowerShell 7+ emits an ISO
+// 8601 duration such as "PT2H"; and some builds emit the "/Date(ms)/" form or
+// an already-formatted "02:00:00". All four describe 02:00 and must read the
+// same way.
+//
+// An unrecognized value is returned trimmed rather than dropped, so an
+// unfamiliar serialization surfaces as itself instead of as an empty string
+// that would read as "no schedule".
+func ScheduleTime(raw json.RawMessage) string {
 	s := strings.TrimSpace(string(raw))
 	if s == "" || s == "null" {
 		return ""
 	}
+
+	// PowerShell 5.1: a serialized TimeSpan object.
+	if s[0] == '{' {
+		var ts struct {
+			Ticks *int64 `json:"Ticks"`
+		}
+		if err := json.Unmarshal(raw, &ts); err == nil && ts.Ticks != nil {
+			return formatTimeOfDay(time.Duration(*ts.Ticks) * 100)
+		}
+		return s
+	}
+
 	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
 		var v string
 		if err := json.Unmarshal(raw, &v); err == nil {
-			return v
+			return normalizeScheduleString(v)
 		}
 	}
 	return s
+}
+
+// normalizeScheduleString converts the string serializations of a schedule
+// preference to "HH:MM:SS".
+func normalizeScheduleString(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	// The "/Date(ms)/" form carries a full timestamp whose time of day is the
+	// scheduled time.
+	if t := powershell.PSJsonTimestamp(v); t != nil {
+		return t.UTC().Format("15:04:05")
+	}
+	if d, ok := parseISODuration(v); ok {
+		return formatTimeOfDay(d)
+	}
+	return v
+}
+
+// parseISODuration parses the time-only ISO 8601 durations PowerShell 7+ emits
+// for a TimeSpan, for example "PT2H" or "PT1H45M". Durations carrying a date
+// component are rejected, since a schedule preference never has one.
+func parseISODuration(v string) (time.Duration, bool) {
+	rest, ok := strings.CutPrefix(strings.ToUpper(v), "PT")
+	if !ok || rest == "" {
+		return 0, false
+	}
+	var total time.Duration
+	num := ""
+	for _, r := range rest {
+		if (r >= '0' && r <= '9') || r == '.' {
+			num += string(r)
+			continue
+		}
+		if num == "" {
+			return 0, false
+		}
+		f, err := strconv.ParseFloat(num, 64)
+		if err != nil {
+			return 0, false
+		}
+		switch r {
+		case 'H':
+			total += time.Duration(f * float64(time.Hour))
+		case 'M':
+			total += time.Duration(f * float64(time.Minute))
+		case 'S':
+			total += time.Duration(f * float64(time.Second))
+		default:
+			return 0, false
+		}
+		num = ""
+	}
+	if num != "" {
+		return 0, false
+	}
+	return total, true
+}
+
+// formatTimeOfDay renders a duration since midnight as "HH:MM:SS".
+func formatTimeOfDay(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	secs := int64(d / time.Second)
+	return fmt.Sprintf("%02d:%02d:%02d", (secs/3600)%24, (secs/60)%60, secs%60)
 }
 
 // MpComputerStatus mirrors the relevant fields of Get-MpComputerStatus.
@@ -402,22 +492,22 @@ type MpPreference struct {
 	DisableGenericReports *bool `json:"DisableGenericRePorts"`
 }
 
-// ScanScheduleTimeString returns the raw scheduled-scan time value.
-func (p *MpPreference) ScanScheduleTimeString() string { return rawString(p.ScanScheduleTime) }
+// ScanScheduleTimeString returns the scheduled-scan time of day.
+func (p *MpPreference) ScanScheduleTimeString() string { return ScheduleTime(p.ScanScheduleTime) }
 
-// ScanScheduleQuickScanTimeString returns the raw scheduled quick-scan time value.
+// ScanScheduleQuickScanTimeString returns the scheduled quick-scan time of day.
 func (p *MpPreference) ScanScheduleQuickScanTimeString() string {
-	return rawString(p.ScanScheduleQuickScanTime)
+	return ScheduleTime(p.ScanScheduleQuickScanTime)
 }
 
-// SignatureScheduleTimeString returns the raw scheduled signature-update time value.
+// SignatureScheduleTimeString returns the scheduled signature-update time of day.
 func (p *MpPreference) SignatureScheduleTimeString() string {
-	return rawString(p.SignatureScheduleTime)
+	return ScheduleTime(p.SignatureScheduleTime)
 }
 
-// RemediationScheduleTimeString returns the raw scheduled-remediation time value.
+// RemediationScheduleTimeString returns the scheduled-remediation time of day.
 func (p *MpPreference) RemediationScheduleTimeString() string {
-	return rawString(p.RemediationScheduleTime)
+	return ScheduleTime(p.RemediationScheduleTime)
 }
 
 // MpThreat mirrors the relevant fields of Get-MpThreat.

--- a/providers/os/resources/windows/defender.go
+++ b/providers/os/resources/windows/defender.go
@@ -239,6 +239,8 @@ func ScheduleTime(raw json.RawMessage) string {
 			Ticks *int64 `json:"Ticks"`
 		}
 		if err := json.Unmarshal(raw, &ts); err == nil && ts.Ticks != nil {
+			// A .NET tick is 100 nanoseconds, and time.Duration counts
+			// nanoseconds, so the tick count scales by 100.
 			return formatTimeOfDay(time.Duration(*ts.Ticks) * 100)
 		}
 		return s
@@ -280,20 +282,27 @@ func parseISODuration(v string) (time.Duration, bool) {
 		return 0, false
 	}
 	var total time.Duration
-	num := ""
-	for _, r := range rest {
-		if (r >= '0' && r <= '9') || r == '.' {
-			num += string(r)
+	// start indexes the first byte of the number currently being read. Slicing
+	// rest keeps the digits where they already are instead of rebuilding them a
+	// character at a time, which would allocate once per digit on every
+	// schedule field of every scan.
+	start := -1
+	for i := 0; i < len(rest); i++ {
+		c := rest[i]
+		if (c >= '0' && c <= '9') || c == '.' {
+			if start < 0 {
+				start = i
+			}
 			continue
 		}
-		if num == "" {
+		if start < 0 {
 			return 0, false
 		}
-		f, err := strconv.ParseFloat(num, 64)
+		f, err := strconv.ParseFloat(rest[start:i], 64)
 		if err != nil {
 			return 0, false
 		}
-		switch r {
+		switch c {
 		case 'H':
 			total += time.Duration(f * float64(time.Hour))
 		case 'M':
@@ -303,9 +312,10 @@ func parseISODuration(v string) (time.Duration, bool) {
 		default:
 			return 0, false
 		}
-		num = ""
+		start = -1
 	}
-	if num != "" {
+	// A trailing number with no unit, for example "PT2".
+	if start >= 0 {
 		return 0, false
 	}
 	return total, true

--- a/providers/os/resources/windows/defender.go
+++ b/providers/os/resources/windows/defender.go
@@ -248,7 +248,7 @@ type MpComputerStatus struct {
 	ComputerID                       string
 	ComputerState                    int64
 	DefenderSignaturesOutOfDate      bool
-	DeviceControlDefaultEnforcement  string
+	DeviceControlDefaultEnforcement  *string
 	DeviceControlPoliciesLastUpdated string
 	DeviceControlState               string
 	FullScanAge                      int64
@@ -309,7 +309,7 @@ type MpPreference struct {
 	DisableBehaviorMonitoring        bool
 	DisableIOAVProtection            bool
 	DisableScriptScanning            bool
-	DisableIntrusionPreventionSystem bool
+	DisableIntrusionPreventionSystem *bool
 	RealTimeScanDirection            int64
 	EnableFileHashComputation        bool
 
@@ -365,15 +365,15 @@ type MpPreference struct {
 	RemoteEncryptionProtectionMaxBlockTime    int64
 
 	// local setting overrides (whether a local preference may override policy)
-	LocalSettingOverrideSpynetReporting                  bool
-	LocalSettingOverrideRealtimeMonitoring               bool
-	LocalSettingOverrideDisableBehaviorMonitoring        bool
-	LocalSettingOverrideDisableIOAVProtection            bool
-	LocalSettingOverrideDisableIntrusionPreventionSystem bool
-	LocalSettingOverrideDisableOnAccessProtection        bool
-	LocalSettingOverrideScanParameters                   bool
-	LocalSettingOverrideScanScheduleDay                  bool
-	LocalSettingOverrideAvgCPULoadFactor                 bool
+	LocalSettingOverrideSpynetReporting                  *bool
+	LocalSettingOverrideRealtimeMonitoring               *bool
+	LocalSettingOverrideDisableBehaviorMonitoring        *bool
+	LocalSettingOverrideDisableIOAVProtection            *bool
+	LocalSettingOverrideDisableIntrusionPreventionSystem *bool
+	LocalSettingOverrideDisableOnAccessProtection        *bool
+	LocalSettingOverrideScanParameters                   *bool
+	LocalSettingOverrideScanScheduleDay                  *bool
+	LocalSettingOverrideAvgCPULoadFactor                 *bool
 
 	// remediation
 	RemediationScheduleDay         int64
@@ -399,7 +399,7 @@ type MpPreference struct {
 	// Defender uses the historical "RePorts" casing for this preference; the
 	// json tag matches it explicitly so the field is populated regardless of how
 	// the cmdlet serializes it.
-	DisableGenericReports bool `json:"DisableGenericRePorts"`
+	DisableGenericReports *bool `json:"DisableGenericRePorts"`
 }
 
 // ScanScheduleTimeString returns the raw scheduled-scan time value.

--- a/providers/os/resources/windows/defender_live_test.go
+++ b/providers/os/resources/windows/defender_live_test.go
@@ -162,3 +162,46 @@ func keysOf(m map[string]json.RawMessage) []string {
 	}
 	return out
 }
+
+// TestScheduleTime covers every serialization a Defender schedule preference
+// has been observed to arrive in. Windows PowerShell 5.1, which is what ships
+// on Windows Server, sends a whole TimeSpan object.
+func TestScheduleTime(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"powershell 5.1 TimeSpan object", `{"Ticks":72000000000,"Days":0,"Hours":2,"Minutes":0,"Seconds":0,"TotalHours":2}`, "02:00:00"},
+		{"TimeSpan object at midnight", `{"Ticks":0,"Days":0,"Hours":0,"Minutes":0,"Seconds":0}`, "00:00:00"},
+		{"TimeSpan object with minutes", `{"Ticks":63000000000,"Hours":1,"Minutes":45}`, "01:45:00"},
+		{"iso duration hours", `"PT2H"`, "02:00:00"},
+		{"iso duration hours and minutes", `"PT1H45M"`, "01:45:00"},
+		{"iso duration seconds", `"PT30S"`, "00:00:30"},
+		{"already formatted", `"02:00:00"`, "02:00:00"},
+		{"powershell date form", `"/Date(1705276800000)/"`, "00:00:00"},
+		{"null", `null`, ""},
+		{"empty", ``, ""},
+		{"unrecognized string is preserved", `"whenever"`, "whenever"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ScheduleTime(json.RawMessage(tt.raw)))
+		})
+	}
+}
+
+// TestLiveScheduleTimes pins the schedule preferences read off the live hosts.
+func TestLiveScheduleTimes(t *testing.T) {
+	for _, v := range defenderLiveVersions {
+		t.Run(v, func(t *testing.T) {
+			pref, err := ParseMpPreference(readFixture(t, "defender_preference_win"+v+".json"))
+			require.NoError(t, err)
+
+			assert.Equal(t, "02:00:00", pref.ScanScheduleTimeString())
+			assert.Equal(t, "00:00:00", pref.ScanScheduleQuickScanTimeString())
+			assert.Equal(t, "01:45:00", pref.SignatureScheduleTimeString())
+			assert.Equal(t, "02:00:00", pref.RemediationScheduleTimeString())
+		})
+	}
+}

--- a/providers/os/resources/windows/defender_live_test.go
+++ b/providers/os/resources/windows/defender_live_test.go
@@ -63,7 +63,7 @@ func TestMpComputerStatusLiveDecodes(t *testing.T) {
 			// default enforcement unset on a host with no device-control
 			// policy, so it must not read as a number either.
 			assert.Equal(t, "Disabled", status.DeviceControlState)
-			assert.Empty(t, status.DeviceControlDefaultEnforcement)
+			assert.Nil(t, status.DeviceControlDefaultEnforcement)
 
 			// A host that has never run a scan reports uint32 max for the scan
 			// age and leaves the scan times null.
@@ -113,6 +113,22 @@ func TestMpPreferenceLiveDecodes(t *testing.T) {
 			assert.Empty(t, pref.ThreatIDDefaultAction_Actions)
 			assert.Empty(t, pref.ControlledFolderAccessAllowedApplications)
 			assert.Empty(t, pref.ControlledFolderAccessProtectedFolders)
+
+			// The Defender platform on these hosts does not report these
+			// preferences at all. They must stay nil rather than decoding to
+			// false, which would claim a hardened configuration that nothing
+			// verified.
+			assert.Nil(t, pref.DisableIntrusionPreventionSystem)
+			assert.Nil(t, pref.DisableGenericReports)
+			assert.Nil(t, pref.LocalSettingOverrideSpynetReporting)
+			assert.Nil(t, pref.LocalSettingOverrideRealtimeMonitoring)
+			assert.Nil(t, pref.LocalSettingOverrideDisableBehaviorMonitoring)
+			assert.Nil(t, pref.LocalSettingOverrideDisableIOAVProtection)
+			assert.Nil(t, pref.LocalSettingOverrideDisableIntrusionPreventionSystem)
+			assert.Nil(t, pref.LocalSettingOverrideDisableOnAccessProtection)
+			assert.Nil(t, pref.LocalSettingOverrideScanParameters)
+			assert.Nil(t, pref.LocalSettingOverrideScanScheduleDay)
+			assert.Nil(t, pref.LocalSettingOverrideAvgCPULoadFactor)
 		})
 	}
 }

--- a/providers/os/resources/windows/defender_live_test.go
+++ b/providers/os/resources/windows/defender_live_test.go
@@ -183,6 +183,8 @@ func TestScheduleTime(t *testing.T) {
 		{"null", `null`, ""},
 		{"empty", ``, ""},
 		{"unrecognized string is preserved", `"whenever"`, "whenever"},
+		{"trailing number with no unit is not a duration", `"PT2"`, "PT2"},
+		{"no unit at all is not a duration", `"PTX"`, "PTX"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/providers/os/resources/windows/defender_test.go
+++ b/providers/os/resources/windows/defender_test.go
@@ -100,14 +100,17 @@ func TestParseMpPreference(t *testing.T) {
 	assert.Equal(t, int64(1), pref.RemoteEncryptionProtectionConfiguredState)
 
 	// local setting overrides
-	assert.False(t, pref.LocalSettingOverrideSpynetReporting)
-	assert.False(t, pref.LocalSettingOverrideRealtimeMonitoring)
+	require.NotNil(t, pref.LocalSettingOverrideSpynetReporting)
+	assert.False(t, *pref.LocalSettingOverrideSpynetReporting)
+	require.NotNil(t, pref.LocalSettingOverrideRealtimeMonitoring)
+	assert.False(t, *pref.LocalSettingOverrideRealtimeMonitoring)
 
 	// misc
 	assert.Equal(t, int64(1), pref.PUAProtection)
 	assert.True(t, pref.RandomizeScheduleTaskTimes)
 	// the "RePorts" casing is matched via the explicit json tag
-	assert.True(t, pref.DisableGenericReports)
+	require.NotNil(t, pref.DisableGenericReports)
+	assert.True(t, *pref.DisableGenericReports)
 }
 
 func TestParseMpThreats(t *testing.T) {

--- a/providers/os/resources/windows_defender.go
+++ b/providers/os/resources/windows_defender.go
@@ -64,7 +64,7 @@ func (d *mqlWindowsDefender) status() (*mqlWindowsDefenderStatus, error) {
 		"computerID":                       llx.StringData(status.ComputerID),
 		"computerState":                    llx.IntData(status.ComputerState),
 		"defenderSignaturesOutOfDate":      llx.BoolData(status.DefenderSignaturesOutOfDate),
-		"deviceControlDefaultEnforcement":  llx.StringData(status.DeviceControlDefaultEnforcement),
+		"deviceControlDefaultEnforcement":  llx.StringDataPtr(status.DeviceControlDefaultEnforcement),
 		"deviceControlPoliciesLastUpdated": llx.TimeDataPtr(windows.DefenderTime(status.DeviceControlPoliciesLastUpdated)),
 		"deviceControlState":               llx.StringData(status.DeviceControlState),
 		"fullScanAge":                      llx.IntData(status.FullScanAge),
@@ -269,7 +269,7 @@ func (p *mqlWindowsDefenderPreferences) realTimeProtection() (*mqlWindowsDefende
 		"disableBehaviorMonitoring":        llx.BoolData(prefs.DisableBehaviorMonitoring),
 		"disableIOAVProtection":            llx.BoolData(prefs.DisableIOAVProtection),
 		"disableScriptScanning":            llx.BoolData(prefs.DisableScriptScanning),
-		"disableIntrusionPreventionSystem": llx.BoolData(prefs.DisableIntrusionPreventionSystem),
+		"disableIntrusionPreventionSystem": llx.BoolDataPtr(prefs.DisableIntrusionPreventionSystem),
 		"realTimeScanDirection":            llx.IntData(prefs.RealTimeScanDirection),
 		"enableFileHashComputation":        llx.BoolData(prefs.EnableFileHashComputation),
 	})
@@ -410,15 +410,15 @@ func (p *mqlWindowsDefenderPreferences) localSettingOverrides() (*mqlWindowsDefe
 	}
 	res, err := CreateResource(p.MqlRuntime, "windows.defender.localSettingOverrides", map[string]*llx.RawData{
 		"__id":                             llx.StringData("windows.defender.localSettingOverrides"),
-		"spynetReporting":                  llx.BoolData(prefs.LocalSettingOverrideSpynetReporting),
-		"realtimeMonitoring":               llx.BoolData(prefs.LocalSettingOverrideRealtimeMonitoring),
-		"disableBehaviorMonitoring":        llx.BoolData(prefs.LocalSettingOverrideDisableBehaviorMonitoring),
-		"disableIOAVProtection":            llx.BoolData(prefs.LocalSettingOverrideDisableIOAVProtection),
-		"disableIntrusionPreventionSystem": llx.BoolData(prefs.LocalSettingOverrideDisableIntrusionPreventionSystem),
-		"disableOnAccessProtection":        llx.BoolData(prefs.LocalSettingOverrideDisableOnAccessProtection),
-		"scanParameters":                   llx.BoolData(prefs.LocalSettingOverrideScanParameters),
-		"scanScheduleDay":                  llx.BoolData(prefs.LocalSettingOverrideScanScheduleDay),
-		"avgCPULoadFactor":                 llx.BoolData(prefs.LocalSettingOverrideAvgCPULoadFactor),
+		"spynetReporting":                  llx.BoolDataPtr(prefs.LocalSettingOverrideSpynetReporting),
+		"realtimeMonitoring":               llx.BoolDataPtr(prefs.LocalSettingOverrideRealtimeMonitoring),
+		"disableBehaviorMonitoring":        llx.BoolDataPtr(prefs.LocalSettingOverrideDisableBehaviorMonitoring),
+		"disableIOAVProtection":            llx.BoolDataPtr(prefs.LocalSettingOverrideDisableIOAVProtection),
+		"disableIntrusionPreventionSystem": llx.BoolDataPtr(prefs.LocalSettingOverrideDisableIntrusionPreventionSystem),
+		"disableOnAccessProtection":        llx.BoolDataPtr(prefs.LocalSettingOverrideDisableOnAccessProtection),
+		"scanParameters":                   llx.BoolDataPtr(prefs.LocalSettingOverrideScanParameters),
+		"scanScheduleDay":                  llx.BoolDataPtr(prefs.LocalSettingOverrideScanScheduleDay),
+		"avgCPULoadFactor":                 llx.BoolDataPtr(prefs.LocalSettingOverrideAvgCPULoadFactor),
 	})
 	if err != nil {
 		return nil, err
@@ -528,7 +528,11 @@ func (p *mqlWindowsDefenderPreferences) disableGenericReports() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return prefs.DisableGenericReports, nil
+	if prefs.DisableGenericReports == nil {
+		p.DisableGenericReports.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
+	return *prefs.DisableGenericReports, nil
 }
 
 // mqlWindowsDefenderThreatActionSettingsInternal caches the per-threat-ID

--- a/providers/os/resources/windows_defender.go
+++ b/providers/os/resources/windows_defender.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"sync"
 
@@ -32,6 +33,57 @@ func (d *mqlWindowsDefender) enabled() (bool, error) {
 		return false, nil
 	}
 	return s.AmServiceEnabled.Data && s.AntivirusEnabled.Data && s.AntispywareEnabled.Data, nil
+}
+
+// windows.defender.status and windows.defender.preferences are reachable by
+// dotted paths that are also their own registered resource names: the field
+// `status` on `windows.defender` and the resource `windows.defender.status`
+// occupy the same path. The compiler resolves the longest matching resource
+// name before it considers a field, so `windows.defender.status` instantiates
+// the sub-resource directly and the parent's status() accessor never runs.
+// Every field is a plain schema field that only the parent populates, so all of
+// them stay unset and report "provider returned no data and no error", then
+// convert as primitives carrying no type information:
+//
+//	windows.defender.status.antivirusEnabled           -> null
+//	windows.defender { status { antivirusEnabled } }   -> true
+//
+// A check reading "antivirus is enabled" off the dotted form therefore reports
+// null on a host where Defender is running. Delegating to the parent's accessor
+// fills the resource in. When the parent creates the resource normally it
+// carries an __id and these are a no-op.
+func initWindowsDefenderChild[T plugin.Resource](
+	runtime *plugin.Runtime,
+	args map[string]*llx.RawData,
+	field string,
+	get func(*mqlWindowsDefender) *plugin.TValue[T],
+) (map[string]*llx.RawData, plugin.Resource, error) {
+	if _, ok := args["__id"]; ok {
+		return args, nil, nil
+	}
+	parent, err := CreateResource(runtime, "windows.defender", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	v := get(parent.(*mqlWindowsDefender))
+	if v.Error != nil {
+		return nil, nil, v.Error
+	}
+	if v.IsNull() {
+		// Defender is not installed. Falling through would build the resource
+		// out of the empty args and report null for every field, which reads as
+		// "not configured" rather than "not present".
+		return nil, nil, fmt.Errorf("cannot read windows.defender.%s: %w", field, windows.ErrDefenderUnavailable)
+	}
+	return args, v.Data, nil
+}
+
+func initWindowsDefenderStatus(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return initWindowsDefenderChild(runtime, args, "status", (*mqlWindowsDefender).GetStatus)
+}
+
+func initWindowsDefenderPreferences(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return initWindowsDefenderChild(runtime, args, "preferences", (*mqlWindowsDefender).GetPreferences)
 }
 
 func (d *mqlWindowsDefender) status() (*mqlWindowsDefenderStatus, error) {

--- a/providers/os/resources/windows_defender_test.go
+++ b/providers/os/resources/windows_defender_test.go
@@ -1,0 +1,32 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// windows.defender.status and windows.defender.preferences are both field paths
+// on windows.defender and registered resource names in their own right. Without
+// an Init the dotted form instantiates the sub-resource, the parent's accessor
+// never runs, and every field reads null - so a check reading "antivirus is
+// enabled" off windows.defender.status.antivirusEnabled reports null on a host
+// where Defender is running and protecting the machine.
+func TestWindowsDefenderSingletonsAreReachableByTheirOwnPath(t *testing.T) {
+	for _, path := range []string{"windows.defender.status", "windows.defender.preferences"} {
+		t.Run(path, func(t *testing.T) {
+			_, isField := getDataFields[path]
+			require.True(t, isField, "%s should be a field path on windows.defender", path)
+
+			factory, isResource := resourceFactories[path]
+			require.True(t, isResource, "%s should also be a registered resource name", path)
+
+			assert.NotNil(t, factory.Init,
+				"%s resolves to the resource, not the field, so without an Init every field reads null", path)
+		})
+	}
+}

--- a/providers/os/resources/windows_dnsserver_test.go
+++ b/providers/os/resources/windows_dnsserver_test.go
@@ -86,8 +86,6 @@ func TestNoNewDottedPathHusks(t *testing.T) {
 		"luks.volume.cipher":              true,
 		"os.date":                         true,
 		"windows.bitlocker.policy":        true,
-		"windows.defender.preferences":    true,
-		"windows.defender.status":         true,
 		"windows.exploitProtection":       true,
 		"windows.exploitProtection.aslr":  true,
 		"windows.exploitProtection.dep":   true,


### PR DESCRIPTION
## What

The four Defender schedule preferences are CIM datetime values. Windows
PowerShell 5.1, which is what ships on Windows Server, serializes them as whole
`TimeSpan` objects, and the field passed the raw JSON straight through:

```
scan: {
  scanScheduleTime: "{\"Ticks\":72000000000,\"Days\":0,\"Hours\":2,\"Milliseconds\":0,\"Minutes\":0,\"Seconds\":0,\"TotalDays\":0.083333333333333329,\"TotalHours\":2,\"TotalMilliseconds\":7200000,\"TotalMinutes\":120,\"TotalSeconds\":7200}"
  scanScheduleQuickScanTime: "{\"Ticks\":0,\"Days\":0,\"Hours\":0,...}"
}
signatureUpdates: { signatureScheduleTime: "{\"Ticks\":63000000000,...}" }
remediation:      { remediationScheduleTime: "{\"Ticks\":72000000000,...}" }
```

Nothing can be asserted against a serialized .NET object. Worse, the same
setting serializes four different ways depending on the host, so a policy
written against one host's output would not match another's:

| host | `ScanScheduleTime` for 02:00 |
|---|---|
| Windows PowerShell 5.1 | `{"Ticks":72000000000,...}` |
| PowerShell 7+ | `"PT2H"` |
| some builds | `"/Date(...)/"` |
| already formatted | `"02:00:00"` |

## Fix

All four normalize to `"HH:MM:SS"`. An unrecognized value is passed through
trimmed rather than dropped, so a serialization we have not seen surfaces as
itself instead of as an empty string that would read as "no schedule
configured".

## Versions affected

Windows Server **2016, 2019, 2022 and 2025**, all returning the PowerShell 5.1
`TimeSpan` object form. Windows Server 2025 ships Windows PowerShell 5.1 as its
system shell just as the older releases do, so the newest version is affected
exactly like the oldest.

## Verification

Against Windows Server 2016 after the fix, with 2019 and 2022 identical:

```
scan:             { scanScheduleTime: "02:00:00", scanScheduleQuickScanTime: "00:00:00" }
signatureUpdates: { signatureScheduleTime: "01:45:00" }
remediation:      { remediationScheduleTime: "02:00:00" }
```

which matches the raw preferences: `ScanScheduleTime` 72000000000 ticks = 2h,
`SignatureScheduleTime` 63000000000 ticks = 1h45m.

`TestScheduleTime` covers all four serializations plus the null, empty and
unrecognized cases; `TestLiveScheduleTimes` pins the values read off each of the
four captured hosts.

## Note on shipped behaviour

The string value these fields return changes shape. No consumer can have
depended on the old value, because the whole `preferences` subtree errored
before #10369.

## Stack

Builds on #10370.

---

# Also in this PR: the two dotted-path husks

#10373 merged into this branch while the stack was being rebased, so its
commit rides here. Its content:

### What

`windows.defender.status` and `windows.defender.preferences` are both field
paths on `windows.defender` **and** registered resource names in their own
right. The compiler resolves the longest matching resource name before it
considers a field, so the dotted form instantiates the sub-resource and the
parent's accessor never runs. Every field of both is a plain schema field that
only the parent populates, so none is ever set:

```
$ mql run ssh Administrator@<2016-host> -c "windows.defender.status { antivirusEnabled realTimeProtectionEnabled amProductVersion }"
x provider returned no data and no error for a field; the field was never set on the resource (provider bug) field=antivirusEnabled id= provider=os resource=windows.defender.status
x llx: encountered a primitive with no type information, coercing to null
...
windows.defender.status: {
  amProductVersion:          null
  antivirusEnabled:          null
  realTimeProtectionEnabled: null
  isTamperProtected:         null
}

$ mql run ssh Administrator@<2016-host> -c "windows.defender { status { antivirusEnabled } }"
windows.defender: { status: { antivirusEnabled: true } }
```

Same host, same field, opposite answers, and the failing direction is the one
that reads as "not configured" on a machine Defender is actively protecting.

### Versions affected

Windows Server **2016, 2019, 2022 and 2025**. This is a schema-shape bug rather
than a platform one, so it affects every Windows target regardless of version.

### Fix

An `Init` on each delegates to the parent's accessor, the same shape used for
the `windows.dnsServer` singletons in `initWindowsDnsServerChild`.

When Defender is not installed the `Init` returns an error naming that, rather
than falling through to build the resource from empty args. Falling through
would put back the null-for-every-field behaviour this fixes, and let a check
pass on a host with no antivirus at all.

Both paths come off the `TestNoNewDottedPathHusks` ratchet list, and
`windows_defender_test.go` pins them the way the DNS server singletons are
pinned.

### Verification

Against Windows Server 2016 after the fix:

```
$ ... -c "windows.defender.status { antivirusEnabled realTimeProtectionEnabled amProductVersion }"
windows.defender.status: {
  amProductVersion:          "4.18.26070.9"
  antivirusEnabled:          true
  realTimeProtectionEnabled: true
}

$ ... -c "windows.defender.preferences.puaProtection"
windows.defender.preferences.puaProtection: 0

$ ... -c "windows.defender.preferences { scan { scanScheduleTime } }"
windows.defender.preferences: { scan: { scanScheduleTime: "02:00:00" } }
```



## Windows Server 2025, after the fix

The replacement 2025 host was reached late in the run. It confirms every fix in
this stack, and reports exactly what 2016, 2019 and 2022 do:

```
windows.defender: {
  enabled: true
  status: {
    amProductVersion:                "4.18.26070.9"
    amRunningMode:                   "Normal"
    antivirusEnabled:                true
    realTimeProtectionEnabled:       true
    nisEnabled:                      true
    isTamperProtected:               false
    tamperProtectionSource:          "Signatures"
    deviceControlState:              "Disabled"
    deviceControlDefaultEnforcement: null
    smartAppControlState:            "Off"
    fullScanAge:                     4294967295
  }
  preferences: {
    scan: { scanScheduleTime: "02:00:00", scanScheduleQuickScanTime: "00:00:00",
            checkForSignaturesBeforeRunningScan: false }
    signatureUpdates: { signatureScheduleTime: "01:45:00" }
    remediation:      { remediationScheduleTime: "02:00:00" }
    realTimeProtection: { disableIntrusionPreventionSystem: null,
                          disableRealtimeMonitoring: false }
    localSettingOverrides: { spynetReporting: null, avgCPULoadFactor: null }
    disableGenericReports: null
    exclusions: { paths: [] }
  }
}
```

and the dotted path resolves:

```
$ ... -c "windows.defender.status { antivirusEnabled amProductVersion }"
windows.defender.status: { amProductVersion: "4.18.26070.9", antivirusEnabled: true }
```
