### PR TITLE
⭐ os: expose the Defender antimalware running mode

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -13951,6 +13951,16 @@ private windows.defender.status @defaults("antivirusEnabled realTimeProtectionEn
   amEngineVersion string
   // Antimalware client (product) version
   amProductVersion string
+  // Mode the Defender antimalware engine is running in
+  //
+  // "Normal" means Defender is the active antivirus. "Passive Mode" and
+  // "SxS Passive Mode" mean another antivirus is active and Defender is not
+  // remediating threats, even though amServiceEnabled and antivirusEnabled
+  // still report true. "EDR Block Mode" means Defender remediates only what
+  // endpoint detection and response identifies, and "Not running" means the
+  // engine is stopped. Check this before reading the protection toggles as
+  // proof the host is being defended.
+  amRunningMode string
   // Whether the Windows Defender antimalware service is running
   amServiceEnabled bool
   // Antimalware service version

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -13951,6 +13951,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"windows.defender.status.amProductVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsDefenderStatus).GetAmProductVersion()).ToDataRes(types.String)
 	},
+	"windows.defender.status.amRunningMode": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsDefenderStatus).GetAmRunningMode()).ToDataRes(types.String)
+	},
 	"windows.defender.status.amServiceEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsDefenderStatus).GetAmServiceEnabled()).ToDataRes(types.Bool)
 	},
@@ -33172,6 +33175,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"windows.defender.status.amProductVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindowsDefenderStatus).AmProductVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.defender.status.amRunningMode": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsDefenderStatus).AmRunningMode, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"windows.defender.status.amServiceEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -85469,6 +85476,7 @@ type mqlWindowsDefenderStatus struct {
 	// optional: if you define mqlWindowsDefenderStatusInternal it will be used here
 	AmEngineVersion                  plugin.TValue[string]
 	AmProductVersion                 plugin.TValue[string]
+	AmRunningMode                    plugin.TValue[string]
 	AmServiceEnabled                 plugin.TValue[bool]
 	AmServiceVersion                 plugin.TValue[string]
 	AntispywareEnabled               plugin.TValue[bool]
@@ -85555,6 +85563,10 @@ func (c *mqlWindowsDefenderStatus) GetAmEngineVersion() *plugin.TValue[string] {
 
 func (c *mqlWindowsDefenderStatus) GetAmProductVersion() *plugin.TValue[string] {
 	return &c.AmProductVersion
+}
+
+func (c *mqlWindowsDefenderStatus) GetAmRunningMode() *plugin.TValue[string] {
+	return &c.AmRunningMode
 }
 
 func (c *mqlWindowsDefenderStatus) GetAmServiceEnabled() *plugin.TValue[bool] {

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -4273,6 +4273,7 @@ windows.defender.signatureSettings.signatureUpdateInterval 13.29.1
 windows.defender.status 13.29.1
 windows.defender.status.amEngineVersion 13.29.1
 windows.defender.status.amProductVersion 13.29.1
+windows.defender.status.amRunningMode 13.40.10
 windows.defender.status.amServiceEnabled 13.29.1
 windows.defender.status.amServiceVersion 13.29.1
 windows.defender.status.antispywareEnabled 13.29.1

--- a/providers/os/resources/windows/defender.go
+++ b/providers/os/resources/windows/defender.go
@@ -324,6 +324,7 @@ func formatTimeOfDay(d time.Duration) string {
 type MpComputerStatus struct {
 	AMEngineVersion                  string
 	AMProductVersion                 string
+	AMRunningMode                    string
 	AMServiceEnabled                 bool
 	AMServiceVersion                 string
 	AntispywareEnabled               bool

--- a/providers/os/resources/windows/defender_live_test.go
+++ b/providers/os/resources/windows/defender_live_test.go
@@ -57,6 +57,11 @@ func TestMpComputerStatusLiveDecodes(t *testing.T) {
 			assert.False(t, status.IsTamperProtected)
 			assert.False(t, status.RebootRequired)
 			assert.Equal(t, "4.18.26070.9", status.AMProductVersion)
+
+			// "Normal" means Defender is the active antivirus. A passive-mode
+			// host still reports amServiceEnabled and antivirusEnabled true, so
+			// this is what separates "protected" from "installed".
+			assert.Equal(t, "Normal", status.AMRunningMode)
 			assert.Equal(t, "Off", status.SmartAppControlState)
 
 			// Device control reports names, not numbers. Defender leaves the

--- a/providers/os/resources/windows_defender.go
+++ b/providers/os/resources/windows_defender.go
@@ -102,6 +102,7 @@ func (d *mqlWindowsDefender) status() (*mqlWindowsDefenderStatus, error) {
 		"__id":                             llx.StringData("windows.defender.status"),
 		"amEngineVersion":                  llx.StringData(status.AMEngineVersion),
 		"amProductVersion":                 llx.StringData(status.AMProductVersion),
+		"amRunningMode":                    llx.StringData(status.AMRunningMode),
 		"amServiceEnabled":                 llx.BoolData(status.AMServiceEnabled),
 		"amServiceVersion":                 llx.StringData(status.AMServiceVersion),
 		"antispywareEnabled":               llx.BoolData(status.AntispywareEnabled),


### PR DESCRIPTION
## What

`Get-MpComputerStatus` reports `AMRunningMode` and `windows.defender.status` did
not model it. It is the field that separates "Defender is installed" from
"Defender is protecting this host":

| value | meaning |
|---|---|
| `Normal` | Defender is the active antivirus |
| `Passive Mode` | another antivirus is active; Defender does not remediate |
| `SxS Passive Mode` | same, alongside endpoint detection and response |
| `EDR Block Mode` | remediates only what EDR identifies |
| `Not running` | the engine is stopped |

## Why it matters

A passive-mode host still reports every protection toggle as healthy:

```
amServiceEnabled:          true
antivirusEnabled:          true
antispywareEnabled:        true
realTimeProtectionEnabled: true
```

Those are the three fields `windows.defender.enabled` is computed from. On a
server where Defender has stood down for a third-party antivirus, the whole
resource reads as "protected" and nothing in the schema said otherwise.

## What this deliberately does not change

`windows.defender.enabled` is left as it is. Narrowing it to require `Normal`
would be a shipped-behaviour change, and passive mode could not be reproduced on
any verification host - it needs a third-party antivirus installed, which was
not acceptable on shared hosts. The field comment points the reader at
`amRunningMode` instead of quietly redefining `enabled`.

## Verification

Live, via `mql run ssh`:

| version | `amRunningMode` |
|---|---|
| Server 2016 | `"Normal"` |
| Server 2019 | `"Normal"` |
| Server 2022 | `"Normal"` |

```
windows.defender.status: {
  amRunningMode:    "Normal"
  amServiceEnabled: true
  antivirusEnabled: true
}
```

Windows Server 2025 reports `AMRunningMode: "Normal"` in its captured
`Get-MpComputerStatus` output and is pinned by the fixture test alongside the
other three; its `mql run` was still in flight when this was opened. **Only
`Normal` was observed** - the other four values in the table come from the
cmdlet documentation and are not verified against a live host.

`.lr.versions` entry added at `13.40.10`, one patch after the provider's current
`13.40.9`.

## Stack

Builds on #10374, the last of the Defender fix stack, because it touches the
same files.
