### PR TITLE
🐛 copy pre-release artifacts to releases.mondoo.com

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -257,6 +257,11 @@ jobs:
     name: Copy pre-release to releases.mondoo.com
     if: ${{ needs.goreleaser.outputs.skip-publish == 'true' }}
     needs: goreleaser
+    # id-token: write lets the called workflow auth to GCP via WIF.
+    # contents: read is required to download the releasr binary.
+    permissions:
+      contents: read
+      id-token: write
     uses: mondoohq/releasr/.github/workflows/github_copy.yaml@main
     with:
       repository: mql

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -45,6 +45,8 @@ permissions:
 
 jobs:
   goreleaser:
+    outputs:
+      skip-publish: ${{ steps.skip-publish.outputs.skip-publish }}
     permissions:
       # Add "contents" to write release
       contents: "write"
@@ -243,3 +245,23 @@ jobs:
           client-payload: '{
             "version": "${{  github.ref_name }}"
             }'
+
+  # For pre-release tags (-alpha, -beta, -pre, -rc) the installer chain
+  # doesn't fire (Trigger mql bump in cnspec above is gated on skip-publish),
+  # so nothing normally copies the artifacts to releases.mondoo.com. Call
+  # releasr's github_copy workflow explicitly so the deb/rpm/tarball assets
+  # from the GH pre-release show up at releases.mondoo.com/mql/<version>/
+  # -- without repointing apt/yum "latest" to the pre-release (that's what
+  # include-prereleases: false in releasr's `idx` step guarantees).
+  copy-prerelease-to-releases-mondoo-com:
+    name: Copy pre-release to releases.mondoo.com
+    if: ${{ needs.goreleaser.outputs.skip-publish == 'true' }}
+    needs: goreleaser
+    uses: mondoohq/releasr/.github/workflows/github_copy.yaml@main
+    with:
+      repository: mql
+      version: ${{ github.ref_name }}
+      bucket: releases-us.mondoo.io
+      include-prereleases: false
+      update-parent: true
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds a `copy-prerelease-to-releases-mondoo-com` job that fires on pre-release tags (`-alpha`/`-beta`/`-pre`/`-rc`) and copies the GH release artifacts to `releases.mondoo.com/mql/<version>/` — without repointing apt/yum "latest".

## Why

The installer chain (`Trigger mql bump in cnspec` → cnspec release → installer release → `pkg_published_trigger_build_release.yaml` → `releasr release cp` + `releasr idx`) is gated on `skip-publish != 'true'`, so for pre-release tags the whole chain never runs. Historic v13.0.0-rc2/rc3 tarballs made it to `releases.mondoo.com` only because someone manually dispatched `releasr`'s `github_copy.yaml`; nothing auto-copies today.

This PR closes that gap for pre-releases without touching the stable-release path.

## Change

- Added job-level `outputs.skip-publish` on the `goreleaser:` job so a downstream job can gate on it.
- New `copy-prerelease-to-releases-mondoo-com` job at the bottom of the file: `if: skip-publish == 'true'`, `needs: goreleaser`, calls `mondoohq/releasr/.github/workflows/github_copy.yaml@main` via `uses:` with `include-prereleases: false` and `update-parent: true`.
- `secrets: inherit` propagates `GCP_CREDENTIALS` and the mergebot app secrets that releasr's workflow needs.

## Why `uses:` and not `repository_dispatch:`

Explicit call chain — the copy job shows up as a downstream node under the goreleaser run in the Actions view, rather than a fire-and-forget dispatch that lands in a separate run on the releasr repo. Also synchronous, so any future step that needs to gate on the copy finishing can just `needs:` this job.

## Dependency

Needs [mondoohq/releasr#<num>](https://github.com/mondoohq/releasr/pulls/philipbalinov) merged first — that PR adds the `workflow_call:` trigger to `github_copy.yaml`. This PR references `@main`, so land the releasr PR before merging this one.

## Test plan

- [ ] Land releasr PR first.
- [ ] Tag a `v14.0.0-pre.2` on mql main → verify the `copy-prerelease-to-releases-mondoo-com` job runs and succeeds → verify `curl -sI https://releases.mondoo.com/mql/14.0.0-pre.2/mql_14.0.0-pre.2_linux_amd64.tar.gz` returns 200.
- [ ] Verify `curl -sL 'https://releases.mondoo.com/debian/dists/stable/main/binary-amd64/Packages.gz' | gunzip | grep -A1 '^Package: mql' | grep '^Version:'` still returns v13.35.2 (no apt-latest demotion).
- [ ] Tag a stable `v13.35.3` (hypothetical) on the v13 branch → verify the new job **does NOT run** (skip-publish == false), and the existing installer chain still handles the stable copy.
