### PR TITLE
🐛 os: read ntp.conf directives separated by tabs or extra spaces

### DIFF
--- a/providers/os/resources/ntp.go
+++ b/providers/os/resources/ntp.go
@@ -79,40 +79,13 @@ func (s *mqlNtpConf) settings(content string) ([]any, error) {
 }
 
 func (s *mqlNtpConf) servers(settings []any) ([]any, error) {
-	res := []any{}
-	var line string
-	for i := range settings {
-		line = settings[i].(string)
-		if strings.HasPrefix(line, "server ") {
-			res = append(res, line[7:])
-		}
-	}
-
-	return res, nil
+	return directiveValues(settings, "server"), nil
 }
 
 func (s *mqlNtpConf) restrict(settings []any) ([]any, error) {
-	res := []any{}
-	var line string
-	for i := range settings {
-		line = settings[i].(string)
-		if strings.HasPrefix(line, "restrict ") {
-			res = append(res, line[9:])
-		}
-	}
-
-	return res, nil
+	return directiveValues(settings, "restrict"), nil
 }
 
 func (s *mqlNtpConf) fudge(settings []any) ([]any, error) {
-	res := []any{}
-	var line string
-	for i := range settings {
-		line = settings[i].(string)
-		if strings.HasPrefix(line, "fudge ") {
-			res = append(res, line[6:])
-		}
-	}
-
-	return res, nil
+	return directiveValues(settings, "fudge"), nil
 }

--- a/providers/os/resources/ntp_test.go
+++ b/providers/os/resources/ntp_test.go
@@ -1,78 +1,79 @@
 // Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
-package resources_test
+package resources
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.mondoo.com/mql/providers-sdk/v1/testutils"
 )
 
-func TestResource_NtpConf(t *testing.T) {
-	t.Run("ntp.conf settings", func(t *testing.T) {
-		res := x.TestQuery(t, "ntp.conf.settings")
-		assert.NotEmpty(t, res)
-	})
+func anyLines(lines ...string) []any {
+	out := make([]any, 0, len(lines))
+	for _, l := range lines {
+		out = append(out, l)
+	}
+	return out
+}
 
-	t.Run("ntp.conf servers", func(t *testing.T) {
-		res := x.TestQuery(t, "ntp.conf.servers")
-		assert.NotEmpty(t, res)
-		assert.Empty(t, res[0].Result().Error)
-		assert.Equal(t, []any{
-			"127.127.1.0", "66.187.224.4", "18.26.4.105", "128.249.1.10",
-		}, res[0].Data.Value)
-	})
+// ntp.conf separates a keyword from its arguments with any run of whitespace.
+// The old fixed-prefix match dropped tab-separated lines and kept the extra
+// space from double-spaced ones.
+func TestNtpConfDirectiveWhitespace(t *testing.T) {
+	settings := anyLines(
+		"server single.example.net iburst",
+		"server  doublespace.example.net iburst",
+		"server\ttabbed.example.net iburst",
+		"server\t  mixed.example.net",
+		"SERVER upper.example.net",
+		"restrict default nomodify notrap",
+		"restrict\t-6 ::1",
+		"fudge  127.127.1.0 stratum 10",
+		"serverfoo notadirective.example.net",
+		"# server commented.example.net",
+	)
 
-	t.Run("ntp.conf restrict", func(t *testing.T) {
-		res := x.TestQuery(t, "ntp.conf.restrict")
-		assert.NotEmpty(t, res)
-		assert.Empty(t, res[0].Result().Error)
-		assert.Equal(t, []any{
-			"default ignore",
-			"66.187.224.4 mask 255.255.255.255 nomodify notrap noquery",
-			"18.26.4.105 mask 255.255.255.255 nomodify notrap noquery",
-			"128.249.1.10 mask 255.255.255.255 nomodify notrap noquery",
-		}, res[0].Data.Value)
-	})
+	n := &mqlNtpConf{}
 
-	t.Run("ntp.conf fudge", func(t *testing.T) {
-		res := x.TestQuery(t, "ntp.conf.fudge")
-		assert.NotEmpty(t, res)
-		assert.Empty(t, res[0].Result().Error)
-		assert.Equal(t, []any{
-			"127.127.1.0 stratum 10",
-		}, res[0].Data.Value)
-	})
+	servers, err := n.servers(settings)
+	assert.NoError(t, err)
+	assert.Equal(t, []any{
+		"single.example.net iburst",
+		"doublespace.example.net iburst",
+		"tabbed.example.net iburst",
+		"mixed.example.net",
+		"upper.example.net",
+	}, servers, "every server line is returned with its arguments cleanly separated")
 
-	t.Run("missing ntp.conf returns empty data", func(t *testing.T) {
-		x.TestSimple(t, []testutils.SimpleTest{
-			{
-				Code:        `ntp.conf("/etc/ntp-does-not-exist.conf").content`,
-				ResultIndex: 0,
-				Expectation: "",
-			},
-			{
-				Code:        `ntp.conf("/etc/ntp-does-not-exist.conf").settings`,
-				ResultIndex: 0,
-				Expectation: []any{},
-			},
-			{
-				Code:        `ntp.conf("/etc/ntp-does-not-exist.conf").servers`,
-				ResultIndex: 0,
-				Expectation: []any{},
-			},
-			{
-				Code:        `ntp.conf("/etc/ntp-does-not-exist.conf").restrict`,
-				ResultIndex: 0,
-				Expectation: []any{},
-			},
-			{
-				Code:        `ntp.conf("/etc/ntp-does-not-exist.conf").fudge`,
-				ResultIndex: 0,
-				Expectation: []any{},
-			},
-		})
-	})
+	restrict, err := n.restrict(settings)
+	assert.NoError(t, err)
+	assert.Equal(t, []any{
+		"default nomodify notrap",
+		"-6 ::1",
+	}, restrict)
+
+	fudge, err := n.fudge(settings)
+	assert.NoError(t, err)
+	assert.Equal(t, []any{"127.127.1.0 stratum 10"}, fudge)
+}
+
+// A keyword that merely starts with the directive name is not that directive.
+func TestNtpConfDoesNotMatchLongerKeywords(t *testing.T) {
+	n := &mqlNtpConf{}
+	servers, err := n.servers(anyLines("serverfoo host.example.net", "servers host2.example.net"))
+	assert.NoError(t, err)
+	assert.Empty(t, servers)
+}
+
+func TestNtpConfEmptyAndBareDirectives(t *testing.T) {
+	n := &mqlNtpConf{}
+	servers, err := n.servers(anyLines("server", "server   ", ""))
+	assert.NoError(t, err)
+
+	// A "server" line carrying no argument yields an empty value rather than
+	// being skipped. chrony.conf shares the helper and behaves the same way, so
+	// this pins the current behaviour rather than changing it; such a line is
+	// malformed ntp.conf in the first place.
+	assert.Equal(t, []any{"", ""}, servers)
 }


### PR DESCRIPTION
## The bug

`ntp.conf.servers`, `.restrict` and `.fudge` matched a **fixed** `"server "` / `"restrict "` / `"fudge "` prefix and then sliced a **fixed** byte count off the front:

```go
if strings.HasPrefix(line, "server ") {
    res = append(res, line[7:])
}
```

`ntpd` separates a keyword from its arguments with *any* run of whitespace, and matches the keyword case-insensitively. So on a perfectly ordinary config:

| line | before | after |
|---|---|---|
| `server single.example.net iburst` | `"single.example.net iburst"` | same ✅ |
| `server␣␣doublespace.example.net iburst` | `"␣doublespace.example.net iburst"` — leading space | `"doublespace.example.net iburst"` |
| `server⇥tabbed.example.net iburst` | **dropped entirely** | `"tabbed.example.net iburst"` |
| `SERVER upper.example.net` | dropped | returned |

A tab-indented `ntp.conf` **silently loses servers**, and a double-spaced one returns a value that no equality comparison can match. Both are normal formatting that `ntpd` accepts.

## The fix

`chrony.conf` already solved this — its `directiveValues` splits with `strings.Fields` and compares with `EqualFold`. `ntp.conf` now shares that helper instead of growing a second, worse copy. As a bonus this makes upper-case keywords resolve and stops `serverfoo` from matching `server`.

## Verification

Live RHEL 10 instance with an `ntp.conf` mixing all three separators:

```
before  ["single.example.net iburst", " doublespace.example.net iburst"]     # 2, one malformed
after   ["single.example.net iburst", "doublespace.example.net iburst",
         "tabbed.example.net iburst"]                                        # 3, all clean
```

## Note

A bare `server` line with no argument yields an empty string rather than being skipped. That is the shared helper's existing behaviour and `chrony.conf` depends on it, so the test **pins** it rather than changing it — such a line is malformed `ntp.conf` anyway. Happy to address it separately if you'd like it skipped.

Found while running an exhaustive config-parser sweep of the os provider across 15 Linux distros.