### PR TITLE
🐛 fix stale mql/v13 imports in the blockexec bench

### DIFF
--- a/exec/blockexec_bench_test.go
+++ b/exec/blockexec_bench_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	"go.mondoo.com/mql/v13/exec"
-	"go.mondoo.com/mql/v13/llx"
-	"go.mondoo.com/mql/v13/mqlc"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/testutils"
+	"go.mondoo.com/mql/exec"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/mqlc"
+	"go.mondoo.com/mql/providers-sdk/v1/testutils"
 )
 
 // arrayLiteralQuery builds `[0,1,...,n-1]` followed by tail.


### PR DESCRIPTION
Main is red: `Code Test` fails on `0161b9d5a` and earlier — `exec/blockexec_bench_test.go` still imports `go.mondoo.com/mql/v13/*`, left behind by the de-versioning (#6599), and the module no longer requires `mql/v13`, so `go test ./exec/` dies at setup (`no required module provides package go.mondoo.com/mql/v13/exec`) and the go-mod tidy check drifts.

Import paths corrected to the unsuffixed module; bench compiles and runs (`BenchmarkBlockExec`, 1x smoke). `go mod tidy` is clean after the fix — no go.mod/go.sum change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)