### PR TITLE
🐛 os: fix five Windows dotted-path husks in windows.update and windows.spooler

### DIFF
--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -2278,11 +2278,11 @@ func init() {
 			Create: createWindowsUpdateEntry,
 		},
 		"windows.update.config": {
-			// to override args, implement: initWindowsUpdateConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initWindowsUpdateConfig,
 			Create: createWindowsUpdateConfig,
 		},
 		"windows.update.policy": {
-			// to override args, implement: initWindowsUpdatePolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initWindowsUpdatePolicy,
 			Create: createWindowsUpdatePolicy,
 		},
 		"windows.serverFeature": {
@@ -2358,15 +2358,15 @@ func init() {
 			Create: createWindowsSpooler,
 		},
 		"windows.spooler.pointAndPrint": {
-			// to override args, implement: initWindowsSpoolerPointAndPrint(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initWindowsSpoolerPointAndPrint,
 			Create: createWindowsSpoolerPointAndPrint,
 		},
 		"windows.spooler.rpc": {
-			// to override args, implement: initWindowsSpoolerRpc(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initWindowsSpoolerRpc,
 			Create: createWindowsSpoolerRpc,
 		},
 		"windows.spooler.ipp": {
-			// to override args, implement: initWindowsSpoolerIpp(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initWindowsSpoolerIpp,
 			Create: createWindowsSpoolerIpp,
 		},
 		"windows.telemetry": {

--- a/providers/os/resources/windows.go
+++ b/providers/os/resources/windows.go
@@ -49,6 +49,45 @@ func runWindowsPowerShell(runtime *plugin.Runtime, script, what string) (io.Read
 	return executedCmd.Stdout, nil
 }
 
+// initWindowsSingletonChild fills in a singleton sub-resource that is reached
+// by a dotted path which is also its own registered resource name.
+//
+// The field `config` on `windows.update` and the resource
+// `windows.update.config` occupy the same path. The compiler resolves the
+// longest matching resource name before it considers a field, so the dotted
+// path instantiates the sub-resource directly and the parent's accessor never
+// runs. Its plain schema fields are populated only by the parent, so every one
+// stays unset and reports "provider returned no data and no error".
+//
+// Worse, the husk is created with the same __id the parent would use, so it
+// also occupies the runtime cache entry for the real resource: a query that
+// mixes the dotted and the block form resolves the husk first and the block
+// form then reads the husk's unset fields as null.
+//
+// Delegating to the parent's accessor fills the resource in. The block form
+// `windows.update { config { ... } }` binds the field instead of resolving a
+// resource name and was never affected. When the resource is created normally
+// by the parent it carries an __id, and this is a no-op.
+func initWindowsSingletonChild[T plugin.Resource](
+	runtime *plugin.Runtime,
+	args map[string]*llx.RawData,
+	parentName string,
+	get func(plugin.Resource) *plugin.TValue[T],
+) (map[string]*llx.RawData, plugin.Resource, error) {
+	if _, ok := args["__id"]; ok {
+		return args, nil, nil
+	}
+	parent, err := CreateResource(runtime, parentName, map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	v := get(parent)
+	if v.Error != nil {
+		return nil, nil, v.Error
+	}
+	return args, v.Data, nil
+}
+
 func (s *mqlWindows) computerInfo() (map[string]any, error) {
 	conn := s.MqlRuntime.Connection.(shared.Connection)
 

--- a/providers/os/resources/windows_dnsserver_test.go
+++ b/providers/os/resources/windows_dnsserver_test.go
@@ -100,11 +100,6 @@ func TestNoNewDottedPathHusks(t *testing.T) {
 		"windows.smartScreen":             true,
 		"windows.smb.clientConfiguration": true,
 		"windows.smb.serverConfiguration": true,
-		"windows.spooler.ipp":             true,
-		"windows.spooler.pointAndPrint":   true,
-		"windows.spooler.rpc":             true,
-		"windows.update.config":           true,
-		"windows.update.policy":           true,
 		"windows.winrm.client":            true,
 		"windows.winrm.service":           true,
 	}

--- a/providers/os/resources/windows_powershell.go
+++ b/providers/os/resources/windows_powershell.go
@@ -200,49 +200,28 @@ func powershellLanguageMode(state int64) string {
 	return "FullLanguage"
 }
 
-// Each singleton sub-resource below is reachable by a dotted path that is also
-// its own registered resource name: the field `transcription` on
-// `windows.powershell` and the resource `windows.powershell.transcription`
-// occupy the same path. The compiler resolves the longest matching resource
-// name before it considers a field, so the dotted path instantiates the
-// sub-resource directly and the parent's accessor never runs. Its plain schema
-// fields are populated only by the parent, so every one stays unset and reports
-// "provider returned no data and no error".
-//
-// Delegating to the parent's accessor fills the resource in. The block form
-// `windows.powershell { transcription { ... } }` binds the field instead of
-// resolving a resource name and was never affected. When the resource is
-// created normally by the parent it carries an __id, and each of these is a
-// no-op.
-func initWindowsPowershellChild[T plugin.Resource](
-	runtime *plugin.Runtime,
-	args map[string]*llx.RawData,
-	get func(*mqlWindowsPowershell) *plugin.TValue[T],
-) (map[string]*llx.RawData, plugin.Resource, error) {
-	if _, ok := args["__id"]; ok {
-		return args, nil, nil
-	}
-	parent, err := CreateResource(runtime, "windows.powershell", map[string]*llx.RawData{})
-	if err != nil {
-		return nil, nil, err
-	}
-	v := get(parent.(*mqlWindowsPowershell))
-	if v.Error != nil {
-		return nil, nil, v.Error
-	}
-	return args, v.Data, nil
-}
-
+// Each singleton sub-resource below shares its name with the dotted path that
+// reaches it, so querying `windows.powershell.transcription.enabled` resolved
+// the resource instead of the field. See initWindowsSingletonChild.
 func initWindowsPowershellScriptBlockLogging(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return initWindowsPowershellChild(runtime, args, (*mqlWindowsPowershell).GetScriptBlockLogging)
+	return initWindowsSingletonChild(runtime, args, "windows.powershell",
+		func(r plugin.Resource) *plugin.TValue[*mqlWindowsPowershellScriptBlockLogging] {
+			return r.(*mqlWindowsPowershell).GetScriptBlockLogging()
+		})
 }
 
 func initWindowsPowershellModuleLogging(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return initWindowsPowershellChild(runtime, args, (*mqlWindowsPowershell).GetModuleLogging)
+	return initWindowsSingletonChild(runtime, args, "windows.powershell",
+		func(r plugin.Resource) *plugin.TValue[*mqlWindowsPowershellModuleLogging] {
+			return r.(*mqlWindowsPowershell).GetModuleLogging()
+		})
 }
 
 func initWindowsPowershellTranscription(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return initWindowsPowershellChild(runtime, args, (*mqlWindowsPowershell).GetTranscription)
+	return initWindowsSingletonChild(runtime, args, "windows.powershell",
+		func(r plugin.Resource) *plugin.TValue[*mqlWindowsPowershellTranscription] {
+			return r.(*mqlWindowsPowershell).GetTranscription()
+		})
 }
 
 func (r *mqlWindowsPowershell) scriptBlockLogging() (*mqlWindowsPowershellScriptBlockLogging, error) {

--- a/providers/os/resources/windows_spooler.go
+++ b/providers/os/resources/windows_spooler.go
@@ -270,6 +270,31 @@ func (r *mqlWindowsSpooler) windowsProtectedPrintGroupPolicyState() (bool, error
 
 // --- sub-resources ----------------------------------------------------------
 
+// Each singleton sub-resource below shares its name with the dotted path that
+// reaches it, so querying `windows.spooler.pointAndPrint.…` resolved the
+// resource instead of the field and reported null for every setting. See
+// initWindowsSingletonChild.
+func initWindowsSpoolerPointAndPrint(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return initWindowsSingletonChild(runtime, args, "windows.spooler",
+		func(r plugin.Resource) *plugin.TValue[*mqlWindowsSpoolerPointAndPrint] {
+			return r.(*mqlWindowsSpooler).GetPointAndPrint()
+		})
+}
+
+func initWindowsSpoolerRpc(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return initWindowsSingletonChild(runtime, args, "windows.spooler",
+		func(r plugin.Resource) *plugin.TValue[*mqlWindowsSpoolerRpc] {
+			return r.(*mqlWindowsSpooler).GetRpc()
+		})
+}
+
+func initWindowsSpoolerIpp(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return initWindowsSingletonChild(runtime, args, "windows.spooler",
+		func(r plugin.Resource) *plugin.TValue[*mqlWindowsSpoolerIpp] {
+			return r.(*mqlWindowsSpooler).GetIpp()
+		})
+}
+
 func (r *mqlWindowsSpooler) pointAndPrint() (*mqlWindowsSpoolerPointAndPrint, error) {
 	reg, err := r.load()
 	if err != nil {

--- a/providers/os/resources/windows_update.go
+++ b/providers/os/resources/windows_update.go
@@ -170,6 +170,24 @@ func deriveCatalogSource(read bool, useWUServer bool, wsusServerURL string, auOp
 	return "windowsUpdate"
 }
 
+// windows.update.config and windows.update.policy share their names with the
+// dotted paths that reach them, so `windows.update.config.catalogSource`
+// resolved the resource instead of the field and reported null for every
+// setting. See initWindowsSingletonChild.
+func initWindowsUpdateConfig(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return initWindowsSingletonChild(runtime, args, "windows.update",
+		func(r plugin.Resource) *plugin.TValue[*mqlWindowsUpdateConfig] {
+			return r.(*mqlWindowsUpdate).GetConfig()
+		})
+}
+
+func initWindowsUpdatePolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return initWindowsSingletonChild(runtime, args, "windows.update",
+		func(r plugin.Resource) *plugin.TValue[*mqlWindowsUpdatePolicy] {
+			return r.(*mqlWindowsUpdate).GetPolicy()
+		})
+}
+
 func (w *mqlWindowsUpdate) config() (*mqlWindowsUpdateConfig, error) {
 	policy, okPolicy := w.readRegistryKey(wuPolicyKey)
 	au, okAU := w.readRegistryKey(wuPolicyAUKey)


### PR DESCRIPTION
Five sub-resources under `windows.update` and `windows.spooler` share a name with the field path that reaches them. The compiler resolves the longest matching resource name before it considers a field, so the dotted path instantiates the sub-resource directly and the parent's accessor never runs. Every plain schema field stays unset, which surfaces as `provider returned no data and no error for a field` followed by `llx: encountered a primitive with no type information, coercing to null`.

This is the same defect #10361 fixed for `windows.powershell`; these five were left on the known-husk list in `TestNoNewDottedPathHusks`.

## Measured

Windows Server 2016 (14393), 2019 (17763), 2022 (20348) and 2025 (26100), over SSH, identical on all four.

**Before** — dotted form:

| query | before | after |
|---|---|---|
| `windows.update.config.catalogSource` | *unset* | `"disabled"` |
| `windows.update.config.auOptions` | *unset* | `2` |
| `windows.update.policy.automaticUpdatesEnabled` | *unset* | `false` |
| `windows.spooler.pointAndPrint.restrictDriverInstallationToAdministrators` | *unset* | `true` |
| `windows.spooler.rpc.forceKerberos` | *unset* | `false` |
| `windows.spooler.ipp.requireIpps` | *unset* | `false` |

The block forms read correctly before and after:

```
windows.update { config { catalogSource } }  ->  "windowsUpdate"
windows.spooler { pointAndPrint { restrictDriverInstallationToAdministrators } }  ->  true
```

## The part that is worse than a null

The husk is created with the same `__id` the parent would use, so it also occupies the runtime cache entry for the real resource. A single query that mixes the two forms resolves the husk first, and the block form then reads the husk's unset fields as null. Observed on all four hosts: in one `mql run` containing both forms, `windows.spooler { pointAndPrint { … } }` reported every setting as null, while the same block form alone reported the real values. So the dotted path could take the correct form down with it.

## Fix

Each of the five gets an `init` that delegates to the parent's accessor. The three `windows.powershell` inits from #10361 are refactored onto the shared helper rather than keeping a second copy of the same code.

`TestNoNewDottedPathHusks` already listed all five as known; those entries are **removed**, so the ratchet shrinks by five and a regression fails the test.

## Verification

Rebuilt provider against Windows Server 2022 and 2016: every dotted path above now returns the value the block form returns, and the block form is unaffected. `go test ./resources/...` passes, including the ratchet.
