### PR TITLE
🐛 os: stop reading the legacy Kerberos encryption types on Windows Server 2025

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -11908,12 +11908,16 @@ windows.lsa {
   // set.
   //
   // Read from the policy location
-  // SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Kerberos\Parameters,
-  // falling back to the legacy location Lsa\Kerberos\Parameters that Windows
-  // Server 2025 no longer honors. Null when neither location carries the value,
-  // in which case Windows uses its built-in default set rather than a
-  // configured 0. The kerberosAllows fields decode the well-known bits, since
-  // MQL has no bitwise operators to test them with.
+  // SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Kerberos\Parameters.
+  // Up to Windows Server 2022 the legacy location Lsa\Kerberos\Parameters is
+  // read as a fallback when the policy value is absent. Windows Server 2025
+  // (build 26100) no longer honors that location at all, so on that release and
+  // later it is not consulted and a value left there by an older hardening
+  // script does not appear here: it is inert on the host, and reporting it
+  // would describe a configuration Windows is not applying. Null when no
+  // honored location carries the value, in which case Windows uses its built-in
+  // default set rather than a configured 0. The kerberosAllows fields decode
+  // the well-known bits, since MQL has no bitwise operators to test them with.
   kerberosSupportedEncryptionTypes() int
   // LDAP client signing requirement (Services\LDAP\LDAPClientIntegrity)
   //

--- a/providers/os/resources/windows_lsa.go
+++ b/providers/os/resources/windows_lsa.go
@@ -5,10 +5,12 @@ package resources
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/connection/shared"
 	"go.mondoo.com/mql/providers/os/registry"
 	"go.mondoo.com/ranger-rpc/codes"
 	"go.mondoo.com/ranger-rpc/status"
@@ -37,9 +39,11 @@ const (
 // The Kerberos supported encryption types are written by the "Network
 // security: Configure encryption types allowed for Kerberos" policy to the
 // Policies hive, which is the location Windows honors. The identically named
-// value under Lsa\Kerberos\Parameters is the legacy location: Windows Server
-// 2025 no longer reads it, but it is still effective on earlier releases, so it
-// is consulted as a fallback when the policy value is absent.
+// value under Lsa\Kerberos\Parameters is the legacy location: it is still
+// effective up to Windows Server 2022, so it is consulted as a fallback when
+// the policy value is absent, but Windows Server 2025 (build 26100) no longer
+// reads it at all, so on that release and later the fallback is skipped and an
+// absent policy value resolves to null.
 //
 // The two LDAP server settings live under the NTDS service, which is installed
 // only on a domain controller. On a member server or a standalone host the key
@@ -342,15 +346,28 @@ type lsaKerberosValues struct {
 	AllowsAes256             *bool
 }
 
+// kerberosLegacyEtypeLastBuild is the highest Windows build that still honors
+// the legacy Lsa\Kerberos\Parameters\SupportedEncryptionTypes value. Windows
+// Server 2025 is build 26100 and no longer reads it, so anything from that
+// build on must not fall back to it.
+const kerberosLegacyEtypeLastBuild = 26100
+
 // computeLsaKerberos extracts the Kerberos supported encryption types and
 // decodes the well-known bits. The policy hive wins over the legacy
 // Lsa\Kerberos\Parameters location, matching how Windows resolves the setting.
-// When neither location carries the value every field stays null: an absent
+//
+// legacyHonored says whether this release still reads the legacy location.
+// When it does not, a value left there by a pre-2025 hardening script is inert:
+// reporting it would describe a configuration Windows is not applying, and
+// would do so in the unsafe direction, since a leftover AES-only mask reads as
+// "RC4 is not allowed" on a host whose built-in default set does allow it.
+//
+// When no location carries an honored value every field stays null: an absent
 // value means Windows uses its built-in default set, which is not the same as a
 // configured mask of 0. Pure function for unit testing.
-func computeLsaKerberos(policy, legacy map[string]registry.RegistryKeyItem) lsaKerberosValues {
+func computeLsaKerberos(policy, legacy map[string]registry.RegistryKeyItem, legacyHonored bool) lsaKerberosValues {
 	mask := regIntPtr(policy, "SupportedEncryptionTypes")
-	if mask == nil {
+	if mask == nil && legacyHonored {
 		mask = regIntPtr(legacy, "SupportedEncryptionTypes")
 	}
 	if mask == nil {
@@ -433,7 +450,7 @@ func (r *mqlWindowsLsa) populateKerberos() error {
 	if err != nil {
 		return err
 	}
-	v := computeLsaKerberos(policy, legacy)
+	v := computeLsaKerberos(policy, legacy, r.legacyKerberosEtypeHonored())
 
 	r.KerberosSupportedEncryptionTypes = intFieldPtr(v.SupportedEncryptionTypes)
 	r.KerberosAllowsAes128 = boolFieldPtr(v.AllowsAes128)
@@ -544,4 +561,25 @@ func initWindowsLsaSecureChannel(runtime *plugin.Runtime, args map[string]*llx.R
 		return nil, nil, errors.New("could not read the Netlogon secure-channel settings from windows.lsa")
 	}
 	return nil, sc.Data, nil
+}
+
+// legacyKerberosEtypeHonored reports whether this Windows release still reads
+// Lsa\Kerberos\Parameters\SupportedEncryptionTypes. Windows reports its build
+// as the platform version, so the test is a numeric comparison against the
+// Windows Server 2025 build. An unreadable or unparseable version keeps the
+// fallback, which is the behavior every release up to Windows Server 2022 needs.
+func (r *mqlWindowsLsa) legacyKerberosEtypeHonored() bool {
+	conn, ok := r.MqlRuntime.Connection.(shared.Connection)
+	if !ok {
+		return true
+	}
+	asset := conn.Asset()
+	if asset == nil || asset.Platform == nil {
+		return true
+	}
+	build, err := strconv.Atoi(asset.Platform.Version)
+	if err != nil {
+		return true
+	}
+	return build < kerberosLegacyEtypeLastBuild
 }

--- a/providers/os/resources/windows_lsa_internal_test.go
+++ b/providers/os/resources/windows_lsa_internal_test.go
@@ -404,7 +404,7 @@ func TestComputeLsaKerberos(t *testing.T) {
 	empty := map[string]registry.RegistryKeyItem{}
 
 	t.Run("absent in both locations yields null everywhere", func(t *testing.T) {
-		v := computeLsaKerberos(empty, empty)
+		v := computeLsaKerberos(empty, empty, true)
 		assert.Nil(t, v.SupportedEncryptionTypes)
 		assert.Nil(t, v.AllowsDesCbcCrc)
 		assert.Nil(t, v.AllowsDesCbcMd5)
@@ -424,6 +424,7 @@ func TestComputeLsaKerberos(t *testing.T) {
 		v := computeLsaKerberos(
 			items(d("SupportedEncryptionTypes", 0x18)),
 			items(d("SupportedEncryptionTypes", 0x4)),
+			true,
 		)
 		require.NotNil(t, v.SupportedEncryptionTypes)
 		assert.Equal(t, int64(0x18), *v.SupportedEncryptionTypes)
@@ -432,11 +433,39 @@ func TestComputeLsaKerberos(t *testing.T) {
 	})
 
 	t.Run("the legacy location is used when the policy value is absent", func(t *testing.T) {
-		v := computeLsaKerberos(empty, items(d("SupportedEncryptionTypes", 0x4)))
+		v := computeLsaKerberos(empty, items(d("SupportedEncryptionTypes", 0x4)), true)
 		require.NotNil(t, v.SupportedEncryptionTypes)
 		assert.Equal(t, int64(0x4), *v.SupportedEncryptionTypes)
 		require.NotNil(t, v.AllowsRc4Hmac)
 		assert.True(t, *v.AllowsRc4Hmac)
+	})
+
+	// Windows Server 2025 stopped reading the legacy location. A mask left
+	// there by a pre-2025 hardening script is inert, and reporting it would
+	// describe a configuration the host is not applying. The unsafe direction
+	// is the one asserted here: a leftover AES-only mask must not read as
+	// "RC4 is not allowed" when the built-in default set is what is in force.
+	t.Run("the legacy location is ignored where the release does not honor it", func(t *testing.T) {
+		v := computeLsaKerberos(empty, items(d("SupportedEncryptionTypes", 0x18)), false)
+		assert.Nil(t, v.SupportedEncryptionTypes)
+		assert.Nil(t, v.AllowsRc4Hmac)
+		assert.Nil(t, v.AllowsAes256)
+		assert.True(t, isNullInt(v.SupportedEncryptionTypes))
+		assert.True(t, isNullBool(v.AllowsRc4Hmac))
+	})
+
+	// the policy location keeps working on those releases; it is the only
+	// location Windows Server 2025 reads
+	t.Run("the policy location still applies where the legacy one is ignored", func(t *testing.T) {
+		v := computeLsaKerberos(
+			items(d("SupportedEncryptionTypes", 0x18)),
+			items(d("SupportedEncryptionTypes", 0x4)),
+			false,
+		)
+		require.NotNil(t, v.SupportedEncryptionTypes)
+		assert.Equal(t, int64(0x18), *v.SupportedEncryptionTypes)
+		require.NotNil(t, v.AllowsRc4Hmac)
+		assert.False(t, *v.AllowsRc4Hmac)
 	})
 
 	tests := []struct {
@@ -465,7 +494,7 @@ func TestComputeLsaKerberos(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			v := computeLsaKerberos(items(d("SupportedEncryptionTypes", tc.mask)), empty)
+			v := computeLsaKerberos(items(d("SupportedEncryptionTypes", tc.mask)), empty, true)
 
 			require.NotNil(t, v.SupportedEncryptionTypes)
 			assert.Equal(t, tc.mask, *v.SupportedEncryptionTypes, "the raw mask is reported unchanged")
@@ -545,4 +574,27 @@ func TestComputeLsaLdap(t *testing.T) {
 		v := computeLsaLdap(empty, items(d("LDAPServerIntegrity", 2)))
 		assert.Nil(t, v.ServerIntegrity)
 	})
+}
+
+// TestKerberosLegacyEtypeLastBuild pins the build the legacy-location gate turns
+// on. Windows reports its build as the platform version, so the comparison is
+// against 26100, which is Windows Server 2025 and Windows 11 24H2. Windows
+// Server 2016 (14393), 2019 (17763), and 2022 (20348) all sit below it and keep
+// the fallback.
+func TestKerberosLegacyEtypeLastBuild(t *testing.T) {
+	cases := map[string]struct {
+		build   int
+		honored bool
+	}{
+		"windows server 2016": {14393, true},
+		"windows server 2019": {17763, true},
+		"windows server 2022": {20348, true},
+		"windows server 2025": {26100, false},
+		"a later build":       {27000, false},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, c.honored, c.build < kerberosLegacyEtypeLastBuild)
+		})
+	}
 }


### PR DESCRIPTION
## What

Microsoft documents that **beginning with Windows Server 2025, Kerberos no longer honors** the legacy `REG_DWORD SupportedEncryptionTypes` under `HKLM\SYSTEM\CurrentControlSet\Control\Lsa\Kerberos\Parameters`, and that group policy is the only supported location:

> Beginning with Windows Server 2025, Kerberos no longer honors the legacy registry key `REG_DWORD SupportedEncryptionTypes` found in the path `HKEY_LOCAL_MACHINE\CurrentControlSet\Control\Lsa\Kerberos\Parameters`. Microsoft recommends using group policy instead.
>
> -- [Kerberos authentication overview](https://learn.microsoft.com/windows-server/security/kerberos/kerberos-authentication-overview#encryption-types), repeated in [What's new in Windows Server 2025](https://learn.microsoft.com/windows-server/get-started/whats-new-windows-server-2025#advanced-multilayer-security)

`computeLsaKerberos` read the policy hive first and fell back to that legacy location on **every** release, so on Server 2025 it reported a mask the operating system is not applying.

### The failure direction is the unsafe one

A pre-2025 hardening script writes `0x18` (AES only) to the legacy location, and that value survives an in-place upgrade. On Server 2025 it is inert -- Windows uses its built-in default set, which does permit RC4 -- but the resource read it as a real configuration:

```
windows.lsa.kerberosAllowsRc4Hmac  ->  false
```

so a check asserting RC4 is not allowed **passed on a host that allows it**. That is the direction that matters: the audit reports hardened, the host is not.

## Changes

The legacy fallback is gated on the platform build. Below 26100 it is read exactly as before; from Windows Server 2025 on it is skipped, and an absent policy value resolves to null -- which is already what this field means by "Windows is using its built-in default set rather than a configured 0".

`computeLsaKerberos` takes the honored/not-honored decision as a parameter so it stays a pure function; the build comparison lives in a small `legacyKerberosEtypeHonored` helper that fails **open** (keeps the fallback) if the platform version is missing or unparseable.

## Verified live

Windows Server 2025 (10.0.26100, `asset.version == "26100"`) and Windows Server 2022 (10.0.20348), over SSH. Registry restored to baseline after each state.

**Server 2025, legacy `SupportedEncryptionTypes = 0x18`, no policy value:**

| field | before | after |
|---|---|---|
| `kerberosSupportedEncryptionTypes` | `24` | **null** |
| `kerberosAllowsRc4Hmac` | `false` | **null** |
| `kerberosAllowsDesCbcCrc` | `false` | **null** |
| `kerberosAllowsAes128` | `true` | **null** |
| `kerberosAllowsAes256` | `true` | **null** |

**Server 2025, policy `0x4` with legacy `0x18` still present** -- the policy location is the one Windows reads, and it still wins:

```
kerberosSupportedEncryptionTypes: 4
kerberosAllowsRc4Hmac:           true
kerberosAllowsAes256:            false
```

**Server 2022, legacy `0x4`, no policy value** -- regression check, the fallback is untouched on releases that still honor it:

```
kerberosSupportedEncryptionTypes: 4
kerberosAllowsRc4Hmac:           true
kerberosAllowsAes256:            false
```

The same fallback and precedence were re-confirmed on Windows Server 2016 (build 14393) before this change: legacy `0x4` alone reported `4`, and adding policy `0x18` moved it to `24` with `kerberosAllowsRc4Hmac` false.

Note that on all four stock hosts (2016, 2019, 2022, 2025) `Lsa\Kerberos\Parameters` exists but carries **no** `SupportedEncryptionTypes` value, and the policy key does not exist at all, so out of the box every one of these fields is null on every version, before and after.

## Tests

`TestComputeLsaKerberos` gains the two cases the gate introduces: the legacy location ignored where the release does not honor it (asserting null, not a decoded `false`), and the policy location still applying on those releases. `TestKerberosLegacyEtypeLastBuild` pins the build boundary against the real build numbers of Server 2016, 2019, 2022, and 2025.
