### PR TITLE
🐛 os: correct two windows.rdp settings that reported a state the host was not in

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -11520,6 +11520,10 @@ windows.rdp {
   // Whether supported Plug and Play device redirection is disabled (fDisablePNPRedir)
   pnpDeviceRedirectionDisabled() bool
   // Whether saving of Remote Desktop passwords is disabled (DisablePasswordSaving)
+  //
+  // A Group Policy-only setting under the Terminal Services policy key. False
+  // when no policy sets it, because Windows documents the unconfigured
+  // behavior as letting the user save passwords in Remote Desktop Connection.
   passwordSavingDisabled() bool
   // Whether temporary folders are deleted when the session exits (DeleteTempDirsOnExit)
   deleteTempDirsOnExit() bool

--- a/providers/os/resources/windows_rdp.go
+++ b/providers/os/resources/windows_rdp.go
@@ -178,8 +178,13 @@ func (r *mqlWindowsRdp) pnpDeviceRedirectionDisabled() (bool, error) {
 }
 
 func (r *mqlWindowsRdp) passwordSavingDisabled() (bool, error) {
-	// Windows disables saving Remote Desktop passwords by default
-	return r.resolveBool("DisablePasswordSaving", rdpWinStations, 1)
+	// Policy-only setting. Microsoft documents the unconfigured behavior as
+	// "the user will be able to save passwords using Remote Desktop
+	// Connection", so saving is allowed and this reports false. Defaulting to
+	// true claimed the hardened state on every host that had not set the
+	// policy, which is the direction that makes a check pass without reading
+	// anything.
+	return r.resolveBool("DisablePasswordSaving", rdpWinStations, 0)
 }
 
 func (r *mqlWindowsRdp) deleteTempDirsOnExit() (bool, error) {
@@ -228,13 +233,18 @@ func (r *mqlWindowsRdp) perSessionTempDirsUsed() (bool, error) {
 }
 
 func (r *mqlWindowsRdp) solicitedRemoteAssistanceAllowed() (bool, error) {
-	// Remote Assistance is a policy-only setting; off when not configured
-	return r.resolveBool("fAllowToGetHelp", rdpWinStations, 0)
+	// Remote Assistance is machine-wide, not per-listener: the policy writes
+	// fAllowToGetHelp under the Terminal Services policy key and enabling it
+	// locally writes it under the Terminal Server key. Neither is under
+	// WinStations\RDP-Tcp, so looking there missed a host that had turned
+	// Remote Assistance on outside Group Policy and reported it as off.
+	return r.resolveBool("fAllowToGetHelp", rdpTerminalServer, 0)
 }
 
 func (r *mqlWindowsRdp) offerRemoteAssistanceAllowed() (bool, error) {
-	// offering unsolicited Remote Assistance is off when not configured
-	return r.resolveBool("fAllowUnsolicited", rdpWinStations, 0)
+	// machine-wide for the same reason as fAllowToGetHelp; off when nothing
+	// sets it
+	return r.resolveBool("fAllowUnsolicited", rdpTerminalServer, 0)
 }
 
 func (r *mqlWindowsRdp) webAuthnRedirectionDisabled() (bool, error) {

--- a/providers/os/resources/windows_rdp_internal_test.go
+++ b/providers/os/resources/windows_rdp_internal_test.go
@@ -76,3 +76,40 @@ func toLowerASCII(s string) string {
 	}
 	return string(b)
 }
+
+// Remote Assistance is machine-wide, not per-listener. Its value is written
+// under the Terminal Server key when it is enabled outside Group Policy, never
+// under WinStations\RDP-Tcp, so resolving it against the per-listener map
+// misses a host that has it turned on and reports Remote Assistance as off.
+func TestRemoteAssistanceResolvesAgainstTheMachineWideKey(t *testing.T) {
+	for _, name := range []string{"fAllowToGetHelp", "fAllowUnsolicited"} {
+		t.Run(name, func(t *testing.T) {
+			// how a host with Remote Assistance enabled locally looks: the
+			// value is under the Terminal Server key and no policy sets it
+			tsRoot := map[string]int64{toLowerASCII(name): 1}
+			winSta := map[string]int64{}
+
+			assert.Equal(t, int64(1), resolveRdpValue(nil, tsRoot, name, 0),
+				"the machine-wide key holds the value and has to be the source consulted")
+			assert.Equal(t, int64(0), resolveRdpValue(nil, winSta, name, 0),
+				"the per-listener key never holds it, so resolving there reports the default")
+		})
+	}
+}
+
+// DisablePasswordSaving is a Group Policy-only setting. Microsoft documents the
+// unconfigured behavior as "the user will be able to save passwords using
+// Remote Desktop Connection", so an absent value means saving is allowed and
+// the field is false. Defaulting to true claimed the hardened state on every
+// host that had not set the policy, which is the direction that lets a check
+// pass without reading anything.
+func TestPasswordSavingDefaultsToAllowed(t *testing.T) {
+	assert.Equal(t, int64(0), resolveRdpValue(nil, nil, "DisablePasswordSaving", 0))
+
+	// the policy still wins when it is set, in both directions
+	enabled := map[string]int64{"disablepasswordsaving": 1}
+	assert.Equal(t, int64(1), resolveRdpValue(enabled, nil, "DisablePasswordSaving", 0))
+
+	disabled := map[string]int64{"disablepasswordsaving": 0}
+	assert.Equal(t, int64(0), resolveRdpValue(disabled, nil, "DisablePasswordSaving", 0))
+}


### PR DESCRIPTION
Two separate faults in `windows.rdp`, both in the direction that lets a check **pass without reading anything**.

## 1. `passwordSavingDisabled` claimed the hardened state by default

`DisablePasswordSaving` is a Group Policy-only setting, and the resource defaulted it to **1** when the policy was absent. Microsoft documents the unconfigured behavior as the opposite:

> If you disable this setting or **leave it not configured, the user will be able to save passwords** using Remote Desktop Connection.
> — [Policy CSP - RemoteDesktopServices › DoNotAllowPasswordSaving](https://learn.microsoft.com/windows/client-management/mdm/policy-csp-remotedesktopservices#donotallowpasswordsaving)

The policy is absent on stock Server **2016, 2019, 2022 and 2025**:

```
DisablePasswordSaving: <set in neither the policy key nor WinStations\RDP-Tcp>
```

| | before | after | actual |
|---|---|---|---|
| `windows.rdp.passwordSavingDisabled` | **`true`** | `false` | `false` |

So all four reported the hardened state with nothing on the host saying so, and a check asserting that password saving is disabled **passed on every one of them**. That is a silent false negative: the audit reports compliance it never established.

**Affected versions: 2016, 2019, 2022, 2025 — all of them.**

## 2. Remote Assistance was resolved against the wrong key

`solicitedRemoteAssistanceAllowed` and `offerRemoteAssistanceAllowed` resolved `fAllowToGetHelp` / `fAllowUnsolicited` against `WinStations\RDP-Tcp`.

Remote Assistance is **machine-wide, not per-listener**. Group Policy writes the value under the Terminal Services policy key ([RemoteAssistance ADMX mapping](https://learn.microsoft.com/windows/client-management/mdm/policy-csp-remoteassistance#solicitedremoteassistance)), and enabling it outside Group Policy writes it under `SYSTEM\CurrentControlSet\Control\Terminal Server`. Neither is `WinStations\RDP-Tcp`.

The policy path was already correct, so this only bit a host with Remote Assistance turned on **locally** — which is exactly the host worth finding.

### Live A/B

Set `fAllowToGetHelp = 1` under the Terminal Server key on a Server 2022 host and ran both builds against it:

| build | `solicitedRemoteAssistanceAllowed` |
|---|---|
| `main` | **`false`** (wrong — Remote Assistance is on) |
| this branch | `true` |

**Host state restored.** The value was removed again and the key diffed against the capture taken before the change:

```
=== diff against pre-change capture ===
IDENTICAL to before -- restore verified
```

and the resource reads `false` again on the restored host.

## Verification

```
$ mql run ssh Administrator@<host> -c 'windows.rdp { passwordSavingDisabled
    solicitedRemoteAssistanceAllowed offerRemoteAssistanceAllowed
    networkLevelAuthentication securityLayer minEncryptionLevel connectionsDenied }'
```

2016, 2019 and 2022 all now report `passwordSavingDisabled: false`, with the surrounding fields unchanged and still matching the registry (`networkLevelAuthentication: true`, `securityLayer: 2`, `minEncryptionLevel: 2`, `connectionsDenied: false`).

Unit tests added for both: the machine-wide-vs-per-listener source selection, and the password-saving default in the absent case plus both explicit policy values. `go test ./resources/` passes.

## Not changed

The other 21 `windows.rdp` fields were cross-checked field by field against raw registry reads on all four versions and every one matched. Details in the validation report.
