### PR TITLE
🐛 os: follow includes out of rsyslog fragments found by .d auto-discovery

### DIFF
--- a/providers/os/resources/rsyslog.go
+++ b/providers/os/resources/rsyslog.go
@@ -227,55 +227,67 @@ func (s *mqlRsyslogConf) files(path string) ([]any, error) {
 		path  string
 		depth int
 	}
-	queue := []queued{{path: path, depth: 0}}
+	var queue []queued
 
-	for len(queue) > 0 {
-		head := queue[0]
-		queue = queue[1:]
+	// drain walks the queue, following includes out of every file it reads.
+	// It runs once for the main config and again for the `.d` fragments, so a
+	// fragment reached only by auto-discovery still gets its own includes
+	// followed instead of being listed as a leaf.
+	drain := func() error {
+		for len(queue) > 0 {
+			head := queue[0]
+			queue = queue[1:]
 
-		clean := filepath.Clean(head.path)
-		if visited[clean] {
-			continue
-		}
-		visited[clean] = true
-
-		f, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
-			"path": llx.StringData(clean),
-		})
-		if err != nil {
-			return nil, err
-		}
-		mf := f.(*mqlFile)
-		out = append(out, mf)
-
-		if head.depth >= maxRsyslogIncludeDepth {
-			continue
-		}
-
-		content := mf.GetContent()
-		if content.Error != nil {
-			if errors.Is(content.Error, resources.NotFoundError{}) {
+			clean := filepath.Clean(head.path)
+			if visited[clean] {
 				continue
 			}
-			// Other read errors (permission denied, IO) are non-fatal here:
-			// the file is still listed via the resource, and the caller can
-			// inspect it for the error. Don't abort the whole walk.
-			continue
-		}
+			visited[clean] = true
 
-		patterns := parseRsyslogIncludes(content.Data)
-		parentDir := filepath.Dir(clean)
-		for _, pat := range patterns {
-			matches, err := s.expandIncludePattern(parentDir, pat)
+			f, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
+				"path": llx.StringData(clean),
+			})
 			if err != nil {
+				return err
+			}
+			mf := f.(*mqlFile)
+			out = append(out, mf)
+
+			if head.depth >= maxRsyslogIncludeDepth {
 				continue
 			}
-			for _, m := range matches {
-				if !visited[filepath.Clean(m)] {
-					queue = append(queue, queued{path: m, depth: head.depth + 1})
+
+			content := mf.GetContent()
+			if content.Error != nil {
+				if errors.Is(content.Error, resources.NotFoundError{}) {
+					continue
+				}
+				// Other read errors (permission denied, IO) are non-fatal here:
+				// the file is still listed via the resource, and the caller can
+				// inspect it for the error. Don't abort the whole walk.
+				continue
+			}
+
+			patterns := parseRsyslogIncludes(content.Data)
+			parentDir := filepath.Dir(clean)
+			for _, pat := range patterns {
+				matches, err := s.expandIncludePattern(parentDir, pat)
+				if err != nil {
+					continue
+				}
+				for _, m := range matches {
+					if !visited[filepath.Clean(m)] {
+						queue = append(queue, queued{path: m, depth: head.depth + 1})
+					}
 				}
 			}
 		}
+		return nil
+	}
+
+	queue = append(queue, queued{path: path, depth: 0})
+	if err := drain(); err != nil {
+		return nil, err
 	}
 
 	// Legacy `.d` auto-discovery: configurations that rely on the
@@ -304,10 +316,16 @@ func (s *mqlRsyslogConf) files(path string) ([]any, error) {
 				if visited[filepath.Clean(mf.Path.Data)] {
 					continue
 				}
-				visited[filepath.Clean(mf.Path.Data)] = true
-				out = append(out, mf)
+				// Queue rather than append: a fragment dropped into `<conf>.d`
+				// may carry its own $IncludeConfig, and appending it directly
+				// left those nested files out of the list entirely.
+				queue = append(queue, queued{path: mf.Path.Data, depth: 0})
 			}
 		}
+	}
+
+	if err := drain(); err != nil {
+		return nil, err
 	}
 
 	return out, nil

--- a/providers/os/resources/rsyslog_include_internal_test.go
+++ b/providers/os/resources/rsyslog_include_internal_test.go
@@ -188,3 +188,18 @@ func TestRsyslogIncludeMatches(t *testing.T) {
 		})
 	}
 }
+
+// A fragment reached only through `<conf>.d` auto-discovery must still have its
+// own includes followed. The sweep used to append such fragments as leaves, so
+// anything they included was silently missing from rsyslog.conf.files.
+func TestRsyslogConf_DotDFragmentIncludesAreFollowed(t *testing.T) {
+	paths := rsyslogFixtureFilesFrom(t, "testdata/rsyslog_dotd_nested.toml")
+
+	assert.Contains(t, paths, "/etc/rsyslog.conf")
+	assert.Contains(t, paths, "/etc/rsyslog.d/50-frag.conf",
+		"the fragment is found by .d auto-discovery")
+	assert.Contains(t, paths, "/etc/rsyslog.nested/90-nested.conf",
+		"the fragment's own $IncludeConfig must be followed")
+	assert.NotContains(t, paths, "/etc/rsyslog.nested/notes.txt",
+		"the include glob still applies to the nested directory")
+}

--- a/providers/os/resources/testdata/rsyslog_dotd_nested.toml
+++ b/providers/os/resources/testdata/rsyslog_dotd_nested.toml
@@ -1,0 +1,47 @@
+# A host whose main rsyslog.conf does NOT include its own `.d` directory.
+#
+# Debian and Ubuntu ship `$IncludeConfig /etc/rsyslog.d/*.conf`, but plenty of
+# configurations leave it out and rely on rsyslog's own handling, so the
+# fragments are reachable only through the resource's `<conf>.d` auto-discovery.
+#
+# The fragment found that way carries its own `$IncludeConfig`. Before the fix
+# the auto-discovery sweep appended fragments as leaves without reading them,
+# so /etc/rsyslog.nested/90-nested.conf never appeared in rsyslog.conf.files.
+
+[files."/etc/rsyslog.conf"]
+path = "/etc/rsyslog.conf"
+content = """$ModLoad imuxsock
+
+*.info;mail.none /var/log/messages
+"""
+
+# Reached only by `<conf>.d` auto-discovery, and pulls in another directory.
+[files."/etc/rsyslog.d/50-frag.conf"]
+path = "/etc/rsyslog.d/50-frag.conf"
+content = """local0.* /var/log/frag.log
+
+$IncludeConfig /etc/rsyslog.nested/*.conf
+"""
+
+# Only reachable through the fragment above.
+[files."/etc/rsyslog.nested/90-nested.conf"]
+path = "/etc/rsyslog.nested/90-nested.conf"
+content = """local2.* /var/log/nested.log
+"""
+
+# Shares the nested directory but does not match the include's `*.conf` glob.
+[files."/etc/rsyslog.nested/notes.txt"]
+path = "/etc/rsyslog.nested/notes.txt"
+content = """not a config fragment
+"""
+
+# Legacy `<conf>.d` auto-discovery.
+[commands."find -L \"/etc/rsyslog.d\" -xdev -type f -perm -0"]
+stdout = """/etc/rsyslog.d/50-frag.conf
+"""
+
+# Include expansion out of the auto-discovered fragment.
+[commands."find -L \"/etc/rsyslog.nested\" -xdev -type f -perm -0 -maxdepth 1"]
+stdout = """/etc/rsyslog.nested/90-nested.conf
+/etc/rsyslog.nested/notes.txt
+"""


### PR DESCRIPTION
## The bug

`rsyslog.conf.files` walks `$IncludeConfig` and `include()` recursively — but the `<conf>.d` auto-discovery sweep runs **after** that walk finishes and appends whatever it finds straight onto the result:

```go
for _, item := range list.Data {
    ...
    visited[...] = true
    out = append(out, mf)     // <- appended as a leaf, never read
}
```

So a fragment reached *only* through auto-discovery is treated as a leaf. Its own includes are never parsed, and the files it pulls in are **missing from the list with no error**.

## When it bites

Whenever the main `rsyslog.conf` does not itself include its `.d` directory. Debian and Ubuntu ship `$IncludeConfig /etc/rsyslog.d/*.conf`, but plenty of configurations leave it out and rely on rsyslog's own handling — the fragments are then reachable only through auto-discovery, and a fragment that includes a site directory silently hides everything in it.

```
/etc/rsyslog.conf                     (no include of .d)
/etc/rsyslog.d/50-frag.conf           found by auto-discovery
    $IncludeConfig /etc/rsyslog.nested/*.conf
/etc/rsyslog.nested/90-nested.conf    <- invisible

before  ["/etc/rsyslog.conf", "/etc/rsyslog.d/50-frag.conf"]
after   ["/etc/rsyslog.conf", "/etc/rsyslog.d/50-frag.conf",
         "/etc/rsyslog.nested/90-nested.conf"]
```

Any check reading rsyslog's effective configuration was working from a truncated file set.

## The fix

The BFS body becomes a closure that runs **twice**: once for the main config, then again after the `.d` sweep has *queued* its fragments instead of appending them. The fragments now go through the same walker rather than bypassing it.

Deliberately unchanged: output ordering (include-traversal files first, auto-discovered ones after), the `visited` dedup, the depth bound, and the tolerance of unreadable files.

## Verification

New fixture `rsyslog_dotd_nested.toml` — main conf with no `.d` include, a fragment found only by auto-discovery, and a nested directory reachable only from that fragment. It also keeps a `notes.txt` in the nested directory to confirm the include's `*.conf` glob still applies.

The test **fails on main**:

```
[]string{"/etc/rsyslog.conf", "/etc/rsyslog.d/50-frag.conf"}
    does not contain "/etc/rsyslog.nested/90-nested.conf"
```

and passes here. Existing rsyslog tests unchanged and green.

Found while running an exhaustive config-parser sweep of the os provider across 15 Linux distros.