### PR TITLE
🐛 os: give fstab entries a unique __id so rows stop disappearing

### DIFF
--- a/providers/os/resources/fstab.go
+++ b/providers/os/resources/fstab.go
@@ -137,5 +137,10 @@ func ParseFstab(file io.Reader) ([]FstabEntry, error) {
 }
 
 func (e *mqlFstabEntry) id() (string, error) {
-	return e.Device.Data, nil
+	// The device alone is not unique: "tmpfs /tmp" and "tmpfs /dev/shm" are both
+	// ordinary fstab rows, as are two swap devices that both mount at "none".
+	// Sharing an __id makes the runtime serve the first entry for every
+	// collision, so the later rows vanish from the list entirely. A mount point
+	// appears at most once, so device plus mount point is unique.
+	return e.Device.Data + " " + e.Mountpoint.Data, nil
 }

--- a/providers/os/resources/fstab_id_test.go
+++ b/providers/os/resources/fstab_id_test.go
@@ -1,0 +1,73 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+func fstabEntry(device, mountpoint string) *mqlFstabEntry {
+	return &mqlFstabEntry{
+		Device:     plugin.TValue[string]{Data: device, State: plugin.StateIsSet},
+		Mountpoint: plugin.TValue[string]{Data: mountpoint, State: plugin.StateIsSet},
+	}
+}
+
+// Two rows sharing a device is ordinary in /etc/fstab. When their __id
+// collides the runtime serves the first for both, and the later rows drop out
+// of fstab.entries without any error.
+func TestFstabEntryIDIsUniquePerMountPoint(t *testing.T) {
+	tests := []struct {
+		name string
+		a    *mqlFstabEntry
+		b    *mqlFstabEntry
+	}{
+		{
+			// The reported case, and the stock layout on many distros.
+			name: "two tmpfs mounts",
+			a:    fstabEntry("tmpfs", "/tmp"),
+			b:    fstabEntry("tmpfs", "/dev/shm"),
+		},
+		{
+			name: "two swap devices both mounting at none",
+			a:    fstabEntry("/dev/sda2", "none"),
+			b:    fstabEntry("/dev/sda3", "none"),
+		},
+		{
+			name: "two none-device pseudo filesystems",
+			a:    fstabEntry("none", "/proc/sys/fs/binfmt_misc"),
+			b:    fstabEntry("none", "/sys/kernel/debug"),
+		},
+		{
+			name: "same mount point, different device",
+			a:    fstabEntry("/dev/sdb1", "/data"),
+			b:    fstabEntry("/dev/sdc1", "/data"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ida, err := tc.a.id()
+			assert.NoError(t, err)
+			idb, err := tc.b.id()
+			assert.NoError(t, err)
+			assert.NotEqual(t, ida, idb,
+				"distinct fstab rows must not share an __id, or the later row is dropped")
+		})
+	}
+}
+
+func TestFstabEntryIDIsStable(t *testing.T) {
+	e := fstabEntry("tmpfs", "/dev/shm")
+	first, err := e.id()
+	assert.NoError(t, err)
+	second, err := e.id()
+	assert.NoError(t, err)
+	assert.Equal(t, first, second, "__id must be stable across calls")
+	assert.Contains(t, first, "tmpfs")
+	assert.Contains(t, first, "/dev/shm")
+}


### PR DESCRIPTION
## The bug

`fstab.entry` used **the device column alone** as its `__id`:

```go
func (e *mqlFstabEntry) id() (string, error) {
	return e.Device.Data, nil
}
```

Sharing a device is completely ordinary in `/etc/fstab`, so entries collided in the resource cache. Per the caching rules, the runtime then serves the *first* resource for every collision — so the later rows **disappear from `fstab.entries` with no error at all**.

Live reproduction on RHEL 10:

```
tmpfs /mnt/mqlA tmpfs defaults,size=11m 0 0
tmpfs /mnt/mqlB tmpfs defaults,size=22m 0 0
```

```
before  [{mountpoint:"/mnt/mqlA", options:"defaults,size=11m"},
         {mountpoint:"/mnt/mqlA", options:"defaults,size=11m"}]   <- mqlB gone, mqlA duplicated
after   [{mountpoint:"/mnt/mqlA", options:"defaults,size=11m"},
         {mountpoint:"/mnt/mqlB", options:"defaults,size=22m"}]
```

## Why it matters

This is not a synthetic case. Colliding rows appear in stock layouts:

| collision | example |
|---|---|
| two `tmpfs` mounts | `tmpfs /tmp` + `tmpfs /dev/shm` |
| two swap devices | `/dev/sda2 none swap` + `/dev/sda3 none swap` |
| `none`-device pseudo filesystems | `none /proc/sys/fs/binfmt_misc` + `none /sys/kernel/debug` |

Any check that walks `fstab.entries` to assert mount options — `nodev`, `nosuid`, `noexec` on the temp filesystems — was evaluating one mount twice and never seeing the other, **while reporting success**. That is a silent false pass, which is the worst failure mode for an audit.

## The fix

A mount point appears at most once in `/etc/fstab`, so device plus mount point is unique. `__id` becomes `"<device> <mountpoint>"`.

## Verification

Live RHEL 10 instance, before and after, against the two rows above — both now returned with their own distinct options.

Unit tests cover all four collision shapes plus `__id` stability across calls.

```
ok  go.mondoo.com/mql/providers/os/resources
```

Found while running an exhaustive config-parser sweep of the os provider across 15 Linux distros.