### PR TITLE
🐛 os: report SMBv1 as disabled when the mrxsmb10 driver is not installed

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -12811,10 +12811,13 @@ windows.smb {
   serverConfiguration() windows.smb.serverConfiguration
   // SMB client (LanmanWorkstation) registry configuration
   clientConfiguration() windows.smb.clientConfiguration
-  // Whether the SMBv1 client driver (mrxsmb10) is enabled (Start != 4)
+  // Whether the SMBv1 client driver (mrxsmb10) is enabled
   //
-  // True when the mrxsmb10 service Start value is anything other than 4
-  // (disabled). SMBv1 is deprecated and should be disabled.
+  // True when the mrxsmb10 service Start value is present and is anything
+  // other than 4 (disabled). False when the service key is absent, which is
+  // how a host that has had the SMB1Protocol optional feature removed looks:
+  // the feature removal deletes the key outright. Server 2019 and later ship
+  // without it. SMBv1 is deprecated and should be disabled.
   smbv1Enabled() bool
 }
 

--- a/providers/os/resources/windows_smb.go
+++ b/providers/os/resources/windows_smb.go
@@ -273,14 +273,27 @@ func computeSmbClientConfig(policy, params, service map[string]registry.Registry
 }
 
 // computeSmbV1Enabled reports whether the SMBv1 client driver (mrxsmb10) is
-// enabled. The driver is enabled unless its Start value is explicitly 4
-// (disabled); an absent value means the default-installed driver is present, so
-// it is treated as enabled.
+// enabled.
+//
+// The driver is enabled when its Start value is present and is anything other
+// than 4 (disabled). An absent Start value means the driver is not installed:
+// removing the SMB1Protocol optional feature deletes the mrxsmb10 service key
+// outright, which is exactly the state a host that has had SMBv1 removed is
+// in. Server 2019, 2022 and 2025 all ship that way, and all three report
+// Get-WindowsOptionalFeature -FeatureName SMB1Protocol as Disabled while the
+// key is gone; Server 2016 still carries the key with Start 2 and reports the
+// feature as Enabled.
+//
+// Treating the absent key as enabled reported SMBv1 as on for every host that
+// had properly removed it, so the field could not return false on any
+// supported Windows Server and an audit requiring SMBv1 to be disabled failed
+// on hosts that had disabled it.
 func computeSmbV1Enabled(driver map[string]registry.RegistryKeyItem) bool {
-	if it, ok := driver["start"]; ok {
-		return it.Value.Number != smbServiceDisabled
+	it, ok := driver["start"]
+	if !ok {
+		return false
 	}
-	return true
+	return it.Value.Number != smbServiceDisabled
 }
 
 func (w *mqlWindowsSmb) serverConfiguration() (*mqlWindowsSmbServerConfiguration, error) {

--- a/providers/os/resources/windows_smb_internal_test.go
+++ b/providers/os/resources/windows_smb_internal_test.go
@@ -218,6 +218,19 @@ func TestComputeSmbV1Enabled(t *testing.T) {
 	// manual start (3) -> enabled
 	assert.True(t, computeSmbV1Enabled(regMap(d("start", 3))))
 
-	// absent -> treated as enabled (default-installed driver present)
-	assert.True(t, computeSmbV1Enabled(map[string]registry.RegistryKeyItem{}))
+	// boot start (0) and system start (1) -> enabled
+	assert.True(t, computeSmbV1Enabled(regMap(d("start", 0))))
+	assert.True(t, computeSmbV1Enabled(regMap(d("start", 1))))
+
+	// An absent service key means the SMB1Protocol optional feature was
+	// removed, which deletes the mrxsmb10 key outright. That is not-installed,
+	// so not enabled. Server 2019, 2022 and 2025 are all in this state on a
+	// stock install; reading it as enabled meant the field could not return
+	// false on any of them.
+	assert.False(t, computeSmbV1Enabled(map[string]registry.RegistryKeyItem{}))
+	assert.False(t, computeSmbV1Enabled(nil))
+
+	// A key present but carrying no Start value cannot say the driver will
+	// load, so it is not reported as enabled either.
+	assert.False(t, computeSmbV1Enabled(regMap(d("type", 2))))
 }


### PR DESCRIPTION
## The bug

`windows.smb.smbv1Enabled` treated an absent `mrxsmb10` service key as *"the default-installed driver is present"* and reported SMBv1 as **enabled**:

```go
if it, ok := driver["start"]; ok {
    return it.Value.Number != smbServiceDisabled
}
return true   // absent -> enabled
```

That is backwards. Removing the **SMB1Protocol** optional feature deletes the `mrxsmb10` service key outright, so an absent key is precisely what a host that has had SMBv1 removed looks like. Windows Server 2019 and later ship that way.

## Reproduction

The registry state and the optional feature agree with each other on every host, and both disagree with the field:

| version | `mrxsmb10` key | `Get-WindowsOptionalFeature SMB1Protocol` | reported | actual |
|---|---|---|---|---|
| 2016 | present, `Start=2` | `Enabled` | `true` | `true` ✓ |
| 2019 | **ABSENT** | `Disabled` | **`true`** | `false` |
| 2022 | **ABSENT** | `Disabled` | **`true`** | `false` |
| 2025 | **ABSENT** | `Disabled` | **`true`** | `false` |

**Affected versions: 2019, 2022, 2025.**

The consequence is worse than three wrong hosts. The only way to reach `false` was a host that kept the driver *installed* and set `Start` to 4 — so on a stock supported Windows Server the field **could not return `false` at all**. Every one reported SMBv1 as enabled. A check requiring SMBv1 to be disabled failed on hosts that had removed it, and the field carried no information about the host whatsoever.

## The fix

The driver is reported as enabled only when a `Start` value is **present** and is not 4. An absent `Start` cannot say the driver will load, so it is not enabled.

## Verification

Built from this branch and run against the live hosts:

```
$ mql run ssh Administrator@<host> -c 'windows.smb { smbv1Enabled }'

2016   smbv1Enabled: true      (key present, Start=2, feature Enabled)
2019   smbv1Enabled: false     (key absent, feature Disabled)
2022   smbv1Enabled: false     (key absent, feature Disabled)
2025   smbv1Enabled: false     (key absent, feature Disabled)
```

All four versions verified against live hosts. 2016 is the only one that legitimately reports `true`, and it is the only one where SMBv1 is genuinely installed and enabled.

Unit tests extended to cover the absent key, a nil map, a key present with no `Start` value, and boot/system start values (0 and 1) which were previously untested. `go test ./resources/` passes.
