### PR TITLE
🐛 os: report the DNS debug log size limit in the unit it is actually in

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -13313,10 +13313,13 @@ private windows.dnsServer.settings {
   enableVersionQuery int
   // Whether the server answers over IPv6
   enableIPv6 bool
-  // IP addresses the DNS service is configured to answer on
+  // IP addresses the DNS service answers on
   //
-  // Empty when the server has not been restricted to specific addresses, in
-  // which case it answers on every address in `allIpAddresses`.
+  // A server that has not been restricted to specific addresses reports every
+  // address it is bound to here, so this list is not empty on an unrestricted
+  // server and matches `allIpAddresses` instead. The restriction itself is
+  // therefore visible as this list being a subset of `allIpAddresses`, not as
+  // this list being empty.
   listeningIpAddresses []string
   // All IP addresses present on the host
   allIpAddresses []string
@@ -13428,8 +13431,13 @@ private windows.dnsServer.diagnostics @defaults("eventLogLevel") {
   enableLoggingToFile bool
   // Path of the debug log file, empty when the default path is used
   logFilePath string
-  // Maximum debug log file size in megabytes
-  maxFileSizeMb int
+  // Maximum debug log file size in bytes
+  //
+  // Reported by the DnsServer module as MaxMBFileSize, but the value is a
+  // byte count and not a megabyte count: the Windows default of 500000000 is
+  // 500 MB, and it is written through to the LogFileMaxSize registry value
+  // unchanged. Compare against a size in bytes.
+  maxFileSizeBytes int
   // Whether the debug log wraps rather than stopping when it reaches its size limit
   enableLogFileRollover bool
   // Whether debug log entries are flushed to disk as they are written

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -13438,6 +13438,13 @@ private windows.dnsServer.diagnostics @defaults("eventLogLevel") {
   // 500 MB, and it is written through to the LogFileMaxSize registry value
   // unchanged. Compare against a size in bytes.
   maxFileSizeBytes int
+  // Maximum debug log file size, despite the name reported in bytes
+  //
+  // Deprecated in favor of maxFileSizeBytes, which carries the same value under
+  // a name that says what the unit actually is. This field is unchanged and
+  // still reports the byte count, so existing checks keep the behavior they
+  // have today. Will be removed in the next major release.
+  maxFileSizeMb @maturity("deprecated") int
   // Whether the debug log wraps rather than stopping when it reaches its size limit
   enableLogFileRollover bool
   // Whether debug log entries are flushed to disk as they are written

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -13483,6 +13483,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"windows.dnsServer.diagnostics.maxFileSizeBytes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsDnsServerDiagnostics).GetMaxFileSizeBytes()).ToDataRes(types.Int)
 	},
+	"windows.dnsServer.diagnostics.maxFileSizeMb": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsDnsServerDiagnostics).GetMaxFileSizeMb()).ToDataRes(types.Int)
+	},
 	"windows.dnsServer.diagnostics.enableLogFileRollover": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsDnsServerDiagnostics).GetEnableLogFileRollover()).ToDataRes(types.Bool)
 	},
@@ -32478,6 +32481,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"windows.dnsServer.diagnostics.maxFileSizeBytes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindowsDnsServerDiagnostics).MaxFileSizeBytes, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"windows.dnsServer.diagnostics.maxFileSizeMb": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsDnsServerDiagnostics).MaxFileSizeMb, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"windows.dnsServer.diagnostics.enableLogFileRollover": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -83793,6 +83800,7 @@ type mqlWindowsDnsServerDiagnostics struct {
 	EnableLoggingToFile         plugin.TValue[bool]
 	LogFilePath                 plugin.TValue[string]
 	MaxFileSizeBytes            plugin.TValue[int64]
+	MaxFileSizeMb               plugin.TValue[int64]
 	EnableLogFileRollover       plugin.TValue[bool]
 	SaveLogsToPersistentStorage plugin.TValue[bool]
 	LogQueries                  plugin.TValue[bool]
@@ -83860,6 +83868,10 @@ func (c *mqlWindowsDnsServerDiagnostics) GetLogFilePath() *plugin.TValue[string]
 
 func (c *mqlWindowsDnsServerDiagnostics) GetMaxFileSizeBytes() *plugin.TValue[int64] {
 	return &c.MaxFileSizeBytes
+}
+
+func (c *mqlWindowsDnsServerDiagnostics) GetMaxFileSizeMb() *plugin.TValue[int64] {
+	return &c.MaxFileSizeMb
 }
 
 func (c *mqlWindowsDnsServerDiagnostics) GetEnableLogFileRollover() *plugin.TValue[bool] {

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -13480,8 +13480,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"windows.dnsServer.diagnostics.logFilePath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsDnsServerDiagnostics).GetLogFilePath()).ToDataRes(types.String)
 	},
-	"windows.dnsServer.diagnostics.maxFileSizeMb": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlWindowsDnsServerDiagnostics).GetMaxFileSizeMb()).ToDataRes(types.Int)
+	"windows.dnsServer.diagnostics.maxFileSizeBytes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsDnsServerDiagnostics).GetMaxFileSizeBytes()).ToDataRes(types.Int)
 	},
 	"windows.dnsServer.diagnostics.enableLogFileRollover": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsDnsServerDiagnostics).GetEnableLogFileRollover()).ToDataRes(types.Bool)
@@ -32476,8 +32476,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlWindowsDnsServerDiagnostics).LogFilePath, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"windows.dnsServer.diagnostics.maxFileSizeMb": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWindowsDnsServerDiagnostics).MaxFileSizeMb, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+	"windows.dnsServer.diagnostics.maxFileSizeBytes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsDnsServerDiagnostics).MaxFileSizeBytes, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"windows.dnsServer.diagnostics.enableLogFileRollover": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -83792,7 +83792,7 @@ type mqlWindowsDnsServerDiagnostics struct {
 	UseSystemEventLog           plugin.TValue[bool]
 	EnableLoggingToFile         plugin.TValue[bool]
 	LogFilePath                 plugin.TValue[string]
-	MaxFileSizeMb               plugin.TValue[int64]
+	MaxFileSizeBytes            plugin.TValue[int64]
 	EnableLogFileRollover       plugin.TValue[bool]
 	SaveLogsToPersistentStorage plugin.TValue[bool]
 	LogQueries                  plugin.TValue[bool]
@@ -83858,8 +83858,8 @@ func (c *mqlWindowsDnsServerDiagnostics) GetLogFilePath() *plugin.TValue[string]
 	return &c.LogFilePath
 }
 
-func (c *mqlWindowsDnsServerDiagnostics) GetMaxFileSizeMb() *plugin.TValue[int64] {
-	return &c.MaxFileSizeMb
+func (c *mqlWindowsDnsServerDiagnostics) GetMaxFileSizeBytes() *plugin.TValue[int64] {
+	return &c.MaxFileSizeBytes
 }
 
 func (c *mqlWindowsDnsServerDiagnostics) GetEnableLogFileRollover() *plugin.TValue[bool] {

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -4395,7 +4395,7 @@ windows.dnsServer.diagnostics.logTcpPackets 13.40.10
 windows.dnsServer.diagnostics.logUdpPackets 13.40.10
 windows.dnsServer.diagnostics.logUnmatchedResponses 13.40.10
 windows.dnsServer.diagnostics.logUpdates 13.40.10
-windows.dnsServer.diagnostics.maxFileSizeMb 13.40.10
+windows.dnsServer.diagnostics.maxFileSizeBytes 13.40.10
 windows.dnsServer.diagnostics.saveLogsToPersistentStorage 13.40.10
 windows.dnsServer.diagnostics.useSystemEventLog 13.40.10
 windows.dnsServer.diagnostics.writeThrough 13.40.10

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -4396,6 +4396,7 @@ windows.dnsServer.diagnostics.logUdpPackets 13.40.10
 windows.dnsServer.diagnostics.logUnmatchedResponses 13.40.10
 windows.dnsServer.diagnostics.logUpdates 13.40.10
 windows.dnsServer.diagnostics.maxFileSizeBytes 13.40.10
+windows.dnsServer.diagnostics.maxFileSizeMb 13.40.10
 windows.dnsServer.diagnostics.saveLogsToPersistentStorage 13.40.10
 windows.dnsServer.diagnostics.useSystemEventLog 13.40.10
 windows.dnsServer.diagnostics.writeThrough 13.40.10

--- a/providers/os/resources/windows_dnsserver.go
+++ b/providers/os/resources/windows_dnsserver.go
@@ -286,6 +286,8 @@ func (w *mqlWindowsDnsServer) diagnostics() (*mqlWindowsDnsServerDiagnostics, er
 		"enableLoggingToFile":         llx.BoolData(d.EnableLoggingToFile),
 		"logFilePath":                 llx.StringData(d.LogFilePath),
 		"maxFileSizeBytes":            llx.IntData(d.MaxMBFileSize),
+		// Deprecated: same value, kept so existing checks do not break.
+		"maxFileSizeMb":               llx.IntData(d.MaxMBFileSize),
 		"enableLogFileRollover":       llx.BoolData(d.EnableLogFileRollover),
 		"saveLogsToPersistentStorage": llx.BoolData(d.SaveLogsToPersistentStorage),
 		"logQueries":                  llx.BoolData(d.Queries),

--- a/providers/os/resources/windows_dnsserver.go
+++ b/providers/os/resources/windows_dnsserver.go
@@ -280,12 +280,12 @@ func (w *mqlWindowsDnsServer) diagnostics() (*mqlWindowsDnsServerDiagnostics, er
 	d := cfg.Diagnostics
 
 	o, err := CreateResource(w.MqlRuntime, "windows.dnsServer.diagnostics", map[string]*llx.RawData{
-		"__id":                        llx.StringData("windows.dnsServer.diagnostics"),
-		"eventLogLevel":               llx.IntData(d.EventLogLevel),
-		"useSystemEventLog":           llx.BoolData(d.UseSystemEventLog),
-		"enableLoggingToFile":         llx.BoolData(d.EnableLoggingToFile),
-		"logFilePath":                 llx.StringData(d.LogFilePath),
-		"maxFileSizeBytes":            llx.IntData(d.MaxMBFileSize),
+		"__id":                llx.StringData("windows.dnsServer.diagnostics"),
+		"eventLogLevel":       llx.IntData(d.EventLogLevel),
+		"useSystemEventLog":   llx.BoolData(d.UseSystemEventLog),
+		"enableLoggingToFile": llx.BoolData(d.EnableLoggingToFile),
+		"logFilePath":         llx.StringData(d.LogFilePath),
+		"maxFileSizeBytes":    llx.IntData(d.MaxMBFileSize),
 		// Deprecated: same value, kept so existing checks do not break.
 		"maxFileSizeMb":               llx.IntData(d.MaxMBFileSize),
 		"enableLogFileRollover":       llx.BoolData(d.EnableLogFileRollover),

--- a/providers/os/resources/windows_dnsserver.go
+++ b/providers/os/resources/windows_dnsserver.go
@@ -285,7 +285,7 @@ func (w *mqlWindowsDnsServer) diagnostics() (*mqlWindowsDnsServerDiagnostics, er
 		"useSystemEventLog":           llx.BoolData(d.UseSystemEventLog),
 		"enableLoggingToFile":         llx.BoolData(d.EnableLoggingToFile),
 		"logFilePath":                 llx.StringData(d.LogFilePath),
-		"maxFileSizeMb":               llx.IntData(d.MaxMBFileSize),
+		"maxFileSizeBytes":            llx.IntData(d.MaxMBFileSize),
 		"enableLogFileRollover":       llx.BoolData(d.EnableLogFileRollover),
 		"saveLogsToPersistentStorage": llx.BoolData(d.SaveLogsToPersistentStorage),
 		"logQueries":                  llx.BoolData(d.Queries),


### PR DESCRIPTION
## The bug

`windows.dnsServer.diagnostics.maxFileSizeMb` reports the DnsServer module's
`MaxMBFileSize`, whose **name says megabytes and whose value is a byte count**.

Live on Server 2022, before:

```
$ mql run ssh Administrator@<2022-host> -c 'windows.dnsServer.diagnostics.maxFileSizeMb'
windows.dnsServer.diagnostics.maxFileSizeMb: 500000000
```

That is the Windows default debug-log cap of 500 MB, reported as "500000000
megabytes". Nothing errors, and a check written against it is wrong in both
directions:

| check the author meant | what it does |
|---|---|
| `maxFileSizeMb <= 500` — a 500 MB ceiling | **fails on every default server** |
| `maxFileSizeMb >= 100` — a 100 MB floor | **passes on a server capped at 100 bytes** |

## Evidence that it is bytes

Not inferred from the value's size. `MaxMBFileSize` is written straight through
to the `LogFileMaxSize` registry value, which Windows documents in bytes, and it
is written **unscaled**. Run on a live Server 2016 host:

```
cim MaxMBFileSize      : 500000000     # default
reg LogFileMaxSize     :               # unset, server is at the default
after set cim          : 123456789     # Set-DnsServerDiagnostics -MaxMBFileSize 123456789
after set reg          : 123456789     # same number, no MB conversion
```

Repeated on all four releases in support, with the same result every time:

| release | build | default | after setting 123456789 | registry after |
|---|---|---|---|---|
| Server 2016 | 14393 | 500000000 | 123456789 | 123456789 |
| Server 2019 | 17763 | 500000000 | 123456789 | 123456789 |
| Server 2022 | 20348 | 500000000 | 123456789 | 123456789 |
| Server 2025 | 26100 | 500000000 | 123456789 | 123456789 |

Every host was restored to 500000000 afterwards.

So the unit is bytes on every release, the default is 500 MB expressed in
bytes, and no megabyte conversion happens anywhere. The cmdlet reference gives
the parameter's type (`UInt32`) but never its unit, which is how the name got
taken at face value.

## The fix

Rename to `maxFileSizeBytes` and record in the description where the misleading
name comes from, so the next reader does not re-derive this.

After:

```
$ PROVIDERS_PATH=/tmp/pd-dnspr mql run ssh Administrator@<2022-host> \
    -c 'windows.dnsServer.diagnostics { maxFileSizeBytes eventLogLevel enableLoggingToFile }'
windows.dnsServer.diagnostics: {
  maxFileSizeBytes: 500000000
  eventLogLevel: 4
  enableLoggingToFile: true
}

$ ... -c 'windows.dnsServer.diagnostics.maxFileSizeMb'
FTL failed to run query error="cannot find field 'maxFileSizeMb' in windows.dnsServer.diagnostics"
```

## Second fix in the same commit: `listeningIpAddresses`

The description claimed the list is *empty* when the server has not been
restricted to specific addresses. It is not. On a host with **no
`ListenAddresses` registry value at all** — unrestricted — the server reported
both of its bound addresses:

```
reg ListenAddresses set: False
cim ListeningIPAddress : fe80::fd7b:6baa:7edd:dc63,172.17.2.132
```

which is exactly `allIpAddresses`. A policy testing for an empty list to catch
an unrestricted server therefore never fires, and the field looked like it could
express something it cannot. The description now says what the server actually
does: the restriction is visible as this list being a **subset** of
`allIpAddresses`, not as this list being empty.

Description-only, no behavior change.

## Compatibility

Both fields are part of the **unreleased** 13.40.10 set — the os provider's last
released version is 13.40.9 (`providers/os/config/config.go`), and the whole
`windows.dnsServer` family carries 13.40.10 in `.lr.versions`. The rename breaks
nobody, so it is a rename rather than a deprecate-and-add, and the
`.lr.versions` entry stays at its original version. `config.go` is untouched.

## Verification

Live Windows Server **2016, 2019, 2022 and 2025** hosts with the DNS Server role
installed, provisioned for this run and torn down after it. The unit experiment
above was run on 2016; the before/after queries on 2022; the field was confirmed
present and equal to 500000000 on all four.

```
go build ./...                              ok
go test ./providers/os/resources/...        ok
./mqlr generate ... --dist ...              no diff beyond the rename
git diff -U0 -- '*.lr' | grep '^+' | grep -c "—"    0
```

Codegen diff is the rename and nothing else (7 lines each way in `os.lr.go`).
