### PR TITLE
🐛 os: stop reporting the Debian kernel metapackage as an installed kernel

### DIFF
--- a/providers/os/resources/kernel.go
+++ b/providers/os/resources/kernel.go
@@ -113,6 +113,34 @@ func suseKernelMatchesRunning(pkgVersion, pkgName, runningKernelVersion string) 
 	return strings.HasPrefix(stripRPMEpoch(pkgVersion), versionPrefix)
 }
 
+// debianImageKernelName reports the kernel release a linux-image package
+// carries, and whether the package holds a kernel at all.
+//
+// Debian and Ubuntu ship a metapackage alongside the versioned images:
+// linux-image-cloud-amd64 on Debian, linux-image-aws on Ubuntu. Its only job
+// is to depend on the newest kernel, so it contains no kernel of its own and
+// listing it invents an installed kernel named after the flavour ("aws",
+// "cloud-amd64") that is not on disk.
+//
+// A real image package always names a release, and a release always starts
+// with a digit. A flavour never does.
+func debianImageKernelName(pkgName string) (string, bool) {
+	name, ok := strings.CutPrefix(pkgName, "linux-image-")
+	if !ok {
+		return "", false
+	}
+
+	// Ubuntu ships the unsigned build as linux-image-unsigned-<release>, so the
+	// release is not in front. Debian appends -unsigned instead, which leaves it
+	// where we expect.
+	name = strings.TrimPrefix(name, "unsigned-")
+
+	if name == "" || name[0] < '0' || name[0] > '9' {
+		return "", false
+	}
+	return name, true
+}
+
 func (k *mqlKernel) installed() ([]any, error) {
 	res := []KernelVersion{}
 
@@ -164,19 +192,16 @@ func (k *mqlKernel) installed() ([]any, error) {
 			//	version: "4.19+105+deb10u8"
 			//}]
 			filterKernel = func(pkg *mqlPackage) {
-				if strings.HasPrefix(pkg.Name.Data, "linux-image") {
-					kernelName := strings.TrimPrefix(pkg.Name.Data, "linux-image-")
-					running := false
-					if kernelName == runningKernelVersion {
-						running = true
-					}
-
-					res = append(res, KernelVersion{
-						Name:    kernelName,
-						Version: pkg.Version.Data,
-						Running: running,
-					})
+				kernelName, ok := debianImageKernelName(pkg.Name.Data)
+				if !ok {
+					return
 				}
+
+				res = append(res, KernelVersion{
+					Name:    kernelName,
+					Version: pkg.Version.Data,
+					Running: kernelName == runningKernelVersion,
+				})
 			}
 		} else if platform.Name == "oraclelinux" {
 			// ORacleLinux is an rpm based systems, but might be running the UEK kernel

--- a/providers/os/resources/kernel_debian_test.go
+++ b/providers/os/resources/kernel_debian_test.go
@@ -1,0 +1,69 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDebianImageKernelName(t *testing.T) {
+	tests := []struct {
+		pkg      string
+		wantName string
+		wantOK   bool
+		why      string
+	}{
+		// Real image packages, as installed on the live hosts these cases came from.
+		{"linux-image-6.17.0-1019-aws", "6.17.0-1019-aws", true, "ubuntu 24.04"},
+		{"linux-image-5.4.0-1156-aws", "5.4.0-1156-aws", true, "ubuntu 18.04"},
+		{"linux-image-5.10.0-46-cloud-amd64", "5.10.0-46-cloud-amd64", true, "debian 11"},
+		{"linux-image-6.12.101+deb13-cloud-amd64", "6.12.101+deb13-cloud-amd64", true, "debian 13"},
+
+		// The metapackages. These are the regression: each one used to be
+		// reported as an installed kernel named after the flavour.
+		{"linux-image-aws", "", false, "ubuntu metapackage"},
+		{"linux-image-cloud-amd64", "", false, "debian metapackage"},
+		{"linux-image-amd64", "", false, "debian generic metapackage"},
+		{"linux-image-generic", "", false, "ubuntu generic metapackage"},
+		{"linux-image-virtual", "", false, "ubuntu virtual metapackage"},
+
+		// Bare name, no release and no trailing dash.
+		{"linux-image", "", false, "bare metapackage"},
+
+		// Unsigned builds: ubuntu puts the marker in front of the release,
+		// debian appends it, so only ubuntu needs the prefix stripped.
+		{"linux-image-unsigned-6.17.0-1019-aws", "6.17.0-1019-aws", true, "ubuntu unsigned"},
+		{"linux-image-5.10.0-46-cloud-amd64-unsigned", "5.10.0-46-cloud-amd64-unsigned", true, "debian unsigned"},
+
+		// Neighbours that share the prefix but hold no kernel.
+		{"linux-image-extra-virtual", "", false, "extra metapackage"},
+		{"linux-headers-6.17.0-1019-aws", "", false, "headers, not an image"},
+		{"linux-modules-6.17.0-1019-aws", "", false, "modules, not an image"},
+		{"", "", false, "empty"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.pkg, func(t *testing.T) {
+			name, ok := debianImageKernelName(tc.pkg)
+			assert.Equal(t, tc.wantOK, ok, tc.why)
+			assert.Equal(t, tc.wantName, name, tc.why)
+		})
+	}
+}
+
+// The running kernel must still be matched after the metapackage is dropped.
+func TestDebianImageKernelNameMatchesRunning(t *testing.T) {
+	running := "6.12.101+deb13-cloud-amd64"
+
+	name, ok := debianImageKernelName("linux-image-" + running)
+	assert.True(t, ok)
+	assert.Equal(t, running, name, "the versioned image is the running kernel")
+
+	// The metapackage carries the same version string in dpkg, which is exactly
+	// why it looked like a second kernel. It must not be considered at all.
+	_, ok = debianImageKernelName("linux-image-cloud-amd64")
+	assert.False(t, ok, "the metapackage is never a kernel, matching or not")
+}


### PR DESCRIPTION
## The bug

`kernel.installed` reports a kernel that is not installed, on **every Debian and Ubuntu host**.

```
# Ubuntu 24.04, before
kernel.installed: [
  0: { name: "6.17.0-1019-aws"  running: true   version: "6.17.0-1019.19~24.04.1" }
  1: { name: "aws"              running: false  version: "6.17.0-1019.19~24.04.1" }   # <- not a kernel
]
```

Found while sweeping the os provider across 15 Linux distros. RHEL, Amazon Linux and SLES each returned exactly one entry; every Debian-family host returned two.

| distro | phantom entry |
|---|---|
| Ubuntu 18.04 / 20.04 / 24.04 / 26.04 | `aws` |
| Debian 11 / 12 / 13 | `cloud-amd64` |

## Why

Debian and Ubuntu ship a *metapackage* alongside the versioned images — `linux-image-cloud-amd64` on Debian, `linux-image-aws` on Ubuntu. Its only job is to depend on the newest kernel; it contains no kernel itself.

The filter matched any package prefixed `linux-image` and trimmed the prefix, so the flavour name became a kernel release. The comment directly above the filter even lists `linux-image-cloud-amd64` among the expected input — the case was seen but never excluded.

## The fix

A real image package always names a release, and a release always starts with a digit. A flavour never does. `debianImageKernelName` uses exactly that, and strips Ubuntu's `unsigned-` infix so a host running only `linux-image-unsigned-<release>` still reports its kernel instead of dropping it.

## Impact

Any policy that counts installed kernels, or asserts that no unused kernel is left installed, saw a false extra on every Debian-family asset.

## Verification

Live EC2 instances, before and after, same hosts:

| host | running | before | after |
|---|---|---|---|
| Ubuntu 18.04 | `5.4.0-1156-aws` | 2 entries | **1** — `5.4.0-1156-aws` |
| Ubuntu 24.04 | `6.17.0-1019-aws` | 2 entries | **1** — `6.17.0-1019-aws` |
| Debian 11 | `5.10.0-46-cloud-amd64` | 2 entries | **1** — `5.10.0-46-cloud-amd64` |
| Debian 13 | `6.12.101+deb13-cloud-amd64` | 2 entries | **1** — `6.12.101+deb13-cloud-amd64` |
| RHEL 9 | `5.14.0-570...el9_6` | 1 entry | 1 — `kernel` (unchanged) |
| SLES 16 | `6.12.0-160000.35-default` | 1 entry | 1 — `kernel-default` (unchanged) |

Unit tests cover the real packages, all five metapackage spellings, both unsigned conventions, and the `linux-headers` / `linux-modules` neighbours that share the prefix.

```
ok  go.mondoo.com/mql/providers/os/resources
```