### PR TITLE
🐛 os: don't panic when the process resource is queried without a pid

### DIFF
--- a/providers/os/resources/processes.go
+++ b/providers/os/resources/processes.go
@@ -102,14 +102,21 @@ func (p *mqlProcess) gatherProcessInfo() error {
 	conn := p.MqlRuntime.Connection.(shared.Connection)
 	opm, err := processes.ResolveManager(conn)
 	if err != nil {
-		p.processInfoError = err
-		return errors.New("cannot find process manager")
+		p.processInfoError = fmt.Errorf("cannot find process manager: %w", err)
+		return p.processInfoError
 	}
 
 	process, err := opm.Process(p.Pid.Data)
 	if err != nil {
-		p.processInfoError = err
-		return errors.New("cannot gather process details")
+		p.processInfoError = fmt.Errorf("cannot gather process details: %w", err)
+		return p.processInfoError
+	}
+	// A manager may report a pid it cannot find without an error. Guard the
+	// dereference so an unresolvable process surfaces as an error rather than
+	// taking down the provider.
+	if process == nil {
+		p.processInfoError = fmt.Errorf("cannot gather process details: process %d does not exist", p.Pid.Data)
+		return p.processInfoError
 	}
 
 	p.State = plugin.TValue[string]{Data: process.State, State: plugin.StateIsSet}

--- a/providers/os/resources/processes/unixps.go
+++ b/providers/os/resources/processes/unixps.go
@@ -373,18 +373,21 @@ func (upm *UnixProcessManager) ListSocketInodesByProcess() (map[int64]plugin.TVa
 }
 
 func (upm *UnixProcessManager) Exists(pid int64) (bool, error) {
-	process, err := upm.Process(pid)
-	if err != nil {
+	upm.lock.Lock()
+	defer upm.lock.Unlock()
+
+	if _, err := upm.listLocked(); err != nil {
 		return false, err
 	}
 
-	if process == nil {
-		return false, nil
-	}
-
-	return true, nil
+	_, ok := upm.byPid[pid]
+	return ok, nil
 }
 
+// Process returns the process for the given pid. A pid that is not in the
+// process list is reported as an error, matching the linux, docker and windows
+// managers: callers check err and then dereference, so a (nil, nil) not-found
+// result panicked them instead.
 func (upm *UnixProcessManager) Process(pid int64) (*OSProcess, error) {
 	upm.lock.Lock()
 	defer upm.lock.Unlock()
@@ -393,11 +396,12 @@ func (upm *UnixProcessManager) Process(pid int64) (*OSProcess, error) {
 		return nil, err
 	}
 
-	if process, ok := upm.byPid[pid]; ok {
-		return process, nil
+	process, ok := upm.byPid[pid]
+	if !ok {
+		return nil, fmt.Errorf("process %d does not exist", pid)
 	}
 
-	return nil, nil
+	return process, nil
 }
 
 // reFindSocketPrintf parses the output of:

--- a/providers/os/resources/processes/unixps_cache_test.go
+++ b/providers/os/resources/processes/unixps_cache_test.go
@@ -80,7 +80,7 @@ func TestUnixProcessManagerCachesPsOutput(t *testing.T) {
 	assert.Equal(t, "[Timer]", proc.Command)
 
 	missing, err := upm.Process(9999999)
-	require.NoError(t, err)
+	require.Error(t, err, "an unresolvable pid must be reported as an error, not (nil, nil)")
 	assert.Nil(t, missing)
 
 	// Despite 6 lookups, `ps` must have run exactly once.

--- a/providers/os/resources/processes/unixps_missing_pid_test.go
+++ b/providers/os/resources/processes/unixps_missing_pid_test.go
@@ -1,0 +1,64 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package processes_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+	"go.mondoo.com/mql/providers/os/resources/processes"
+)
+
+func macosProcessManager(t *testing.T) processes.OSProcessManager {
+	t.Helper()
+
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:   "macos",
+			Family: []string{"unix", "darwin"},
+		},
+	}, mock.WithPath("./testdata/osx.toml"))
+	require.NoError(t, err)
+
+	pm, err := processes.ResolveManager(conn)
+	require.NoError(t, err)
+	return pm
+}
+
+// TestUnixProcessManagerMissingPidReturnsError pins the OSProcessManager
+// contract that a pid which cannot be resolved is reported as an error, the
+// way the linux, docker and windows managers already do. Returning (nil, nil)
+// made every caller that only checked err a nil dereference waiting to happen
+// (mondoohq/mql#10355).
+func TestUnixProcessManagerMissingPidReturnsError(t *testing.T) {
+	pm := macosProcessManager(t)
+
+	// macOS `ps` starts at pid 1, so pid 0 never resolves. This is the pid a
+	// bare `process` resource carries, since it is created without one.
+	proc, err := pm.Process(0)
+	require.Error(t, err)
+	assert.Nil(t, proc)
+
+	proc, err = pm.Process(9999999)
+	require.Error(t, err)
+	assert.Nil(t, proc)
+}
+
+// TestUnixProcessManagerExistsHandlesMissingPid guards the other half of the
+// contract: Exists must keep reporting a missing pid as (false, nil) and not
+// inherit the not-found error that Process now returns.
+func TestUnixProcessManagerExistsHandlesMissingPid(t *testing.T) {
+	pm := macosProcessManager(t)
+
+	exists, err := pm.Exists(0)
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	exists, err = pm.Exists(1)
+	require.NoError(t, err)
+	assert.True(t, exists)
+}

--- a/providers/os/resources/processes_internal_test.go
+++ b/providers/os/resources/processes_internal_test.go
@@ -1,0 +1,77 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+	"go.mondoo.com/mql/utils/syncx"
+)
+
+func newMacosProcessRuntime(t *testing.T) *plugin.Runtime {
+	t.Helper()
+
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:   "macos",
+			Family: []string{"unix", "darwin"},
+		},
+	}, mock.WithPath("./processes/testdata/osx.toml"))
+	require.NoError(t, err)
+
+	return &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+}
+
+// TestProcessWithoutPidDoesNotPanic covers mondoohq/mql#10355: querying the
+// bare `process` resource creates it without a pid, so gatherProcessInfo looks
+// up pid 0. macOS `ps` starts at pid 1, so that lookup misses and the process
+// manager used to hand back (nil, nil), which the accessors dereferenced.
+func TestProcessWithoutPidDoesNotPanic(t *testing.T) {
+	proc := &mqlProcess{MqlRuntime: newMacosProcessRuntime(t)}
+
+	state := proc.GetState()
+	require.Error(t, state.Error, "a process that cannot be resolved must report an error")
+	assert.Empty(t, state.Data)
+
+	executable := proc.GetExecutable()
+	require.Error(t, executable.Error)
+	assert.Empty(t, executable.Data)
+
+	command := proc.GetCommand()
+	require.Error(t, command.Error)
+	assert.Empty(t, command.Data)
+
+	// Every field failed for the same reason, so they must say the same thing.
+	// The memoized error used to surface only from the second accessor onwards,
+	// which reported one cause as two unrelated-looking errors.
+	assert.Equal(t, state.Error.Error(), executable.Error.Error())
+	assert.Equal(t, state.Error.Error(), command.Error.Error())
+	assert.Contains(t, state.Error.Error(), "process 0 does not exist")
+}
+
+// TestProcessWithKnownPidResolves proves the not-found path did not cost us the
+// happy path: a pid that is present in `ps` still populates every field.
+func TestProcessWithKnownPidResolves(t *testing.T) {
+	proc := &mqlProcess{MqlRuntime: newMacosProcessRuntime(t)}
+	proc.Pid = plugin.TValue[int64]{Data: 1, State: plugin.StateIsSet}
+
+	executable := proc.GetExecutable()
+	require.NoError(t, executable.Error)
+	assert.Equal(t, "launchd", executable.Data)
+
+	command := proc.GetCommand()
+	require.NoError(t, command.Error)
+	assert.Equal(t, "/sbin/launchd", command.Data)
+
+	state := proc.GetState()
+	require.NoError(t, state.Error)
+}


### PR DESCRIPTION
Fixes #10355.

## What was wrong

`mql run local -c "process"` panicked the os provider on macOS with a nil pointer dereference at `providers/os/resources/processes.go:115`, once per field the query touched.

A bare `process` is created without a pid, so `gatherProcessInfo` looks up pid 0. macOS `ps` starts at pid 1, so that lookup always misses — and `UnixProcessManager.Process` reported the miss as `(nil, nil)`. The caller checked `err` and then dereferenced.

`UnixProcessManager` was the only manager using a nil-nil sentinel for not-found:

| manager | used for | missing pid, before |
|---|---|---|
| `UnixProcessManager` | macOS, other unix, and linux over SSH/mock (procfs is disabled for those transports) | **`(nil, nil)`** → panic |
| `LinuxProcManager` | local linux | error |
| `DockerTopManager` | containers | error |
| `WindowsProcessManager` | windows | error |

That is why it never reproduced on local linux, and why the blast radius is wider than the macOS report: anything routed to `UnixProcessManager` was affected.

The explicit-pid form was already safe — `process(pid: 999999)` goes through `opm.Exists()`, which did nil-check. The bare query was the one entry point that reached `gatherProcessInfo` unguarded.

## What changed

- **`UnixProcessManager.Process` returns an error for a pid it cannot find**, matching the other three managers.
- **`UnixProcessManager.Exists` consults the memoized pid map directly.** It was the only caller relying on the nil-nil sentinel, and it still reports a missing pid as `(false, nil)` rather than inheriting the new error. The `ps` command stays memoized — the existing cache test still proves one invocation across six lookups.
- **`gatherProcessInfo` guards the dereference**, so a manager handing back nil can no longer crash the provider regardless of which manager it is.
- **The memoized error is the error that gets returned.** `gatherProcessInfo` stored the cause but returned a generic message, so the first failing field and every field after it described one condition with two different texts ("cannot gather process details" then "process 0 does not exist"). This is why the original report showed two errors for a single cause.

## Test plan

Tests were written first and observed failing — the resource-level one reproduces the reported panic at the exact reported line, and the `osx.toml` fixture makes it reproduce on any CI host because its `ps` output starts at pid 1, like real macOS. (The neighboring FreeBSD fixture contains a pid 0, which is why the existing cache test never tripped over this.)

New:
- `TestProcessWithoutPidDoesNotPanic` — the bare-resource case: errors instead of panicking, and all three accessors agree on the message.
- `TestProcessWithKnownPidResolves` — the happy path still populates `pid`, `state`, `executable`, `command`.
- `TestUnixProcessManagerMissingPidReturnsError` — pins the `OSProcessManager` not-found contract.
- `TestUnixProcessManagerExistsHandlesMissingPid` — guards `Exists` against inheriting the new error.

Updated: `TestUnixProcessManagerCachesPsOutput` asserted the old `(nil, nil)` contract; its actual purpose (proving `ps` runs once) is unchanged.

```
go test ./providers/os/resources/... ./providers/os/connection/...
ok    go.mondoo.com/mql/providers/os/resources
ok    go.mondoo.com/mql/providers/os/resources/processes
(all others ok)
```

`providers/os/connection/device/linux` fails to build on this checkout, before and after this change — it needs mockgen-generated mocks that are not checked in. Untouched here.

### Live verification on macOS

Built from this branch and run against the reporting platform via `PROVIDERS_PATH`:

```
$ mql run local -c "process"
1 error occurred:
    * cannot gather process details: process 0 does not exist
process: executable=null pid=null state=null      # was: 2 panics

$ mql run local -c "processes.length"
processes.length: 616

$ mql run local -c "process(pid: 1) { pid state executable command }"
process: { command: "/sbin/launchd"  executable: "launchd"  pid: 1  state: "" }

$ mql run local -c "process(pid: 999999).state"
process 999999 does not exist                     # unchanged

$ mql run local -c "processes.where(executable == 'launchd') { pid executable }"
processes.where.list: [ 0: { pid: 1  executable: "launchd" } ]
```

## Note on the remaining warning

The bare query still logs `provider returned no data and no error for a field ... field=pid`. That is the bare-resource husk — `pid` is genuinely unset on a `process` built with no arguments — and it predates this change. Left alone deliberately: whether a bare `process` should render as a clean empty resource is a separate call from the crash, and is called out in #10355.
