### PR TITLE
🐛 llx: only log the malformed-primitive error for husks that hold content

### DIFF
--- a/llx/data_conversions.go
+++ b/llx/data_conversions.go
@@ -816,25 +816,41 @@ func primitive2rawdataMapV2(m map[string]*Primitive) (map[string]any, error) {
 // RawData converts the primitive into the internal go-representation of the
 // data that can be used for computations
 func (p *Primitive) RawData() *RawData {
-	// A primitive with no type information is malformed: it is never produced
-	// deliberately (a genuine null is `NilPrimitive`, with Type == types.Nil).
-	// It only appears when an upstream layer emits a broken primitive — a
-	// provider encoding an unset field (see plugin.TValue.ToDataRes) or the
-	// compiler binding a predicate's value field to a resource that lacks it
-	// (see mqlc.addValueFieldChunks).
+	// A primitive with no type information is never produced deliberately (a
+	// genuine null is `NilPrimitive`, with Type == types.Nil). It appears in
+	// two situations, distinguished by whether it carries content:
 	//
-	// Behavior here is loud-and-narrow:
-	//   - narrow: coerce just this field to null instead of returning an error.
-	//     An error would propagate through primitive2array / primitive2rawdataMapV2
-	//     and discard the entire surrounding collection (parray2raw rewrites the
-	//     dropped slice to an empty `[]`), so one broken leaf would empty a whole
-	//     failing-resource list and surface as an empty assessment.
-	//   - loud: log it. Silently coercing to a fake-valid null is what made the
-	//     original compiler bug nearly impossible to find; logging keeps the
-	//     underlying (usually compiler) defect visible even though we degrade
-	//     gracefully for the surrounding data.
+	//   - A nil or completely empty primitive is the husk of a value that was
+	//     holding an error or was never set: an errored value frequently
+	//     carries no type (e.g. a provider error is wrapped as a bare
+	//     &RawData{Error: ...} at the plugin boundary), RawData.Result() stamps
+	//     only the type on it, and block2result strips the per-field error when
+	//     nesting, leaving {} behind (e.g. a `ports { process }` block where a
+	//     port's process lookup failed). A provider that answers with neither
+	//     data nor an error hands us a nil *Primitive outright (see
+	//     providers.Runtime watchAndUpdate), which is why the checks below go
+	//     through the nil-safe generated getters rather than the fields. The
+	//     error, if any, already surfaced on the Result / query score, and a
+	//     provider unset field is separately reported with full
+	//     provider/resource/field attribution by providers.Runtime GetData, so
+	//     re-reporting the husk on every read of the stored data would only
+	//     duplicate it as unattributable noise. Coerce it to null quietly.
+	//
+	//   - A typeless primitive that still holds content is malformed: an
+	//     upstream layer emitted a broken primitive, e.g. the compiler binding
+	//     a predicate's value field to a resource that lacks it (see
+	//     mqlc.addValueFieldChunks). Stay loud-and-narrow: log at error level
+	//     (silently coercing is what made the original compiler bug nearly
+	//     impossible to find), but coerce just this field to null instead of
+	//     returning an error — an error would propagate through
+	//     primitive2array / primitive2rawdataMapV2 and discard the entire
+	//     surrounding collection (parray2raw rewrites the dropped slice to an
+	//     empty `[]`), so one broken leaf would empty a whole failing-resource
+	//     list and surface as an empty assessment.
 	if p.GetType() == "" {
-		log.Error().Msg("llx: encountered a primitive with no type information, coercing to null (an upstream layer — a provider or the compiler — produced a malformed primitive)")
+		if len(p.GetValue()) != 0 || len(p.GetArray()) != 0 || len(p.GetMap()) != 0 {
+			log.Error().Msg("llx: encountered a primitive with no type information, coercing to null (an upstream layer — a provider or the compiler — produced a malformed primitive)")
+		}
 		return &RawData{Type: types.Nil}
 	}
 

--- a/llx/data_conversions_test.go
+++ b/llx/data_conversions_test.go
@@ -4,6 +4,7 @@
 package llx_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -87,6 +88,81 @@ func TestEmptyTypePrimitiveConvertsToNil(t *testing.T) {
 	require.NoError(t, rd.Error)
 	assert.Equal(t, types.Nil, rd.Type)
 	assert.Nil(t, rd.Value)
+}
+
+// TestNilPrimitiveConvertsToNil is a regression test for a nil-receiver panic.
+// providers.Runtime watchAndUpdate calls data.Data.RawData() unconditionally,
+// and a provider that answers with neither data nor an error leaves data.Data
+// nil — so RawData must tolerate a nil *Primitive. Probing the husk with the
+// bare fields (p.Value) instead of the nil-safe generated getters crashes the
+// whole scan here, because the executor runs blocks in goroutines.
+func TestNilPrimitiveConvertsToNil(t *testing.T) {
+	var p *llx.Primitive
+	require.NotPanics(t, func() {
+		rd := p.RawData()
+		require.NoError(t, rd.Error)
+		assert.Equal(t, types.Nil, rd.Type)
+		assert.Nil(t, rd.Value)
+	})
+}
+
+// TestErroredUntypedRawDataRoundTrip: an errored RawData without type info
+// (e.g. a provider error wrapped as a bare &RawData{Error: ...} at the plugin
+// boundary) serializes with a typeless data primitive next to the error;
+// reading it back must yield a clean typed null carrying the error.
+func TestErroredUntypedRawDataRoundTrip(t *testing.T) {
+	rd := &llx.RawData{Error: errors.New("field failed")}
+	res := rd.Result()
+	require.NotNil(t, res)
+	assert.Equal(t, "field failed", res.Error)
+	require.NotNil(t, res.Data)
+	assert.Equal(t, "", res.Data.Type)
+
+	back := res.RawData()
+	assert.Equal(t, types.Nil, back.Type)
+	assert.EqualError(t, back.Error, "field failed")
+}
+
+// An errored RawData that does carry type info must keep it.
+func TestErroredTypedRawDataResultKeepsType(t *testing.T) {
+	rd := &llx.RawData{Type: types.Bool, Error: errors.New("field failed")}
+	res := rd.Result()
+	require.NotNil(t, res)
+	assert.Equal(t, string(types.Bool), res.Data.Type)
+	assert.Equal(t, "field failed", res.Error)
+}
+
+// TestBlockWithErroredFieldReadsBackAsNull mirrors a `ports { ... process }`
+// block where one field errored: block2result keeps only Result().Data for
+// nested fields (the error is carried by the query score instead), leaving a
+// typeless empty husk behind. Reading the block back must coerce the husk to
+// a clean null and must not error or drop the surrounding block.
+func TestBlockWithErroredFieldReadsBackAsNull(t *testing.T) {
+	blk := &llx.RawData{
+		Type: types.Block,
+		Value: map[string]any{
+			"ok":  llx.StringData("fine"),
+			"bad": &llx.RawData{Error: errors.New("no process for this port")},
+		},
+	}
+	res := blk.Result()
+	require.NotNil(t, res)
+	require.NotNil(t, res.Data)
+	m := res.Data.Map
+	require.NotNil(t, m)
+	require.Contains(t, m, "bad")
+	assert.Equal(t, "", m["bad"].Type,
+		"the nested errored field serializes as a typeless husk (Primitive cannot carry the error)")
+	assert.Equal(t, string(types.String), m["ok"].Type)
+
+	back := res.RawData()
+	require.NoError(t, back.Error)
+	backMap, ok := back.Value.(map[string]any)
+	require.True(t, ok)
+	badBack, ok := backMap["bad"].(*llx.RawData)
+	require.True(t, ok)
+	assert.Equal(t, types.Nil, badBack.Type)
+	assert.Nil(t, badBack.Value)
 }
 
 // TestEmptyTypePrimitiveKeepsCollection is a regression test for empty


### PR DESCRIPTION
Follow-up to #10377 — the log-noise half of mondoo-community/customer-issues#219, split out so the port fix ships independently.

## Problem

When a field errors, the error frequently crosses the plugin boundary as a bare `&RawData{Error: ...}` with **no type** (`providers/runtime.go` wraps `DataRes` errors this way, and many llx builtins return the same shape). `block2result` nests only `Result().Data` into block values, stripping the per-field error — the proto `Primitive` has no error field, so there is nowhere for it to go on the wire. The stored report ends up holding a bare `{}` husk for that field, and every later read of the data (e.g. the CLI reporter rendering the report after a scan) logged the anonymous

```
llx: encountered a primitive with no type information, coercing to null (...)
```

once per husk, even though the error already surfaced on the top-level `Result.Error` and the query score. In the customer's bundle: 6 TIME_WAIT sockets erroring in `ports { process }` blocks x 2 queries = 12 unattributable log lines per scan.

## Fix

`Primitive.RawData()` now distinguishes the two typeless-primitive cases by the only signal that survives serialization — the primitive's shape:

- **Completely empty** (`{}`: no value bytes, no array, no map): the husk of an errored or unset value. Nothing on the error path can produce anything else, coercing it to null loses no data, and the error was already reported (on the Result/score; a provider unset field is separately reported with full provider/resource/field attribution by `providers.Runtime.GetData`). Coerced quietly.
- **Holds content** (value/array/map non-empty): cannot come from the error path — something upstream built a primitive with real data and lost the type, and that data is about to be silently dropped. This keeps the error-level log (the genuine compiler-bug fingerprint, e.g. `mqlc.addValueFieldChunks`).

An earlier revision of this PR also stamped `types.Nil` on untyped errored values in `RawData.Result()` so husks would serialize as typed nulls; that was dropped for now to avoid changing the wire shape of errored results while we think through the implications. The deeper gap — the per-field error not surviving `block2result` at all — would need an error field on the proto `Primitive` and stays out of scope.

## Testing

- New unit tests: an untyped errored RawData round-trips to a typed null carrying the error; a typed errored RawData keeps its type; a `ports { process }`-shaped block with an errored field serializes the field as a typeless husk and reads back as a clean null without dropping the surrounding block.
- `gofmt`, `go build ./llx/...`, `go vet ./llx/` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)