### PR TITLE
🐛 os: make the SMB and WinRM configuration resources reachable by their own path

### DIFF
--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -2310,11 +2310,11 @@ func init() {
 			Create: createWindowsWinrmListener,
 		},
 		"windows.winrm.client": {
-			// to override args, implement: initWindowsWinrmClient(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initWindowsWinrmClient,
 			Create: createWindowsWinrmClient,
 		},
 		"windows.winrm.service": {
-			// to override args, implement: initWindowsWinrmService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initWindowsWinrmService,
 			Create: createWindowsWinrmService,
 		},
 		"windows.deviceGuard": {
@@ -2418,11 +2418,11 @@ func init() {
 			Create: createWindowsSmb,
 		},
 		"windows.smb.serverConfiguration": {
-			// to override args, implement: initWindowsSmbServerConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initWindowsSmbServerConfiguration,
 			Create: createWindowsSmbServerConfiguration,
 		},
 		"windows.smb.clientConfiguration": {
-			// to override args, implement: initWindowsSmbClientConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initWindowsSmbClientConfiguration,
 			Create: createWindowsSmbClientConfiguration,
 		},
 		"windows.smb.share": {

--- a/providers/os/resources/windows_dnsserver_test.go
+++ b/providers/os/resources/windows_dnsserver_test.go
@@ -96,10 +96,6 @@ func TestNoNewDottedPathHusks(t *testing.T) {
 		"windows.scheduledTask.principal": true,
 		"windows.scheduledTask.settings":  true,
 		"windows.smartScreen":             true,
-		"windows.smb.clientConfiguration": true,
-		"windows.smb.serverConfiguration": true,
-		"windows.winrm.client":            true,
-		"windows.winrm.service":           true,
 	}
 
 	var unexpected []string

--- a/providers/os/resources/windows_smb.go
+++ b/providers/os/resources/windows_smb.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers/os/connection/shared"
 	"go.mondoo.com/mql/providers/os/registry"
 	"go.mondoo.com/mql/providers/os/resources/powershell"
@@ -396,4 +397,47 @@ func (w *mqlWindowsSmb) connections() ([]any, error) {
 		res = append(res, r)
 	}
 	return res, nil
+}
+
+// windows.smb.serverConfiguration and windows.smb.clientConfiguration are both
+// a field path on windows.smb and a resource name in their own right. The
+// compiler resolves the longest matching resource name before it considers a
+// field, so the dotted form instantiates the sub-resource directly and the
+// parent's accessor never runs. Every field on these resources is a plain
+// schema field that only the parent populates, so none is ever set: the query
+// reports null for each one with "provider returned no data and no error", and
+// the values convert as primitives carrying no type information.
+//
+// That is worse than an error, because a check reading "SMB signing is
+// required" off a null does not fail on a host that does not require it.
+//
+// Delegating to the parent's accessor fills the resource in. The block form
+// `windows.smb { serverConfiguration { ... } }` binds the field instead of
+// resolving a resource name and was never affected. When the resource is
+// created normally by the parent it carries an __id and this is a no-op.
+func initWindowsSmbChild[T plugin.Resource](
+	runtime *plugin.Runtime,
+	args map[string]*llx.RawData,
+	get func(*mqlWindowsSmb) *plugin.TValue[T],
+) (map[string]*llx.RawData, plugin.Resource, error) {
+	if _, ok := args["__id"]; ok {
+		return args, nil, nil
+	}
+	parent, err := CreateResource(runtime, "windows.smb", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	v := get(parent.(*mqlWindowsSmb))
+	if v.Error != nil {
+		return nil, nil, v.Error
+	}
+	return args, v.Data, nil
+}
+
+func initWindowsSmbServerConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return initWindowsSmbChild(runtime, args, (*mqlWindowsSmb).GetServerConfiguration)
+}
+
+func initWindowsSmbClientConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return initWindowsSmbChild(runtime, args, (*mqlWindowsSmb).GetClientConfiguration)
 }

--- a/providers/os/resources/windows_smb_internal_test.go
+++ b/providers/os/resources/windows_smb_internal_test.go
@@ -221,3 +221,26 @@ func TestComputeSmbV1Enabled(t *testing.T) {
 	// absent -> treated as enabled (default-installed driver present)
 	assert.True(t, computeSmbV1Enabled(map[string]registry.RegistryKeyItem{}))
 }
+
+// windows.smb.serverConfiguration and windows.smb.clientConfiguration are each
+// both a field path on windows.smb and a resource name, which is the condition
+// that makes an Init necessary: the compiler resolves the resource name first,
+// so the dotted form skips the parent's accessor and every field the parent
+// would have populated stays unset.
+func TestWindowsSmbSingletonsAreReachableByTheirOwnPath(t *testing.T) {
+	for _, path := range []string{
+		"windows.smb.serverConfiguration",
+		"windows.smb.clientConfiguration",
+	} {
+		t.Run(path, func(t *testing.T) {
+			_, isField := getDataFields[path]
+			require.True(t, isField, "%s should be a field path on its parent", path)
+
+			factory, isResource := resourceFactories[path]
+			require.True(t, isResource, "%s should also be a registered resource name", path)
+
+			assert.NotNil(t, factory.Init,
+				"%s resolves to the resource, not the field, so without an Init every field reads null", path)
+		})
+	}
+}

--- a/providers/os/resources/windows_winrm.go
+++ b/providers/os/resources/windows_winrm.go
@@ -281,3 +281,45 @@ func (r *mqlWindowsWinrm) listeners() ([]any, error) {
 	}
 	return res, nil
 }
+
+// windows.winrm.client and windows.winrm.service are both a field path on
+// windows.winrm and a resource name in their own right. The compiler resolves
+// the longest matching resource name before it considers a field, so the dotted
+// form instantiates the sub-resource directly and the parent's accessor never
+// runs. The fields the parent populates are then never set, and the query
+// reports null for each one with "provider returned no data and no error".
+//
+// A null is worse than an error here, because a check reading "the service does
+// not allow unencrypted traffic" off a null does not fail on a service that
+// allows it.
+//
+// Delegating to the parent's accessor fills the resource in. The block form
+// `windows.winrm { service { ... } }` binds the field instead of resolving a
+// resource name and was never affected. When the resource is created normally
+// by the parent it carries an __id and this is a no-op.
+func initWindowsWinrmChild[T plugin.Resource](
+	runtime *plugin.Runtime,
+	args map[string]*llx.RawData,
+	get func(*mqlWindowsWinrm) *plugin.TValue[T],
+) (map[string]*llx.RawData, plugin.Resource, error) {
+	if _, ok := args["__id"]; ok {
+		return args, nil, nil
+	}
+	parent, err := CreateResource(runtime, "windows.winrm", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	v := get(parent.(*mqlWindowsWinrm))
+	if v.Error != nil {
+		return nil, nil, v.Error
+	}
+	return args, v.Data, nil
+}
+
+func initWindowsWinrmClient(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return initWindowsWinrmChild(runtime, args, (*mqlWindowsWinrm).GetClient)
+}
+
+func initWindowsWinrmService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return initWindowsWinrmChild(runtime, args, (*mqlWindowsWinrm).GetService)
+}

--- a/providers/os/resources/windows_winrm_internal_test.go
+++ b/providers/os/resources/windows_winrm_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWinRMBool(t *testing.T) {
@@ -130,4 +131,27 @@ func TestComputeWinRMServiceStartMode(t *testing.T) {
 		// loader lower-cases names; the lookup uses the lower-cased "start"
 		assert.Equal(t, int64(2), computeWinRMServiceStartMode(map[string]int64{"start": 2}))
 	})
+}
+
+// windows.winrm.client and windows.winrm.service are each both a field path on
+// windows.winrm and a resource name, which is the condition that makes an Init
+// necessary: the compiler resolves the resource name first, so the dotted form
+// skips the parent's accessor and every field the parent would have populated
+// stays unset.
+func TestWindowsWinrmSingletonsAreReachableByTheirOwnPath(t *testing.T) {
+	for _, path := range []string{
+		"windows.winrm.client",
+		"windows.winrm.service",
+	} {
+		t.Run(path, func(t *testing.T) {
+			_, isField := getDataFields[path]
+			require.True(t, isField, "%s should be a field path on its parent", path)
+
+			factory, isResource := resourceFactories[path]
+			require.True(t, isResource, "%s should also be a registered resource name", path)
+
+			assert.NotNil(t, factory.Init,
+				"%s resolves to the resource, not the field, so without an Init every field reads null", path)
+		})
+	}
 }


### PR DESCRIPTION
## The bug

`windows.smb.serverConfiguration`, `windows.smb.clientConfiguration`, `windows.winrm.client` and `windows.winrm.service` are each **both a field path on their parent and a registered resource name**. The compiler resolves the longest matching resource name before it considers a field, so the dotted form instantiates the sub-resource directly and the parent's accessor never runs. Every field on these resources is populated only by that accessor, so none of them is ever set.

## Reproduction

On a live Server 2022, the dotted and block forms were run **in the same scan**. The dotted form reported nothing at all:

```
x provider returned no data and no error for a field; the field was never set
  on the resource (provider bug) field=requireSecuritySignature
  id=windows.smb.serverConfiguration
x llx: encountered a primitive with no type information, coercing to null

[failed] windows.smb.serverConfiguration.requireSecuritySignature
  actual:   _
[failed] windows.smb.clientConfiguration.enableSecuritySignature
  actual:   _
[failed] windows.winrm.service.allowBasic
  actual:   _
```

while the block form on the same host returned the real values:

```
windows.smb: {
  serverConfiguration: { requireSecuritySignature: false  autoDisconnectMinutes: 15  ... }
  clientConfiguration: { enableSecuritySignature: true  enablePlainTextPassword: false  ... }
}
```

That gap is the whole bug. An operator reading `windows.smb.serverConfiguration.requireSecuritySignature` got **null**, and a check reading *"SMB signing is required"* off a null **does not fail** on a host that does not require it.

Reproduces on **2016, 2019, 2022 and 2025** — it is a schema-shape bug, not a host-dependent one.

Note `windows.winrm.service.ipv4Filter` was **not** affected and returned `"*"` correctly: it is a computed method on the sub-resource itself, so it fetches its own data. Only the fields the parent populates were lost, which is what makes the failure so selective and easy to miss.

## The fix

These four were already recorded in the `TestNoNewDottedPathHusks` ratchet, which exists so the set **can shrink but not grow**. This shrinks it by four, using the same parent-delegating `Init` that `windows.dnsServer` and `windows.defender` already use.

## Verification

Built from this branch and run against a live Server 2022. Every dotted path now returns a real value, and each agrees with the block form:

| dotted path | value |
|---|---|
| `windows.smb.serverConfiguration.requireSecuritySignature` | `false` |
| `windows.smb.serverConfiguration.enableSecuritySignature` | `false` |
| `windows.smb.serverConfiguration.autoDisconnectMinutes` | `15` |
| `windows.smb.serverConfiguration.serviceStart` | `2` |
| `windows.smb.serverConfiguration.restrictNullSessionAccess` | `true` |
| `windows.smb.clientConfiguration.enableSecuritySignature` | `true` |
| `windows.smb.clientConfiguration.enablePlainTextPassword` | `false` |
| `windows.smb.clientConfiguration.serviceStart` | `2` |
| `windows.winrm.client.allowBasic` | `true` |
| `windows.winrm.service.disableRunAs` | `false` |
| `windows.winrm.service.allowAutoConfig` | `false` |

Every one of these matches the registry on the host (`autodisconnect=15`, `enablesecuritysignature=0` on the server side and `1` on the client side, `EnablePlainTextPassword=0`, LanmanServer `Start=2`). No `provider returned no data` and no `primitive with no type information` remain.

Positive tests added for all four paths, mirroring the existing `windows.dnsServer` and `windows.defender` ones, so the fix is pinned rather than only recorded as an absence in the ratchet.
