### PR TITLE
🐛 os: split mysql/mariadb tmpdir on the separator the server actually uses

### DIFF
--- a/providers/os/resources/mariadb.go
+++ b/providers/os/resources/mariadb.go
@@ -308,7 +308,7 @@ func (s *mqlMariadbConf) basedir(serverOptions map[string]any) (string, error) {
 }
 
 func (s *mqlMariadbConf) tmpdir(serverOptions map[string]any) ([]any, error) {
-	return optionList(serverOptions, "tmpdir"), nil
+	return optionPathList(serverOptions, "tmpdir"), nil
 }
 
 func (s *mqlMariadbConf) secureFilePriv(serverOptions map[string]any) (string, error) {

--- a/providers/os/resources/mycnf.go
+++ b/providers/os/resources/mycnf.go
@@ -474,6 +474,12 @@ func optionList(options map[string]any, key string) []any {
 	return toAnySlice(mycnf.SplitList(optionString(options, key)))
 }
 
+// optionPathList resolves an option whose value is a list of directories.
+// These use ":" (Unix) or ";" (Windows) rather than the comma/space form.
+func optionPathList(options map[string]any, key string) []any {
+	return toAnySlice(mycnf.SplitPathList(optionString(options, key)))
+}
+
 // bindAddressList resolves bind_address. The server listens on every
 // interface when the option is unset, which "*" denotes, so an empty result
 // would misreport an unrestricted listener as no listener at all.

--- a/providers/os/resources/mycnf/parser.go
+++ b/providers/os/resources/mycnf/parser.go
@@ -539,9 +539,73 @@ func IsTruthy(value string, bare bool) bool {
 	return false
 }
 
+// SplitPathList splits an option value holding a list of directories, which
+// MySQL and MariaDB separate differently from their comma lists: with ":" on
+// Unix and ";" on Windows. tmpdir is the option that uses this form.
+//
+// A Windows drive letter carries its own colon ("C:\\tmp"), so a colon in the
+// second character position followed by a path separator is part of the path,
+// not a delimiter.
+func SplitPathList(value string) []string {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return nil
+	}
+
+	// A semicolon anywhere means the value uses the Windows separator, where a
+	// bare colon is always part of a drive letter.
+	if strings.ContainsRune(v, ';') {
+		return cleanPathElems(strings.Split(v, ";"))
+	}
+
+	var elems []string
+	start := 0
+	for i := 0; i < len(v); i++ {
+		if v[i] != ':' {
+			continue
+		}
+		if isDriveColon(v, i) {
+			continue
+		}
+		elems = append(elems, v[start:i])
+		start = i + 1
+	}
+	elems = append(elems, v[start:])
+	return cleanPathElems(elems)
+}
+
+// isDriveColon reports whether the colon at i separates a Windows drive letter
+// from its path, as in "C:\\tmp", rather than delimiting two directories.
+func isDriveColon(v string, i int) bool {
+	if i != 1 {
+		return false
+	}
+	c := v[0]
+	if (c < 'A' || c > 'Z') && (c < 'a' || c > 'z') {
+		return false
+	}
+	return i+1 < len(v) && (v[i+1] == '\\' || v[i+1] == '/')
+}
+
+func cleanPathElems(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, e := range in {
+		e = strings.Trim(strings.TrimSpace(e), `"'`)
+		if e != "" {
+			out = append(out, e)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // SplitList splits an option value holding a comma- or space-separated list
-// (tls_version, tmpdir, sql_mode, ...). Elements are trimmed of whitespace
-// and surrounding quotes; empty elements are dropped.
+// (tls_version, sql_mode, ...). Elements are trimmed of whitespace and
+// surrounding quotes; empty elements are dropped.
+//
+// Path lists are not this shape: use SplitPathList for those.
 func SplitList(value string) []string {
 	if strings.TrimSpace(value) == "" {
 		return nil

--- a/providers/os/resources/mycnf/pathlist_test.go
+++ b/providers/os/resources/mycnf/pathlist_test.go
@@ -1,0 +1,95 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mycnf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitPathList(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  []string
+	}{
+		{
+			// The reported case: MySQL and MariaDB separate tmpdir with ':' on
+			// Unix, so this used to come back as one element holding both paths.
+			name:  "unix colon separated",
+			value: "/srv/mqlprobe/tmp1:/srv/mqlprobe/tmp2",
+			want:  []string{"/srv/mqlprobe/tmp1", "/srv/mqlprobe/tmp2"},
+		},
+		{
+			name:  "three unix paths",
+			value: "/var/tmp:/tmp:/mnt/fast",
+			want:  []string{"/var/tmp", "/tmp", "/mnt/fast"},
+		},
+		{
+			name:  "single path is unchanged",
+			value: "/var/tmp",
+			want:  []string{"/var/tmp"},
+		},
+		{
+			name:  "surrounding whitespace and quotes are trimmed",
+			value: `  "/var/tmp" : '/tmp'  `,
+			want:  []string{"/var/tmp", "/tmp"},
+		},
+		{
+			name:  "empty elements are dropped",
+			value: "/var/tmp::/tmp:",
+			want:  []string{"/var/tmp", "/tmp"},
+		},
+		{
+			name:  "empty value",
+			value: "",
+			want:  nil,
+		},
+		{
+			name:  "whitespace only",
+			value: "   ",
+			want:  nil,
+		},
+		{
+			// Windows uses ';'. A drive letter's own colon must survive.
+			name:  "windows semicolon separated",
+			value: `C:\temp;D:\scratch`,
+			want:  []string{`C:\temp`, `D:\scratch`},
+		},
+		{
+			name:  "single windows path keeps its drive colon",
+			value: `C:\temp`,
+			want:  []string{`C:\temp`},
+		},
+		{
+			name:  "windows forward slashes",
+			value: `C:/temp`,
+			want:  []string{`C:/temp`},
+		},
+		{
+			// A comma is a legal directory character and must NOT split here,
+			// which is exactly why tmpdir cannot reuse SplitList.
+			name:  "comma is not a separator for paths",
+			value: "/var/tmp,odd",
+			want:  []string{"/var/tmp,odd"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, SplitPathList(tc.value))
+		})
+	}
+}
+
+// SplitList must keep its comma/space behaviour: it still backs tls_version,
+// sql_mode and friends, where ':' is not a delimiter.
+func TestSplitListUnchangedForCommaLists(t *testing.T) {
+	assert.Equal(t, []string{"TLSv1.2", "TLSv1.3"}, SplitList("TLSv1.2,TLSv1.3"))
+	assert.Equal(t, []string{"NO_ENGINE_SUBSTITUTION", "STRICT_TRANS_TABLES"},
+		SplitList("NO_ENGINE_SUBSTITUTION STRICT_TRANS_TABLES"))
+	assert.Equal(t, []string{"a:b"}, SplitList("a:b"), "SplitList must not split on a colon")
+	assert.Nil(t, SplitList(""))
+}

--- a/providers/os/resources/mysql.go
+++ b/providers/os/resources/mysql.go
@@ -341,7 +341,7 @@ func (s *mqlMysqlConf) basedir(serverOptions map[string]any) (string, error) {
 }
 
 func (s *mqlMysqlConf) tmpdir(serverOptions map[string]any) ([]any, error) {
-	return optionList(serverOptions, "tmpdir"), nil
+	return optionPathList(serverOptions, "tmpdir"), nil
 }
 
 func (s *mqlMysqlConf) secureFilePriv(serverOptions map[string]any) (string, error) {


### PR DESCRIPTION
## The bug

`mysql.conf.tmpdir` / `mariadb.conf.tmpdir` are declared `[]string` and documented as *"tmpdir option split into individual directories"* — but they resolve through `SplitList`, which splits only on **comma, space and tab**.

MySQL and MariaDB separate `tmpdir` with **`:`** on Unix (and `;` on Windows). So a multi-directory `tmpdir` came back as one element holding the raw value:

```
tmpdir = /srv/mqlprobe/tmp1:/srv/mqlprobe/tmp2

before  ["/srv/mqlprobe/tmp1:/srv/mqlprobe/tmp2"]     <- one bogus path
after   ["/srv/mqlprobe/tmp1", "/srv/mqlprobe/tmp2"]
```

Any policy that iterates `tmpdir` to check per-directory ownership or permissions was silently examining a single path that does not exist on disk.

## The fix

`SplitList` keeps its comma/space behaviour — `tls_version`, `sql_mode` and the other list options genuinely use that shape, and a colon is legal *inside* those values, so widening it would have broken them. `tmpdir` instead goes through a new `SplitPathList`, which:

- splits on `:` (Unix) or `;` (Windows, detected by the presence of a semicolon)
- leaves a Windows drive letter's own colon intact (`C:\temp` stays one path)
- trims whitespace/quotes and drops empty elements, matching `SplitList`

## Verification

Seeded `my.cnf` with `tmpdir = /srv/mqlprobe/tmp1:/srv/mqlprobe/tmp2`, then queried live EC2 instances before and after:

| host | before | after |
|---|---|---|
| RHEL 10 | `["/srv/mqlprobe/tmp1:/srv/mqlprobe/tmp2"]` | `["/srv/mqlprobe/tmp1","/srv/mqlprobe/tmp2"]` |
| Debian 13 | same | same ✅ |
| SLES 15 | same | same ✅ |

Both `mysql.conf` and `mariadb.conf` confirmed.

Unit tests cover Unix colon lists, Windows semicolon lists, drive-letter colons, quoting/whitespace, empty elements, and a regression test asserting `SplitList` still does **not** split on a colon.

```
ok  go.mondoo.com/mql/providers/os/resources/mycnf
```

Found while running an exhaustive config-parser sweep of the os provider across 15 Linux distros.