### PR TITLE
🐛 os: read Event Log retention for modern channels, not just the classic logs

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -11462,9 +11462,17 @@ windows.eventlog @defaults("name") {
   maxSizeKB() int
   // Retention behavior when the log reaches its maximum size
   //
-  // One of "overwrite_as_needed" (Retention 0), "overwrite_by_days" (a
-  // positive retention period in seconds), or "never_overwrite" (Retention
-  // 4294967295 or -1).
+  // One of "overwrite_as_needed", "overwrite_by_days" (a positive retention
+  // period), or "never_overwrite". Resolved from the first source that
+  // carries a value: the Group Policy Retention, the classic channel
+  // configuration under Services\EventLog, the WINEVT channel key, and then
+  // the retention mode the channel itself reports. The first two use a period
+  // in seconds (0 as needed, a positive count of seconds by days, 4294967295
+  // or -1 never); the WINEVT key uses a flag instead, 0 as needed and non-zero
+  // never. A modern provider channel is not under Services\EventLog at all,
+  // so without the last two sources every one of them resolved to the Windows
+  // default. Falls back to "overwrite_as_needed", the documented default, only
+  // when no source reports a behavior.
   retention() string
   // Whether the channel overwrites events as needed when full (Retention 0)
   overwriteAsNeeded() bool

--- a/providers/os/resources/windows/eventlog.go
+++ b/providers/os/resources/windows/eventlog.go
@@ -49,6 +49,7 @@ IsClassicLog=[bool]$l.IsClassicLog
 LogFilePath=[string]$l.LogFilePath
 SystemRoot=[string]$env:SystemRoot
 RecordCount=$(if($null -eq $l.RecordCount){0}else{[int64]$l.RecordCount})
+LogMode=[string]$l.LogMode
 }|ConvertTo-Json -Depth 3 -Compress`
 }
 
@@ -98,6 +99,11 @@ type EventLogChannel struct {
 	// never collected anything, which is why it is only meaningful read
 	// together with IsEnabled.
 	RecordCount int64 `json:"RecordCount"`
+	// LogMode is the effective retention behavior Windows resolved for the
+	// channel: Circular, AutoBackup or Retain. It is the only source that
+	// covers a modern provider channel left at its manifest default, where
+	// neither the classic Services\EventLog key nor an override exists.
+	LogMode string `json:"LogMode"`
 }
 
 // ExpandedLogFilePath is the full path of the backing .evtx file, with the

--- a/providers/os/resources/windows_eventlog.go
+++ b/providers/os/resources/windows_eventlog.go
@@ -209,8 +209,13 @@ func (w *mqlWindowsEventlog) maxSizeKB() (int64, error) {
 	return eventlogDefaultMaxSizeKB, nil
 }
 
-// retentionRaw returns the effective Retention value (policy wins) and whether
-// it was set in either source.
+// retentionRaw returns the effective Retention value from the two keys that
+// use the legacy seconds encoding (policy wins) and whether either carried a
+// value.
+//
+// The WINEVT channel key is deliberately not consulted here: it stores
+// Retention as a boolean rather than a period, so its value cannot be fed to
+// decodeRetention. resolveRetention reads it separately.
 func (w *mqlWindowsEventlog) retentionRaw() (int64, bool, error) {
 	if err := w.load(); err != nil {
 		return 0, false, err
@@ -224,16 +229,69 @@ func (w *mqlWindowsEventlog) retentionRaw() (int64, bool, error) {
 	return 0, false, nil
 }
 
-func (w *mqlWindowsEventlog) retention() (string, error) {
+// decodeChannelRetention maps the WINEVT channel Retention value to a
+// behavior. This key does not use the legacy seconds encoding the classic logs
+// use: it is a flag, 0 for "overwrite events as needed" and non-zero for "do
+// not overwrite events". Passing it to decodeRetention would read a channel
+// configured to retain its events as one that overwrites them after a day.
+func decodeChannelRetention(n int64) string {
+	if n == 0 {
+		return retentionOverwriteAsNeeded
+	}
+	return retentionNeverOverwrite
+}
+
+// decodeLogMode maps the effective LogMode Windows reports for a channel to a
+// behavior, and reports whether it was recognized. AutoBackup archives the log
+// when it is full and starts a new one, so like Retain it does not overwrite.
+func decodeLogMode(mode string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "circular":
+		return retentionOverwriteAsNeeded, true
+	case "autobackup", "retain":
+		return retentionNeverOverwrite, true
+	default:
+		return "", false
+	}
+}
+
+// resolveRetention picks the retention behavior out of the sources in the
+// order Windows applies them.
+//
+// A modern provider channel such as Microsoft-Windows-PowerShell/Operational
+// is not under Services\EventLog at all. Without the WINEVT and LogMode
+// sources every one of them resolved to the documented Windows default, so a
+// channel explicitly configured not to overwrite its events was reported as
+// overwriting them as needed, which is the reading that lets an audit pass.
+func (w *mqlWindowsEventlog) resolveRetention() (string, error) {
 	n, ok, err := w.retentionRaw()
 	if err != nil {
 		return "", err
 	}
-	if !ok {
-		// Windows overwrites events as needed by default
-		return retentionOverwriteAsNeeded, nil
+	if ok {
+		return decodeRetention(n), nil
 	}
-	return decodeRetention(n), nil
+
+	if n, ok := lookupInt(w.channel, "retention"); ok {
+		return decodeChannelRetention(n), nil
+	}
+
+	// The effective behavior the channel itself reports. It costs a command,
+	// so a connection that cannot run one still resolves to the default below
+	// rather than failing: this source is an improvement on the default, not a
+	// replacement for the registry chain.
+	if state, err := w.loadState(); err == nil {
+		if mode, ok := decodeLogMode(state.LogMode); ok {
+			return mode, nil
+		}
+	}
+
+	// Windows overwrites events as needed by default
+	return retentionOverwriteAsNeeded, nil
+}
+
+func (w *mqlWindowsEventlog) retention() (string, error) {
+	return w.resolveRetention()
 }
 
 // decodeRetention maps a Retention value to a human-readable behavior. The
@@ -250,15 +308,14 @@ func decodeRetention(n int64) string {
 	}
 }
 
+// overwriteAsNeeded is derived from the same resolution retention uses, so the
+// two can never disagree about the same channel.
 func (w *mqlWindowsEventlog) overwriteAsNeeded() (bool, error) {
-	n, ok, err := w.retentionRaw()
+	behavior, err := w.resolveRetention()
 	if err != nil {
 		return false, err
 	}
-	if !ok {
-		return true, nil
-	}
-	return n == 0, nil
+	return behavior == retentionOverwriteAsNeeded, nil
 }
 
 // lookupInt returns the int64 value of a registry item from the given key map.

--- a/providers/os/resources/windows_eventlog_internal_test.go
+++ b/providers/os/resources/windows_eventlog_internal_test.go
@@ -121,3 +121,45 @@ func TestResolveMaxSizeKB(t *testing.T) {
 		assert.Equal(t, int64(0), n)
 	})
 }
+
+func TestDecodeChannelRetention(t *testing.T) {
+	// The WINEVT channel key is a flag, not the seconds period the classic
+	// Services\EventLog key uses. Feeding a 1 to decodeRetention would report
+	// a channel configured to retain its events as one that overwrites them
+	// after a single day, which is the mistake this decode exists to avoid.
+	assert.Equal(t, retentionOverwriteAsNeeded, decodeChannelRetention(0))
+	assert.Equal(t, retentionNeverOverwrite, decodeChannelRetention(1))
+	assert.Equal(t, retentionNeverOverwrite, decodeChannelRetention(-1))
+
+	assert.Equal(t, retentionOverwriteByDays, decodeRetention(1),
+		"the seconds encoding must keep reading a 1 as a period, so the two decodes stay distinct")
+}
+
+func TestDecodeLogMode(t *testing.T) {
+	tests := []struct {
+		mode string
+		want string
+		ok   bool
+	}{
+		{mode: "Circular", want: retentionOverwriteAsNeeded, ok: true},
+		{mode: "circular", want: retentionOverwriteAsNeeded, ok: true},
+		// Both of these keep the events: Retain refuses new ones once full,
+		// AutoBackup archives the log and starts a new one. Neither overwrites.
+		{mode: "Retain", want: retentionNeverOverwrite, ok: true},
+		{mode: "AutoBackup", want: retentionNeverOverwrite, ok: true},
+		{mode: " Retain ", want: retentionNeverOverwrite, ok: true},
+		// An unrecognized or absent mode must not resolve to anything, so the
+		// caller falls through to the documented default rather than guessing.
+		{mode: "", ok: false},
+		{mode: "Whatever", ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.mode, func(t *testing.T) {
+			got, ok := decodeLogMode(tt.mode)
+			assert.Equal(t, tt.ok, ok)
+			if tt.ok {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`windows.eventlog.retention` and `overwriteAsNeeded` consulted only the Group Policy key and the classic `Services\EventLog` key. A modern provider channel such as `Microsoft-Windows-PowerShell/Operational` is not under `Services\EventLog` at all, so every one of them missed both sources and fell through to the documented Windows default. A channel explicitly configured **not** to overwrite its events was reported as overwriting them as needed — the reading that lets an audit pass.

#10362 added the WINEVT channel key as a source for `maxSizeKB`; `retention` never got it. This is the follow-up that PR deliberately deferred.

## Measured

Windows Server 2022, by setting the flag and restoring it:

```
HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WINEVT\Channels\
  Microsoft-Windows-TaskScheduler/Operational
    Retention = 1        (do not overwrite events)
```

| | `retention` | `overwriteAsNeeded` |
|---|---|---|
| before | `"overwrite_as_needed"` | `true` |
| after | `"never_overwrite"` | `false` |

The same channel's `maxSizeKB` read `10240` from that key throughout, so the two fields were sourced inconsistently from one registry key.

## Why it could not just be appended to the chain

The WINEVT key does not use the legacy seconds encoding the classic logs use. It is a flag: `0` for "overwrite as needed", non-zero for "do not overwrite". Feeding it to `decodeRetention` would have read a channel configured to *retain* its events as one that overwrites them after a single day. It gets its own decode.

## LogMode as a last source

The channel's own effective `LogMode` is added before the default, so a channel left at whatever its manifest declares resolves from what Windows actually does rather than from an assumption. It costs nothing: `loadState` already fetches the channel in the same round trip that backs `enabled`, `logFilePath` and `recordCount`. `AutoBackup` and `Retain` both mean the channel does not overwrite; `Circular` means it does.

A connection that cannot run commands still resolves through the registry chain to the default, exactly as before — this source is an improvement on the default, not a replacement for the registry.

## Resolution order

`retention` now reads the first source that carries a value: Group Policy `Retention` → `Services\EventLog\Retention` (both seconds) → WINEVT `Retention` (flag) → live `LogMode` → the documented `overwrite_as_needed` default.

`overwriteAsNeeded` is derived from that same resolution, so the two can no longer disagree about one channel.

## Verification

Rebuilt provider against Server 2016, 2022 and 2025: `Security` 20480 KB / `overwrite_as_needed`, `Microsoft-Windows-PowerShell/Operational` 15360 KB / `overwrite_as_needed`, `Microsoft-Windows-WinRM/Operational` 1028 KB / `overwrite_as_needed` — all matching `Get-WinEvent -ListLog` on the same host.
