### PR TITLE
📄 os: describe what a Windows DNS zone reports when it has no such setting

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -13204,7 +13204,11 @@ private windows.acl.auditEntry @defaults("identity auditFlags rights") {
 // read once per scan in a single batched call rather than one call per field.
 // Every field requires the DNS Server role to be installed; gate an audit on
 // `windows.serverFeature(name: "DNS").installed` so the checks do not run on
-// hosts that are not name servers. Complements the client-side `dns` resource
+// hosts that are not name servers. That gate narrows an audit but does not
+// close it: a host where the role was added and the restart has not happened
+// yet reports the feature as installed while the management module is still
+// absent, and every field here reports an error on such a host rather than a
+// configuration. Complements the client-side `dns` resource
 // in the network provider, which resolves names through the public DNS system
 // and cannot see a server's own configuration.
 windows.dnsServer {
@@ -13489,6 +13493,16 @@ private windows.dnsServer.rootHint @defaults("nameServer") {
 // that decide who may transfer it, who may change it, and whether its answers
 // are signed. Iterated from `windows.dnsServer.zones`. The `dnssec` and
 // `signingKeys` fields are populated only for a signed zone.
+//
+// A stub or forwarder zone holds no authoritative data, so the server reports
+// no value at all for the settings that govern such data: `dynamicUpdate`,
+// `secureSecondaries` and `notify` are empty on those zones rather than
+// carrying one of the values listed below, and `isSigned` and `isWinsEnabled`
+// are false because there is nothing to sign or to resolve through WINS. An
+// audit written over the whole zone list should select the zone types it means
+// to judge, for example
+// `windows.dnsServer.zones.where(zoneType == "Primary")`, so that a stub zone
+// does not fail a check about a setting it cannot have.
 private windows.dnsServer.zone @defaults("name zoneType isSigned") {
   // Zone name, for example example.com
   name string
@@ -13499,28 +13513,33 @@ private windows.dnsServer.zone @defaults("name zoneType isSigned") {
   zoneType string
   // Which clients may register records in the zone through dynamic update
   //
-  // One of None, NonsecureAndSecure, or Secure. NonsecureAndSecure lets any
-  // host on the network create or overwrite a record without authenticating,
-  // so a zone that accepts it cannot be trusted to name what it claims to.
+  // One of None, NonsecureAndSecure, or Secure, and empty on a stub or
+  // forwarder zone, which takes no dynamic updates at all. NonsecureAndSecure
+  // lets any host on the network create or overwrite a record without
+  // authenticating, so a zone that accepts it cannot be trusted to name what
+  // it claims to.
   dynamicUpdate string
   // Which servers the zone may be transferred to
   //
   // One of NoTransfer, TransferAnyServer, TransferToZoneNameServer, or
-  // TransferToSecureServers. TransferAnyServer hands the full contents of the
+  // TransferToSecureServers, and empty on a stub or forwarder zone, which has
+  // no contents to transfer. TransferAnyServer hands the full contents of the
   // zone, and therefore an inventory of the network, to anyone who asks.
   secureSecondaries string
   // Servers explicitly allowed to transfer the zone, used when secureSecondaries is TransferToSecureServers
   secondaryServers []string
   // Which secondaries are notified when the zone changes
   //
-  // One of NoNotify, Notify, or NotifyServers.
+  // One of NoNotify, Notify, or NotifyServers, and empty on a stub or
+  // forwarder zone, which has no secondaries to notify.
   notify string
   // Servers notified when the zone changes, used when notify is NotifyServers
   notifyServers []string
   // Whether the zone is DNSSEC signed
   //
   // A signed zone serves an RRSIG alongside every answer, which is what lets
-  // a validating resolver detect a forged or modified response.
+  // a validating resolver detect a forged or modified response. False on a
+  // stub or forwarder zone, which holds no records of its own to sign.
   isSigned bool
   // Whether the zone is stored in Active Directory rather than in a zone file
   isDsIntegrated bool
@@ -13537,7 +13556,7 @@ private windows.dnsServer.zone @defaults("name zoneType isSigned") {
   // Whether the zone resolves single-label names through WINS
   //
   // WINS lookup embeds an unauthenticated legacy name service in the zone's
-  // answers.
+  // answers. False on a stub or forwarder zone, which resolves nothing itself.
   isWinsEnabled bool
   // Name of the zone file, empty for a directory-integrated zone
   zoneFile string


### PR DESCRIPTION
## Two descriptions that promise more than the server delivers

Both were found by running the family against live hosts, and neither is
reachable by reading the code. Descriptions only, no schema or behavior change,
and codegen produces no diff.

### 1. Zone settings a stub or forwarder zone does not have

`dynamicUpdate`, `secureSecondaries` and `notify` each enumerate their possible
values, and every one of those lists is written for a zone holding
authoritative data. A stub or forwarder zone holds none, so the server reports
**no value at all** and the field comes back empty, which is not among the
listed values.

Raw `Get-DnsServerZone` output from a live Server 2016 host, two zones from the
same payload:

```json
{ "ZoneName": "fwd.test",  "ZoneType": "Forwarder",
  "DynamicUpdate": null, "SecureSecondaries": null, "Notify": null,
  "IsSigned": null, "IsWinsEnabled": null }

{ "ZoneName": "lab.test",  "ZoneType": "Primary",
  "DynamicUpdate": "NonsecureAndSecure", "SecureSecondaries": "TransferToSecureServers",
  "Notify": "NotifyServers", "IsSigned": false, "IsWinsEnabled": false }
```

A stub zone behaves identically (`ZoneType: "Stub"`, same three nulls).

Through the resource:

```
$ mql run ssh Administrator@<2016-host> \
    -c 'windows.dnsServer.zones.where(name == "fwd.test" || name == "lab.test") { name zoneType secureSecondaries dynamicUpdate notify }'
  0: { name: "fwd.test"  zoneType: "Forwarder"  secureSecondaries: ""  dynamicUpdate: ""   notify: "" }
  1: { name: "lab.test"  zoneType: "Primary"    secureSecondaries: "TransferToSecureServers"
                                                dynamicUpdate: "NonsecureAndSecure"  notify: "NotifyServers" }
```

The cost is a check that fires on the wrong zone: `zones.all(dynamicUpdate ==
"None")` reports a stub zone as a finding over a setting a stub zone cannot
have. The descriptions now say which zone types carry each setting and point at
selecting the type the audit means to judge.

**Why the empty string and not null.** Null would read better but audit worse.
MQL's three-valued logic lets a comparison against null satisfy an `all()`, so
`zones.all(dynamicUpdate == "None")` would stop being a false alarm and start
being a **vacuous pass** on the zone it never evaluated. A visible false alarm
the author can filter is the safer of the two, so this is a documentation fix
rather than a change to what the fields return.

`isSigned` and `isWinsEnabled` are null in the same payload and read as false.
That is the right answer for a zone with nothing to sign and nothing to resolve
through WINS, and it is now stated rather than left to be inferred.

### 2. The role gate is necessary but not sufficient

The resource description tells the reader to gate an audit on
`windows.serverFeature(name: "DNS").installed`. Good advice, and not enough: on
a host where the role was added but the restart has not happened, the feature
reports installed while the DnsServer module is still absent.

A live Server 2025 host in exactly that state (`Get-WindowsFeature DNS` →
`Installed`, no `DNS` service, `Get-DnsServerSetting` unrecognized, reboot
pending):

```
$ mql run ssh Administrator@<2025-host> -c 'windows.serverFeature(name: "DNS") { name installed }'
windows.serverFeature: { installed: true  name: "DNS" }

$ mql run ssh Administrator@<2025-host> -c 'windows.dnsServer.recursion.enabled'
error: failed to read the DNS server configuration, the DNS Server role may not be installed:
       Import-Module : The specified module 'DnsServer' was not loaded ...
```

The gate opens and the fields then error. Erroring is the safe outcome and the
resource is behaving correctly, but it is not what the description implies, so
the description now says so.

## Verification

Live Windows Server 2016, 2019, 2022 and 2025 hosts with the DNS Server role
installed, plus one 2025 host with the role staged but not yet applied, which is
what produced the second finding.

```
./mqlr generate ... --dist ...              no diff (comment-only change)
go build ./...                              ok
go test ./providers/os/resources/windows/   ok
git diff -U0 -- '*.lr' | grep '^+' | grep -c "—"    0
```
