### PR TITLE
🧹 os: capture real Windows DNS Server output as per-release test fixtures

### DIFF
--- a/providers/os/resources/windows/dnsserver_versions_test.go
+++ b/providers/os/resources/windows/dnsserver_versions_test.go
@@ -1,0 +1,303 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package windows
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The fixtures behind this file are the verbatim stdout of DNS_SERVER_SETTINGS
+// and DNS_SERVER_ZONES, captured over SSH from four Windows Server hosts with
+// the DNS Server role installed: 2016 (build 14393), 2019 (17763), 2022 (20348)
+// and 2025 (26100). Host names, the host's own addresses and the DNSSEC key
+// identifiers are replaced with fixed placeholders; every configured value the
+// server reported is untouched.
+//
+// Each host was put into the same state before capture, so the four payloads
+// are comparable field by field:
+//
+//   - two forwarders, which is the case that decodes through the
+//     {"value":[...],"Count":n} shape rather than a plain array,
+//   - a debug-log address filter, a second list in that shape,
+//   - one permissive unsigned zone (lab.test), which transfers to any server
+//     and accepts unauthenticated dynamic updates,
+//   - one DNSSEC-signed zone (signed.test) with a key signing key and a zone
+//     signing key,
+//   - and the three auto-created reverse zones a stock server carries.
+type dnsServerRelease struct {
+	name  string
+	build int64
+}
+
+var dnsServerReleases = []dnsServerRelease{
+	{name: "2016", build: 14393},
+	{name: "2019", build: 17763},
+	{name: "2022", build: 20348},
+	{name: "2025", build: 26100},
+}
+
+func loadReleaseConfig(t *testing.T, release string) *WindowsDnsServerConfig {
+	t.Helper()
+	f, err := os.Open("testdata/dnsserver-settings-" + release + ".json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	res, err := ParseWindowsDnsServerConfig(f)
+	require.NoError(t, err)
+	return res
+}
+
+func loadReleaseZones(t *testing.T, release string) map[string]WindowsDnsServerZone {
+	t.Helper()
+	f, err := os.Open("testdata/dnsserver-zones-" + release + ".json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	zones, err := ParseWindowsDnsServerZones(f)
+	require.NoError(t, err)
+
+	byName := make(map[string]WindowsDnsServerZone, len(zones))
+	for _, z := range zones {
+		byName[z.ZoneName] = z
+	}
+	return byName
+}
+
+// Every value asserted here was read off a live server. A property the DnsServer
+// module stops reporting on a newer release comes back as JSON null and decodes
+// to a Go zero value, which for most of these is the hardened reading: recursion
+// off, pollution protection off, no forwarders, no listening addresses. Pinning
+// the real values on each release is what separates "the server reports this" from
+// "the server reported nothing and we called it false".
+func TestParseWindowsDnsServerAcrossReleases(t *testing.T) {
+	for _, release := range dnsServerReleases {
+		t.Run(release.name, func(t *testing.T) {
+			cfg := loadReleaseConfig(t, release.name)
+
+			s := cfg.Settings
+			assert.Equal(t, release.build, s.BuildNumber, "wrong capture for this release")
+			assert.Equal(t, int64(10), s.MajorVersion)
+			assert.True(t, s.EnableDnsSec)
+			assert.True(t, s.EnableIPv6)
+			assert.True(t, s.EnableOnlineSigning)
+			assert.True(t, s.RoundRobin)
+			assert.False(t, s.BindSecondaries)
+			assert.False(t, s.StrictFileParsing)
+			assert.False(t, s.DsAvailable, "a standalone server is not directory joined")
+			assert.False(t, s.IsReadOnlyDC)
+			assert.Equal(t, int64(2500), s.SocketPoolSize, "the source port randomization pool")
+			assert.Equal(t, int64(0), s.EnableVersionQuery)
+			assert.Equal(t, int64(2), s.NameCheckFlag)
+			assert.Equal(t, int64(0), s.AddressAnswerLimit)
+			assert.Equal(t, int64(30), s.XfrConnectTimeout)
+			assert.Equal(t, "", s.ServerLevelPluginDll, "no plug-in DLL is loaded on a stock server")
+			assert.Equal(t, "https://data.iana.org/root-anchors/root-anchors.xml", s.RootTrustAnchorsURL)
+			assert.Empty(t, s.SocketPoolExcludedPortRanges)
+
+			// The addresses arrive wrapped by Select-Object rather than as a
+			// plain array. None of these servers was restricted to specific
+			// addresses, and an unrestricted server still reports every address
+			// it is bound to: the list is populated and equals AllIPAddress
+			// rather than being empty.
+			assert.Equal(t, PSStringArray{"fe80::73f5:a0d4:e6d3:d2a9", "10.0.0.4"}, s.ListeningIPAddress)
+			assert.Equal(t, s.AllIPAddress, s.ListeningIPAddress)
+
+			assert.True(t, cfg.Recursion.Enable)
+			assert.True(t, cfg.Recursion.SecureResponse)
+			assert.Equal(t, int64(8), cfg.Recursion.Timeout)
+			assert.Equal(t, int64(3), cfg.Recursion.RetryInterval)
+			assert.Equal(t, int64(4), cfg.Recursion.AdditionalTimeout)
+
+			assert.True(t, cfg.Cache.EnablePollutionProtection)
+			assert.True(t, cfg.Cache.StoreEmptyAuthenticationResponse)
+			assert.False(t, cfg.Cache.IgnorePolicies)
+			assert.Equal(t, int64(100), cfg.Cache.LockingPercent)
+			assert.Equal(t, int64(0), cfg.Cache.MaxKBSize)
+			require.NotNil(t, cfg.Cache.MaxTtl)
+			assert.Equal(t, int64(86400), *cfg.Cache.MaxTtl.Seconds())
+			require.NotNil(t, cfg.Cache.MaxNegativeTtl)
+			assert.Equal(t, int64(900), *cfg.Cache.MaxNegativeTtl.Seconds())
+
+			d := cfg.Diagnostics
+			assert.Equal(t, int64(4), d.EventLogLevel)
+			assert.False(t, d.UseSystemEventLog)
+			assert.True(t, d.EnableLoggingToFile)
+			assert.Equal(t, "", d.LogFilePath, "the default path is reported as absent")
+			// MaxMBFileSize is a byte count despite its name: this is the
+			// Windows default of 500 MB, written through to the LogFileMaxSize
+			// registry value unchanged.
+			assert.Equal(t, int64(500000000), d.MaxMBFileSize)
+			assert.False(t, d.Queries)
+			assert.False(t, d.Answers)
+			assert.False(t, d.FullPackets)
+			assert.Equal(t, PSStringArray{"192.0.2.10"}, d.FilterIPAddressList,
+				"a one-element list flattens, and must not decode to empty")
+
+			sc := cfg.Scavenging
+			assert.False(t, sc.ScavengingState)
+			require.NotNil(t, sc.RefreshInterval)
+			assert.Equal(t, int64(604800), *sc.RefreshInterval.Seconds())
+			require.NotNil(t, sc.NoRefreshInterval)
+			assert.Equal(t, int64(604800), *sc.NoRefreshInterval.Seconds())
+			// Never scavenged, so the timestamp stays null rather than
+			// becoming the zero time.
+			assert.Equal(t, PSString(""), sc.LastScavengeTime)
+			assert.Nil(t, ParseDnsServerTime(sc.LastScavengeTime))
+
+			// Response rate limiting arrived in Server 2016, so it is present
+			// on every release in scope and must not be nil.
+			require.NotNil(t, cfg.ResponseRateLimiting, "rate limiting is reported on this release")
+			rrl := cfg.ResponseRateLimiting
+			assert.Equal(t, "Disable", rrl.Mode)
+			assert.Equal(t, int64(5), rrl.ResponsesPerSec)
+			assert.Equal(t, int64(5), rrl.ErrorsPerSec)
+			assert.Equal(t, int64(5), rrl.WindowInSec)
+			assert.Equal(t, int64(24), rrl.IPv4PrefixLength)
+			assert.Equal(t, int64(56), rrl.IPv6PrefixLength)
+			assert.Equal(t, int64(3), rrl.LeakRate)
+			assert.Equal(t, int64(2), rrl.TruncateRate)
+			assert.Equal(t, int64(1024), rrl.MaximumResponsesPerWindow)
+
+			// Two forwarders were configured. Decoding this to empty is the
+			// failure that reports an open resolver as one that forwards.
+			require.NotNil(t, cfg.Forwarders)
+			assert.Equal(t, PSStringArray{"1.1.1.1", "9.9.9.9"}, cfg.Forwarders.IPAddress)
+			assert.True(t, cfg.Forwarders.UseRootHint)
+			assert.True(t, cfg.Forwarders.EnableReordering)
+			assert.Equal(t, int64(3), cfg.Forwarders.Timeout)
+
+			require.Len(t, cfg.RootHints, 13)
+			assert.Equal(t, "A.ROOT-SERVERS.NET.", cfg.RootHints[0].NameServer)
+			assert.Equal(t, PSStringArray{"198.41.0.4", "2001:503:ba3e::2:30"}, cfg.RootHints[0].IPAddress)
+			// E.ROOT-SERVERS.NET carries only a v4 glue record, which is the
+			// branch that falls back from IPv4Address to IPv6Address.
+			assert.Equal(t, PSStringArray{"192.203.230.10"}, cfg.RootHints[4].IPAddress)
+		})
+	}
+}
+
+func TestParseWindowsDnsServerZonesAcrossReleases(t *testing.T) {
+	for _, release := range dnsServerReleases {
+		t.Run(release.name, func(t *testing.T) {
+			zones := loadReleaseZones(t, release.name)
+			require.Len(t, zones, 5)
+
+			// An auto-created reverse zone reports no zone file at all, which
+			// is a separate case from a directory-integrated zone reporting
+			// none.
+			reverse := zones["127.in-addr.arpa"]
+			assert.True(t, reverse.IsAutoCreated)
+			assert.True(t, reverse.IsReverseLookupZone)
+			assert.Equal(t, "", reverse.ZoneFile)
+			assert.Equal(t, "None", reverse.ReplicationScope)
+
+			// The permissive zone: hands the full zone to anyone who asks, and
+			// takes record changes from anyone who sends them.
+			lab := zones["lab.test"]
+			assert.Equal(t, "Primary", lab.ZoneType)
+			assert.Equal(t, "TransferAnyServer", lab.SecureSecondaries)
+			assert.Equal(t, "NonsecureAndSecure", lab.DynamicUpdate)
+			assert.Equal(t, "NoNotify", lab.Notify)
+			assert.False(t, lab.IsSigned)
+			assert.False(t, lab.IsDsIntegrated)
+			assert.False(t, lab.IsAutoCreated)
+			assert.False(t, lab.IsWinsEnabled)
+			assert.Equal(t, "lab.test.dns", lab.ZoneFile)
+			assert.Empty(t, lab.SecondaryServers)
+			// An unsigned zone carries no DNSSEC settings and no keys.
+			assert.Nil(t, lab.Dnssec)
+			assert.Empty(t, lab.SigningKeys)
+
+			signed := zones["signed.test"]
+			assert.True(t, signed.IsSigned)
+			assert.Equal(t, "None", signed.DynamicUpdate)
+			assert.Equal(t, "TransferToZoneNameServer", signed.SecureSecondaries)
+
+			require.NotNil(t, signed.Dnssec, "a signed zone's settings must be attached to it")
+			ds := signed.Dnssec
+			assert.Equal(t, "NSec3", ds.DenialOfExistence)
+			assert.Equal(t, int64(50), ds.NSec3Iterations)
+			assert.Equal(t, int64(8), ds.NSec3RandomSaltLength)
+			assert.False(t, ds.NSec3OptOut)
+			assert.True(t, ds.EnableRfc5011KeyRollover)
+			assert.False(t, ds.ParentHasSecureDelegation)
+			assert.True(t, ds.IsKeyMasterServer)
+			assert.Equal(t, PSStringArray{"Sha1", "Sha256"}, ds.DSRecordGenerationAlgorithm)
+			assert.Equal(t, PSStringArray{"None"}, ds.DistributeTrustAnchor)
+			require.NotNil(t, ds.SignatureInceptionOffset)
+			assert.Equal(t, int64(3600), *ds.SignatureInceptionOffset.Seconds())
+			require.NotNil(t, ds.SecureDelegationPollingPeriod)
+			assert.Equal(t, int64(43200), *ds.SecureDelegationPollingPeriod.Seconds())
+			require.NotNil(t, ds.DSRecordSetTtl)
+			assert.Equal(t, int64(3600), *ds.DSRecordSetTtl.Seconds())
+			require.NotNil(t, ds.DnsKeyRecordSetTtl)
+			assert.Equal(t, int64(3600), *ds.DnsKeyRecordSetTtl.Seconds())
+			// PropagationTime is genuinely zero on a single-server zone, which
+			// is a reported value and not an absent one.
+			require.NotNil(t, ds.PropagationTime)
+			assert.Equal(t, int64(0), *ds.PropagationTime.Seconds())
+
+			byType := map[string]WindowsDnsServerSigningKey{}
+			for _, k := range signed.SigningKeys {
+				byType[k.KeyType] = k
+			}
+			require.Len(t, signed.SigningKeys, 2)
+			require.Contains(t, byType, "KeySigningKey")
+			require.Contains(t, byType, "ZoneSigningKey")
+
+			ksk := byType["KeySigningKey"]
+			assert.Equal(t, "signed.test", ksk.ZoneName, "a key without its zone name joins to no zone")
+			assert.Equal(t, "RsaSha256", ksk.CryptoAlgorithm)
+			assert.Equal(t, int64(2048), ksk.KeyLength)
+			assert.Equal(t, "Active", ksk.CurrentState)
+			assert.Equal(t, "Microsoft Software Key Storage Provider", ksk.KeyStorageProvider)
+			assert.False(t, ksk.StoreKeysInAD)
+			assert.True(t, ksk.IsRolloverEnabled)
+			require.NotNil(t, ksk.RolloverPeriod)
+			assert.Equal(t, int64(65232000), *ksk.RolloverPeriod.Seconds())
+			require.NotNil(t, ksk.DnsKeySignatureValidityPeriod)
+			assert.Equal(t, int64(604800), *ksk.DnsKeySignatureValidityPeriod.Seconds())
+			require.NotNil(t, ksk.ZoneSignatureValidityPeriod)
+			assert.Equal(t, int64(864000), *ksk.ZoneSignatureValidityPeriod.Seconds())
+
+			zsk := byType["ZoneSigningKey"]
+			assert.Equal(t, int64(1024), zsk.KeyLength)
+			require.NotNil(t, zsk.RolloverPeriod)
+			assert.Equal(t, int64(7776000), *zsk.RolloverPeriod.Seconds())
+			assert.NotEqual(t, ksk.KeyId, zsk.KeyId, "the two keys of one zone must be distinguishable")
+		})
+	}
+}
+
+// The four hosts were configured identically, so any difference between the
+// decoded payloads is the DnsServer module reporting something differently on
+// one release rather than the servers disagreeing. Nothing in the modeled set
+// differs today, build number aside. A future release that renames, retypes or
+// drops one of these properties fails here, where the cause is legible, instead
+// of surfacing as a field that quietly reads false on that release alone.
+func TestWindowsDnsServerDoesNotDriftAcrossReleases(t *testing.T) {
+	base := dnsServerReleases[0]
+
+	normalize := func(cfg *WindowsDnsServerConfig) string {
+		t.Helper()
+		// The build number is the one value that is meant to differ.
+		cfg.Settings.BuildNumber = 0
+		out, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		return string(out)
+	}
+
+	want := normalize(loadReleaseConfig(t, base.name))
+	for _, release := range dnsServerReleases[1:] {
+		t.Run(release.name, func(t *testing.T) {
+			assert.Equal(t, want, normalize(loadReleaseConfig(t, release.name)),
+				"the server configuration decodes differently on %s than on %s", release.name, base.name)
+		})
+	}
+}

--- a/providers/os/resources/windows/testdata/dnsserver-settings-2016.json
+++ b/providers/os/resources/windows/testdata/dnsserver-settings-2016.json
@@ -1,0 +1,265 @@
+{
+  "Settings": {
+    "ComputerName": "dnslab",
+    "MajorVersion": 10,
+    "MinorVersion": 0,
+    "BuildNumber": 14393,
+    "EnableDnsSec": true,
+    "EnableVersionQuery": 0,
+    "EnableIPv6": true,
+    "SocketPoolSize": 2500,
+    "RoundRobin": true,
+    "BindSecondaries": false,
+    "StrictFileParsing": false,
+    "NameCheckFlag": 2,
+    "EnableOnlineSigning": true,
+    "AddressAnswerLimit": 0,
+    "XfrConnectTimeout": 30,
+    "DsAvailable": false,
+    "IsReadOnlyDC": false,
+    "ServerLevelPluginDll": null,
+    "RootTrustAnchorsURL": "https://data.iana.org/root-anchors/root-anchors.xml",
+    "ListeningIPAddress": {
+      "value": [
+        "fe80::73f5:a0d4:e6d3:d2a9",
+        "10.0.0.4"
+      ],
+      "Count": 2
+    },
+    "AllIPAddress": {
+      "value": [
+        "fe80::73f5:a0d4:e6d3:d2a9",
+        "10.0.0.4"
+      ],
+      "Count": 2
+    },
+    "SocketPoolExcludedPortRanges": {
+      "value": [],
+      "Count": 0
+    }
+  },
+  "Recursion": {
+    "Enable": true,
+    "SecureResponse": true,
+    "Timeout": 8,
+    "RetryInterval": 3,
+    "AdditionalTimeout": 4
+  },
+  "Cache": {
+    "EnablePollutionProtection": true,
+    "LockingPercent": 100,
+    "MaxKBSize": 0,
+    "MaxTtl": {
+      "Ticks": 864000000000,
+      "Days": 1,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 0,
+      "Seconds": 0,
+      "TotalDays": 1,
+      "TotalHours": 24,
+      "TotalMilliseconds": 86400000,
+      "TotalMinutes": 1440,
+      "TotalSeconds": 86400
+    },
+    "MaxNegativeTtl": {
+      "Ticks": 9000000000,
+      "Days": 0,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 15,
+      "Seconds": 0,
+      "TotalDays": 0.010416666666666666,
+      "TotalHours": 0.25,
+      "TotalMilliseconds": 900000,
+      "TotalMinutes": 15,
+      "TotalSeconds": 900
+    },
+    "StoreEmptyAuthenticationResponse": true,
+    "IgnorePolicies": false
+  },
+  "Diagnostics": {
+    "EventLogLevel": 4,
+    "UseSystemEventLog": false,
+    "EnableLoggingToFile": true,
+    "LogFilePath": null,
+    "MaxMBFileSize": 500000000,
+    "EnableLogFileRollover": false,
+    "SaveLogsToPersistentStorage": false,
+    "Queries": false,
+    "Answers": false,
+    "Notifications": false,
+    "Update": false,
+    "QuestionTransactions": false,
+    "UnmatchedResponse": false,
+    "SendPackets": false,
+    "ReceivePackets": false,
+    "TcpPackets": false,
+    "UdpPackets": false,
+    "FullPackets": false,
+    "WriteThrough": false,
+    "FilterIPAddressList": {
+      "value": [
+        "192.0.2.10"
+      ],
+      "Count": 1
+    }
+  },
+  "Scavenging": {
+    "ScavengingState": false,
+    "ScavengingInterval": {
+      "Ticks": 0,
+      "Days": 0,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 0,
+      "Seconds": 0,
+      "TotalDays": 0,
+      "TotalHours": 0,
+      "TotalMilliseconds": 0,
+      "TotalMinutes": 0,
+      "TotalSeconds": 0
+    },
+    "RefreshInterval": {
+      "Ticks": 6048000000000,
+      "Days": 7,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 0,
+      "Seconds": 0,
+      "TotalDays": 7,
+      "TotalHours": 168,
+      "TotalMilliseconds": 604800000,
+      "TotalMinutes": 10080,
+      "TotalSeconds": 604800
+    },
+    "NoRefreshInterval": {
+      "Ticks": 6048000000000,
+      "Days": 7,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 0,
+      "Seconds": 0,
+      "TotalDays": 7,
+      "TotalHours": 168,
+      "TotalMilliseconds": 604800000,
+      "TotalMinutes": 10080,
+      "TotalSeconds": 604800
+    },
+    "LastScavengeTime": ""
+  },
+  "ResponseRateLimiting": {
+    "Mode": "Disable",
+    "ResponsesPerSec": 5,
+    "ErrorsPerSec": 5,
+    "WindowInSec": 5,
+    "IPv4PrefixLength": 24,
+    "IPv6PrefixLength": 56,
+    "LeakRate": 3,
+    "TruncateRate": 2,
+    "MaximumResponsesPerWindow": 1024
+  },
+  "Forwarders": {
+    "UseRootHint": true,
+    "Timeout": 3,
+    "EnableReordering": true,
+    "IPAddress": {
+      "value": [
+        "1.1.1.1",
+        "9.9.9.9"
+      ],
+      "Count": 2
+    }
+  },
+  "RootHints": [
+    {
+      "NameServer": "A.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "198.41.0.4",
+        "2001:503:ba3e::2:30"
+      ]
+    },
+    {
+      "NameServer": "B.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.228.79.201",
+        "2001:500:84::b"
+      ]
+    },
+    {
+      "NameServer": "C.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.33.4.12",
+        "2001:500:2::c"
+      ]
+    },
+    {
+      "NameServer": "D.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "199.7.91.13",
+        "2001:500:2d::d"
+      ]
+    },
+    {
+      "NameServer": "E.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.203.230.10"
+      ]
+    },
+    {
+      "NameServer": "F.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.5.5.241",
+        "2001:500:2f::f"
+      ]
+    },
+    {
+      "NameServer": "G.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.112.36.4"
+      ]
+    },
+    {
+      "NameServer": "H.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "198.97.190.53",
+        "2001:500:1::53"
+      ]
+    },
+    {
+      "NameServer": "I.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.36.148.17",
+        "2001:7fe::53"
+      ]
+    },
+    {
+      "NameServer": "J.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.58.128.30",
+        "2001:503:c27::2:30"
+      ]
+    },
+    {
+      "NameServer": "K.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "193.0.14.129",
+        "2001:7fd::1"
+      ]
+    },
+    {
+      "NameServer": "L.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "199.7.83.42",
+        "2001:500:9f::42"
+      ]
+    },
+    {
+      "NameServer": "M.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "202.12.27.33",
+        "2001:dc3::35"
+      ]
+    }
+  ]
+}

--- a/providers/os/resources/windows/testdata/dnsserver-settings-2019.json
+++ b/providers/os/resources/windows/testdata/dnsserver-settings-2019.json
@@ -1,0 +1,265 @@
+{
+  "Settings": {
+    "ComputerName": "dnslab",
+    "MajorVersion": 10,
+    "MinorVersion": 0,
+    "BuildNumber": 17763,
+    "EnableDnsSec": true,
+    "EnableVersionQuery": 0,
+    "EnableIPv6": true,
+    "SocketPoolSize": 2500,
+    "RoundRobin": true,
+    "BindSecondaries": false,
+    "StrictFileParsing": false,
+    "NameCheckFlag": 2,
+    "EnableOnlineSigning": true,
+    "AddressAnswerLimit": 0,
+    "XfrConnectTimeout": 30,
+    "DsAvailable": false,
+    "IsReadOnlyDC": false,
+    "ServerLevelPluginDll": null,
+    "RootTrustAnchorsURL": "https://data.iana.org/root-anchors/root-anchors.xml",
+    "ListeningIPAddress": {
+      "value": [
+        "fe80::73f5:a0d4:e6d3:d2a9",
+        "10.0.0.4"
+      ],
+      "Count": 2
+    },
+    "AllIPAddress": {
+      "value": [
+        "fe80::73f5:a0d4:e6d3:d2a9",
+        "10.0.0.4"
+      ],
+      "Count": 2
+    },
+    "SocketPoolExcludedPortRanges": {
+      "value": [],
+      "Count": 0
+    }
+  },
+  "Recursion": {
+    "Enable": true,
+    "SecureResponse": true,
+    "Timeout": 8,
+    "RetryInterval": 3,
+    "AdditionalTimeout": 4
+  },
+  "Cache": {
+    "EnablePollutionProtection": true,
+    "LockingPercent": 100,
+    "MaxKBSize": 0,
+    "MaxTtl": {
+      "Ticks": 864000000000,
+      "Days": 1,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 0,
+      "Seconds": 0,
+      "TotalDays": 1,
+      "TotalHours": 24,
+      "TotalMilliseconds": 86400000,
+      "TotalMinutes": 1440,
+      "TotalSeconds": 86400
+    },
+    "MaxNegativeTtl": {
+      "Ticks": 9000000000,
+      "Days": 0,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 15,
+      "Seconds": 0,
+      "TotalDays": 0.010416666666666666,
+      "TotalHours": 0.25,
+      "TotalMilliseconds": 900000,
+      "TotalMinutes": 15,
+      "TotalSeconds": 900
+    },
+    "StoreEmptyAuthenticationResponse": true,
+    "IgnorePolicies": false
+  },
+  "Diagnostics": {
+    "EventLogLevel": 4,
+    "UseSystemEventLog": false,
+    "EnableLoggingToFile": true,
+    "LogFilePath": null,
+    "MaxMBFileSize": 500000000,
+    "EnableLogFileRollover": false,
+    "SaveLogsToPersistentStorage": false,
+    "Queries": false,
+    "Answers": false,
+    "Notifications": false,
+    "Update": false,
+    "QuestionTransactions": false,
+    "UnmatchedResponse": false,
+    "SendPackets": false,
+    "ReceivePackets": false,
+    "TcpPackets": false,
+    "UdpPackets": false,
+    "FullPackets": false,
+    "WriteThrough": false,
+    "FilterIPAddressList": {
+      "value": [
+        "192.0.2.10"
+      ],
+      "Count": 1
+    }
+  },
+  "Scavenging": {
+    "ScavengingState": false,
+    "ScavengingInterval": {
+      "Ticks": 0,
+      "Days": 0,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 0,
+      "Seconds": 0,
+      "TotalDays": 0,
+      "TotalHours": 0,
+      "TotalMilliseconds": 0,
+      "TotalMinutes": 0,
+      "TotalSeconds": 0
+    },
+    "RefreshInterval": {
+      "Ticks": 6048000000000,
+      "Days": 7,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 0,
+      "Seconds": 0,
+      "TotalDays": 7,
+      "TotalHours": 168,
+      "TotalMilliseconds": 604800000,
+      "TotalMinutes": 10080,
+      "TotalSeconds": 604800
+    },
+    "NoRefreshInterval": {
+      "Ticks": 6048000000000,
+      "Days": 7,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 0,
+      "Seconds": 0,
+      "TotalDays": 7,
+      "TotalHours": 168,
+      "TotalMilliseconds": 604800000,
+      "TotalMinutes": 10080,
+      "TotalSeconds": 604800
+    },
+    "LastScavengeTime": ""
+  },
+  "ResponseRateLimiting": {
+    "Mode": "Disable",
+    "ResponsesPerSec": 5,
+    "ErrorsPerSec": 5,
+    "WindowInSec": 5,
+    "IPv4PrefixLength": 24,
+    "IPv6PrefixLength": 56,
+    "LeakRate": 3,
+    "TruncateRate": 2,
+    "MaximumResponsesPerWindow": 1024
+  },
+  "Forwarders": {
+    "UseRootHint": true,
+    "Timeout": 3,
+    "EnableReordering": true,
+    "IPAddress": {
+      "value": [
+        "1.1.1.1",
+        "9.9.9.9"
+      ],
+      "Count": 2
+    }
+  },
+  "RootHints": [
+    {
+      "NameServer": "A.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "198.41.0.4",
+        "2001:503:ba3e::2:30"
+      ]
+    },
+    {
+      "NameServer": "B.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.228.79.201",
+        "2001:500:84::b"
+      ]
+    },
+    {
+      "NameServer": "C.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.33.4.12",
+        "2001:500:2::c"
+      ]
+    },
+    {
+      "NameServer": "D.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "199.7.91.13",
+        "2001:500:2d::d"
+      ]
+    },
+    {
+      "NameServer": "E.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.203.230.10"
+      ]
+    },
+    {
+      "NameServer": "F.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.5.5.241",
+        "2001:500:2f::f"
+      ]
+    },
+    {
+      "NameServer": "G.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.112.36.4"
+      ]
+    },
+    {
+      "NameServer": "H.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "198.97.190.53",
+        "2001:500:1::53"
+      ]
+    },
+    {
+      "NameServer": "I.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.36.148.17",
+        "2001:7fe::53"
+      ]
+    },
+    {
+      "NameServer": "J.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.58.128.30",
+        "2001:503:c27::2:30"
+      ]
+    },
+    {
+      "NameServer": "K.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "193.0.14.129",
+        "2001:7fd::1"
+      ]
+    },
+    {
+      "NameServer": "L.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "199.7.83.42",
+        "2001:500:9f::42"
+      ]
+    },
+    {
+      "NameServer": "M.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "202.12.27.33",
+        "2001:dc3::35"
+      ]
+    }
+  ]
+}

--- a/providers/os/resources/windows/testdata/dnsserver-settings-2022.json
+++ b/providers/os/resources/windows/testdata/dnsserver-settings-2022.json
@@ -1,0 +1,265 @@
+{
+  "Settings": {
+    "ComputerName": "dnslab",
+    "MajorVersion": 10,
+    "MinorVersion": 0,
+    "BuildNumber": 20348,
+    "EnableDnsSec": true,
+    "EnableVersionQuery": 0,
+    "EnableIPv6": true,
+    "SocketPoolSize": 2500,
+    "RoundRobin": true,
+    "BindSecondaries": false,
+    "StrictFileParsing": false,
+    "NameCheckFlag": 2,
+    "EnableOnlineSigning": true,
+    "AddressAnswerLimit": 0,
+    "XfrConnectTimeout": 30,
+    "DsAvailable": false,
+    "IsReadOnlyDC": false,
+    "ServerLevelPluginDll": null,
+    "RootTrustAnchorsURL": "https://data.iana.org/root-anchors/root-anchors.xml",
+    "ListeningIPAddress": {
+      "value": [
+        "fe80::73f5:a0d4:e6d3:d2a9",
+        "10.0.0.4"
+      ],
+      "Count": 2
+    },
+    "AllIPAddress": {
+      "value": [
+        "fe80::73f5:a0d4:e6d3:d2a9",
+        "10.0.0.4"
+      ],
+      "Count": 2
+    },
+    "SocketPoolExcludedPortRanges": {
+      "value": [],
+      "Count": 0
+    }
+  },
+  "Recursion": {
+    "Enable": true,
+    "SecureResponse": true,
+    "Timeout": 8,
+    "RetryInterval": 3,
+    "AdditionalTimeout": 4
+  },
+  "Cache": {
+    "EnablePollutionProtection": true,
+    "LockingPercent": 100,
+    "MaxKBSize": 0,
+    "MaxTtl": {
+      "Ticks": 864000000000,
+      "Days": 1,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 0,
+      "Seconds": 0,
+      "TotalDays": 1,
+      "TotalHours": 24,
+      "TotalMilliseconds": 86400000,
+      "TotalMinutes": 1440,
+      "TotalSeconds": 86400
+    },
+    "MaxNegativeTtl": {
+      "Ticks": 9000000000,
+      "Days": 0,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 15,
+      "Seconds": 0,
+      "TotalDays": 0.010416666666666666,
+      "TotalHours": 0.25,
+      "TotalMilliseconds": 900000,
+      "TotalMinutes": 15,
+      "TotalSeconds": 900
+    },
+    "StoreEmptyAuthenticationResponse": true,
+    "IgnorePolicies": false
+  },
+  "Diagnostics": {
+    "EventLogLevel": 4,
+    "UseSystemEventLog": false,
+    "EnableLoggingToFile": true,
+    "LogFilePath": null,
+    "MaxMBFileSize": 500000000,
+    "EnableLogFileRollover": false,
+    "SaveLogsToPersistentStorage": false,
+    "Queries": false,
+    "Answers": false,
+    "Notifications": false,
+    "Update": false,
+    "QuestionTransactions": false,
+    "UnmatchedResponse": false,
+    "SendPackets": false,
+    "ReceivePackets": false,
+    "TcpPackets": false,
+    "UdpPackets": false,
+    "FullPackets": false,
+    "WriteThrough": false,
+    "FilterIPAddressList": {
+      "value": [
+        "192.0.2.10"
+      ],
+      "Count": 1
+    }
+  },
+  "Scavenging": {
+    "ScavengingState": false,
+    "ScavengingInterval": {
+      "Ticks": 0,
+      "Days": 0,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 0,
+      "Seconds": 0,
+      "TotalDays": 0,
+      "TotalHours": 0,
+      "TotalMilliseconds": 0,
+      "TotalMinutes": 0,
+      "TotalSeconds": 0
+    },
+    "RefreshInterval": {
+      "Ticks": 6048000000000,
+      "Days": 7,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 0,
+      "Seconds": 0,
+      "TotalDays": 7,
+      "TotalHours": 168,
+      "TotalMilliseconds": 604800000,
+      "TotalMinutes": 10080,
+      "TotalSeconds": 604800
+    },
+    "NoRefreshInterval": {
+      "Ticks": 6048000000000,
+      "Days": 7,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 0,
+      "Seconds": 0,
+      "TotalDays": 7,
+      "TotalHours": 168,
+      "TotalMilliseconds": 604800000,
+      "TotalMinutes": 10080,
+      "TotalSeconds": 604800
+    },
+    "LastScavengeTime": ""
+  },
+  "ResponseRateLimiting": {
+    "Mode": "Disable",
+    "ResponsesPerSec": 5,
+    "ErrorsPerSec": 5,
+    "WindowInSec": 5,
+    "IPv4PrefixLength": 24,
+    "IPv6PrefixLength": 56,
+    "LeakRate": 3,
+    "TruncateRate": 2,
+    "MaximumResponsesPerWindow": 1024
+  },
+  "Forwarders": {
+    "UseRootHint": true,
+    "Timeout": 3,
+    "EnableReordering": true,
+    "IPAddress": {
+      "value": [
+        "1.1.1.1",
+        "9.9.9.9"
+      ],
+      "Count": 2
+    }
+  },
+  "RootHints": [
+    {
+      "NameServer": "A.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "198.41.0.4",
+        "2001:503:ba3e::2:30"
+      ]
+    },
+    {
+      "NameServer": "B.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.228.79.201",
+        "2001:500:84::b"
+      ]
+    },
+    {
+      "NameServer": "C.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.33.4.12",
+        "2001:500:2::c"
+      ]
+    },
+    {
+      "NameServer": "D.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "199.7.91.13",
+        "2001:500:2d::d"
+      ]
+    },
+    {
+      "NameServer": "E.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.203.230.10"
+      ]
+    },
+    {
+      "NameServer": "F.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.5.5.241",
+        "2001:500:2f::f"
+      ]
+    },
+    {
+      "NameServer": "G.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.112.36.4"
+      ]
+    },
+    {
+      "NameServer": "H.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "198.97.190.53",
+        "2001:500:1::53"
+      ]
+    },
+    {
+      "NameServer": "I.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.36.148.17",
+        "2001:7fe::53"
+      ]
+    },
+    {
+      "NameServer": "J.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.58.128.30",
+        "2001:503:c27::2:30"
+      ]
+    },
+    {
+      "NameServer": "K.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "193.0.14.129",
+        "2001:7fd::1"
+      ]
+    },
+    {
+      "NameServer": "L.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "199.7.83.42",
+        "2001:500:9f::42"
+      ]
+    },
+    {
+      "NameServer": "M.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "202.12.27.33",
+        "2001:dc3::35"
+      ]
+    }
+  ]
+}

--- a/providers/os/resources/windows/testdata/dnsserver-settings-2025.json
+++ b/providers/os/resources/windows/testdata/dnsserver-settings-2025.json
@@ -1,0 +1,265 @@
+{
+  "Settings": {
+    "ComputerName": "dnslab",
+    "MajorVersion": 10,
+    "MinorVersion": 0,
+    "BuildNumber": 26100,
+    "EnableDnsSec": true,
+    "EnableVersionQuery": 0,
+    "EnableIPv6": true,
+    "SocketPoolSize": 2500,
+    "RoundRobin": true,
+    "BindSecondaries": false,
+    "StrictFileParsing": false,
+    "NameCheckFlag": 2,
+    "EnableOnlineSigning": true,
+    "AddressAnswerLimit": 0,
+    "XfrConnectTimeout": 30,
+    "DsAvailable": false,
+    "IsReadOnlyDC": false,
+    "ServerLevelPluginDll": null,
+    "RootTrustAnchorsURL": "https://data.iana.org/root-anchors/root-anchors.xml",
+    "ListeningIPAddress": {
+      "value": [
+        "fe80::73f5:a0d4:e6d3:d2a9",
+        "10.0.0.4"
+      ],
+      "Count": 2
+    },
+    "AllIPAddress": {
+      "value": [
+        "fe80::73f5:a0d4:e6d3:d2a9",
+        "10.0.0.4"
+      ],
+      "Count": 2
+    },
+    "SocketPoolExcludedPortRanges": {
+      "value": [],
+      "Count": 0
+    }
+  },
+  "Recursion": {
+    "Enable": true,
+    "SecureResponse": true,
+    "Timeout": 8,
+    "RetryInterval": 3,
+    "AdditionalTimeout": 4
+  },
+  "Cache": {
+    "EnablePollutionProtection": true,
+    "LockingPercent": 100,
+    "MaxKBSize": 0,
+    "MaxTtl": {
+      "Ticks": 864000000000,
+      "Days": 1,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 0,
+      "Seconds": 0,
+      "TotalDays": 1,
+      "TotalHours": 24,
+      "TotalMilliseconds": 86400000,
+      "TotalMinutes": 1440,
+      "TotalSeconds": 86400
+    },
+    "MaxNegativeTtl": {
+      "Ticks": 9000000000,
+      "Days": 0,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 15,
+      "Seconds": 0,
+      "TotalDays": 0.010416666666666666,
+      "TotalHours": 0.25,
+      "TotalMilliseconds": 900000,
+      "TotalMinutes": 15,
+      "TotalSeconds": 900
+    },
+    "StoreEmptyAuthenticationResponse": true,
+    "IgnorePolicies": false
+  },
+  "Diagnostics": {
+    "EventLogLevel": 4,
+    "UseSystemEventLog": false,
+    "EnableLoggingToFile": true,
+    "LogFilePath": null,
+    "MaxMBFileSize": 500000000,
+    "EnableLogFileRollover": false,
+    "SaveLogsToPersistentStorage": false,
+    "Queries": false,
+    "Answers": false,
+    "Notifications": false,
+    "Update": false,
+    "QuestionTransactions": false,
+    "UnmatchedResponse": false,
+    "SendPackets": false,
+    "ReceivePackets": false,
+    "TcpPackets": false,
+    "UdpPackets": false,
+    "FullPackets": false,
+    "WriteThrough": false,
+    "FilterIPAddressList": {
+      "value": [
+        "192.0.2.10"
+      ],
+      "Count": 1
+    }
+  },
+  "Scavenging": {
+    "ScavengingState": false,
+    "ScavengingInterval": {
+      "Ticks": 0,
+      "Days": 0,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 0,
+      "Seconds": 0,
+      "TotalDays": 0,
+      "TotalHours": 0,
+      "TotalMilliseconds": 0,
+      "TotalMinutes": 0,
+      "TotalSeconds": 0
+    },
+    "RefreshInterval": {
+      "Ticks": 6048000000000,
+      "Days": 7,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 0,
+      "Seconds": 0,
+      "TotalDays": 7,
+      "TotalHours": 168,
+      "TotalMilliseconds": 604800000,
+      "TotalMinutes": 10080,
+      "TotalSeconds": 604800
+    },
+    "NoRefreshInterval": {
+      "Ticks": 6048000000000,
+      "Days": 7,
+      "Hours": 0,
+      "Milliseconds": 0,
+      "Minutes": 0,
+      "Seconds": 0,
+      "TotalDays": 7,
+      "TotalHours": 168,
+      "TotalMilliseconds": 604800000,
+      "TotalMinutes": 10080,
+      "TotalSeconds": 604800
+    },
+    "LastScavengeTime": ""
+  },
+  "ResponseRateLimiting": {
+    "Mode": "Disable",
+    "ResponsesPerSec": 5,
+    "ErrorsPerSec": 5,
+    "WindowInSec": 5,
+    "IPv4PrefixLength": 24,
+    "IPv6PrefixLength": 56,
+    "LeakRate": 3,
+    "TruncateRate": 2,
+    "MaximumResponsesPerWindow": 1024
+  },
+  "Forwarders": {
+    "UseRootHint": true,
+    "Timeout": 3,
+    "EnableReordering": true,
+    "IPAddress": {
+      "value": [
+        "1.1.1.1",
+        "9.9.9.9"
+      ],
+      "Count": 2
+    }
+  },
+  "RootHints": [
+    {
+      "NameServer": "A.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "198.41.0.4",
+        "2001:503:ba3e::2:30"
+      ]
+    },
+    {
+      "NameServer": "B.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.228.79.201",
+        "2001:500:84::b"
+      ]
+    },
+    {
+      "NameServer": "C.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.33.4.12",
+        "2001:500:2::c"
+      ]
+    },
+    {
+      "NameServer": "D.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "199.7.91.13",
+        "2001:500:2d::d"
+      ]
+    },
+    {
+      "NameServer": "E.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.203.230.10"
+      ]
+    },
+    {
+      "NameServer": "F.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.5.5.241",
+        "2001:500:2f::f"
+      ]
+    },
+    {
+      "NameServer": "G.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.112.36.4"
+      ]
+    },
+    {
+      "NameServer": "H.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "198.97.190.53",
+        "2001:500:1::53"
+      ]
+    },
+    {
+      "NameServer": "I.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.36.148.17",
+        "2001:7fe::53"
+      ]
+    },
+    {
+      "NameServer": "J.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "192.58.128.30",
+        "2001:503:c27::2:30"
+      ]
+    },
+    {
+      "NameServer": "K.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "193.0.14.129",
+        "2001:7fd::1"
+      ]
+    },
+    {
+      "NameServer": "L.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "199.7.83.42",
+        "2001:500:9f::42"
+      ]
+    },
+    {
+      "NameServer": "M.ROOT-SERVERS.NET.",
+      "IPAddress": [
+        "202.12.27.33",
+        "2001:dc3::35"
+      ]
+    }
+  ]
+}

--- a/providers/os/resources/windows/testdata/dnsserver-zones-2016.json
+++ b/providers/os/resources/windows/testdata/dnsserver-zones-2016.json
@@ -1,0 +1,354 @@
+{
+  "Zones": [
+    {
+      "ZoneName": "0.in-addr.arpa",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "None",
+      "SecureSecondaries": "TransferToZoneNameServer",
+      "Notify": "Notify",
+      "IsSigned": false,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": true,
+      "IsReverseLookupZone": true,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": null,
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    },
+    {
+      "ZoneName": "127.in-addr.arpa",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "None",
+      "SecureSecondaries": "TransferToZoneNameServer",
+      "Notify": "Notify",
+      "IsSigned": false,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": true,
+      "IsReverseLookupZone": true,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": null,
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    },
+    {
+      "ZoneName": "255.in-addr.arpa",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "None",
+      "SecureSecondaries": "TransferToZoneNameServer",
+      "Notify": "Notify",
+      "IsSigned": false,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": true,
+      "IsReverseLookupZone": true,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": null,
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    },
+    {
+      "ZoneName": "lab.test",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "NonsecureAndSecure",
+      "SecureSecondaries": "TransferAnyServer",
+      "Notify": "NoNotify",
+      "IsSigned": false,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": false,
+      "IsReverseLookupZone": false,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": "lab.test.dns",
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    },
+    {
+      "ZoneName": "signed.test",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "None",
+      "SecureSecondaries": "TransferToZoneNameServer",
+      "Notify": "Notify",
+      "IsSigned": true,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": false,
+      "IsReverseLookupZone": false,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": "signed.test.dns",
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    }
+  ],
+  "DnsSec": [
+    {
+      "ZoneName": "signed.test",
+      "DenialOfExistence": "NSec3",
+      "NSec3HashAlgorithm": "RsaSha1",
+      "NSec3Iterations": 50,
+      "NSec3OptOut": false,
+      "NSec3RandomSaltLength": 8,
+      "EnableRfc5011KeyRollover": true,
+      "DSRecordSetTtl": {
+        "Ticks": 36000000000,
+        "Days": 0,
+        "Hours": 1,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0.041666666666666664,
+        "TotalHours": 1,
+        "TotalMilliseconds": 3600000,
+        "TotalMinutes": 60,
+        "TotalSeconds": 3600
+      },
+      "DnsKeyRecordSetTtl": {
+        "Ticks": 36000000000,
+        "Days": 0,
+        "Hours": 1,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0.041666666666666664,
+        "TotalHours": 1,
+        "TotalMilliseconds": 3600000,
+        "TotalMinutes": 60,
+        "TotalSeconds": 3600
+      },
+      "SignatureInceptionOffset": {
+        "Ticks": 36000000000,
+        "Days": 0,
+        "Hours": 1,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0.041666666666666664,
+        "TotalHours": 1,
+        "TotalMilliseconds": 3600000,
+        "TotalMinutes": 60,
+        "TotalSeconds": 3600
+      },
+      "SecureDelegationPollingPeriod": {
+        "Ticks": 432000000000,
+        "Days": 0,
+        "Hours": 12,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0.5,
+        "TotalHours": 12,
+        "TotalMilliseconds": 43200000,
+        "TotalMinutes": 720,
+        "TotalSeconds": 43200
+      },
+      "ParentHasSecureDelegation": false,
+      "PropagationTime": {
+        "Ticks": 0,
+        "Days": 0,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0,
+        "TotalHours": 0,
+        "TotalMilliseconds": 0,
+        "TotalMinutes": 0,
+        "TotalSeconds": 0
+      },
+      "IsKeyMasterServer": true,
+      "KeyMasterServer": "dnslab",
+      "DistributeTrustAnchor": {
+        "value": [
+          "None"
+        ],
+        "Count": 1
+      },
+      "DSRecordGenerationAlgorithm": {
+        "value": [
+          "Sha1",
+          "Sha256"
+        ],
+        "Count": 2
+      }
+    }
+  ],
+  "SigningKeys": [
+    {
+      "ZoneName": "signed.test",
+      "KeyType": "KeySigningKey",
+      "CryptoAlgorithm": "RsaSha256",
+      "KeyLength": 2048,
+      "CurrentState": "Active",
+      "KeyStorageProvider": "Microsoft Software Key Storage Provider",
+      "StoreKeysInAD": false,
+      "IsRolloverEnabled": true,
+      "RolloverPeriod": {
+        "Ticks": 652320000000000,
+        "Days": 755,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 755,
+        "TotalHours": 18120,
+        "TotalMilliseconds": 65232000000,
+        "TotalMinutes": 1087200,
+        "TotalSeconds": 65232000
+      },
+      "DnsKeySignatureValidityPeriod": {
+        "Ticks": 6048000000000,
+        "Days": 7,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 7,
+        "TotalHours": 168,
+        "TotalMilliseconds": 604800000,
+        "TotalMinutes": 10080,
+        "TotalSeconds": 604800
+      },
+      "DSSignatureValidityPeriod": {
+        "Ticks": 6048000000000,
+        "Days": 7,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 7,
+        "TotalHours": 168,
+        "TotalMilliseconds": 604800000,
+        "TotalMinutes": 10080,
+        "TotalSeconds": 604800
+      },
+      "ZoneSignatureValidityPeriod": {
+        "Ticks": 8640000000000,
+        "Days": 10,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 10,
+        "TotalHours": 240,
+        "TotalMilliseconds": 864000000,
+        "TotalMinutes": 14400,
+        "TotalSeconds": 864000
+      },
+      "KeyId": "0f1c2d3e-4a5b-6c7d-8e9f-a0b1c2d3e4f5"
+    },
+    {
+      "ZoneName": "signed.test",
+      "KeyType": "ZoneSigningKey",
+      "CryptoAlgorithm": "RsaSha256",
+      "KeyLength": 1024,
+      "CurrentState": "Active",
+      "KeyStorageProvider": "Microsoft Software Key Storage Provider",
+      "StoreKeysInAD": false,
+      "IsRolloverEnabled": true,
+      "RolloverPeriod": {
+        "Ticks": 77760000000000,
+        "Days": 90,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 90,
+        "TotalHours": 2160,
+        "TotalMilliseconds": 7776000000,
+        "TotalMinutes": 129600,
+        "TotalSeconds": 7776000
+      },
+      "DnsKeySignatureValidityPeriod": {
+        "Ticks": 6048000000000,
+        "Days": 7,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 7,
+        "TotalHours": 168,
+        "TotalMilliseconds": 604800000,
+        "TotalMinutes": 10080,
+        "TotalSeconds": 604800
+      },
+      "DSSignatureValidityPeriod": {
+        "Ticks": 6048000000000,
+        "Days": 7,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 7,
+        "TotalHours": 168,
+        "TotalMilliseconds": 604800000,
+        "TotalMinutes": 10080,
+        "TotalSeconds": 604800
+      },
+      "ZoneSignatureValidityPeriod": {
+        "Ticks": 8640000000000,
+        "Days": 10,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 10,
+        "TotalHours": 240,
+        "TotalMilliseconds": 864000000,
+        "TotalMinutes": 14400,
+        "TotalSeconds": 864000
+      },
+      "KeyId": "1a2b3c4d-5e6f-7a8b-9c0d-e1f2a3b4c5d6"
+    }
+  ]
+}

--- a/providers/os/resources/windows/testdata/dnsserver-zones-2019.json
+++ b/providers/os/resources/windows/testdata/dnsserver-zones-2019.json
@@ -1,0 +1,354 @@
+{
+  "Zones": [
+    {
+      "ZoneName": "0.in-addr.arpa",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "None",
+      "SecureSecondaries": "TransferToZoneNameServer",
+      "Notify": "Notify",
+      "IsSigned": false,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": true,
+      "IsReverseLookupZone": true,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": null,
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    },
+    {
+      "ZoneName": "127.in-addr.arpa",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "None",
+      "SecureSecondaries": "TransferToZoneNameServer",
+      "Notify": "Notify",
+      "IsSigned": false,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": true,
+      "IsReverseLookupZone": true,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": null,
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    },
+    {
+      "ZoneName": "255.in-addr.arpa",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "None",
+      "SecureSecondaries": "TransferToZoneNameServer",
+      "Notify": "Notify",
+      "IsSigned": false,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": true,
+      "IsReverseLookupZone": true,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": null,
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    },
+    {
+      "ZoneName": "lab.test",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "NonsecureAndSecure",
+      "SecureSecondaries": "TransferAnyServer",
+      "Notify": "NoNotify",
+      "IsSigned": false,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": false,
+      "IsReverseLookupZone": false,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": "lab.test.dns",
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    },
+    {
+      "ZoneName": "signed.test",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "None",
+      "SecureSecondaries": "TransferToZoneNameServer",
+      "Notify": "Notify",
+      "IsSigned": true,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": false,
+      "IsReverseLookupZone": false,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": "signed.test.dns",
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    }
+  ],
+  "DnsSec": [
+    {
+      "ZoneName": "signed.test",
+      "DenialOfExistence": "NSec3",
+      "NSec3HashAlgorithm": "RsaSha1",
+      "NSec3Iterations": 50,
+      "NSec3OptOut": false,
+      "NSec3RandomSaltLength": 8,
+      "EnableRfc5011KeyRollover": true,
+      "DSRecordSetTtl": {
+        "Ticks": 36000000000,
+        "Days": 0,
+        "Hours": 1,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0.041666666666666664,
+        "TotalHours": 1,
+        "TotalMilliseconds": 3600000,
+        "TotalMinutes": 60,
+        "TotalSeconds": 3600
+      },
+      "DnsKeyRecordSetTtl": {
+        "Ticks": 36000000000,
+        "Days": 0,
+        "Hours": 1,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0.041666666666666664,
+        "TotalHours": 1,
+        "TotalMilliseconds": 3600000,
+        "TotalMinutes": 60,
+        "TotalSeconds": 3600
+      },
+      "SignatureInceptionOffset": {
+        "Ticks": 36000000000,
+        "Days": 0,
+        "Hours": 1,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0.041666666666666664,
+        "TotalHours": 1,
+        "TotalMilliseconds": 3600000,
+        "TotalMinutes": 60,
+        "TotalSeconds": 3600
+      },
+      "SecureDelegationPollingPeriod": {
+        "Ticks": 432000000000,
+        "Days": 0,
+        "Hours": 12,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0.5,
+        "TotalHours": 12,
+        "TotalMilliseconds": 43200000,
+        "TotalMinutes": 720,
+        "TotalSeconds": 43200
+      },
+      "ParentHasSecureDelegation": false,
+      "PropagationTime": {
+        "Ticks": 0,
+        "Days": 0,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0,
+        "TotalHours": 0,
+        "TotalMilliseconds": 0,
+        "TotalMinutes": 0,
+        "TotalSeconds": 0
+      },
+      "IsKeyMasterServer": true,
+      "KeyMasterServer": "dnslab",
+      "DistributeTrustAnchor": {
+        "value": [
+          "None"
+        ],
+        "Count": 1
+      },
+      "DSRecordGenerationAlgorithm": {
+        "value": [
+          "Sha1",
+          "Sha256"
+        ],
+        "Count": 2
+      }
+    }
+  ],
+  "SigningKeys": [
+    {
+      "ZoneName": "signed.test",
+      "KeyType": "KeySigningKey",
+      "CryptoAlgorithm": "RsaSha256",
+      "KeyLength": 2048,
+      "CurrentState": "Active",
+      "KeyStorageProvider": "Microsoft Software Key Storage Provider",
+      "StoreKeysInAD": false,
+      "IsRolloverEnabled": true,
+      "RolloverPeriod": {
+        "Ticks": 652320000000000,
+        "Days": 755,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 755,
+        "TotalHours": 18120,
+        "TotalMilliseconds": 65232000000,
+        "TotalMinutes": 1087200,
+        "TotalSeconds": 65232000
+      },
+      "DnsKeySignatureValidityPeriod": {
+        "Ticks": 6048000000000,
+        "Days": 7,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 7,
+        "TotalHours": 168,
+        "TotalMilliseconds": 604800000,
+        "TotalMinutes": 10080,
+        "TotalSeconds": 604800
+      },
+      "DSSignatureValidityPeriod": {
+        "Ticks": 6048000000000,
+        "Days": 7,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 7,
+        "TotalHours": 168,
+        "TotalMilliseconds": 604800000,
+        "TotalMinutes": 10080,
+        "TotalSeconds": 604800
+      },
+      "ZoneSignatureValidityPeriod": {
+        "Ticks": 8640000000000,
+        "Days": 10,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 10,
+        "TotalHours": 240,
+        "TotalMilliseconds": 864000000,
+        "TotalMinutes": 14400,
+        "TotalSeconds": 864000
+      },
+      "KeyId": "0f1c2d3e-4a5b-6c7d-8e9f-a0b1c2d3e4f5"
+    },
+    {
+      "ZoneName": "signed.test",
+      "KeyType": "ZoneSigningKey",
+      "CryptoAlgorithm": "RsaSha256",
+      "KeyLength": 1024,
+      "CurrentState": "Active",
+      "KeyStorageProvider": "Microsoft Software Key Storage Provider",
+      "StoreKeysInAD": false,
+      "IsRolloverEnabled": true,
+      "RolloverPeriod": {
+        "Ticks": 77760000000000,
+        "Days": 90,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 90,
+        "TotalHours": 2160,
+        "TotalMilliseconds": 7776000000,
+        "TotalMinutes": 129600,
+        "TotalSeconds": 7776000
+      },
+      "DnsKeySignatureValidityPeriod": {
+        "Ticks": 6048000000000,
+        "Days": 7,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 7,
+        "TotalHours": 168,
+        "TotalMilliseconds": 604800000,
+        "TotalMinutes": 10080,
+        "TotalSeconds": 604800
+      },
+      "DSSignatureValidityPeriod": {
+        "Ticks": 6048000000000,
+        "Days": 7,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 7,
+        "TotalHours": 168,
+        "TotalMilliseconds": 604800000,
+        "TotalMinutes": 10080,
+        "TotalSeconds": 604800
+      },
+      "ZoneSignatureValidityPeriod": {
+        "Ticks": 8640000000000,
+        "Days": 10,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 10,
+        "TotalHours": 240,
+        "TotalMilliseconds": 864000000,
+        "TotalMinutes": 14400,
+        "TotalSeconds": 864000
+      },
+      "KeyId": "1a2b3c4d-5e6f-7a8b-9c0d-e1f2a3b4c5d6"
+    }
+  ]
+}

--- a/providers/os/resources/windows/testdata/dnsserver-zones-2022.json
+++ b/providers/os/resources/windows/testdata/dnsserver-zones-2022.json
@@ -1,0 +1,354 @@
+{
+  "Zones": [
+    {
+      "ZoneName": "0.in-addr.arpa",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "None",
+      "SecureSecondaries": "TransferToZoneNameServer",
+      "Notify": "Notify",
+      "IsSigned": false,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": true,
+      "IsReverseLookupZone": true,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": null,
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    },
+    {
+      "ZoneName": "127.in-addr.arpa",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "None",
+      "SecureSecondaries": "TransferToZoneNameServer",
+      "Notify": "Notify",
+      "IsSigned": false,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": true,
+      "IsReverseLookupZone": true,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": null,
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    },
+    {
+      "ZoneName": "255.in-addr.arpa",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "None",
+      "SecureSecondaries": "TransferToZoneNameServer",
+      "Notify": "Notify",
+      "IsSigned": false,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": true,
+      "IsReverseLookupZone": true,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": null,
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    },
+    {
+      "ZoneName": "lab.test",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "NonsecureAndSecure",
+      "SecureSecondaries": "TransferAnyServer",
+      "Notify": "NoNotify",
+      "IsSigned": false,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": false,
+      "IsReverseLookupZone": false,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": "lab.test.dns",
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    },
+    {
+      "ZoneName": "signed.test",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "None",
+      "SecureSecondaries": "TransferToZoneNameServer",
+      "Notify": "Notify",
+      "IsSigned": true,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": false,
+      "IsReverseLookupZone": false,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": "signed.test.dns",
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    }
+  ],
+  "DnsSec": [
+    {
+      "ZoneName": "signed.test",
+      "DenialOfExistence": "NSec3",
+      "NSec3HashAlgorithm": "RsaSha1",
+      "NSec3Iterations": 50,
+      "NSec3OptOut": false,
+      "NSec3RandomSaltLength": 8,
+      "EnableRfc5011KeyRollover": true,
+      "DSRecordSetTtl": {
+        "Ticks": 36000000000,
+        "Days": 0,
+        "Hours": 1,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0.041666666666666664,
+        "TotalHours": 1,
+        "TotalMilliseconds": 3600000,
+        "TotalMinutes": 60,
+        "TotalSeconds": 3600
+      },
+      "DnsKeyRecordSetTtl": {
+        "Ticks": 36000000000,
+        "Days": 0,
+        "Hours": 1,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0.041666666666666664,
+        "TotalHours": 1,
+        "TotalMilliseconds": 3600000,
+        "TotalMinutes": 60,
+        "TotalSeconds": 3600
+      },
+      "SignatureInceptionOffset": {
+        "Ticks": 36000000000,
+        "Days": 0,
+        "Hours": 1,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0.041666666666666664,
+        "TotalHours": 1,
+        "TotalMilliseconds": 3600000,
+        "TotalMinutes": 60,
+        "TotalSeconds": 3600
+      },
+      "SecureDelegationPollingPeriod": {
+        "Ticks": 432000000000,
+        "Days": 0,
+        "Hours": 12,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0.5,
+        "TotalHours": 12,
+        "TotalMilliseconds": 43200000,
+        "TotalMinutes": 720,
+        "TotalSeconds": 43200
+      },
+      "ParentHasSecureDelegation": false,
+      "PropagationTime": {
+        "Ticks": 0,
+        "Days": 0,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0,
+        "TotalHours": 0,
+        "TotalMilliseconds": 0,
+        "TotalMinutes": 0,
+        "TotalSeconds": 0
+      },
+      "IsKeyMasterServer": true,
+      "KeyMasterServer": "dnslab",
+      "DistributeTrustAnchor": {
+        "value": [
+          "None"
+        ],
+        "Count": 1
+      },
+      "DSRecordGenerationAlgorithm": {
+        "value": [
+          "Sha1",
+          "Sha256"
+        ],
+        "Count": 2
+      }
+    }
+  ],
+  "SigningKeys": [
+    {
+      "ZoneName": "signed.test",
+      "KeyType": "KeySigningKey",
+      "CryptoAlgorithm": "RsaSha256",
+      "KeyLength": 2048,
+      "CurrentState": "Active",
+      "KeyStorageProvider": "Microsoft Software Key Storage Provider",
+      "StoreKeysInAD": false,
+      "IsRolloverEnabled": true,
+      "RolloverPeriod": {
+        "Ticks": 652320000000000,
+        "Days": 755,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 755,
+        "TotalHours": 18120,
+        "TotalMilliseconds": 65232000000,
+        "TotalMinutes": 1087200,
+        "TotalSeconds": 65232000
+      },
+      "DnsKeySignatureValidityPeriod": {
+        "Ticks": 6048000000000,
+        "Days": 7,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 7,
+        "TotalHours": 168,
+        "TotalMilliseconds": 604800000,
+        "TotalMinutes": 10080,
+        "TotalSeconds": 604800
+      },
+      "DSSignatureValidityPeriod": {
+        "Ticks": 6048000000000,
+        "Days": 7,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 7,
+        "TotalHours": 168,
+        "TotalMilliseconds": 604800000,
+        "TotalMinutes": 10080,
+        "TotalSeconds": 604800
+      },
+      "ZoneSignatureValidityPeriod": {
+        "Ticks": 8640000000000,
+        "Days": 10,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 10,
+        "TotalHours": 240,
+        "TotalMilliseconds": 864000000,
+        "TotalMinutes": 14400,
+        "TotalSeconds": 864000
+      },
+      "KeyId": "0f1c2d3e-4a5b-6c7d-8e9f-a0b1c2d3e4f5"
+    },
+    {
+      "ZoneName": "signed.test",
+      "KeyType": "ZoneSigningKey",
+      "CryptoAlgorithm": "RsaSha256",
+      "KeyLength": 1024,
+      "CurrentState": "Active",
+      "KeyStorageProvider": "Microsoft Software Key Storage Provider",
+      "StoreKeysInAD": false,
+      "IsRolloverEnabled": true,
+      "RolloverPeriod": {
+        "Ticks": 77760000000000,
+        "Days": 90,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 90,
+        "TotalHours": 2160,
+        "TotalMilliseconds": 7776000000,
+        "TotalMinutes": 129600,
+        "TotalSeconds": 7776000
+      },
+      "DnsKeySignatureValidityPeriod": {
+        "Ticks": 6048000000000,
+        "Days": 7,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 7,
+        "TotalHours": 168,
+        "TotalMilliseconds": 604800000,
+        "TotalMinutes": 10080,
+        "TotalSeconds": 604800
+      },
+      "DSSignatureValidityPeriod": {
+        "Ticks": 6048000000000,
+        "Days": 7,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 7,
+        "TotalHours": 168,
+        "TotalMilliseconds": 604800000,
+        "TotalMinutes": 10080,
+        "TotalSeconds": 604800
+      },
+      "ZoneSignatureValidityPeriod": {
+        "Ticks": 8640000000000,
+        "Days": 10,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 10,
+        "TotalHours": 240,
+        "TotalMilliseconds": 864000000,
+        "TotalMinutes": 14400,
+        "TotalSeconds": 864000
+      },
+      "KeyId": "1a2b3c4d-5e6f-7a8b-9c0d-e1f2a3b4c5d6"
+    }
+  ]
+}

--- a/providers/os/resources/windows/testdata/dnsserver-zones-2025.json
+++ b/providers/os/resources/windows/testdata/dnsserver-zones-2025.json
@@ -1,0 +1,354 @@
+{
+  "Zones": [
+    {
+      "ZoneName": "0.in-addr.arpa",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "None",
+      "SecureSecondaries": "TransferToZoneNameServer",
+      "Notify": "Notify",
+      "IsSigned": false,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": true,
+      "IsReverseLookupZone": true,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": null,
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    },
+    {
+      "ZoneName": "127.in-addr.arpa",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "None",
+      "SecureSecondaries": "TransferToZoneNameServer",
+      "Notify": "Notify",
+      "IsSigned": false,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": true,
+      "IsReverseLookupZone": true,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": null,
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    },
+    {
+      "ZoneName": "255.in-addr.arpa",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "None",
+      "SecureSecondaries": "TransferToZoneNameServer",
+      "Notify": "Notify",
+      "IsSigned": false,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": true,
+      "IsReverseLookupZone": true,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": null,
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    },
+    {
+      "ZoneName": "lab.test",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "NonsecureAndSecure",
+      "SecureSecondaries": "TransferAnyServer",
+      "Notify": "NoNotify",
+      "IsSigned": false,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": false,
+      "IsReverseLookupZone": false,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": "lab.test.dns",
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    },
+    {
+      "ZoneName": "signed.test",
+      "ZoneType": "Primary",
+      "DynamicUpdate": "None",
+      "SecureSecondaries": "TransferToZoneNameServer",
+      "Notify": "Notify",
+      "IsSigned": true,
+      "IsDsIntegrated": false,
+      "IsAutoCreated": false,
+      "IsReverseLookupZone": false,
+      "IsPaused": false,
+      "IsShutdown": false,
+      "IsReadOnly": false,
+      "IsWinsEnabled": false,
+      "ZoneFile": "signed.test.dns",
+      "ReplicationScope": "None",
+      "DirectoryPartitionName": null,
+      "SecondaryServers": {
+        "value": [],
+        "Count": 0
+      },
+      "NotifyServers": {
+        "value": [],
+        "Count": 0
+      }
+    }
+  ],
+  "DnsSec": [
+    {
+      "ZoneName": "signed.test",
+      "DenialOfExistence": "NSec3",
+      "NSec3HashAlgorithm": "RsaSha1",
+      "NSec3Iterations": 50,
+      "NSec3OptOut": false,
+      "NSec3RandomSaltLength": 8,
+      "EnableRfc5011KeyRollover": true,
+      "DSRecordSetTtl": {
+        "Ticks": 36000000000,
+        "Days": 0,
+        "Hours": 1,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0.041666666666666664,
+        "TotalHours": 1,
+        "TotalMilliseconds": 3600000,
+        "TotalMinutes": 60,
+        "TotalSeconds": 3600
+      },
+      "DnsKeyRecordSetTtl": {
+        "Ticks": 36000000000,
+        "Days": 0,
+        "Hours": 1,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0.041666666666666664,
+        "TotalHours": 1,
+        "TotalMilliseconds": 3600000,
+        "TotalMinutes": 60,
+        "TotalSeconds": 3600
+      },
+      "SignatureInceptionOffset": {
+        "Ticks": 36000000000,
+        "Days": 0,
+        "Hours": 1,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0.041666666666666664,
+        "TotalHours": 1,
+        "TotalMilliseconds": 3600000,
+        "TotalMinutes": 60,
+        "TotalSeconds": 3600
+      },
+      "SecureDelegationPollingPeriod": {
+        "Ticks": 432000000000,
+        "Days": 0,
+        "Hours": 12,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0.5,
+        "TotalHours": 12,
+        "TotalMilliseconds": 43200000,
+        "TotalMinutes": 720,
+        "TotalSeconds": 43200
+      },
+      "ParentHasSecureDelegation": false,
+      "PropagationTime": {
+        "Ticks": 0,
+        "Days": 0,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 0,
+        "TotalHours": 0,
+        "TotalMilliseconds": 0,
+        "TotalMinutes": 0,
+        "TotalSeconds": 0
+      },
+      "IsKeyMasterServer": true,
+      "KeyMasterServer": "dnslab",
+      "DistributeTrustAnchor": {
+        "value": [
+          "None"
+        ],
+        "Count": 1
+      },
+      "DSRecordGenerationAlgorithm": {
+        "value": [
+          "Sha1",
+          "Sha256"
+        ],
+        "Count": 2
+      }
+    }
+  ],
+  "SigningKeys": [
+    {
+      "ZoneName": "signed.test",
+      "KeyType": "KeySigningKey",
+      "CryptoAlgorithm": "RsaSha256",
+      "KeyLength": 2048,
+      "CurrentState": "Active",
+      "KeyStorageProvider": "Microsoft Software Key Storage Provider",
+      "StoreKeysInAD": false,
+      "IsRolloverEnabled": true,
+      "RolloverPeriod": {
+        "Ticks": 652320000000000,
+        "Days": 755,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 755,
+        "TotalHours": 18120,
+        "TotalMilliseconds": 65232000000,
+        "TotalMinutes": 1087200,
+        "TotalSeconds": 65232000
+      },
+      "DnsKeySignatureValidityPeriod": {
+        "Ticks": 6048000000000,
+        "Days": 7,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 7,
+        "TotalHours": 168,
+        "TotalMilliseconds": 604800000,
+        "TotalMinutes": 10080,
+        "TotalSeconds": 604800
+      },
+      "DSSignatureValidityPeriod": {
+        "Ticks": 6048000000000,
+        "Days": 7,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 7,
+        "TotalHours": 168,
+        "TotalMilliseconds": 604800000,
+        "TotalMinutes": 10080,
+        "TotalSeconds": 604800
+      },
+      "ZoneSignatureValidityPeriod": {
+        "Ticks": 8640000000000,
+        "Days": 10,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 10,
+        "TotalHours": 240,
+        "TotalMilliseconds": 864000000,
+        "TotalMinutes": 14400,
+        "TotalSeconds": 864000
+      },
+      "KeyId": "0f1c2d3e-4a5b-6c7d-8e9f-a0b1c2d3e4f5"
+    },
+    {
+      "ZoneName": "signed.test",
+      "KeyType": "ZoneSigningKey",
+      "CryptoAlgorithm": "RsaSha256",
+      "KeyLength": 1024,
+      "CurrentState": "Active",
+      "KeyStorageProvider": "Microsoft Software Key Storage Provider",
+      "StoreKeysInAD": false,
+      "IsRolloverEnabled": true,
+      "RolloverPeriod": {
+        "Ticks": 77760000000000,
+        "Days": 90,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 90,
+        "TotalHours": 2160,
+        "TotalMilliseconds": 7776000000,
+        "TotalMinutes": 129600,
+        "TotalSeconds": 7776000
+      },
+      "DnsKeySignatureValidityPeriod": {
+        "Ticks": 6048000000000,
+        "Days": 7,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 7,
+        "TotalHours": 168,
+        "TotalMilliseconds": 604800000,
+        "TotalMinutes": 10080,
+        "TotalSeconds": 604800
+      },
+      "DSSignatureValidityPeriod": {
+        "Ticks": 6048000000000,
+        "Days": 7,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 7,
+        "TotalHours": 168,
+        "TotalMilliseconds": 604800000,
+        "TotalMinutes": 10080,
+        "TotalSeconds": 604800
+      },
+      "ZoneSignatureValidityPeriod": {
+        "Ticks": 8640000000000,
+        "Days": 10,
+        "Hours": 0,
+        "Milliseconds": 0,
+        "Minutes": 0,
+        "Seconds": 0,
+        "TotalDays": 10,
+        "TotalHours": 240,
+        "TotalMilliseconds": 864000000,
+        "TotalMinutes": 14400,
+        "TotalSeconds": 864000
+      },
+      "KeyId": "1a2b3c4d-5e6f-7a8b-9c0d-e1f2a3b4c5d6"
+    }
+  ]
+}


### PR DESCRIPTION
## What this is

Real, per-release test fixtures for the `windows.dnsServer` family, captured
from four live Windows Server hosts, plus the parser tests that pin them.

The family had a single fixture pair. The parser tests behind it are thorough,
but they can only speak for the one release the capture came from. That is the
gap this closes, because of how the failure looks when a release does differ:
a property the DnsServer module stops reporting arrives as JSON null and
decodes to a Go zero value. For most of this family the zero value is the
*hardened* reading, so nothing errors and the audit passes on a server that was
never read.

| decodes to | reads as |
|---|---|
| `Recursion.Enable` false | not an open resolver |
| `Cache.EnablePollutionProtection` false | reported as off when it may be on |
| `Forwarders.IPAddress` empty | no forwarders configured |
| `ListeningIPAddress` empty | not restricted to specific addresses |
| `ResponseRateLimiting` nil | rate limiting not reported on this release |

## The captures

Verbatim stdout of `DNS_SERVER_SETTINGS` and `DNS_SERVER_ZONES`, one pair per
release, taken over SSH from hosts with the DNS Server role installed:

| release | build | fixtures |
|---|---|---|
| Server 2016 | 14393 | `dnsserver-{settings,zones}-2016.json` |
| Server 2019 | 17763 | `dnsserver-{settings,zones}-2019.json` |
| Server 2022 | 20348 | `dnsserver-{settings,zones}-2022.json` |
| Server 2025 | 26100 | `dnsserver-{settings,zones}-2025.json` |

Each host was driven into the same state before capture, so the four payloads
are comparable field by field:

- **two forwarders** (`1.1.1.1`, `9.9.9.9`) and a **debug-log address filter**
  (`192.0.2.10`). Both serialize as `{"value":[...],"Count":n}` rather than as
  a plain array, which is the shape a plain `[]string` tag decodes to empty.
  The filter is a one-element list, which PowerShell flattens to a bare string.
- **one permissive unsigned zone** (`lab.test`): `TransferAnyServer` plus
  `NonsecureAndSecure` dynamic update.
- **one DNSSEC-signed zone** (`signed.test`) holding a 2048-bit key signing key
  and a 1024-bit zone signing key, both `Active`.
- the three auto-created reverse zones a stock server carries, which report no
  zone file at all: a separate case from a directory-integrated zone reporting
  none.

## The tests

`TestParseWindowsDnsServerAcrossReleases` and
`TestParseWindowsDnsServerZonesAcrossReleases` pin the real values on each
release, so a field that stops being reported fails instead of reading as the
safe answer.

`TestWindowsDnsServerDoesNotDriftAcrossReleases` normalizes the build number
away and requires all four to decode identically. The hosts were configured the
same, so any difference is the module reporting something differently on one
release rather than the servers disagreeing.

**Nothing in the modeled set differs today.** That was checked two ways, and
both agree: the decoded payloads are identical build number aside, and a
`Get-Member` inventory of all eleven cmdlets the family calls
(`Get-DnsServerSetting -All`, `Recursion`, `Cache`, `Diagnostics`, `Scavenging`,
`ResponseRateLimiting`, `Forwarder`, `RootHint`, `Zone`, `DnsSecZoneSetting`,
`SigningKey`) returns the same property names and types on 2016 as on 2025 —
including the DNSSEC key-management surface, which is where drift was most
expected. The test is a ratchet against a future release, not a fix for
something broken now.

## Sanitization

`mql` is public, so the captures are scrubbed:

- host names (`EC2AMAZ-*`) and `KeyMasterServer` to `dnslab`
- each host's own IPv4 and link-local IPv6 addresses to `10.0.0.4` and
  `fe80::73f5:a0d4:e6d3:d2a9`
- DNSSEC key identifiers to fixed placeholder GUIDs

Root hint addresses are public and kept as captured. `192.0.2.10` is RFC 5737
documentation space. Zone names are RFC 6761 `.test` names. Every configured
value the servers reported is untouched, and no key material is in the payload
to begin with: the collection script selects configured properties only, and
deliberately omits `ActiveKey`, `StandbyKey` and `NextKey`.

## Verification

```
go test ./providers/os/resources/windows/    ok
```

The drift test was mutation-checked rather than assumed: flipping
`Recursion.Enable` in the 2025 fixture fails it with the two payloads diffed,
and restoring the fixture passes.
