### PR TITLE
🛑 os: Defender threat history null, running mode, and a preferences-cache race

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -14036,8 +14036,15 @@ windows.defender @defaults("enabled") {
   // Configurable Defender preferences and policy (Get-MpPreference)
   preferences() windows.defender.preferences
   // Threats recorded in the Defender threat history
+  //
+  // An empty list means Defender has recorded no threats. Null means the
+  // history could not be read because Defender is not installed, and must not
+  // be read as "no threats found".
   threats() []windows.defender.threat
   // Malware detections recorded by Defender
+  //
+  // An empty list means Defender has recorded no detections. Null means the
+  // history could not be read because Defender is not installed.
   threatDetections() []windows.defender.threatDetection
 }
 

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -14063,6 +14063,16 @@ private windows.defender.status @defaults("antivirusEnabled realTimeProtectionEn
   amEngineVersion string
   // Antimalware client (product) version
   amProductVersion string
+  // Mode the Defender antimalware engine is running in
+  //
+  // "Normal" means Defender is the active antivirus. "Passive Mode" and
+  // "SxS Passive Mode" mean another antivirus is active and Defender is not
+  // remediating threats, even though amServiceEnabled and antivirusEnabled
+  // still report true. "EDR Block Mode" means Defender remediates only what
+  // endpoint detection and response identifies, and "Not running" means the
+  // engine is stopped. Check this before reading the protection toggles as
+  // proof the host is being defended.
+  amRunningMode string
   // Whether the Windows Defender antimalware service is running
   amServiceEnabled bool
   // Antimalware service version

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -13957,6 +13957,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"windows.defender.status.amProductVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsDefenderStatus).GetAmProductVersion()).ToDataRes(types.String)
 	},
+	"windows.defender.status.amRunningMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsDefenderStatus).GetAmRunningMode()).ToDataRes(types.String)
+	},
 	"windows.defender.status.amServiceEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsDefenderStatus).GetAmServiceEnabled()).ToDataRes(types.Bool)
 	},
@@ -33186,6 +33189,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"windows.defender.status.amProductVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindowsDefenderStatus).AmProductVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.defender.status.amRunningMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsDefenderStatus).AmRunningMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"windows.defender.status.amServiceEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -85509,6 +85516,7 @@ type mqlWindowsDefenderStatus struct {
 	// optional: if you define mqlWindowsDefenderStatusInternal it will be used here
 	AmEngineVersion                  plugin.TValue[string]
 	AmProductVersion                 plugin.TValue[string]
+	AmRunningMode                    plugin.TValue[string]
 	AmServiceEnabled                 plugin.TValue[bool]
 	AmServiceVersion                 plugin.TValue[string]
 	AntispywareEnabled               plugin.TValue[bool]
@@ -85595,6 +85603,10 @@ func (c *mqlWindowsDefenderStatus) GetAmEngineVersion() *plugin.TValue[string] {
 
 func (c *mqlWindowsDefenderStatus) GetAmProductVersion() *plugin.TValue[string] {
 	return &c.AmProductVersion
+}
+
+func (c *mqlWindowsDefenderStatus) GetAmRunningMode() *plugin.TValue[string] {
+	return &c.AmRunningMode
 }
 
 func (c *mqlWindowsDefenderStatus) GetAmServiceEnabled() *plugin.TValue[bool] {

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -4274,6 +4274,7 @@ windows.defender.signatureSettings.signatureUpdateInterval 13.29.1
 windows.defender.status 13.29.1
 windows.defender.status.amEngineVersion 13.29.1
 windows.defender.status.amProductVersion 13.29.1
+windows.defender.status.amRunningMode 13.40.10
 windows.defender.status.amServiceEnabled 13.29.1
 windows.defender.status.amServiceVersion 13.29.1
 windows.defender.status.antispywareEnabled 13.29.1

--- a/providers/os/resources/windows/defender.go
+++ b/providers/os/resources/windows/defender.go
@@ -334,6 +334,7 @@ func formatTimeOfDay(d time.Duration) string {
 type MpComputerStatus struct {
 	AMEngineVersion                  string
 	AMProductVersion                 string
+	AMRunningMode                    string
 	AMServiceEnabled                 bool
 	AMServiceVersion                 string
 	AntispywareEnabled               bool

--- a/providers/os/resources/windows/defender_live_test.go
+++ b/providers/os/resources/windows/defender_live_test.go
@@ -57,6 +57,11 @@ func TestMpComputerStatusLiveDecodes(t *testing.T) {
 			assert.False(t, status.IsTamperProtected)
 			assert.False(t, status.RebootRequired)
 			assert.Equal(t, "4.18.26070.9", status.AMProductVersion)
+
+			// "Normal" means Defender is the active antivirus. A passive-mode
+			// host still reports amServiceEnabled and antivirusEnabled true, so
+			// this is what separates "protected" from "installed".
+			assert.Equal(t, "Normal", status.AMRunningMode)
 			assert.Equal(t, "Off", status.SmartAppControlState)
 
 			// Device control reports names, not numbers. Defender leaves the

--- a/providers/os/resources/windows_defender.go
+++ b/providers/os/resources/windows_defender.go
@@ -191,7 +191,12 @@ func (d *mqlWindowsDefender) threats() ([]any, error) {
 	threats, err := windows.GetDefenderThreats(conn)
 	if err != nil {
 		if errors.Is(err, windows.ErrDefenderUnavailable) {
-			return []any{}, nil
+			// An empty list would make threats.none(...) and threats.all(...)
+			// pass on a host that has no antivirus recording threats at all.
+			// Null says the history could not be read, matching how status and
+			// preferences resolve on the same host.
+			d.Threats.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}
@@ -224,7 +229,8 @@ func (d *mqlWindowsDefender) threatDetections() ([]any, error) {
 	detections, err := windows.GetDefenderThreatDetections(conn)
 	if err != nil {
 		if errors.Is(err, windows.ErrDefenderUnavailable) {
-			return []any{}, nil
+			d.ThreatDetections.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/providers/os/resources/windows_defender.go
+++ b/providers/os/resources/windows_defender.go
@@ -181,8 +181,7 @@ func (d *mqlWindowsDefender) preferences() (*mqlWindowsDefenderPreferences, erro
 	// Seed the cache so the grouped sub-accessors reuse this result instead of
 	// running Get-MpPreference a second time.
 	p := res.(*mqlWindowsDefenderPreferences)
-	p.prefs = prefs
-	p.fetched = true
+	p.seedPrefs(prefs)
 	return p, nil
 }
 
@@ -270,6 +269,37 @@ type mqlWindowsDefenderPreferencesInternal struct {
 	fetched bool
 	prefs   *windows.MpPreference
 	err     error
+}
+
+// seedPrefs installs an already-fetched Get-MpPreference result.
+//
+// It must take the same lock getPrefs uses. CreateResource looks the __id up in
+// the runtime cache and returns the existing resource when it finds one, so the
+// instance handed back here may already be published and in use by another
+// goroutine reading these fields under the lock. Writing them unlocked is a
+// data race, and without the happens-before edge the lock provides a reader can
+// observe fetched as true while prefs is still nil, which makes getPrefs return
+// (nil, nil) and every grouped accessor dereference it.
+//
+// The fetched guard keeps a second seeder from replacing a result that has
+// already been handed out.
+func (p *mqlWindowsDefenderPreferences) seedPrefs(prefs *windows.MpPreference) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if p.fetched {
+		return
+	}
+	p.prefs = prefs
+	p.fetched = true
+}
+
+// peekPrefs reports the cached Get-MpPreference result without fetching. The
+// third return value is false when nothing has been cached yet. It exists so a
+// test can observe the seeded state under the lock.
+func (p *mqlWindowsDefenderPreferences) peekPrefs() (*windows.MpPreference, error, bool) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	return p.prefs, p.err, p.fetched
 }
 
 // getPrefs fetches Get-MpPreference once and caches the result.

--- a/providers/os/resources/windows_defender.go
+++ b/providers/os/resources/windows_defender.go
@@ -102,6 +102,7 @@ func (d *mqlWindowsDefender) status() (*mqlWindowsDefenderStatus, error) {
 		"__id":                             llx.StringData("windows.defender.status"),
 		"amEngineVersion":                  llx.StringData(status.AMEngineVersion),
 		"amProductVersion":                 llx.StringData(status.AMProductVersion),
+		"amRunningMode":                    llx.StringData(status.AMRunningMode),
 		"amServiceEnabled":                 llx.BoolData(status.AMServiceEnabled),
 		"amServiceVersion":                 llx.StringData(status.AMServiceVersion),
 		"antispywareEnabled":               llx.BoolData(status.AntispywareEnabled),

--- a/providers/os/resources/windows_defender_test.go
+++ b/providers/os/resources/windows_defender_test.go
@@ -4,10 +4,12 @@
 package resources
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers/os/resources/windows"
 )
 
 // windows.defender.status and windows.defender.preferences are both field paths
@@ -29,4 +31,56 @@ func TestWindowsDefenderSingletonsAreReachableByTheirOwnPath(t *testing.T) {
 				"%s resolves to the resource, not the field, so without an Init every field reads null", path)
 		})
 	}
+}
+
+// seedPrefs installs an already-fetched Get-MpPreference result onto a resource
+// that CreateResource may have returned from the runtime cache, where another
+// goroutine can already be reading it. This asserts what seedPrefs itself
+// guarantees: concurrent seeds and reads are race-free, a reader never observes
+// fetched as true with a nil prefs, and a second seed does not replace a result
+// already handed out.
+//
+// It does not reproduce the unlocked-write bug this replaced. That write lived
+// in preferences(), which needs a live runtime and connection to reach, so the
+// race there is established by reading the code rather than by this test.
+func TestWindowsDefenderPreferencesSeedIsSynchronized(t *testing.T) {
+	const workers = 16
+
+	p := &mqlWindowsDefenderPreferences{}
+	seeded := &windows.MpPreference{ScanParameters: 2}
+
+	// A start barrier, so the seeders and the readers actually overlap rather
+	// than running one after another.
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			p.seedPrefs(seeded)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			prefs, err, ok := p.peekPrefs()
+			if ok {
+				assert.NoError(t, err)
+				assert.NotNil(t, prefs, "fetched was observed true with a nil prefs")
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	prefs, err := p.getPrefs()
+	require.NoError(t, err)
+	require.NotNil(t, prefs)
+	assert.Equal(t, int64(2), prefs.ScanParameters)
+
+	// A later seed must not replace what has already been handed out.
+	p.seedPrefs(&windows.MpPreference{ScanParameters: 99})
+	prefs, err = p.getPrefs()
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), prefs.ScanParameters)
 }


### PR DESCRIPTION
## What

`windows.defender.threats` and `windows.defender.threatDetections` returned an
empty list when the Defender cmdlets are not present. That is the case this
family explicitly handles: a Windows Server whose Defender feature has been
removed in favour of a third-party antivirus.

An empty list is indistinguishable from "Defender has recorded no threats", so
every assertion over the collection passes vacuously:

```
windows.defender.threats.none(isActive)              // passes, nothing was read
windows.defender.threatDetections.all(actionSuccess) // passes, nothing was read
```

on a host that has no antivirus recording threats at all.

It is also inconsistent with the rest of the family. `status` and `preferences`
already resolve to null on such a host; only the two collections claimed a clean
result.

## Fix

Both resolve to null on the availability sentinel, and the field comments say
what an empty list means versus what a null means. A non-zero exit that is *not*
the availability sentinel still surfaces as an error, unchanged.

## This changes shipped behaviour

A query that read `[]` on a Defender-less Windows host now reads null, and a
policy relying on the vacuous pass will start reporting the field as unknown.
That is the point of the change, and it is why this is separate from the other
four Defender PRs in the stack rather than riding along with them.

## Verification and its limits

**The availability branch was not reproduced on a live host.** All four
verification hosts (Windows Server 2016, 2019, 2022 and 2025) have Defender
installed and running, so the branch is not reachable on them, and removing the
Defender feature from a shared host was not acceptable. The change is justified
by reading the code path and by its inconsistency with `status`/`preferences`,
not by a live reproduction.

What *was* confirmed live is the no-regression case: on Windows Server 2016,
2019, 2022 and 2025, where Defender is present and has recorded nothing, both
fields still read `[]`:

```
windows.defender: { threats: [], threatDetections: [] }
```

The availability detection that feeds this branch is already covered by
`TestDefenderUnavailable` and `TestDefenderScriptsHaveAvailabilityGuard`.

Separately, on a non-Windows target the cmdlets fail without the sentinel and
both fields correctly surface an error rather than an empty list, which is
unchanged here:

```
$ mql run local -c "windows.defender { threats }"
windows.defender: { threats: failed to query microsoft defender: sh: powershell.exe: command not found }
```

## Stack

Builds on #10373. Last of the five Defender PRs.


## Windows Server 2025, after the fix

The replacement 2025 host was reached late in the run. It confirms every fix in
this stack, and reports exactly what 2016, 2019 and 2022 do:

```
windows.defender: {
  enabled: true
  status: {
    amProductVersion:                "4.18.26070.9"
    amRunningMode:                   "Normal"
    antivirusEnabled:                true
    realTimeProtectionEnabled:       true
    nisEnabled:                      true
    isTamperProtected:               false
    tamperProtectionSource:          "Signatures"
    deviceControlState:              "Disabled"
    deviceControlDefaultEnforcement: null
    smartAppControlState:            "Off"
    fullScanAge:                     4294967295
  }
  preferences: {
    scan: { scanScheduleTime: "02:00:00", scanScheduleQuickScanTime: "00:00:00",
            checkForSignaturesBeforeRunningScan: false }
    signatureUpdates: { signatureScheduleTime: "01:45:00" }
    remediation:      { remediationScheduleTime: "02:00:00" }
    realTimeProtection: { disableIntrusionPreventionSystem: null,
                          disableRealtimeMonitoring: false }
    localSettingOverrides: { spynetReporting: null, avgCPULoadFactor: null }
    disableGenericReports: null
    exclusions: { paths: [] }
  }
}
```

and the dotted path resolves:

```
$ ... -c "windows.defender.status { antivirusEnabled amProductVersion }"
windows.defender.status: { amProductVersion: "4.18.26070.9", antivirusEnabled: true }
```


---

# Rebased onto main, and now carries three commits

The four PRs below this one in the stack have merged, so this was rebuilt on
`main`. It now carries the remaining three Defender changes:

**1. `🛑 report the Defender threat history as null when Defender is absent`** -
the change described above.

**2. `⭐ expose the Defender antimalware running mode`** (was #10381, approved;
its merge went into this branch rather than into main, so it travels here).
`Get-MpComputerStatus` reports `AMRunningMode` and `windows.defender.status` did
not model it. A passive-mode host - Defender standing down for a third-party
antivirus - still reports `amServiceEnabled`, `antivirusEnabled` and
`realTimeProtectionEnabled` all true, which is what `windows.defender.enabled`
is computed from, so the whole resource reads as "protected" with nothing saying
otherwise. `windows.defender.enabled` is deliberately unchanged: narrowing it
would be a shipped-behaviour change and passive mode could not be reproduced on
a shared host. Verified `"Normal"` on all four versions; only `Normal` was
observed, the other four values come from the cmdlet documentation.
`.lr.versions` entry at `13.40.10`.

**3. `🐎 take the lock when seeding the Defender preferences cache`** - a data
race found while answering the review comment on this PR. `preferences()` wrote
`p.prefs` and `p.fetched` directly onto a resource `CreateResource` may have
returned from the runtime cache, where another goroutine can already be reading
those fields under `p.lock`. Unlocked write racing a locked read: a reader can
observe `fetched` true with `prefs` still nil, `getPrefs` returns `(nil, nil)`,
and every grouped accessor dereferences it - a panic that takes the scan down.
Seeding now goes through `seedPrefs`, which takes the lock and will not replace
a result already handed out. See the thread for why the reviewer's stated
mechanism ("the cache serialises this") is not what the runtime actually does.
