### PR TITLE
🐛 os: report ports without an owning process as null instead of erroring

### DIFF
--- a/providers/os/resources/port.go
+++ b/providers/os/resources/port.go
@@ -806,7 +806,11 @@ func (s *mqlPort) process() (*mqlProcess, error) {
 
 	// TODO: refresh on the fly, eg when loading this from a recording
 	if s.inode == 0 {
-		return nil, errors.New("no iNode found for this port and cannot yet refresh it")
+		// Sockets without an owning process (TIME_WAIT, kernel-held sockets)
+		// report inode 0 in /proc/net; that is a legitimate "no process",
+		// not an error.
+		s.Process.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
 	}
 
 	procs, err := ports.processesBySocket()


### PR DESCRIPTION
## Problem

Customers scanning Linux hosts saw this on every scan:

```
error: no iNode found for this port and cannot yet refresh it
```

Any TCP socket without an owning process (TIME_WAIT, kernel-held) reports **inode 0** in `/proc/net`, which `port.process()` treated as an error. Since almost any active host has a few TIME_WAIT sockets at scan time, the `mondoo-linux-all-connections` and `mondoo-linux-active-connections` queries (which run `ports { ... process ... }` blocks) errored on nearly every scan — the customer's bundle showed 6 of 13 ports in `time wait`, all failing on exactly this.

## Fix

A port with inode 0 legitimately has no owning process: `process()` now returns a typed null instead of erroring, matching the function's existing handling of an inode that is missing from the process-by-socket map.

This also removes the main source of the anonymous `llx: encountered a primitive with no type information, coercing to null` log lines from the same scans: the per-port process error was serialized into the stored report as a typeless primitive husk, which every later read of the report data logged (6 sockets x 2 queries = the 12 lines in the customer's log). The systemic half — carrying type info for errored values through serialization so *any* errored field nests as a typed null — is split into #10385 for separate consideration.

The remaining `sh: 1: iptables: not found` error in the customer's bundle is a legitimate finding (nftables-only host), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)