### PR TITLE
🐛 os: report a scheduled task that has never run as null, not as 1999

### DIFF
--- a/providers/os/resources/windows_scheduledtask.go
+++ b/providers/os/resources/windows_scheduledtask.go
@@ -319,10 +319,27 @@ func parseWindowsTaskTime(value string) *time.Time {
 	return nil
 }
 
-// normalizeWindowsTaskTime maps the Task Scheduler "never ran" sentinel — any
-// pre-1980 date, e.g. 1899-11-30 — to nil.
+// taskSchedulerNeverRun is the "never ran" value the Task Scheduler 2.0 API
+// reports for a task that has not run: 1999-11-30T00:00:00. It is not a
+// plausible run time, but it is recent enough that a pre-1980 cutoff lets it
+// through, and every task Windows ships with but never runs carries it. The
+// legacy API uses 1899-12-30 instead, which the cutoff does catch.
+var taskSchedulerNeverRun = time.Date(1999, time.November, 30, 0, 0, 0, 0, time.UTC)
+
+// normalizeWindowsTaskTime maps the Task Scheduler "never ran" sentinels to
+// nil: any pre-1980 date (e.g. 1899-12-30) and the 1999-11-30 value the modern
+// API uses.
+//
+// Reporting the sentinel as a real timestamp is worse than reporting nothing.
+// A task that has never run answers "when did this last run" with a concrete
+// date, so an audit asserting that a task ran recently sees a value rather
+// than a null, and one asserting the field is set passes on a task that has
+// never executed.
 func normalizeWindowsTaskTime(tm *time.Time) *time.Time {
 	if tm == nil || tm.Year() < 1980 {
+		return nil
+	}
+	if tm.UTC().Equal(taskSchedulerNeverRun) {
 		return nil
 	}
 	return tm

--- a/providers/os/resources/windows_scheduledtask_test.go
+++ b/providers/os/resources/windows_scheduledtask_test.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,4 +55,44 @@ func TestParseWindowsTaskTime(t *testing.T) {
 
 	// unparseable input yields nil
 	assert.Nil(t, parseWindowsTaskTime("not-a-date"))
+}
+
+func TestParseWindowsTaskTimeNeverRanSentinels(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		// The value the Task Scheduler 2.0 API reports for a task that has
+		// never run. It is recent enough to clear a pre-1980 cutoff, so it
+		// used to be returned as a real timestamp.
+		{name: "modern API sentinel", value: "1999-11-30T00:00:00"},
+		{name: "modern API sentinel, round-trip form", value: "1999-11-30T00:00:00.0000000"},
+		{name: "modern API sentinel, RFC3339 UTC", value: "1999-11-30T00:00:00Z"},
+		{name: "modern API sentinel, /Date(ms)/ form", value: "/Date(943920000000)/"},
+		// The legacy API's sentinel, which the pre-1980 cutoff already caught.
+		{name: "legacy API sentinel", value: "1899-12-30T00:00:00"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Nil(t, parseWindowsTaskTime(tt.value),
+				"a task that has never run must report null, not a date an audit can compare against")
+		})
+	}
+}
+
+func TestParseWindowsTaskTimeKeepsRealRuns(t *testing.T) {
+	// A real run on the day after the sentinel must survive: the guard is an
+	// exact match on the sentinel instant, not a cutoff that swallows 1999.
+	got := parseWindowsTaskTime("1999-12-01T00:00:00Z")
+	require.NotNil(t, got)
+	assert.Equal(t, time.Date(1999, 12, 1, 0, 0, 0, 0, time.UTC), got.UTC())
+
+	// The same date as the sentinel but a different time of day is a real run.
+	got = parseWindowsTaskTime("1999-11-30T09:30:00Z")
+	require.NotNil(t, got)
+	assert.Equal(t, time.Date(1999, 11, 30, 9, 30, 0, 0, time.UTC), got.UTC())
+
+	got = parseWindowsTaskTime("2026-08-12T21:57:57Z")
+	require.NotNil(t, got)
+	assert.Equal(t, time.Date(2026, 8, 12, 21, 57, 57, 0, time.UTC), got.UTC())
 }


### PR DESCRIPTION
`windows.scheduledTask.lastRunTime` normalized the Task Scheduler "never ran" sentinel only when it was pre-1980. The modern Task Scheduler API does not use a pre-1980 value: it reports **1999-11-30T00:00:00**, which sails through the cutoff and was returned as a real timestamp.

## Measured

Windows Server 2016, 2019 and 2022, for a task Windows ships enabled and has never run:

```
Get-ScheduledTaskInfo \Microsoft\Windows\Defrag\ScheduledDefrag
  LastRunTime    : 11/30/1999 12:00:00 AM
  LastTaskResult : 267011          (SCHED_S_TASK_HAS_NOT_RUN)
```

| | `lastRunTime` | `lastTaskResult` |
|---|---|---|
| before | `1999-11-29 16:00:00 -0800 PST` | `267011` |
| after | `null` | `267011` |

The task result says plainly that the task has never run, while `lastRunTime` offered a date. An audit asserting a task ran recently sees a value instead of a null, and one asserting the field is set passes on a task that has never executed.

On Server 2025 the same task *had* run (`LastRunTime 8/12/2026`, `LastTaskResult 0`) and is unaffected — real timestamps are untouched.

## Fix

1999-11-30T00:00:00 is treated as a sentinel alongside the pre-1980 cutoff, which still covers the legacy API's 1899-12-30.

## Verification

Rebuilt provider against Server 2022: `windows.scheduledTasks.where(name == "ScheduledDefrag") { lastRunTime lastTaskResult }` now returns `lastRunTime: null` with `lastTaskResult: 267011`.
