### PR TITLE
🟢 os: pin the Windows platform security parsers to real per-version output

### DIFF
--- a/providers/os/resources/windows/deviceguard_test.go
+++ b/providers/os/resources/windows/deviceguard_test.go
@@ -93,3 +93,62 @@ func TestParseDeviceGuardStatusRejectsEmptyOutput(t *testing.T) {
 	_, err := ParseDeviceGuardStatus(strings.NewReader("   \n"))
 	assert.Error(t, err)
 }
+
+// Real Win32_DeviceGuard readings from Windows Server 2016 (10.0.14393), 2022
+// (10.0.20348) and 2025 (10.0.26100), captured through the shipped
+// PSGetDeviceGuard script. Server 2019 (10.0.17763) produced output identical
+// to 2022, so it is covered by the same fixture.
+//
+// The platform properties are where the versions diverge, and they are the
+// reason a service that is configured will not start: 2016 offers DMA
+// protection, 2022 offers nothing. Neither host has any security service
+// configured or running, and both must read that as a real [0] rather than as
+// a null or an empty list.
+func TestParseDeviceGuardServerBaselines(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		fixture             string
+		availableProperties []int64
+		codeIntegrityStatus int64
+	}{
+		{"Windows Server 2016 offers DMA protection", "deviceguard_server2016.json", []int64{3}, 0},
+		{"Windows Server 2022 offers no relevant property", "deviceguard_server2022.json", []int64{0}, 0},
+		// 2025 is the only one of the four that offers hypervisor support (1),
+		// NX (5) and MBEC (7), and the only one whose kernel code integrity
+		// policy is enforced (2) out of the box.
+		{"Windows Server 2025 offers hypervisor, DMA, NX and MBEC", "deviceguard_server2025.json", []int64{1, 3, 5, 7}, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := os.Open("./testdata/" + tc.fixture)
+			require.NoError(t, err)
+			defer f.Close()
+
+			status, err := ParseDeviceGuardStatus(f)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.availableProperties, []int64(status.AvailableSecurityProperties))
+			// every code the four hosts report has to be one the schema
+			// documents (0-8), or the resource is handing back a number with
+			// no meaning attached
+			for _, code := range status.AvailableSecurityProperties {
+				assert.GreaterOrEqual(t, code, int64(0))
+				assert.LessOrEqual(t, code, int64(8))
+			}
+
+			// "nothing is running" is an answer, not an absence: these must be
+			// a one-element list holding 0, never nil.
+			require.NotNil(t, status.SecurityServicesConfigured)
+			require.NotNil(t, status.SecurityServicesRunning)
+			assert.Equal(t, []int64{0}, []int64(status.SecurityServicesConfigured))
+			assert.Equal(t, []int64{0}, []int64(status.SecurityServicesRunning))
+
+			// the scalars are reported, so they must be 0 rather than null
+			require.NotNil(t, status.VirtualizationBasedSecurityStatus)
+			require.NotNil(t, status.CodeIntegrityPolicyEnforcementStatus)
+			require.NotNil(t, status.UsermodeCodeIntegrityPolicyEnforcementStatus)
+			assert.Equal(t, int64(0), *status.VirtualizationBasedSecurityStatus)
+			assert.Equal(t, tc.codeIntegrityStatus, *status.CodeIntegrityPolicyEnforcementStatus)
+			assert.Equal(t, int64(0), *status.UsermodeCodeIntegrityPolicyEnforcementStatus)
+		})
+	}
+}

--- a/providers/os/resources/windows/exploitprotection_test.go
+++ b/providers/os/resources/windows/exploitprotection_test.go
@@ -105,3 +105,63 @@ func TestExploitProtectionResult(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+// A real Get-ProcessMitigation -System reading from a stock Windows Server
+// 2019 (10.0.17763) and 2022 (10.0.20348), which produced identical output.
+//
+// This is the case that separates "not configured" from "off". Every
+// system-wide mitigation on an unhardened host reports NOTSET, and NOTSET must
+// survive to the resource as itself: reading it as OFF would claim the
+// administrator turned DEP, ASLR, CFG, SEHOP and heap termination off, and
+// reading it as ON would claim they were enforced.
+func TestParseExploitProtectionSettings_NotSet(t *testing.T) {
+	data, err := os.ReadFile("testdata/exploitprotection_notset.json")
+	require.NoError(t, err)
+
+	s, err := ParseExploitProtectionSettings(data)
+	require.NoError(t, err)
+
+	// the cmdlet is present, so the sub-resources resolve
+	assert.True(t, s.Available)
+
+	for name, got := range map[string]string{
+		"DepEnable":                 s.DepEnable,
+		"DepEmulateAtlThunks":       s.DepEmulateAtlThunks,
+		"AslrBottomUp":              s.AslrBottomUp,
+		"AslrForceRelocateImages":   s.AslrForceRelocateImages,
+		"AslrHighEntropy":           s.AslrHighEntropy,
+		"AslrRequireInfo":           s.AslrRequireInfo,
+		"CfgEnable":                 s.CfgEnable,
+		"CfgSuppressExports":        s.CfgSuppressExports,
+		"CfgStrictControlFlowGuard": s.CfgStrictControlFlowGuard,
+		"SehopEnable":               s.SehopEnable,
+		"SehopTelemetryOnly":        s.SehopTelemetryOnly,
+		"HeapTerminateOnError":      s.HeapTerminateOnError,
+	} {
+		assert.Equal(t, "NOTSET", got, "%s must stay NOTSET, not become OFF or ON", name)
+	}
+
+	// the override policy is genuinely absent, which is not the same as 0
+	assert.Nil(t, s.DisallowOverride)
+	assert.False(t, s.DisallowOverrideEnabled())
+}
+
+// Windows Server 2016 (10.0.14393) does not ship the ProcessMitigations
+// module: Get-ProcessMitigation is not a recognized cmdlet there, despite the
+// feature being documented as in-box from Server 2016 onwards. The shipped
+// exploitprotection_unavailable.json fixture is byte-for-byte what that host
+// produces, so the unavailable path is a real reading rather than a
+// constructed one.
+func TestParseExploitProtectionSettings_Server2016IsUnavailable(t *testing.T) {
+	data, err := os.ReadFile("testdata/exploitprotection_unavailable.json")
+	require.NoError(t, err)
+
+	s, err := ParseExploitProtectionSettings(data)
+	require.NoError(t, err)
+
+	assert.False(t, s.Available)
+	// no value may be invented for a mitigation that was never read
+	assert.Empty(t, s.DepEnable)
+	assert.Empty(t, s.AslrBottomUp)
+	assert.Empty(t, s.HeapTerminateOnError)
+}

--- a/providers/os/resources/windows/secureboot_test.go
+++ b/providers/os/resources/windows/secureboot_test.go
@@ -4,6 +4,7 @@
 package windows
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -46,4 +47,41 @@ func TestParseSecureBoot(t *testing.T) {
 		assert.False(t, status.Enabled)
 		assert.False(t, status.SetupMode)
 	})
+}
+
+// A real reading from a legacy-BIOS host, captured through the shipped
+// PSConfirmSecureBoot script on Windows Server 2016, 2019 and 2022, all of
+// which produced identical output. Confirm-SecureBootUEFI fails there with
+// "Cmdlet not supported on this platform: 0xC0000002", which the script has to
+// turn into efi=false rather than into an error.
+func TestParseSecureBootLegacyBios(t *testing.T) {
+	f, err := os.Open("./testdata/secureboot_legacy_bios.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	status, err := ParseSecureBoot(f)
+	require.NoError(t, err)
+
+	assert.False(t, status.Efi)
+	assert.False(t, status.Enabled)
+	assert.False(t, status.SetupMode)
+}
+
+// A real reading from a UEFI host: Windows Server 2025 (10.0.26100), where
+// Confirm-SecureBootUEFI succeeds and returns False. This is the case the
+// legacy-BIOS fixture cannot cover, because there efi and enabled are both
+// false for the same reason. Here they have to be told apart: the firmware is
+// UEFI, Secure Boot is off, and the platform is in setup mode, which means the
+// platform key can be replaced without authentication.
+func TestParseSecureBootUefiInSetupMode(t *testing.T) {
+	f, err := os.Open("./testdata/secureboot_uefi_setupmode.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	status, err := ParseSecureBoot(f)
+	require.NoError(t, err)
+
+	assert.True(t, status.Efi)
+	assert.False(t, status.Enabled)
+	assert.True(t, status.SetupMode)
 }

--- a/providers/os/resources/windows/security_products_test.go
+++ b/providers/os/resources/windows/security_products_test.go
@@ -147,3 +147,21 @@ func TestSecurityProductsPowershell(t *testing.T) {
 		Timestamp:          mustParse("Fri, 05 Apr 2019 16:26:27 GMT"),
 	}, findProduct(products, "{D68DDC3A-831F-4fae-9E44-DA132C1ACF46}", "antispyware"))
 }
+
+// A real SecurityCenter2 reading from Windows Server 2016 (10.0.14393), 2019
+// (10.0.17763) and 2022 (10.0.20348), all of which produced identical output.
+//
+// Windows Server has no Security Center: the root/SecurityCenter2 namespace
+// does not exist, so every class query fails and the script emits three empty
+// arrays. The parse has to produce an empty list without inventing a product,
+// and the caller has to understand that this list means "nothing was
+// enumerable here", not "no antivirus is installed".
+func TestParseWindowsSecurityProducts_None(t *testing.T) {
+	f, err := os.Open("./testdata/security_products_none.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	products, err := ParseWindowsSecurityProducts(f)
+	require.NoError(t, err)
+	assert.Empty(t, products)
+}

--- a/providers/os/resources/windows/smartscreen_test.go
+++ b/providers/os/resources/windows/smartscreen_test.go
@@ -83,3 +83,48 @@ func TestSmartScreenEnabledFlag(t *testing.T) {
 	assert.False(t, enabledFlag(&zero))
 	assert.False(t, enabledFlag(nil))
 }
+
+// Real SmartScreen policy readings from Windows Server 2016 (10.0.14393) and
+// 2022 (10.0.20348); Server 2019 (10.0.17763) matched 2022 exactly.
+//
+// No SmartScreen policy is configured on either host, so every policy toggle
+// is absent and has to stay null rather than becoming an explicit 0 that would
+// read as "administratively disabled". The one value that does exist is the
+// Store apps web-content evaluation setting, and it genuinely differs by
+// version: 0 on 2016, 1 on 2019 and later. That is a real reading, so it has
+// to survive as one.
+func TestParseSmartScreenSettings_ServerBaselines(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		fixture      string
+		storeApps    int64
+		storeEnabled bool
+	}{
+		{"Windows Server 2016", "smartscreen_server2016.json", 0, false},
+		{"Windows Server 2022", "smartscreen_server2022.json", 1, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := os.ReadFile("testdata/" + tc.fixture)
+			require.NoError(t, err)
+
+			s, err := ParseSmartScreenSettings(data)
+			require.NoError(t, err)
+
+			// not configured stays null, so it can never read as "turned off by policy"
+			assert.Nil(t, s.EnableSmartScreen)
+			assert.Nil(t, s.EdgeSmartScreenEnabled)
+			assert.Nil(t, s.EdgeSmartScreenPuaEnabled)
+			assert.Nil(t, s.EdgePreventOverride)
+			assert.Nil(t, s.EdgePreventOverrideForFiles)
+			assert.Empty(t, s.ShellSmartScreenLevel)
+
+			// ... while the derived predicates still report the safe reading
+			assert.False(t, s.ExplorerEnabled())
+			assert.False(t, s.EdgeEnabled())
+
+			require.NotNil(t, s.StoreAppsEnableWebContentEvaluation)
+			assert.Equal(t, tc.storeApps, *s.StoreAppsEnableWebContentEvaluation)
+			assert.Equal(t, tc.storeEnabled, s.StoreAppsEnabled())
+		})
+	}
+}

--- a/providers/os/resources/windows/testdata/deviceguard_server2016.json
+++ b/providers/os/resources/windows/testdata/deviceguard_server2016.json
@@ -1,0 +1,1 @@
+{"AvailableSecurityProperties":[3],"SecurityServicesConfigured":[0],"SecurityServicesRunning":[0],"CodeIntegrityPolicyEnforcementStatus":0,"UsermodeCodeIntegrityPolicyEnforcementStatus":0,"VirtualizationBasedSecurityStatus":0}

--- a/providers/os/resources/windows/testdata/deviceguard_server2022.json
+++ b/providers/os/resources/windows/testdata/deviceguard_server2022.json
@@ -1,0 +1,1 @@
+{"AvailableSecurityProperties":[0],"SecurityServicesConfigured":[0],"SecurityServicesRunning":[0],"CodeIntegrityPolicyEnforcementStatus":0,"UsermodeCodeIntegrityPolicyEnforcementStatus":0,"VirtualizationBasedSecurityStatus":0}

--- a/providers/os/resources/windows/testdata/deviceguard_server2025.json
+++ b/providers/os/resources/windows/testdata/deviceguard_server2025.json
@@ -1,0 +1,1 @@
+{"AvailableSecurityProperties":[1,3,5,7],"SecurityServicesConfigured":[0],"SecurityServicesRunning":[0],"CodeIntegrityPolicyEnforcementStatus":2,"UsermodeCodeIntegrityPolicyEnforcementStatus":0,"VirtualizationBasedSecurityStatus":0}

--- a/providers/os/resources/windows/testdata/exploitprotection_notset.json
+++ b/providers/os/resources/windows/testdata/exploitprotection_notset.json
@@ -1,0 +1,1 @@
+{"Available":true,"DepEnable":"NOTSET","DepEmulateAtlThunks":"NOTSET","AslrBottomUp":"NOTSET","AslrForceRelocateImages":"NOTSET","AslrHighEntropy":"NOTSET","AslrRequireInfo":"NOTSET","CfgEnable":"NOTSET","CfgSuppressExports":"NOTSET","CfgStrictControlFlowGuard":"NOTSET","SehopEnable":"NOTSET","SehopTelemetryOnly":"NOTSET","HeapTerminateOnError":"NOTSET","DisallowOverride":null}

--- a/providers/os/resources/windows/testdata/secureboot_legacy_bios.json
+++ b/providers/os/resources/windows/testdata/secureboot_legacy_bios.json
@@ -1,0 +1,1 @@
+{"Efi":false,"Enabled":false,"SetupMode":false}

--- a/providers/os/resources/windows/testdata/secureboot_uefi_setupmode.json
+++ b/providers/os/resources/windows/testdata/secureboot_uefi_setupmode.json
@@ -1,0 +1,1 @@
+{"Efi":true,"Enabled":false,"SetupMode":true}

--- a/providers/os/resources/windows/testdata/security_products_none.json
+++ b/providers/os/resources/windows/testdata/security_products_none.json
@@ -1,0 +1,1 @@
+{"firewall":[],"antiVirus":[],"antiSpyware":[]}

--- a/providers/os/resources/windows/testdata/smartscreen_server2016.json
+++ b/providers/os/resources/windows/testdata/smartscreen_server2016.json
@@ -1,0 +1,1 @@
+{"EnableSmartScreen":null,"ShellSmartScreenLevel":"","EdgeSmartScreenEnabled":null,"EdgeSmartScreenPuaEnabled":null,"EdgePreventOverride":null,"EdgePreventOverrideForFiles":null,"StoreAppsEnableWebContentEvaluation":0}

--- a/providers/os/resources/windows/testdata/smartscreen_server2022.json
+++ b/providers/os/resources/windows/testdata/smartscreen_server2022.json
@@ -1,0 +1,1 @@
+{"EnableSmartScreen":null,"ShellSmartScreenLevel":"","EdgeSmartScreenEnabled":null,"EdgeSmartScreenPuaEnabled":null,"EdgePreventOverride":null,"EdgePreventOverrideForFiles":null,"StoreAppsEnableWebContentEvaluation":1}

--- a/providers/os/resources/windows/testdata/tpm_absent_server2016.json
+++ b/providers/os/resources/windows/testdata/tpm_absent_server2016.json
@@ -1,0 +1,1 @@
+{"TpmPresent":false,"TpmReady":false,"TpmEnabled":false,"TpmActivated":false,"ManufacturerVersion":"","ManufacturerId":0,"ManufacturerIdTxt":"","LockedOut":false,"LockoutCount":0,"LockoutHealTime":"","AutoProvisioning":"","OwnerClearDisabled":false,"SpecVersion":""}

--- a/providers/os/resources/windows/testdata/tpm_absent_server2022.json
+++ b/providers/os/resources/windows/testdata/tpm_absent_server2022.json
@@ -1,0 +1,1 @@
+{"TpmPresent":false,"TpmReady":false,"TpmEnabled":false,"TpmActivated":false,"ManufacturerVersion":"","ManufacturerId":0,"ManufacturerIdTxt":"","LockedOut":false,"LockoutCount":0,"LockoutHealTime":"","AutoProvisioning":"NotDefined","OwnerClearDisabled":true,"SpecVersion":""}

--- a/providers/os/resources/windows/tpm_test.go
+++ b/providers/os/resources/windows/tpm_test.go
@@ -4,6 +4,7 @@
 package windows
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -169,4 +170,51 @@ func TestTpmManufacturer(t *testing.T) {
 // collected: a field that is never fetched cannot be leaked by any query.
 func TestPSGetTpmDoesNotCollectOwnerAuth(t *testing.T) {
 	assert.NotContains(t, PSGetTpm, "OwnerAuth")
+}
+
+// Real Get-Tpm readings from hosts with no TPM, captured through the shipped
+// PSGetTpm script. Server 2019 (10.0.17763) produced output identical to 2022,
+// so it is covered by the same fixture.
+//
+// The two versions disagree on what a machine without a TPM reports, which is
+// the point of pinning both: on 2016 the TBS service will not start, Get-Tpm
+// throws outright, and every field comes back empty; on 2019 and later Get-Tpm
+// returns an object whose AutoProvisioning is "NotDefined" and whose
+// OwnerClearDisabled is true. The second is the trap the resource
+// documentation warns about, since a host with no TPM at all reports the same
+// value a hardened one would.
+func TestParseTpmAbsentServerBaselines(t *testing.T) {
+	t.Run("Server 2016, where Get-Tpm itself fails", func(t *testing.T) {
+		f, err := os.Open("./testdata/tpm_absent_server2016.json")
+		require.NoError(t, err)
+		defer f.Close()
+
+		info, err := ParseTpm(f)
+		require.NoError(t, err)
+
+		assert.False(t, info.TpmPresent)
+		assert.False(t, info.TpmReady)
+		assert.False(t, info.TpmEnabled)
+		assert.False(t, info.TpmActivated)
+		assert.Empty(t, info.AutoProvisioning)
+		assert.False(t, info.OwnerClearDisabled)
+		assert.Empty(t, info.MajorSpecVersion())
+		assert.Empty(t, info.Manufacturer())
+	})
+
+	t.Run("Server 2022, where Get-Tpm answers for an absent TPM", func(t *testing.T) {
+		f, err := os.Open("./testdata/tpm_absent_server2022.json")
+		require.NoError(t, err)
+		defer f.Close()
+
+		info, err := ParseTpm(f)
+		require.NoError(t, err)
+
+		assert.False(t, info.TpmPresent)
+		assert.Equal(t, "NotDefined", info.AutoProvisioning)
+		// true on a machine that has no TPM to clear
+		assert.True(t, info.OwnerClearDisabled)
+		assert.Empty(t, info.MajorSpecVersion())
+		assert.Empty(t, info.Manufacturer())
+	})
 }


### PR DESCRIPTION
## What

The fixtures behind `windows.deviceGuard`, `windows.tpm`, `windows.exploitProtection`, `windows.smartScreen`, `windows.security.products` and `machine.secureboot` were hand-written. This replaces or supplements them with output captured from **live Windows Server 2016 (10.0.14393), 2019 (10.0.17763), 2022 (10.0.20348) and 2025 (10.0.26100)** hosts, running the shipped collection scripts verbatim.

**No bug was found in any of these parsers.** Every one of them decoded the real output correctly on all four releases. The value here is the *version drift*, which is precisely what a hand-written fixture cannot represent.

## What the four releases actually disagree about

**`Win32_DeviceGuard` platform properties differ on every release that reports anything.** These are the reason a security service that is configured will not start, so getting them wrong is not cosmetic:

| | 2016 | 2019 | 2022 | 2025 |
|---|---|---|---|---|
| `AvailableSecurityProperties` | `[3]` | `[0]` | `[0]` | `[1,3,5,7]` |
| `CodeIntegrityPolicyEnforcementStatus` | 0 | 0 | 0 | **2** |
| `SecurityServicesConfigured` / `Running` | `[0]` | `[0]` | `[0]` | `[0]` |

2025 is the only one of the four whose kernel code integrity policy is enforced out of the box. The test now also asserts every code the four hosts report falls inside the range the schema documents (0-8) — **no undecoded value appeared on any release, including 2025.**

**`Get-Tpm` answers differently for an absent TPM across releases.** On 2016 the TBS service will not start, the cmdlet throws outright, and every field comes back empty. From 2019 on it returns an object whose `AutoProvisioning` is `NotDefined` and whose `OwnerClearDisabled` is **true**. The second is the trap the schema documentation already warns about: a host with no TPM at all reports the same `ownerClearDisabled` a hardened one would.

**`Get-ProcessMitigation` is not present on Server 2016 at all**, despite the module being documented as in-box from Server 2016 onwards — `Get-ProcessMitigation` is not a recognized cmdlet on 10.0.14393. The shipped `exploitprotection_unavailable.json` turned out to be **byte-for-byte** what that host produces, so that path is now known to be a real reading rather than a constructed one. The new NOTSET fixture is 2019, 2022 and 2025 (identical output), and pins the distinction that matters most on this resource: an unconfigured mitigation reports `NOTSET`, and `NOTSET` must reach the resource as itself rather than as `OFF` or `ON`.

**SmartScreen's Store apps setting is a real value that differs by version** (0 on 2016, 1 from 2019 on) while every policy toggle around it is absent and has to stay null rather than becoming an explicit 0 that would read as "administratively disabled".

**`machine.secureboot` gains its first UEFI fixture.** 2016, 2019 and 2022 are all legacy BIOS, where `efi` and `enabled` are both false *for the same reason* and cannot be told apart. 2025 is UEFI with Secure Boot **off** and the platform in **setup mode**, which separates all three fields for the first time.

**`root/SecurityCenter2` has no products to report on any Windows Server**, so the parse has to produce an empty list without inventing one. (Version drift worth noting for later: on 2016/2019/2022 the namespace does not exist at all — `Invalid namespace` — while on 2025 it *does* exist and simply returns zero instances.)

## Sanitization

Every fixture is the collection script's own output with no host identifiers in it: no hostnames, addresses, SIDs, volume or key protector identifiers, TPM vendor strings, or instance IDs. The captured hosts have no TPM and no BitLocker, so no vendor or volume identifier existed to redact in the first place, and nothing credential-shaped is present in any commit on the branch.

## Coverage gap, stated plainly

This PR does **not** add a fixture for a *present* TPM or for a BitLocker volume with real key protectors. All four hosts are EC2 instances with no TPM, and the BitLocker feature is not installed on any of them (`manage-bde`, `BDESVC`, the `fvevol` driver and the WMI namespace are all absent; installing it requires a reboot that was not available). The present-TPM decode and the key-protector decode therefore remain covered only by constructed input.
