### PR TITLE
🐛 os: fail loudly when the SMB collections cannot be read

### DIFF
--- a/providers/os/resources/windows/smb.go
+++ b/providers/os/resources/windows/smb.go
@@ -5,12 +5,33 @@ package windows
 
 import "io"
 
+// $ErrorActionPreference is Stop on each of these deliberately.
+//
+// The SMB cmdlets report a failure as a non-terminating error: they write to
+// stderr, write nothing to stdout, and leave the exit status at 0. The
+// provider only treats a non-zero exit as a failure, so without the guard a
+// cmdlet that could not read anything is indistinguishable from a host that
+// genuinely has no shares, no sessions or no connections, and the resource
+// reports an empty list either way.
+//
+// An empty list is the worst possible answer to be wrong with, because every
+// assertion made about a collection is satisfied by it: none() and all() both
+// pass vacuously, so "no share is exposed to Everyone" passes on a host whose
+// share list nobody managed to read.
+//
+// With the guard the two cases separate cleanly. A cmdlet failure becomes a
+// terminating error and PowerShell exits non-zero, which the provider turns
+// into an error carrying stderr; a host that genuinely has none still exits 0
+// with empty output and still reports an empty list.
 const (
 	// ShareType is an enum; "$($_.ShareType)" forces its label (e.g.
 	// FileSystemDirectory) rather than its numeric value.
-	SMB_SHARES      = `Get-SmbShare | Select-Object Name,Path,Description,ScopeName,@{Name='ShareType';Expression={"$($_.ShareType)"}} | ConvertTo-Json`
-	SMB_SESSIONS    = `Get-SmbSession | Select-Object SessionId,ClientComputerName,ClientUserName,Dialect,NumOpens | ConvertTo-Json`
-	SMB_CONNECTIONS = `Get-SmbConnection | Select-Object ServerName,ShareName,UserName,Dialect | ConvertTo-Json`
+	SMB_SHARES = `$ErrorActionPreference='Stop'
+Get-SmbShare | Select-Object Name,Path,Description,ScopeName,@{Name='ShareType';Expression={"$($_.ShareType)"}} | ConvertTo-Json`
+	SMB_SESSIONS = `$ErrorActionPreference='Stop'
+Get-SmbSession | Select-Object SessionId,ClientComputerName,ClientUserName,Dialect,NumOpens | ConvertTo-Json`
+	SMB_CONNECTIONS = `$ErrorActionPreference='Stop'
+Get-SmbConnection | Select-Object ServerName,ShareName,UserName,Dialect | ConvertTo-Json`
 )
 
 type WindowsSmbShare struct {

--- a/providers/os/resources/windows/smb_test.go
+++ b/providers/os/resources/windows/smb_test.go
@@ -54,3 +54,21 @@ func TestParseWindowsSmbConnections(t *testing.T) {
 	require.Len(t, connections, 1)
 	require.Equal(t, WindowsSmbConnection{ServerName: "fs01", ShareName: "SAP_Export", UserName: "CORP\\bob", Dialect: "3.1.1"}, connections[0])
 }
+
+// The SMB cmdlets report a failure as a non-terminating error: stderr gets the
+// message, stdout gets nothing, and the exit status stays 0. The provider only
+// treats a non-zero exit as a failure, so without this guard a cmdlet that read
+// nothing is indistinguishable from a host that genuinely has no shares, and
+// the resource reports an empty list either way. An empty list satisfies every
+// assertion made about a collection, so the wrong answer passes silently.
+func TestSmbCommandsFailLoudly(t *testing.T) {
+	for name, cmd := range map[string]string{
+		"shares":      SMB_SHARES,
+		"sessions":    SMB_SESSIONS,
+		"connections": SMB_CONNECTIONS,
+	} {
+		require.True(t, strings.HasPrefix(cmd, "$ErrorActionPreference='Stop'\n"),
+			"%s must turn a cmdlet failure into a non-zero exit, or it degrades to an empty list", name)
+		require.LessOrEqual(t, len(cmd), PSMaxScriptLength, "%s", name)
+	}
+}


### PR DESCRIPTION
> **Flagging up front: this changes shipped behavior.** A scan against a host whose SMB stack cannot be read now **errors** on three fields where it previously reported an empty list. That is the point of the change, but it deserves its own decision in review, which is why it is not bundled with the other SMB fix.

## The bug

`windows.smb.shares`, `.sessions` and `.connections` reported an **empty list** when their cmdlet failed — indistinguishable from a host that genuinely has none.

The SMB cmdlets report a failure as a **non-terminating** error: the message goes to stderr, stdout gets nothing, and the **exit status stays 0**. `smbStdout` only treats a non-zero exit as a failure, so the empty stdout went straight to the parser and came back as an empty list.

## Reproduction

On a live Server 2022, running the provider's own `SMB_SHARES` command against a cmdlet made to fail:

```
$ Get-SmbShare -CimSession 'no-such-host' | Select-Object Name,Path,... | ConvertTo-Json

stdout:    (empty)
stderr:    Get-SmbShare : ... Cannot connect to CIM server ...
exit code: 0
```

Exit 0 with empty stdout is exactly what a host with no shares produces, so the provider cannot tell them apart.

## Why an empty list is the worst answer to be wrong with

Every assertion made about a collection is satisfied by an empty one. `none()` and `all()` both pass vacuously, so a check reading *"no share is exposed to Everyone"* **passes on a host whose share list nobody managed to read**. The failure is invisible: no error, no warning, a green result.

## The fix

Set `$ErrorActionPreference='Stop'` on the three collection commands. This is the mechanism the same package **already relies on** for the WinRM listener enumeration, where it is documented for this exact reason:

> A host with no listener configured is a normal, common state and yields an empty array; a configuration that cannot be read at all has to fail loudly instead, because an empty listener list satisfies every assertion an audit makes about listeners.

Verified on a live host that the guard separates the two cases rather than collapsing them:

| case | exit | stdout | result |
|---|---|---|---|
| cmdlet fails, guard set | **1** | empty | error carrying stderr |
| host genuinely has no sessions | **0** | empty | empty list, as before |

The legitimate-empty path is preserved, which is the part that would have made this a bad trade if it were not.

## Verification

No regression on live hosts. Server 2016 and 2022 both still enumerate the stock administrative shares correctly:

```
shares: [ ADMIN$  (FileSystemDirectory, C:\Windows, "Remote Admin")
          C$      (FileSystemDirectory, C:\,        "Default share")
          IPC$    (InterprocessCommunication, "",   "Remote IPC") ]
sessions.length: 0
connections.length: 0
```

`sessions` and `connections` are genuinely empty on these hosts and still report `0` rather than erroring — the case the guard had to leave alone.

A regression test pins the guard on all three commands and checks they still fit `PSMaxScriptLength`.
