### PR TITLE
⭐ UploadResourcesData: resource recording delivered via the scan upload

### DIFF
--- a/feature_string.go
+++ b/feature_string.go
@@ -29,11 +29,12 @@ func _() {
 	_ = x[ScanContentModeServerCompare-19]
 	_ = x[ScanContentModeClientCompare-20]
 	_ = x[ScanContentModeNoCompare-21]
+	_ = x[UploadResourcesData-22]
 }
 
-const _Feature_name = "MassQueriesPiperCodeBoolAssertionsK8sNodeDiscoveryMQLAssetContextErrorsAsFailuresStoreResourcesDataFineGrainedAssetsSerialNumberAsIDForceShellCompletionResourceContextFailIfNoEntryPointsUploadResultsV2AutoUpdateEngineBiosUUIDAsIDExchangeTokenForTokenTerraformResolveVarsScanContentModeShadowScanContentModeServerCompareScanContentModeClientCompareScanContentModeNoCompare"
+const _Feature_name = "MassQueriesPiperCodeBoolAssertionsK8sNodeDiscoveryMQLAssetContextErrorsAsFailuresStoreResourcesDataFineGrainedAssetsSerialNumberAsIDForceShellCompletionResourceContextFailIfNoEntryPointsUploadResultsV2AutoUpdateEngineBiosUUIDAsIDExchangeTokenForTokenTerraformResolveVarsScanContentModeShadowScanContentModeServerCompareScanContentModeClientCompareScanContentModeNoCompareUploadResourcesData"
 
-var _Feature_index = [...]uint16{0, 11, 20, 34, 50, 65, 81, 99, 116, 132, 152, 167, 186, 201, 217, 229, 250, 270, 291, 319, 347, 371}
+var _Feature_index = [...]uint16{0, 11, 20, 34, 50, 65, 81, 99, 116, 132, 152, 167, 186, 201, 217, 229, 250, 270, 291, 319, 347, 371, 390}
 
 func (i Feature) String() string {
 	idx := int(i) - 1

--- a/features.go
+++ b/features.go
@@ -118,9 +118,14 @@ const (
 	// status: new
 	ScanContentModeNoCompare Feature = 21
 
+	// Record resource data (the recording-style rows behind the resource explorer and GetResourcesData/ListResources) while scanning, and deliver it inside the uploaded scan database. Only acts together with UploadResultsV2 - resources ride the uploaded file, never the legacy StoreResults RPC. Successor to StoreResourcesData, which is retired: it required a server-side resolved-policy stamp as a second key and sent resources through the legacy RPC.
+	// start:  v13.x
+	// status: new
+	UploadResourcesData Feature = 22
+
 	// Placeholder to indicate how many feature flags exist. This number
 	// is changing with every new feature and cannot be used as a featureflag itself.
-	MAX_FEATURES byte = 22
+	MAX_FEATURES byte = 23
 )
 
 var FeaturesValue = map[string]Feature{
@@ -145,6 +150,7 @@ var FeaturesValue = map[string]Feature{
 	"ScanContentModeServerCompare": ScanContentModeServerCompare,
 	"ScanContentModeClientCompare": ScanContentModeClientCompare,
 	"ScanContentModeNoCompare":     ScanContentModeNoCompare,
+	"UploadResourcesData":          UploadResourcesData,
 }
 
 // DefaultFeatures are a set of default flags that are active
@@ -166,4 +172,5 @@ var AvailableFeatures = Features{
 	byte(ScanContentModeServerCompare),
 	byte(ScanContentModeClientCompare),
 	byte(ScanContentModeNoCompare),
+	byte(UploadResourcesData),
 }

--- a/features.go
+++ b/features.go
@@ -119,7 +119,7 @@ const (
 	ScanContentModeNoCompare Feature = 21
 
 	// Record resource data (the recording-style rows behind the resource explorer and GetResourcesData/ListResources) while scanning, and deliver it inside the uploaded scan database. Only acts together with UploadResultsV2 - resources ride the uploaded file, never the legacy StoreResults RPC. Successor to StoreResourcesData, which is retired: it required a server-side resolved-policy stamp as a second key and sent resources through the legacy RPC.
-	// start:  v13.x
+	// start:  v14.x
 	// status: new
 	UploadResourcesData Feature = 22
 

--- a/features.yaml
+++ b/features.yaml
@@ -122,5 +122,5 @@ Features:
 - id: UploadResourcesData
   desc: "Record resource data (the recording-style rows behind the resource explorer and GetResourcesData/ListResources) while scanning, and deliver it inside the uploaded scan database. Only acts together with UploadResultsV2 - resources ride the uploaded file, never the legacy StoreResults RPC. Successor to StoreResourcesData, which is retired: it required a server-side resolved-policy stamp as a second key and sent resources through the legacy RPC."
   idx: 22
-  start: v13.x
+  start: v14.x
   status: new

--- a/features.yaml
+++ b/features.yaml
@@ -119,3 +119,8 @@ Features:
   idx: 21
   start: v13.x
   status: new
+- id: UploadResourcesData
+  desc: "Record resource data (the recording-style rows behind the resource explorer and GetResourcesData/ListResources) while scanning, and deliver it inside the uploaded scan database. Only acts together with UploadResultsV2 - resources ride the uploaded file, never the legacy StoreResults RPC. Successor to StoreResourcesData, which is retired: it required a server-side resolved-policy stamp as a second key and sent resources through the legacy RPC."
+  idx: 22
+  start: v13.x
+  status: new


### PR DESCRIPTION
Adds the mql feature `UploadResourcesData` (idx 22) — the successor to `StoreResourcesData` for delivering resource recordings upstream.

Design (server + cnspec changes follow this PR):
- **One key, client-side**: the server advertises this feature per scope via `ScanParameters.enabled_features` (`client_upload_resources_data` flag); there is no second server-side resolved-policy stamp like `ServerFeature_STORE_RESOURCES_DATA`.
- **Bucket-upload only**: cnspec records resources and writes them into the scan database it uploads (`UploadResultsV2`); the legacy `StoreResults` RPC send is removed.
- **New name on purpose**: deployed clients gate recording (`EnableResourcesRecording`) on `StoreResourcesData` alone and would start paying recording cost — or on old-enough versions, sending via the legacy RPC — if the old name were reused. Unknown feature names are dropped with a warning, so only clients carrying this change react.

`StoreResourcesData` (idx 7) stays registered — indexes are never reused — but new servers stop emitting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)