### PR TITLE
🐛 os: read the effective WinRM configuration instead of guessing at it

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -11634,25 +11634,27 @@ private windows.winrm.listener @defaults("transport port address enabled") {
 
 // WinRM client policy
 //
-// WinRM client policy under HKLM\SOFTWARE\Policies\Microsoft
-// \Windows\WinRM\Client. These are GPO-only values; when a value is absent the
-// documented Windows default applies.
+// Live WS-Management client configuration, which already reflects any Group
+// Policy setting applied to it. Reading these needs a connection that can run
+// commands.
 private windows.winrm.client @defaults("allowBasic allowUnencryptedTraffic") {
-  // Whether the WinRM client allows Basic authentication (Client\AllowBasic)
+  // Whether the WinRM client allows Basic authentication
   //
-  // Defaults to true (Windows historically allows Basic auth on the client
-  // when the policy is not configured).
-  allowBasic bool
-  // Whether the WinRM client allows unencrypted traffic (Client\AllowUnencryptedTraffic)
+  // Reports the live WS-Management value (Client\Auth\Basic), which already
+  // reflects any Group Policy setting. True on a stock Windows Server: the
+  // client will offer Basic credentials when a server asks for them.
+  allowBasic() bool
+  // Whether the WinRM client allows unencrypted traffic
   //
-  // Defaults to true (Windows historically allows unencrypted traffic on the
-  // client when the policy is not configured).
-  allowUnencryptedTraffic bool
-  // Whether the WinRM client allows Digest authentication (Client\AllowDigest)
+  // Reports the live WS-Management value (Client\AllowUnencrypted), which
+  // already reflects any Group Policy setting. False on a stock Windows
+  // Server, so the client refuses to send an unencrypted request.
+  allowUnencryptedTraffic() bool
+  // Whether the WinRM client allows Digest authentication
   //
-  // Defaults to true (Digest authentication is enabled on the client when the
-  // policy is not configured).
-  allowDigest bool
+  // Reports the live WS-Management value (Client\Auth\Digest), which already
+  // reflects any Group Policy setting. True on a stock Windows Server.
+  allowDigest() bool
   // Hosts the WinRM client trusts without mutual authentication (Client\TrustedHosts)
   //
   // A comma-separated list, empty when no host is trusted. A single "*"
@@ -11666,35 +11668,43 @@ private windows.winrm.client @defaults("allowBasic allowUnencryptedTraffic") {
 
 // WinRM service policy
 //
-// WinRM service policy under HKLM\SOFTWARE\Policies\Microsoft
-// \Windows\WinRM\Service (and the WinRS subkey). These are GPO-only values;
-// when a value is absent the documented Windows default applies.
+// The WinRM service configuration. The authentication, encryption and remote
+// shell settings are read live from WS-Management, which already reflects any
+// Group Policy applied to them, so reading those needs a connection that can
+// run commands. The remaining settings exist only under
+// HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service and fall back to
+// the documented Windows default when no policy sets them.
 private windows.winrm.service @defaults("allowBasic allowUnencryptedTraffic") {
-  // Whether the WinRM service allows Basic authentication (Service\AllowBasic)
+  // Whether the WinRM service accepts Basic authentication
   //
-  // Defaults to true (Windows historically allows Basic auth on the service
-  // when the policy is not configured).
-  allowBasic bool
-  // Whether the WinRM service allows unencrypted traffic (Service\AllowUnencryptedTraffic)
+  // Reports the live WS-Management value (Service\Auth\Basic), which already
+  // reflects any Group Policy setting. False on a stock Windows Server. Basic
+  // authentication sends the password in a reversible encoding, so a service
+  // that accepts it over an unencrypted transport is handing out credentials.
+  allowBasic() bool
+  // Whether the WinRM service accepts unencrypted traffic
   //
-  // Defaults to true (Windows historically allows unencrypted traffic on the
-  // service when the policy is not configured).
-  allowUnencryptedTraffic bool
+  // Reports the live WS-Management value (Service\AllowUnencrypted), which
+  // already reflects any Group Policy setting. False on a stock Windows
+  // Server. Together with allowBasic this is the pair worth auditing: an
+  // unencrypted transport is what turns Basic authentication into a credential
+  // disclosure.
+  allowUnencryptedTraffic() bool
   // Whether the WinRM service disallows storing RunAs credentials (Service\DisableRunAs)
   //
-  // Defaults to false (RunAs credential storage is not disabled when the
-  // policy is not configured).
+  // Read from the policy key. Defaults to false (RunAs credential storage is
+  // not disabled when the policy is not configured).
   disableRunAs bool
   // Whether the WinRM service allows remote server management / auto config (Service\AllowAutoConfig)
   //
-  // Defaults to false (the listener is not auto-configured when the policy is
-  // not configured).
+  // Read from the policy key. Defaults to false (the listener is not
+  // auto-configured when the policy is not configured).
   allowAutoConfig bool
-  // Whether WinRS allows remote shell access (Service\WinRS\AllowRemoteShellAccess)
+  // Whether WinRS allows remote shell access
   //
-  // Defaults to true (remote shell access is allowed when the policy is not
-  // configured).
-  allowRemoteShellAccess bool
+  // Reports the live WS-Management value (Shell\AllowRemoteShellAccess), which
+  // already reflects any Group Policy setting. True on a stock Windows Server.
+  allowRemoteShellAccess() bool
   // IPv4 addresses the WinRM service accepts requests on (Service\IPv4Filter)
   //
   // A comma-separated list of addresses or ranges, "*" for every IPv4 address,

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -79735,7 +79735,7 @@ func (c *mqlWindowsRdp) GetCloudClipboardIntegrationDisabled() *plugin.TValue[bo
 type mqlWindowsWinrm struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlWindowsWinrmInternal it will be used here
+	mqlWindowsWinrmInternal
 	Client           plugin.TValue[*mqlWindowsWinrmClient]
 	Service          plugin.TValue[*mqlWindowsWinrmService]
 	ServiceStartMode plugin.TValue[int64]
@@ -79951,15 +79951,21 @@ func (c *mqlWindowsWinrmClient) MqlID() string {
 }
 
 func (c *mqlWindowsWinrmClient) GetAllowBasic() *plugin.TValue[bool] {
-	return &c.AllowBasic
+	return plugin.GetOrCompute[bool](&c.AllowBasic, func() (bool, error) {
+		return c.allowBasic()
+	})
 }
 
 func (c *mqlWindowsWinrmClient) GetAllowUnencryptedTraffic() *plugin.TValue[bool] {
-	return &c.AllowUnencryptedTraffic
+	return plugin.GetOrCompute[bool](&c.AllowUnencryptedTraffic, func() (bool, error) {
+		return c.allowUnencryptedTraffic()
+	})
 }
 
 func (c *mqlWindowsWinrmClient) GetAllowDigest() *plugin.TValue[bool] {
-	return &c.AllowDigest
+	return plugin.GetOrCompute[bool](&c.AllowDigest, func() (bool, error) {
+		return c.allowDigest()
+	})
 }
 
 func (c *mqlWindowsWinrmClient) GetTrustedHosts() *plugin.TValue[string] {
@@ -79972,7 +79978,7 @@ func (c *mqlWindowsWinrmClient) GetTrustedHosts() *plugin.TValue[string] {
 type mqlWindowsWinrmService struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	mqlWindowsWinrmServiceInternal
+	// optional: if you define mqlWindowsWinrmServiceInternal it will be used here
 	AllowBasic              plugin.TValue[bool]
 	AllowUnencryptedTraffic plugin.TValue[bool]
 	DisableRunAs            plugin.TValue[bool]
@@ -80020,11 +80026,15 @@ func (c *mqlWindowsWinrmService) MqlID() string {
 }
 
 func (c *mqlWindowsWinrmService) GetAllowBasic() *plugin.TValue[bool] {
-	return &c.AllowBasic
+	return plugin.GetOrCompute[bool](&c.AllowBasic, func() (bool, error) {
+		return c.allowBasic()
+	})
 }
 
 func (c *mqlWindowsWinrmService) GetAllowUnencryptedTraffic() *plugin.TValue[bool] {
-	return &c.AllowUnencryptedTraffic
+	return plugin.GetOrCompute[bool](&c.AllowUnencryptedTraffic, func() (bool, error) {
+		return c.allowUnencryptedTraffic()
+	})
 }
 
 func (c *mqlWindowsWinrmService) GetDisableRunAs() *plugin.TValue[bool] {
@@ -80036,7 +80046,9 @@ func (c *mqlWindowsWinrmService) GetAllowAutoConfig() *plugin.TValue[bool] {
 }
 
 func (c *mqlWindowsWinrmService) GetAllowRemoteShellAccess() *plugin.TValue[bool] {
-	return &c.AllowRemoteShellAccess
+	return plugin.GetOrCompute[bool](&c.AllowRemoteShellAccess, func() (bool, error) {
+		return c.allowRemoteShellAccess()
+	})
 }
 
 func (c *mqlWindowsWinrmService) GetIpv4Filter() *plugin.TValue[string] {

--- a/providers/os/resources/windows/winrm.go
+++ b/providers/os/resources/windows/winrm.go
@@ -6,6 +6,7 @@ package windows
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"strconv"
 	"strings"
@@ -36,18 +37,30 @@ $res+=[ordered]@{Address=[string]$h['Address'];Transport=[string]$h['Transport']
 }
 ConvertTo-Json -InputObject @($res) -Depth 4 -Compress`
 
-// PSGetWinRMConfig reads the WS-Management client and service settings that
-// have no registry equivalent.
+// PSGetWinRMConfig reads the live WS-Management client, service and shell
+// settings.
 //
-// These are the live values, which already carry any Group Policy setting: the
-// WinRM service applies the policy key to its own configuration, so reading
-// the policy key alone would miss a TrustedHosts set locally with
-// `winrm set winrm/config/client`, which is exactly the configuration worth
-// finding.
+// These are the effective values, which already carry any Group Policy
+// setting: the WinRM service applies the policy key to its own configuration.
+// Reading the policy key instead gets two things wrong. It misses a value set
+// locally with `winrm set winrm/config/client`, which is exactly the
+// configuration worth finding. And when the policy key is absent, which is the
+// normal state of a machine nobody has applied a WinRM GPO to, it has nothing
+// to report but a guess at what Windows would do, and the guess does not match
+// what Windows actually does: a stock Server 2016, 2019 and 2022 all report
+// Basic authentication and unencrypted traffic as off on the service, and
+// unencrypted traffic as off on the client.
+//
+// $ErrorActionPreference is Stop deliberately. Every one of these values
+// exists on a supported host, so a read that fails means the configuration
+// could not be reached, and reporting a default in its place would state as
+// fact something nobody managed to check.
 const PSGetWinRMConfig = `$ErrorActionPreference='Stop'
+function V($p){[string](Get-Item -Path ("WSMan:\localhost\"+$p)).Value}
 [ordered]@{
-Client=[ordered]@{TrustedHosts=[string](Get-Item -Path WSMan:\localhost\Client\TrustedHosts).Value}
-Service=[ordered]@{IPv4Filter=[string](Get-Item -Path WSMan:\localhost\Service\IPv4Filter).Value;IPv6Filter=[string](Get-Item -Path WSMan:\localhost\Service\IPv6Filter).Value}
+Client=[ordered]@{TrustedHosts=V 'Client\TrustedHosts';AllowBasic=V 'Client\Auth\Basic';AllowDigest=V 'Client\Auth\Digest';AllowUnencrypted=V 'Client\AllowUnencrypted'}
+Service=[ordered]@{IPv4Filter=V 'Service\IPv4Filter';IPv6Filter=V 'Service\IPv6Filter';AllowBasic=V 'Service\Auth\Basic';AllowUnencrypted=V 'Service\AllowUnencrypted'}
+Shell=[ordered]@{AllowRemoteShellAccess=V 'Shell\AllowRemoteShellAccess'}
 }|ConvertTo-Json -Depth 4 -Compress`
 
 // PSScalar decodes a WS-Management setting value.
@@ -103,6 +116,23 @@ func (l WinRMListener) PortNumber() int64 {
 // as disabled.
 func (l WinRMListener) IsEnabled() bool {
 	return strings.EqualFold(strings.TrimSpace(string(l.Enabled)), "true")
+}
+
+// Bool decodes a WS-Management boolean setting.
+//
+// The WSMan provider renders these as the strings "true" and "false".
+// Anything else means the value read was not the setting expected, and it is
+// reported as an error rather than quietly as false: "the service does not
+// allow unencrypted traffic" is precisely the assertion an audit rests on, so
+// a false here has to be a fact about the host and not a decode that missed.
+func (s PSScalar) Bool() (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(string(s))) {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	}
+	return false, fmt.Errorf("expected a WS-Management boolean, got %q", string(s))
 }
 
 // ID builds the resource id of a listener.
@@ -167,17 +197,28 @@ func ParseWinRMListeners(r io.Reader) ([]WinRMListener, error) {
 type WinRMConfig struct {
 	Client  WinRMClientConfig  `json:"Client"`
 	Service WinRMServiceConfig `json:"Service"`
+	Shell   WinRMShellConfig   `json:"Shell"`
 }
 
 // WinRMClientConfig is the WS-Management client configuration.
 type WinRMClientConfig struct {
-	TrustedHosts PSScalar `json:"TrustedHosts"`
+	TrustedHosts     PSScalar `json:"TrustedHosts"`
+	AllowBasic       PSScalar `json:"AllowBasic"`
+	AllowDigest      PSScalar `json:"AllowDigest"`
+	AllowUnencrypted PSScalar `json:"AllowUnencrypted"`
 }
 
 // WinRMServiceConfig is the WS-Management service configuration.
 type WinRMServiceConfig struct {
-	IPv4Filter PSScalar `json:"IPv4Filter"`
-	IPv6Filter PSScalar `json:"IPv6Filter"`
+	IPv4Filter       PSScalar `json:"IPv4Filter"`
+	IPv6Filter       PSScalar `json:"IPv6Filter"`
+	AllowBasic       PSScalar `json:"AllowBasic"`
+	AllowUnencrypted PSScalar `json:"AllowUnencrypted"`
+}
+
+// WinRMShellConfig is the WS-Management shell (WinRS) configuration.
+type WinRMShellConfig struct {
+	AllowRemoteShellAccess PSScalar `json:"AllowRemoteShellAccess"`
 }
 
 // ParseWinRMConfig decodes the WS-Management client and service settings.

--- a/providers/os/resources/windows/winrm_test.go
+++ b/providers/os/resources/windows/winrm_test.go
@@ -194,3 +194,94 @@ func TestWinRMScriptsFitCommandLine(t *testing.T) {
 	assert.LessOrEqual(t, len(PSGetWinRMListeners), PSMaxScriptLength)
 	assert.LessOrEqual(t, len(PSGetWinRMConfig), PSMaxScriptLength)
 }
+
+// The WS-Management provider reports every setting as a string, so a boolean
+// arrives as "true" or "false". Anything else means the value read was not the
+// setting expected, and has to surface as an error: reporting it as false
+// would state that the service refuses Basic authentication when nobody
+// established that.
+func TestPSScalarBool(t *testing.T) {
+	for _, tc := range []struct {
+		in   PSScalar
+		want bool
+	}{
+		{"true", true},
+		{"false", false},
+		{"True", true},
+		{"FALSE", false},
+		{" true ", true},
+	} {
+		got, err := tc.in.Bool()
+		require.NoError(t, err, "input %q", tc.in)
+		require.Equal(t, tc.want, got, "input %q", tc.in)
+	}
+
+	for _, in := range []PSScalar{"", "yes", "1", "0", "enabled"} {
+		_, err := in.Bool()
+		require.Error(t, err, "input %q should not decode to a boolean", in)
+	}
+}
+
+// The payload captured from a stock Windows Server. Every one of these is the
+// opposite of, or agrees with, what the policy-key fallback used to report:
+// service Basic and unencrypted, and client unencrypted, are all false here
+// while the fallback reported them as true.
+const stockWinRMConfig = `{"Client":{"TrustedHosts":"","AllowBasic":"true","AllowDigest":"true","AllowUnencrypted":"false"},"Service":{"IPv4Filter":"*","IPv6Filter":"*","AllowBasic":"false","AllowUnencrypted":"false"},"Shell":{"AllowRemoteShellAccess":"true"}}`
+
+func TestParseWinRMConfigStockHost(t *testing.T) {
+	config, err := ParseWinRMConfig(strings.NewReader(stockWinRMConfig))
+	require.NoError(t, err)
+
+	require.Empty(t, config.Client.TrustedHosts)
+
+	clientBasic, err := config.Client.AllowBasic.Bool()
+	require.NoError(t, err)
+	require.True(t, clientBasic, "the client offers Basic credentials on a stock host")
+
+	clientDigest, err := config.Client.AllowDigest.Bool()
+	require.NoError(t, err)
+	require.True(t, clientDigest)
+
+	clientUnenc, err := config.Client.AllowUnencrypted.Bool()
+	require.NoError(t, err)
+	require.False(t, clientUnenc, "the client refuses unencrypted requests on a stock host")
+
+	serviceBasic, err := config.Service.AllowBasic.Bool()
+	require.NoError(t, err)
+	require.False(t, serviceBasic, "the service refuses Basic authentication on a stock host")
+
+	serviceUnenc, err := config.Service.AllowUnencrypted.Bool()
+	require.NoError(t, err)
+	require.False(t, serviceUnenc, "the service refuses unencrypted traffic on a stock host")
+
+	shell, err := config.Shell.AllowRemoteShellAccess.Bool()
+	require.NoError(t, err)
+	require.True(t, shell)
+
+	require.Equal(t, PSScalar("*"), config.Service.IPv4Filter)
+	require.Equal(t, PSScalar("*"), config.Service.IPv6Filter)
+}
+
+// A host that has been hardened, to prove the fields move rather than being
+// pinned to whatever a stock host happens to report.
+func TestParseWinRMConfigHardenedHost(t *testing.T) {
+	config, err := ParseWinRMConfig(strings.NewReader(
+		`{"Client":{"TrustedHosts":"*.example.com","AllowBasic":"false","AllowDigest":"false","AllowUnencrypted":"false"},` +
+			`"Service":{"IPv4Filter":"10.0.0.0-10.0.0.255","IPv6Filter":"","AllowBasic":"false","AllowUnencrypted":"false"},` +
+			`"Shell":{"AllowRemoteShellAccess":"false"}}`))
+	require.NoError(t, err)
+
+	require.Equal(t, PSScalar("*.example.com"), config.Client.TrustedHosts)
+	require.Equal(t, PSScalar("10.0.0.0-10.0.0.255"), config.Service.IPv4Filter)
+
+	for name, v := range map[string]PSScalar{
+		"client basic":  config.Client.AllowBasic,
+		"client digest": config.Client.AllowDigest,
+		"service basic": config.Service.AllowBasic,
+		"shell access":  config.Shell.AllowRemoteShellAccess,
+	} {
+		got, err := v.Bool()
+		require.NoError(t, err, name)
+		require.False(t, got, name)
+	}
+}

--- a/providers/os/resources/windows_winrm.go
+++ b/providers/os/resources/windows_winrm.go
@@ -82,30 +82,19 @@ func winrmBool(items map[string]int64, name string, def bool) bool {
 	return def
 }
 
-// computeWinRMClient derives the WinRM client booleans from the raw registry
-// values of the Client policy key. Pure function for unit testing.
-func computeWinRMClient(items map[string]int64) (allowBasic, allowUnencryptedTraffic, allowDigest bool) {
-	// Windows historically allows Basic auth, unencrypted traffic, and Digest
-	// auth on the client when the policy is not configured.
-	allowBasic = winrmBool(items, "AllowBasic", true)
-	allowUnencryptedTraffic = winrmBool(items, "AllowUnencryptedTraffic", true)
-	allowDigest = winrmBool(items, "AllowDigest", true)
-	return
-}
-
-// computeWinRMService derives the WinRM service booleans from the raw registry
-// values of the Service policy key and its WinRS subkey. Pure function for unit
-// testing.
-func computeWinRMService(service, winrs map[string]int64) (allowBasic, allowUnencryptedTraffic, disableRunAs, allowAutoConfig, allowRemoteShellAccess bool) {
-	// Windows historically allows Basic auth and unencrypted traffic on the
-	// service when the policy is not configured; RunAs storage is not disabled
-	// and the listener is not auto-configured by default.
-	allowBasic = winrmBool(service, "AllowBasic", true)
-	allowUnencryptedTraffic = winrmBool(service, "AllowUnencryptedTraffic", true)
+// computeWinRMService derives the WinRM service booleans that exist only in the
+// policy key. Pure function for unit testing.
+//
+// Basic authentication, unencrypted traffic and remote shell access are
+// deliberately absent here: they have a live WS-Management value, which is the
+// effective setting and already carries any policy, so they are read from there
+// instead of guessed at from an absent policy key.
+func computeWinRMService(service map[string]int64) (disableRunAs, allowAutoConfig bool) {
+	// RunAs credential storage is not disabled and the listener is not
+	// auto-configured when the policy is not configured. Neither has a WSMan
+	// equivalent to read instead.
 	disableRunAs = winrmBool(service, "DisableRunAs", false)
 	allowAutoConfig = winrmBool(service, "AllowAutoConfig", false)
-	// remote shell access is allowed by default
-	allowRemoteShellAccess = winrmBool(winrs, "AllowRemoteShellAccess", true)
 	return
 }
 
@@ -120,18 +109,8 @@ func computeWinRMServiceStartMode(items map[string]int64) int64 {
 }
 
 func (r *mqlWindowsWinrm) client() (*mqlWindowsWinrmClient, error) {
-	items, err := r.readWinRMKey(winrmClientPath)
-	if err != nil {
-		return nil, err
-	}
-
-	allowBasic, allowUnencryptedTraffic, allowDigest := computeWinRMClient(items)
-
 	o, err := CreateResource(r.MqlRuntime, "windows.winrm.client", map[string]*llx.RawData{
-		"__id":                    llx.StringData("windows.winrm.client"),
-		"allowBasic":              llx.BoolData(allowBasic),
-		"allowUnencryptedTraffic": llx.BoolData(allowUnencryptedTraffic),
-		"allowDigest":             llx.BoolData(allowDigest),
+		"__id": llx.StringData("windows.winrm.client"),
 	})
 	if err != nil {
 		return nil, err
@@ -144,20 +123,13 @@ func (r *mqlWindowsWinrm) service() (*mqlWindowsWinrmService, error) {
 	if err != nil {
 		return nil, err
 	}
-	winrs, err := r.readWinRMKey(winrmServiceWinRSPath)
-	if err != nil {
-		return nil, err
-	}
 
-	allowBasic, allowUnencryptedTraffic, disableRunAs, allowAutoConfig, allowRemoteShellAccess := computeWinRMService(service, winrs)
+	disableRunAs, allowAutoConfig := computeWinRMService(service)
 
 	o, err := CreateResource(r.MqlRuntime, "windows.winrm.service", map[string]*llx.RawData{
-		"__id":                    llx.StringData("windows.winrm.service"),
-		"allowBasic":              llx.BoolData(allowBasic),
-		"allowUnencryptedTraffic": llx.BoolData(allowUnencryptedTraffic),
-		"disableRunAs":            llx.BoolData(disableRunAs),
-		"allowAutoConfig":         llx.BoolData(allowAutoConfig),
-		"allowRemoteShellAccess":  llx.BoolData(allowRemoteShellAccess),
+		"__id":            llx.StringData("windows.winrm.service"),
+		"disableRunAs":    llx.BoolData(disableRunAs),
+		"allowAutoConfig": llx.BoolData(allowAutoConfig),
 	})
 	if err != nil {
 		return nil, err
@@ -173,51 +145,33 @@ func (r *mqlWindowsWinrm) serviceStartMode() (int64, error) {
 	return computeWinRMServiceStartMode(items), nil
 }
 
-// mqlWindowsWinrmServiceInternal caches the one WS-Management read behind both
-// address filters, so a query that reads the IPv4 and the IPv6 filter costs a
-// single remote command rather than two.
-type mqlWindowsWinrmServiceInternal struct {
+// mqlWindowsWinrmInternal caches the one WS-Management read behind every
+// effective WinRM setting. windows.winrm is a singleton, so the client and the
+// service reach the same instance and a query touching both costs a single
+// remote command rather than one per resource.
+type mqlWindowsWinrmInternal struct {
 	lock    sync.Mutex
 	fetched bool
 	config  *windows.WinRMConfig
 }
 
-// readWinRMConfig reads the live WS-Management client and service settings.
-//
-// These have no registry equivalent that can be trusted. The WinRM service
-// applies the Group Policy key to its own configuration, so this value already
-// carries a policy setting, while reading the policy key alone would miss a
-// TrustedHosts set locally with `winrm set winrm/config/client`, which is the
-// configuration actually worth finding.
-func readWinRMConfig(runtime *plugin.Runtime) (*windows.WinRMConfig, error) {
-	stdout, err := runWindowsPowerShell(runtime, windows.PSGetWinRMConfig, "read the WinRM configuration")
-	if err != nil {
-		return nil, err
-	}
-	return windows.ParseWinRMConfig(stdout)
-}
-
-func (r *mqlWindowsWinrmClient) trustedHosts() (string, error) {
-	config, err := readWinRMConfig(r.MqlRuntime)
-	if err != nil {
-		return "", err
-	}
-	return string(config.Client.TrustedHosts), nil
-}
-
-// serviceConfig reads the WS-Management service settings once and caches them.
+// wsmanConfig reads the live WS-Management configuration once and caches it.
 //
 // The guard is read under the lock, never before it, so a racing accessor
-// cannot see the flag set and the pointer still nil. The lock is uncontended
-// in the common case and the work it guards is a remote command.
-func (r *mqlWindowsWinrmService) serviceConfig() (*windows.WinRMConfig, error) {
+// cannot see the flag set and the pointer still nil. The lock is uncontended in
+// the common case and the work it guards is a remote command.
+func (r *mqlWindowsWinrm) wsmanConfig() (*windows.WinRMConfig, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	if r.fetched {
 		return r.config, nil
 	}
 
-	config, err := readWinRMConfig(r.MqlRuntime)
+	stdout, err := runWindowsPowerShell(r.MqlRuntime, windows.PSGetWinRMConfig, "read the WinRM configuration")
+	if err != nil {
+		return nil, err
+	}
+	config, err := windows.ParseWinRMConfig(stdout)
 	if err != nil {
 		return nil, err
 	}
@@ -227,8 +181,75 @@ func (r *mqlWindowsWinrmService) serviceConfig() (*windows.WinRMConfig, error) {
 	return r.config, nil
 }
 
+// winrmConfig reaches the cached WS-Management configuration from a
+// sub-resource. windows.winrm is a singleton, so CreateResource hands back the
+// instance the parent already built rather than building a second one.
+func winrmConfig(runtime *plugin.Runtime) (*windows.WinRMConfig, error) {
+	o, err := CreateResource(runtime, "windows.winrm", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	return o.(*mqlWindowsWinrm).wsmanConfig()
+}
+
+func (r *mqlWindowsWinrmClient) trustedHosts() (string, error) {
+	config, err := winrmConfig(r.MqlRuntime)
+	if err != nil {
+		return "", err
+	}
+	return string(config.Client.TrustedHosts), nil
+}
+
+func (r *mqlWindowsWinrmClient) allowBasic() (bool, error) {
+	config, err := winrmConfig(r.MqlRuntime)
+	if err != nil {
+		return false, err
+	}
+	return config.Client.AllowBasic.Bool()
+}
+
+func (r *mqlWindowsWinrmClient) allowUnencryptedTraffic() (bool, error) {
+	config, err := winrmConfig(r.MqlRuntime)
+	if err != nil {
+		return false, err
+	}
+	return config.Client.AllowUnencrypted.Bool()
+}
+
+func (r *mqlWindowsWinrmClient) allowDigest() (bool, error) {
+	config, err := winrmConfig(r.MqlRuntime)
+	if err != nil {
+		return false, err
+	}
+	return config.Client.AllowDigest.Bool()
+}
+
+func (r *mqlWindowsWinrmService) allowBasic() (bool, error) {
+	config, err := winrmConfig(r.MqlRuntime)
+	if err != nil {
+		return false, err
+	}
+	return config.Service.AllowBasic.Bool()
+}
+
+func (r *mqlWindowsWinrmService) allowUnencryptedTraffic() (bool, error) {
+	config, err := winrmConfig(r.MqlRuntime)
+	if err != nil {
+		return false, err
+	}
+	return config.Service.AllowUnencrypted.Bool()
+}
+
+func (r *mqlWindowsWinrmService) allowRemoteShellAccess() (bool, error) {
+	config, err := winrmConfig(r.MqlRuntime)
+	if err != nil {
+		return false, err
+	}
+	return config.Shell.AllowRemoteShellAccess.Bool()
+}
+
 func (r *mqlWindowsWinrmService) ipv4Filter() (string, error) {
-	config, err := r.serviceConfig()
+	config, err := winrmConfig(r.MqlRuntime)
 	if err != nil {
 		return "", err
 	}
@@ -236,7 +257,7 @@ func (r *mqlWindowsWinrmService) ipv4Filter() (string, error) {
 }
 
 func (r *mqlWindowsWinrmService) ipv6Filter() (string, error) {
-	config, err := r.serviceConfig()
+	config, err := winrmConfig(r.MqlRuntime)
 	if err != nil {
 		return "", err
 	}

--- a/providers/os/resources/windows_winrm_internal_test.go
+++ b/providers/os/resources/windows_winrm_internal_test.go
@@ -37,81 +37,43 @@ func TestWinRMBool(t *testing.T) {
 	})
 }
 
-func TestComputeWinRMClient(t *testing.T) {
-	t.Run("absent uses documented defaults (allow)", func(t *testing.T) {
-		basic, unenc, digest := computeWinRMClient(map[string]int64{})
-		assert.True(t, basic)
-		assert.True(t, unenc)
-		assert.True(t, digest)
+func TestComputeWinRMService(t *testing.T) {
+	// Only the two policy-key settings are resolved here. Basic authentication,
+	// unencrypted traffic and remote shell access have a live WS-Management
+	// value that already carries any policy, and are read from there instead:
+	// a stock Server 2016, 2019 and 2022 all report Basic and unencrypted as
+	// off on the service, which is the opposite of what an absent policy key
+	// used to be reported as.
+	t.Run("absent uses documented defaults", func(t *testing.T) {
+		disableRunAs, autoConfig := computeWinRMService(map[string]int64{})
+		assert.False(t, disableRunAs) // not disabled by default
+		assert.False(t, autoConfig)   // listener not auto-configured by default
+	})
+
+	t.Run("nil map uses documented defaults", func(t *testing.T) {
+		disableRunAs, autoConfig := computeWinRMService(nil)
+		assert.False(t, disableRunAs)
+		assert.False(t, autoConfig)
 	})
 
 	t.Run("explicit values override defaults", func(t *testing.T) {
-		items := map[string]int64{
-			"allowbasic":              0,
-			"allowunencryptedtraffic": 0,
-			"allowdigest":             0,
-		}
-		basic, unenc, digest := computeWinRMClient(items)
-		assert.False(t, basic)
-		assert.False(t, unenc)
-		assert.False(t, digest)
-	})
-
-	t.Run("present and 1 is true", func(t *testing.T) {
-		items := map[string]int64{
-			"allowbasic":              1,
-			"allowunencryptedtraffic": 1,
-			"allowdigest":             1,
-		}
-		basic, unenc, digest := computeWinRMClient(items)
-		assert.True(t, basic)
-		assert.True(t, unenc)
-		assert.True(t, digest)
-	})
-
-	t.Run("case insensitive value names", func(t *testing.T) {
-		// computeWinRMClient lower-cases via winrmBool; provide already-lowered
-		// keys as the loader does, and verify a mixed-case absence still defaults.
-		items := map[string]int64{"allowdigest": 0}
-		basic, unenc, digest := computeWinRMClient(items)
-		assert.True(t, basic)   // absent -> default true
-		assert.True(t, unenc)   // absent -> default true
-		assert.False(t, digest) // explicit 0
-	})
-}
-
-func TestComputeWinRMService(t *testing.T) {
-	t.Run("absent uses documented defaults", func(t *testing.T) {
-		basic, unenc, disableRunAs, autoConfig, remoteShell := computeWinRMService(map[string]int64{}, map[string]int64{})
-		assert.True(t, basic)         // allow basic defaults true
-		assert.True(t, unenc)         // allow unencrypted defaults true
-		assert.False(t, disableRunAs) // not disabled by default
-		assert.False(t, autoConfig)   // listener not auto-configured by default
-		assert.True(t, remoteShell)   // remote shell allowed by default
-	})
-
-	t.Run("hardened explicit values", func(t *testing.T) {
-		service := map[string]int64{
-			"allowbasic":              0,
-			"allowunencryptedtraffic": 0,
-			"disablerunas":            1,
-			"allowautoconfig":         0,
-		}
-		winrs := map[string]int64{"allowremoteshellaccess": 0}
-		basic, unenc, disableRunAs, autoConfig, remoteShell := computeWinRMService(service, winrs)
-		assert.False(t, basic)
-		assert.False(t, unenc)
+		disableRunAs, autoConfig := computeWinRMService(map[string]int64{
+			"disablerunas":    1,
+			"allowautoconfig": 1,
+		})
 		assert.True(t, disableRunAs)
-		assert.False(t, autoConfig)
-		assert.False(t, remoteShell)
+		assert.True(t, autoConfig)
 	})
 
-	t.Run("WinRS subkey read independently of Service key", func(t *testing.T) {
-		service := map[string]int64{"allowautoconfig": 1}
-		winrs := map[string]int64{"allowremoteshellaccess": 1}
-		_, _, _, autoConfig, remoteShell := computeWinRMService(service, winrs)
-		assert.True(t, autoConfig)
-		assert.True(t, remoteShell)
+	t.Run("explicit zero is not the same as absent for a default-true setting", func(t *testing.T) {
+		// both of these default to false, so an explicit 0 and an absence agree;
+		// the assertion is that an explicit 0 is still read rather than skipped
+		disableRunAs, autoConfig := computeWinRMService(map[string]int64{
+			"disablerunas":    0,
+			"allowautoconfig": 0,
+		})
+		assert.False(t, disableRunAs)
+		assert.False(t, autoConfig)
 	})
 }
 


### PR DESCRIPTION
## The bug

`windows.winrm.client` and `windows.winrm.service` resolved their authentication and encryption settings from the Group Policy key alone:

```
HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\{Client,Service}
```

That key is **absent on any machine nobody has applied a WinRM GPO to** — the normal state of a Windows Server. With nothing to read, the resource returned a hardcoded constant, and three of those constants are the opposite of what Windows actually does.

## Reproduction

All four versions report the policy keys as absent and agree on every effective value.

```
HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client   ABSENT
HKLM:\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service  ABSENT
```

`winrm get winrm/config/service` on each host:

```
    AllowUnencrypted = false
        Basic = false
```

| field | before | after | actual (WSMan / `winrm get`) |
|---|---|---|---|
| `windows.winrm.service.allowBasic` | **`true`** | `false` | `false` |
| `windows.winrm.service.allowUnencryptedTraffic` | **`true`** | `false` | `false` |
| `windows.winrm.client.allowUnencryptedTraffic` | **`true`** | `false` | `false` |
| `windows.winrm.client.allowBasic` | `true` | `true` | `true` |
| `windows.winrm.client.allowDigest` | `true` | `true` | `true` |
| `windows.winrm.service.allowRemoteShellAccess` | `true` | `true` | `true` |

**Affected versions: 2016, 2019, 2022 and 2025 — all of them, identically.**

The direction is what makes it serious. The value did not depend on the host at all, so an audit asserting that the service refuses Basic authentication **failed on every correctly-configured machine**, and one asserting the opposite **passed on every machine without ever reading it**.

## The fix

The mechanism the same resource already used for `trustedHosts`, `ipv4Filter` and `ipv6Filter`: read the live WS-Management value. That is the effective setting and it already carries any Group Policy applied to it, so it is strictly better than the policy key — which additionally misses a value set locally with `winrm set winrm/config/client`.

- `PSGetWinRMConfig` now also reads `Client\Auth\Basic`, `Client\Auth\Digest`, `Client\AllowUnencrypted`, `Service\Auth\Basic`, `Service\AllowUnencrypted`, `Shell\AllowRemoteShellAccess`. **All six verified present on 2016, 2019, 2022 and 2025.**
- The six affected fields become computed, so they cost nothing until read.
- `disableRunAs` and `allowAutoConfig` stay on the policy key — no WSMan equivalent exists, and both already defaulted in the safe direction.
- The single WSMan read is cached on the `windows.winrm` singleton, so a query touching client and service costs **one** remote command rather than two. This replaces the per-service cache, which could only ever cover one of them.

## Behavior change worth flagging

A value that is neither `"true"` nor `"false"`, and a WS-Management configuration that cannot be read at all, now **error** instead of reporting a fabricated default. That is deliberate: a default reported in place of a failed read states as fact something nobody managed to check.

## Verification

Built from this branch and run against all four live hosts via `PROVIDERS_PATH`:

```
windows.winrm { client { allowBasic allowUnencryptedTraffic allowDigest }
                service { allowBasic allowUnencryptedTraffic allowRemoteShellAccess
                          disableRunAs allowAutoConfig } }
```

2016, 2019, 2022 and 2025 all now return:

```
  client:  allowBasic: true   allowUnencryptedTraffic: false  allowDigest: true
  service: allowBasic: false  allowUnencryptedTraffic: false  allowRemoteShellAccess: true
           disableRunAs: false  allowAutoConfig: false
```

`trustedHosts`, `ipv4Filter` (`*`), `ipv6Filter` (`*`) and the listener enumeration are unchanged and still correct.

WinRM configuration on the hosts was **not modified** — these were read at shipped defaults over SSH.

Unit tests added for `PSScalar.Bool` (including the values that must error) and for the extended config decode against both a stock and a hardened payload. `go test ./resources/...` passes.
