### PR TITLE
🧹 os: capture real Get-MpThreat output as Defender test fixtures

### DIFF
--- a/providers/os/resources/windows/defender_threat_live_test.go
+++ b/providers/os/resources/windows/defender_threat_live_test.go
@@ -1,0 +1,90 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package windows
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// defender_threats_win2016.json and defender_threat_detections_win2016.json are
+// the real output of Get-MpThreat and Get-MpThreatDetection on a Windows Server
+// 2016 host after the EICAR antivirus test file was written to disk and
+// Defender remediated it. Until this capture, both resources had only ever been
+// exercised against hand-written fixtures.
+//
+// Sanitized: the host name and the two detection GUIDs are replaced with
+// synthetic values. Every other field is verbatim, including the CIM metadata
+// wrappers being dropped as in the status and preference captures.
+
+func TestParseMpThreatsLive(t *testing.T) {
+	data, err := os.ReadFile("testdata/defender_threats_win2016.json")
+	require.NoError(t, err)
+
+	threats, err := ParseMpThreats(data)
+	require.NoError(t, err)
+	require.Len(t, threats, 1)
+
+	th := threats[0]
+	assert.Equal(t, int64(2147519003), th.ThreatID)
+	assert.Equal(t, "Virus:DOS/EICAR_Test_File", th.ThreatName)
+	assert.Equal(t, int64(5), th.SeverityID)
+	assert.Equal(t, int64(42), th.CategoryID)
+	assert.Equal(t, int64(1), th.RollupStatus)
+	assert.False(t, th.IsActive)
+	assert.False(t, th.DidThreatExecute)
+
+	// Get-MpThreat leaves Resources null even for a threat it has just
+	// remediated. The affected files are reported by Get-MpThreatDetection
+	// instead, so an empty list here is the real answer and not a decode
+	// failure.
+	assert.Empty(t, th.Resources)
+}
+
+func TestParseMpThreatDetectionsLive(t *testing.T) {
+	data, err := os.ReadFile("testdata/defender_threat_detections_win2016.json")
+	require.NoError(t, err)
+
+	dets, err := ParseMpThreatDetections(data)
+	require.NoError(t, err)
+	require.Len(t, dets, 2)
+
+	// One threat produces several detections, one per detection source. They
+	// share a ThreatID and are distinguished only by DetectionID, which is what
+	// the resource keys on.
+	assert.Equal(t, dets[0].ThreatID, dets[1].ThreatID)
+	assert.NotEqual(t, dets[0].DetectionID, dets[1].DetectionID)
+
+	d := dets[0]
+	assert.Equal(t, "{00000000-0000-0000-0000-000000000001}", d.DetectionID)
+	assert.Equal(t, int64(2147519003), d.ThreatID)
+	assert.Equal(t, `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, d.ProcessName)
+	assert.Equal(t, `WIN-EXAMPLE-HOST\Administrator`, d.DomainUser)
+	assert.Equal(t, int64(3), d.DetectionSourceTypeID)
+	assert.Equal(t, int64(1), d.CurrentThreatExecutionStatusID)
+	assert.Equal(t, int64(3), d.ThreatStatusID)
+	assert.Equal(t, int64(2), d.CleaningActionID)
+	assert.True(t, d.ActionSuccess)
+	require.Len(t, d.Resources, 1)
+	assert.Equal(t, `file:_C:\mqlvalidation\eicar-probe.txt`, d.Resources[0])
+
+	// All three timestamps arrive in the PowerShell 5.1 "/Date(ms)/" form.
+	for name, raw := range map[string]string{
+		"initial detection": d.InitialDetectionTime,
+		"status change":     d.LastThreatStatusChangeTime,
+		"remediation":       d.RemediationTime,
+	} {
+		ts := DefenderTime(raw)
+		require.NotNil(t, ts, name)
+		assert.False(t, ts.IsZero(), name)
+	}
+
+	// A detection Defender attributes to no process reports "Unknown" rather
+	// than an empty string.
+	assert.Equal(t, "Unknown", dets[1].ProcessName)
+	assert.Equal(t, `NT AUTHORITY\LOCAL SERVICE`, dets[1].DomainUser)
+}

--- a/providers/os/resources/windows/testdata/defender_threat_detections_win2016.json
+++ b/providers/os/resources/windows/testdata/defender_threat_detections_win2016.json
@@ -1,0 +1,42 @@
+[
+  {
+    "ActionSuccess": true,
+    "AdditionalActionsBitMask": 0,
+    "AMProductVersion": "4.18.26070.9",
+    "CleaningActionID": 2,
+    "CurrentThreatExecutionStatusID": 1,
+    "DetectionID": "{00000000-0000-0000-0000-000000000001}",
+    "DetectionSourceTypeID": 3,
+    "DomainUser": "WIN-EXAMPLE-HOST\\Administrator",
+    "InitialDetectionTime": "/Date(1787635407139)/",
+    "LastThreatStatusChangeTime": "/Date(1787635418235)/",
+    "ProcessName": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    "RemediationTime": "/Date(1787635418235)/",
+    "Resources": [
+      "file:_C:\\mqlvalidation\\eicar-probe.txt"
+    ],
+    "ThreatID": 2147519003,
+    "ThreatStatusErrorCode": 0,
+    "ThreatStatusID": 3
+  },
+  {
+    "ActionSuccess": true,
+    "AdditionalActionsBitMask": 0,
+    "AMProductVersion": "4.18.26070.9",
+    "CleaningActionID": 2,
+    "CurrentThreatExecutionStatusID": 0,
+    "DetectionID": "{00000000-0000-0000-0000-000000000002}",
+    "DetectionSourceTypeID": 2,
+    "DomainUser": "NT AUTHORITY\\LOCAL SERVICE",
+    "InitialDetectionTime": "/Date(1787635415765)/",
+    "LastThreatStatusChangeTime": "/Date(1787635420778)/",
+    "ProcessName": "Unknown",
+    "RemediationTime": "/Date(1787635420778)/",
+    "Resources": [
+      "file:_C:\\mqlvalidation\\eicar-probe.txt"
+    ],
+    "ThreatID": 2147519003,
+    "ThreatStatusErrorCode": 0,
+    "ThreatStatusID": 3
+  }
+]

--- a/providers/os/resources/windows/testdata/defender_threats_win2016.json
+++ b/providers/os/resources/windows/testdata/defender_threats_win2016.json
@@ -1,0 +1,14 @@
+[
+  {
+    "CategoryID": 42,
+    "DidThreatExecute": false,
+    "IsActive": false,
+    "Resources": null,
+    "RollupStatus": 1,
+    "SchemaVersion": "1.0.0.0",
+    "SeverityID": 5,
+    "ThreatID": 2147519003,
+    "ThreatName": "Virus:DOS/EICAR_Test_File",
+    "TypeID": 0
+  }
+]


### PR DESCRIPTION
## What

`windows.defender.threat` and `windows.defender.threatDetection` had only ever
been exercised against hand-written fixtures. None of the four Windows Server
hosts used for this validation (2016, 2019, 2022 and 2025) had recorded a
threat, so the two resources' twenty-one fields had never been read with real
data.

Writing the EICAR antivirus test file to the 2016 host and letting Defender
remediate it produces both. The captured output is added as fixtures with parser
tests.

## Two things the capture pins that the hand-written fixtures did not

**`Get-MpThreat` returns `Resources: null`** even for a threat it has just
remediated. The affected files come from `Get-MpThreatDetection` instead, so an
empty `windows.defender.threat.resources` is the real answer and not a decode
failure. The old fixture put a populated `Resources` array on the threat, which
no host produced.

**One threat produces several detections**, one per detection source, sharing a
`ThreatID` and distinguished only by `DetectionID`. That is exactly what
`windows.defender.threatDetection` keys its `__id` on, so the fixture now covers
the collision shape rather than assuming it away.

## Verification

End to end against the host that produced the capture (Windows Server 2016):

```
windows.defender: {
  threats: [
    0: { threatId: 2147519003, name: "Virus:DOS/EICAR_Test_File",
         severityID: 5, categoryID: 42, rollupStatus: 1,
         isActive: false, didThreatExecute: false, resources: [] }
  ]
  threatDetections: [
    0: { detectionId: "{7DEB...}", detectionSourceTypeId: 3,
         processName: "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
         domainUser: "...\\Administrator", cleaningActionID: 2,
         threatStatusID: 3, currentThreatExecutionStatusID: 1, actionSuccess: true,
         initialDetectionTime: 2026-08-24 22:23:27.139,
         remediationTime: 2026-08-24 22:23:38.235,
         resources: ["file:_C:\\mqlvalidation\\eicar-probe.txt"] }
    1: { detectionId: "{D9B0...}", detectionSourceTypeId: 2,
         processName: "Unknown", domainUser: "NT AUTHORITY\\LOCAL SERVICE", ... }
  ]
}
```

Every field populated, all three timestamps parsed from the PowerShell 5.1
`/Date(ms)/` form.

**No bug was found in either resource.** All twenty-one fields report what
Defender reports.

## Sanitization

Host name and both detection GUIDs replaced with synthetic values; the CIM
metadata wrappers `ConvertTo-Json` emits are dropped. Every other field is
verbatim. The EICAR string itself is not committed anywhere in this branch - it
is assembled at runtime on the host only.

## Independent of the fix stack

This branches off `main` directly. It does not depend on #10369-#10374 and can
merge in any order.
