### PR TITLE
🐛 os: make windows.defender.status and .preferences work by their own path

### DIFF
--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -2542,11 +2542,11 @@ func init() {
 			Create: createWindowsDefender,
 		},
 		"windows.defender.status": {
-			// to override args, implement: initWindowsDefenderStatus(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initWindowsDefenderStatus,
 			Create: createWindowsDefenderStatus,
 		},
 		"windows.defender.preferences": {
-			// to override args, implement: initWindowsDefenderPreferences(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initWindowsDefenderPreferences,
 			Create: createWindowsDefenderPreferences,
 		},
 		"windows.defender.scanSettings": {

--- a/providers/os/resources/windows_defender.go
+++ b/providers/os/resources/windows_defender.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"sync"
 
@@ -32,6 +33,57 @@ func (d *mqlWindowsDefender) enabled() (bool, error) {
 		return false, nil
 	}
 	return s.AmServiceEnabled.Data && s.AntivirusEnabled.Data && s.AntispywareEnabled.Data, nil
+}
+
+// windows.defender.status and windows.defender.preferences are reachable by
+// dotted paths that are also their own registered resource names: the field
+// `status` on `windows.defender` and the resource `windows.defender.status`
+// occupy the same path. The compiler resolves the longest matching resource
+// name before it considers a field, so `windows.defender.status` instantiates
+// the sub-resource directly and the parent's status() accessor never runs.
+// Every field is a plain schema field that only the parent populates, so all of
+// them stay unset and report "provider returned no data and no error", then
+// convert as primitives carrying no type information:
+//
+//	windows.defender.status.antivirusEnabled           -> null
+//	windows.defender { status { antivirusEnabled } }   -> true
+//
+// A check reading "antivirus is enabled" off the dotted form therefore reports
+// null on a host where Defender is running. Delegating to the parent's accessor
+// fills the resource in. When the parent creates the resource normally it
+// carries an __id and these are a no-op.
+func initWindowsDefenderChild[T plugin.Resource](
+	runtime *plugin.Runtime,
+	args map[string]*llx.RawData,
+	field string,
+	get func(*mqlWindowsDefender) *plugin.TValue[T],
+) (map[string]*llx.RawData, plugin.Resource, error) {
+	if _, ok := args["__id"]; ok {
+		return args, nil, nil
+	}
+	parent, err := CreateResource(runtime, "windows.defender", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	v := get(parent.(*mqlWindowsDefender))
+	if v.Error != nil {
+		return nil, nil, v.Error
+	}
+	if v.IsNull() {
+		// Defender is not installed. Falling through would build the resource
+		// out of the empty args and report null for every field, which reads as
+		// "not configured" rather than "not present".
+		return nil, nil, fmt.Errorf("cannot read windows.defender.%s: %w", field, windows.ErrDefenderUnavailable)
+	}
+	return args, v.Data, nil
+}
+
+func initWindowsDefenderStatus(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return initWindowsDefenderChild(runtime, args, "status", (*mqlWindowsDefender).GetStatus)
+}
+
+func initWindowsDefenderPreferences(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return initWindowsDefenderChild(runtime, args, "preferences", (*mqlWindowsDefender).GetPreferences)
 }
 
 func (d *mqlWindowsDefender) status() (*mqlWindowsDefenderStatus, error) {

--- a/providers/os/resources/windows_defender_test.go
+++ b/providers/os/resources/windows_defender_test.go
@@ -1,0 +1,32 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// windows.defender.status and windows.defender.preferences are both field paths
+// on windows.defender and registered resource names in their own right. Without
+// an Init the dotted form instantiates the sub-resource, the parent's accessor
+// never runs, and every field reads null - so a check reading "antivirus is
+// enabled" off windows.defender.status.antivirusEnabled reports null on a host
+// where Defender is running and protecting the machine.
+func TestWindowsDefenderSingletonsAreReachableByTheirOwnPath(t *testing.T) {
+	for _, path := range []string{"windows.defender.status", "windows.defender.preferences"} {
+		t.Run(path, func(t *testing.T) {
+			_, isField := getDataFields[path]
+			require.True(t, isField, "%s should be a field path on windows.defender", path)
+
+			factory, isResource := resourceFactories[path]
+			require.True(t, isResource, "%s should also be a registered resource name", path)
+
+			assert.NotNil(t, factory.Init,
+				"%s resolves to the resource, not the field, so without an Init every field reads null", path)
+		})
+	}
+}

--- a/providers/os/resources/windows_dnsserver_test.go
+++ b/providers/os/resources/windows_dnsserver_test.go
@@ -86,8 +86,6 @@ func TestNoNewDottedPathHusks(t *testing.T) {
 		"luks.volume.cipher":              true,
 		"os.date":                         true,
 		"windows.bitlocker.policy":        true,
-		"windows.defender.preferences":    true,
-		"windows.defender.status":         true,
 		"windows.exploitProtection":       true,
 		"windows.exploitProtection.aslr":  true,
 		"windows.exploitProtection.dep":   true,


### PR DESCRIPTION
## What

`windows.defender.status` and `windows.defender.preferences` are both field
paths on `windows.defender` **and** registered resource names in their own
right. The compiler resolves the longest matching resource name before it
considers a field, so the dotted form instantiates the sub-resource and the
parent's accessor never runs. Every field of both is a plain schema field that
only the parent populates, so none is ever set:

```
$ mql run ssh Administrator@<2016-host> -c "windows.defender.status { antivirusEnabled realTimeProtectionEnabled amProductVersion }"
x provider returned no data and no error for a field; the field was never set on the resource (provider bug) field=antivirusEnabled id= provider=os resource=windows.defender.status
x llx: encountered a primitive with no type information, coercing to null
...
windows.defender.status: {
  amProductVersion:          null
  antivirusEnabled:          null
  realTimeProtectionEnabled: null
  isTamperProtected:         null
}

$ mql run ssh Administrator@<2016-host> -c "windows.defender { status { antivirusEnabled } }"
windows.defender: { status: { antivirusEnabled: true } }
```

Same host, same field, opposite answers, and the failing direction is the one
that reads as "not configured" on a machine Defender is actively protecting.

## Versions affected

Windows Server **2016, 2019, 2022 and 2025**. This is a schema-shape bug rather
than a platform one, so it affects every Windows target regardless of version.

## Fix

An `Init` on each delegates to the parent's accessor, the same shape used for
the `windows.dnsServer` singletons in `initWindowsDnsServerChild`.

When Defender is not installed the `Init` returns an error naming that, rather
than falling through to build the resource from empty args. Falling through
would put back the null-for-every-field behaviour this fixes, and let a check
pass on a host with no antivirus at all.

Both paths come off the `TestNoNewDottedPathHusks` ratchet list, and
`windows_defender_test.go` pins them the way the DNS server singletons are
pinned.

## Verification

Against Windows Server 2016 after the fix:

```
$ ... -c "windows.defender.status { antivirusEnabled realTimeProtectionEnabled amProductVersion }"
windows.defender.status: {
  amProductVersion:          "4.18.26070.9"
  antivirusEnabled:          true
  realTimeProtectionEnabled: true
}

$ ... -c "windows.defender.preferences.puaProtection"
windows.defender.preferences.puaProtection: 0

$ ... -c "windows.defender.preferences { scan { scanScheduleTime } }"
windows.defender.preferences: { scan: { scanScheduleTime: "02:00:00" } }
```

## Stack

Builds on #10371.
