### PR TITLE
🐛 os: stop windows.update reporting a host it could not reach as fully patched

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -11306,8 +11306,9 @@ private windows.update.config @defaults("catalogSource rebootPending") {
   //
   // One of "windowsUpdate" (direct Microsoft Update), "wsus" (a configured
   // WSUS server), "windowsUpdateForBusiness", "disabled" (the agent or
-  // automatic updates are turned off), or "unknown" (the relevant registry
-  // keys could not be read).
+  // automatic updates are turned off, through either AU\NoAutoUpdate or the
+  // legacy AUOptions encoding), or "unknown" (the relevant registry keys could
+  // not be read).
   catalogSource string
   // Configured WSUS server URL (HKLM\...\WindowsUpdate\WUServer)
   wsusServerUrl string
@@ -11334,7 +11335,13 @@ private windows.update.config @defaults("catalogSource rebootPending") {
   lastInstallSuccess time
   // Whether a reboot is pending from a previous update
   rebootPending bool
-  // Windows Update for Business policy state (HKLM\SOFTWARE\Microsoft\WindowsUpdate\UpdatePolicy\PolicyState)
+  // Whether Windows Update for Business is configured
+  //
+  // The IsWUfBConfigured flag under
+  // HKLM\SOFTWARE\Microsoft\WindowsUpdate\UpdatePolicy\PolicyState, 1 when
+  // the host takes its update policy from Windows Update for Business. Null
+  // when the key is absent, which is the state of a host that was never
+  // enrolled.
   policyState int
 }
 

--- a/providers/os/resources/updates/win_updates.go
+++ b/providers/os/resources/updates/win_updates.go
@@ -173,9 +173,24 @@ func ParseWindowsUpdates(input io.Reader) ([]WindowsUpdate, error) {
 // a null decodes to. The script's ErrorActionPreference keeps a failed search
 // from producing one, and this keeps any other source of a blank record from
 // being counted as an outstanding update.
+//
+// The common case is that there is nothing to drop, so the input is returned
+// as it stands and nothing is allocated until a blank record is actually seen.
 func dropEmptyWindowsUpdates(updates []WindowsUpdate) []WindowsUpdate {
-	res := make([]WindowsUpdate, 0, len(updates))
+	first := -1
 	for i := range updates {
+		if updates[i].UpdateID == "" && updates[i].Title == "" {
+			first = i
+			break
+		}
+	}
+	if first < 0 {
+		return updates
+	}
+
+	res := make([]WindowsUpdate, first, len(updates)-1)
+	copy(res, updates[:first])
+	for i := first + 1; i < len(updates); i++ {
 		if updates[i].UpdateID == "" && updates[i].Title == "" {
 			continue
 		}

--- a/providers/os/resources/updates/win_updates.go
+++ b/providers/os/resources/updates/win_updates.go
@@ -34,7 +34,15 @@ const (
 // IMPORTANT: criteria is concatenated into the script verbatim, so it must be
 // a trusted constant (e.g. WindowsUpdateCriteria*), never user input.
 func windowsUpdateSearchQuery(criteria string) string {
+	// $ErrorActionPreference is Stop so a failed search is a terminating error
+	// and powershell.exe exits non-zero. Without it the COM failure is a
+	// non-terminating error: the exit status stays 0, $searcher stays null,
+	// and $searcher.Updates piped to ForEach-Object still runs the block once
+	// with a null input, so the caller is handed one empty update and reads it
+	// as a host with nothing outstanding. A host whose update agent could not
+	// be reached must fail the check, not report itself fully patched.
 	return `
+$ErrorActionPreference='Stop';
 $ProgressPreference='SilentlyContinue';
 $updateSession = new-object -com "Microsoft.Update.Session"
 $searcher = $updateSession.CreateupdateSearcher().Search("` + criteria + `")
@@ -149,12 +157,29 @@ func ParseWindowsUpdates(input io.Reader) ([]WindowsUpdate, error) {
 	var updates []WindowsUpdate
 	arrErr := json.Unmarshal(data, &updates)
 	if arrErr == nil {
-		return updates, nil
+		return dropEmptyWindowsUpdates(updates), nil
 	}
 
 	var single WindowsUpdate
 	if err := json.Unmarshal(data, &single); err != nil {
 		return nil, arrErr
 	}
-	return []WindowsUpdate{single}, nil
+	return dropEmptyWindowsUpdates([]WindowsUpdate{single}), nil
+}
+
+// dropEmptyWindowsUpdates removes records that carry no identity at all.
+//
+// A record with neither an update ID nor a title is not an update; it is what
+// a null decodes to. The script's ErrorActionPreference keeps a failed search
+// from producing one, and this keeps any other source of a blank record from
+// being counted as an outstanding update.
+func dropEmptyWindowsUpdates(updates []WindowsUpdate) []WindowsUpdate {
+	res := make([]WindowsUpdate, 0, len(updates))
+	for i := range updates {
+		if updates[i].UpdateID == "" && updates[i].Title == "" {
+			continue
+		}
+		res = append(res, updates[i])
+	}
+	return res
 }

--- a/providers/os/resources/updates/win_updates_test.go
+++ b/providers/os/resources/updates/win_updates_test.go
@@ -87,3 +87,64 @@ func findKb(pkgs []OperatingSystemUpdate, name string) (OperatingSystemUpdate, e
 	}
 	return OperatingSystemUpdate{}, errors.New("not found")
 }
+
+func TestParseWindowsUpdatesDropsBlankRecords(t *testing.T) {
+	// What a failed Windows Update Agent search leaves on stdout: $searcher is
+	// null, so $searcher.Updates is null, and piping null to ForEach-Object
+	// still runs the block once. Counting that as an outstanding update is
+	// wrong, and so is counting it as a clean scan.
+	updates, err := ParseWindowsUpdates(strings.NewReader(`{"UpdateID": null, "Title": null}`))
+	require.NoError(t, err)
+	assert.Empty(t, updates)
+
+	updates, err = ParseWindowsUpdates(strings.NewReader(`[{"UpdateID": null, "Title": null}]`))
+	require.NoError(t, err)
+	assert.Empty(t, updates)
+
+	// A real update alongside a blank one keeps the real one.
+	updates, err = ParseWindowsUpdates(strings.NewReader(
+		`[{"UpdateID": null, "Title": null},{"UpdateID":"0f1e-2d3c","Title":"2026-08 Cumulative Update (KB5120242)","KBArticleIDs":["5120242"]}]`))
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	assert.Equal(t, "0f1e-2d3c", updates[0].UpdateID)
+
+	// An update with a title but no identity is still an update.
+	updates, err = ParseWindowsUpdates(strings.NewReader(`[{"UpdateID":"","Title":"Some driver"}]`))
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+}
+
+func TestWindowsUpdateSearchQueryStopsOnError(t *testing.T) {
+	// Without this the COM failure is a non-terminating error, powershell.exe
+	// exits 0, the ExitStatus check never fires, and a host that could not be
+	// reached reports itself fully patched.
+	q := windowsUpdateSearchQuery(WindowsUpdateCriteriaAvailable)
+	assert.Contains(t, q, "$ErrorActionPreference='Stop'")
+	assert.Contains(t, q, WindowsUpdateCriteriaAvailable)
+}
+
+func TestDropEmptyWindowsUpdatesKeepsTheInputWhenNothingIsBlank(t *testing.T) {
+	in := []WindowsUpdate{{UpdateID: "a", Title: "A"}, {UpdateID: "b", Title: "B"}}
+	got := dropEmptyWindowsUpdates(in)
+	require.Len(t, got, 2)
+	assert.Equal(t, in, got)
+
+	// Nothing is copied when there is nothing to drop, which is every
+	// successful search.
+	assert.Equal(t, &in[0], &got[0])
+}
+
+func TestDropEmptyWindowsUpdatesPreservesOrder(t *testing.T) {
+	in := []WindowsUpdate{
+		{UpdateID: "a", Title: "A"},
+		{},
+		{UpdateID: "b", Title: "B"},
+		{},
+		{UpdateID: "c", Title: "C"},
+	}
+	got := dropEmptyWindowsUpdates(in)
+	require.Len(t, got, 3)
+	assert.Equal(t, "a", got[0].UpdateID)
+	assert.Equal(t, "b", got[1].UpdateID)
+	assert.Equal(t, "c", got[2].UpdateID)
+}

--- a/providers/os/resources/windows/update.go
+++ b/providers/os/resources/windows/update.go
@@ -50,7 +50,13 @@ func ParseKBID(s string) string {
 // (and de-duplicates by KB), so the two must stay in sync; see
 // TestUpdateHistoryQueryFilterMatchesGo. Dates serialize as PowerShell
 // "/Date(ms)/" strings.
+//
+// $ErrorActionPreference is Stop so a failed COM call exits non-zero. Without
+// it GetTotalHistoryCount failing leaves $count null, the $count -gt 0 guard is
+// false, and the caller is handed an empty history: a host whose update agent
+// could not be reached reports that nothing has ever been installed.
 var WINDOWS_QUERY_UPDATE_HISTORY = `
+$ErrorActionPreference='Stop';
 $ProgressPreference='SilentlyContinue';
 $session = New-Object -ComObject Microsoft.Update.Session
 $searcher = $session.CreateUpdateSearcher()

--- a/providers/os/resources/windows/update_test.go
+++ b/providers/os/resources/windows/update_test.go
@@ -117,3 +117,10 @@ func TestOperationName(t *testing.T) {
 	assert.Equal(t, "Uninstallation", OperationName(UpdateOperationUninstallation))
 	assert.Equal(t, "", OperationName(0))
 }
+
+func TestUpdateHistoryQueryStopsOnError(t *testing.T) {
+	// GetTotalHistoryCount failing without this leaves $count null, the
+	// $count -gt 0 guard false, and an empty history: a host whose update
+	// agent could not be reached reports that nothing was ever installed.
+	assert.Contains(t, WINDOWS_QUERY_UPDATE_HISTORY, "$ErrorActionPreference='Stop'")
+}

--- a/providers/os/resources/windows_update.go
+++ b/providers/os/resources/windows_update.go
@@ -214,11 +214,21 @@ func (w *mqlWindowsUpdate) config() (*mqlWindowsUpdateConfig, error) {
 	noAutoUpdate := regInt(au, "NoAutoUpdate") == 1
 
 	// wufbPolicyState names the key, not a value inside it. Reading a value of
-	// that name found nothing on any host, so the Windows Update for Business
-	// branch below was unreachable and policyState reported a constant 0 that
-	// no host had set. IsWUfBConfigured is the flag the key actually carries.
-	wufbConfigured := regInt(wufb, "IsWUfBConfigured") == 1
+	// that name found nothing on any host: Server 2019, 2022 and 2025 carry
+	// the key with a dozen values (DeferQualityUpdates, BranchReadinessLevel,
+	// IsWUfBConfigured and the rest) and none of them is called PolicyState,
+	// while Server 2016 has no such key at all. So the Windows Update for
+	// Business branch below was unreachable and policyState reported a
+	// constant 0 that no host had set.
+	//
+	// IsWUfBConfigured is the flag the key actually carries, and it is the
+	// whole of what this key says about enrollment, so policyState and the
+	// catalogSource gate are deliberately the same reading rather than two
+	// values that happen to coincide. wufbConfigured is derived from
+	// policyState to keep that explicit: an absent key is not enrollment, and
+	// neither is the flag being present and 0.
 	policyState := regIntPtr(wufb, "IsWUfBConfigured")
+	wufbConfigured := policyState != nil && *policyState == 1
 
 	catalogSource := deriveCatalogSource(read, useWUServer, wsusServerURL, auOptions, noAutoUpdate, wufbConfigured)
 

--- a/providers/os/resources/windows_update.go
+++ b/providers/os/resources/windows_update.go
@@ -154,17 +154,23 @@ func formatWULastError(code int64) string {
 // deriveCatalogSource determines the effective update source from the raw
 // registry signals. Order matters: an explicitly disabled agent wins, then
 // WSUS, then Windows Update for Business, then direct Windows Update.
-func deriveCatalogSource(read bool, useWUServer bool, wsusServerURL string, auOptions int64, hasPolicyState bool) string {
+//
+// noAutoUpdate is the modern way a host turns automatic updates off, and it is
+// checked alongside the legacy AUOptions == 1 encoding. AUOptions has not had
+// a value of 1 since Windows XP, so on any host this provider runs against
+// that test alone never fired and a host with automatic updates switched off
+// reported itself as pulling from Windows Update.
+func deriveCatalogSource(read bool, useWUServer bool, wsusServerURL string, auOptions int64, noAutoUpdate bool, wufbConfigured bool) string {
 	if !read {
 		return "unknown"
 	}
-	if auOptions == 1 {
+	if auOptions == 1 || noAutoUpdate {
 		return "disabled"
 	}
 	if useWUServer && wsusServerURL != "" {
 		return "wsus"
 	}
-	if hasPolicyState && wsusServerURL == "" {
+	if wufbConfigured && wsusServerURL == "" {
 		return "windowsUpdateForBusiness"
 	}
 	return "windowsUpdate"
@@ -205,10 +211,16 @@ func (w *mqlWindowsUpdate) config() (*mqlWindowsUpdateConfig, error) {
 	wsusStatusServerURL := regString(policy, "WUStatusServer")
 	useWUServer := regInt(au, "UseWUServer") == 1
 	auOptions := regInt(au, "AUOptions")
-	hasPolicyState := regHas(wufb, "PolicyState")
-	policyState := regInt(wufb, "PolicyState")
+	noAutoUpdate := regInt(au, "NoAutoUpdate") == 1
 
-	catalogSource := deriveCatalogSource(read, useWUServer, wsusServerURL, auOptions, hasPolicyState)
+	// wufbPolicyState names the key, not a value inside it. Reading a value of
+	// that name found nothing on any host, so the Windows Update for Business
+	// branch below was unreachable and policyState reported a constant 0 that
+	// no host had set. IsWUfBConfigured is the flag the key actually carries.
+	wufbConfigured := regInt(wufb, "IsWUfBConfigured") == 1
+	policyState := regIntPtr(wufb, "IsWUfBConfigured")
+
+	catalogSource := deriveCatalogSource(read, useWUServer, wsusServerURL, auOptions, noAutoUpdate, wufbConfigured)
 
 	rebootPending := w.registryKeyExists(wuRebootCBS) || w.registryKeyExists(wuRebootAU)
 
@@ -224,7 +236,7 @@ func (w *mqlWindowsUpdate) config() (*mqlWindowsUpdateConfig, error) {
 		"lastDownloadSuccess":  llx.TimeDataPtr(parseWULastSuccessTime(regString(download, "LastSuccessTime"))),
 		"lastInstallSuccess":   llx.TimeDataPtr(parseWULastSuccessTime(regString(install, "LastSuccessTime"))),
 		"rebootPending":        llx.BoolData(rebootPending),
-		"policyState":          llx.IntData(policyState),
+		"policyState":          intPtrData(policyState),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/os/resources/windows_update_test.go
+++ b/providers/os/resources/windows_update_test.go
@@ -98,19 +98,28 @@ func TestDeriveCatalogSource(t *testing.T) {
 		useWUServer    bool
 		wsusServerURL  string
 		auOptions      int64
-		hasPolicyState bool
+		noAutoUpdate   bool
+		wufbConfigured bool
 		want           string
 	}{
 		{name: "registry unreadable", read: false, want: "unknown"},
-		{name: "automatic updates disabled", read: true, auOptions: 1, want: "disabled"},
+		{name: "automatic updates disabled, legacy AUOptions encoding", read: true, auOptions: 1, want: "disabled"},
+		// The shape every host running a modern Windows carries: AUOptions
+		// holds a live value and NoAutoUpdate is what switches updates off.
+		{name: "automatic updates disabled by NoAutoUpdate", read: true, auOptions: 2, noAutoUpdate: true, want: "disabled"},
+		{name: "NoAutoUpdate wins over a configured WSUS server", read: true, useWUServer: true, wsusServerURL: "http://wsus.local:8530", auOptions: 4, noAutoUpdate: true, want: "disabled"},
 		{name: "wsus managed", read: true, useWUServer: true, wsusServerURL: "http://wsus.local:8530", auOptions: 4, want: "wsus"},
 		{name: "wsus url without UseWUServer falls through", read: true, useWUServer: false, wsusServerURL: "http://wsus.local:8530", auOptions: 4, want: "windowsUpdate"},
-		{name: "windows update for business", read: true, hasPolicyState: true, auOptions: 0, want: "windowsUpdateForBusiness"},
+		{name: "windows update for business", read: true, wufbConfigured: true, auOptions: 0, want: "windowsUpdateForBusiness"},
 		{name: "direct windows update", read: true, auOptions: 4, want: "windowsUpdate"},
+		// The PolicyState key exists on every Windows Server since 2019 with
+		// IsWUfBConfigured set to 0; its presence alone must not read as
+		// enrollment.
+		{name: "PolicyState present but WUfB not configured", read: true, wufbConfigured: false, auOptions: 4, want: "windowsUpdate"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := deriveCatalogSource(tt.read, tt.useWUServer, tt.wsusServerURL, tt.auOptions, tt.hasPolicyState)
+			got := deriveCatalogSource(tt.read, tt.useWUServer, tt.wsusServerURL, tt.auOptions, tt.noAutoUpdate, tt.wufbConfigured)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
> Stacked on #10379. Review the last commit; the base merges first.

Three wrong answers in `windows.update`, all measured on Windows Server 2016, 2019, 2022 and 2025.

## 1. A failed Windows Update Agent search reported a fully patched host

Neither the search script nor the install-history script set `$ErrorActionPreference`. A COM failure — no route to Windows Update, an unreachable WSUS server, a disabled agent — is a *non-terminating* error, so `powershell.exe` still exits 0 and the `ExitStatus != 0` check never fires.

Reproduced on the exact `-EncodedCommand` path the provider uses, with a criteria the agent rejects:

```
$searcher = $updateSession.CreateupdateSearcher().Search("ThisIsNotAValidCriteria")
$updates  = $searcher.Updates | ForEach-Object { ... }
@($updates) | ConvertTo-Json

stdout: {"UpdateID": null, "Title": null}
exit:   0
```

`$searcher` is null, `$searcher.Updates` is null, and piping null to `ForEach-Object` still runs the block once with `$_ = $null` — so the caller is handed one blank update.

- `windows.update.available` reported that phantom entry.
- `os.updates` dropped it for having no KB and reported an **empty list**, which reads as a fully patched machine.

"The update agent could not be reached" and "there is nothing outstanding" satisfy a patch-level audit identically, and only one of them is an answer. The history script fails the same way: `GetTotalHistoryCount()` failing leaves `$count` null, the `$count -gt 0` guard is false, and `installed` reports that nothing has ever been installed.

Both scripts now stop on error, so a failed search exits non-zero and surfaces as an error. Records carrying neither an update ID nor a title are dropped as a second line of defence.

## 2. `config.policyState` was a constant 0 on every host

`wufbPolicyState` names a registry **key**, not a value inside it, but the code read a value called `PolicyState` from it. No host has one. Ground truth from that key on 2019/2022/2025:

```
DeferQualityUpdates, DeferFeatureUpdates, BranchReadinessLevel,
IsDeferralIsActive, IsWUfBConfigured, IsWUfBDualScanActive, ...
```

The flag the key actually carries is `IsWUfBConfigured`. `policyState` now reports it, and is null when the key is absent — which is the state of Server 2016, where the key does not exist at all — rather than reporting a 0 nobody set.

## 3. `catalogSource` could never say `windowsUpdateForBusiness`, and never said `disabled`

- The WUfB branch was gated on the same absent value, so it was unreachable on any host. It is now gated on `IsWUfBConfigured`, and the key merely *existing* (which it does on every Server since 2019, with the flag set to `0`) does not read as enrollment.
- `"disabled"` was gated on `AUOptions == 1`, an encoding unused since Windows XP. All four test hosts carry `AU\NoAutoUpdate = 1` with `AUOptions = 2`, and every one reported `"windowsUpdate"` as though it were happily pulling from Microsoft. `NoAutoUpdate` is now checked alongside the legacy encoding, which is what the field already documented ("the agent or automatic updates are turned off").

| | before | after |
|---|---|---|
| `catalogSource` (all four hosts) | `"windowsUpdate"` | `"disabled"` |
| `policyState` (2019/2022/2025) | `0` (fabricated) | `0` (real `IsWUfBConfigured`) |
| `policyState` (2016, key absent) | `0` (fabricated) | `null` |

## Verification

Rebuilt provider against Server 2022: `available.length` = 2 and `installed.length` = 1 with no error, matching `Search("IsInstalled=0 and IsHidden=0")` and `QueryHistory` run directly on the host — the happy path is unaffected by the `Stop` preference. `TestDeriveCatalogSource` gains cases for the `NoAutoUpdate` shape every modern host carries and for a `PolicyState` key present with `IsWUfBConfigured = 0`.
