### PR TITLE
🐛 os: stop logrotate's lone-brace log path leaking into globalConfig

### DIFF
--- a/providers/os/resources/logrotate/logrotate.go
+++ b/providers/os/resources/logrotate/logrotate.go
@@ -115,6 +115,14 @@ func ParseContent(filePath string, content string) (globalConfig map[string]stri
 			continue
 		}
 
+		// A path line belonging to a lone-brace block ("paths" on one line,
+		// "{" on the next) is claimed by the brace handler on a later
+		// iteration. Without this it is also recorded here, leaving the log
+		// path in globalConfig as a directive nobody wrote.
+		if nextSignificantIsLoneBrace(lines, i) {
+			continue
+		}
+
 		// Global directive
 		key, value := parseDirective(trimmed)
 		if key != "" {
@@ -160,6 +168,20 @@ func splitPaths(s string) []string {
 		}
 	}
 	return paths
+}
+
+// nextSignificantIsLoneBrace reports whether the next line that is neither
+// blank nor a comment is a lone "{", which makes the current line the path
+// list of the block that brace opens.
+func nextSignificantIsLoneBrace(lines []string, idx int) bool {
+	for j := idx + 1; j < len(lines); j++ {
+		trimmed := strings.TrimSpace(lines[j])
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		return trimmed == "{"
+	}
+	return false
 }
 
 // findPathsBackward scans backward from a lone "{" to find the log path(s).

--- a/providers/os/resources/logrotate/lonebrace_test.go
+++ b/providers/os/resources/logrotate/lonebrace_test.go
@@ -1,0 +1,103 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package logrotate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// logrotate accepts the log path and its opening brace on separate lines. The
+// path line used to be recorded as a global directive before the brace handler
+// claimed it, leaving the log path in globalConfig as a directive nobody wrote.
+func TestParseContentLoneBraceDoesNotLeakPathIntoGlobalConfig(t *testing.T) {
+	content := `weekly
+rotate 4
+
+/var/log/lonebrace.log
+{
+    daily
+    rotate 9
+    compress
+}
+
+/var/log/sameline.log {
+    monthly
+}
+`
+
+	global, entries := ParseContent("/etc/logrotate.conf", content)
+
+	assert.Equal(t, map[string]string{"weekly": "", "rotate": "4"}, global,
+		"only the real global directives belong in globalConfig")
+	assert.NotContains(t, global, "/var/log/lonebrace.log",
+		"the lone-brace block's path must not appear as a global directive")
+
+	assert.Len(t, entries, 2)
+	assert.Equal(t, "/var/log/lonebrace.log", entries[0].Path)
+	assert.Equal(t, "9", entries[0].Config["rotate"], "the block still parses")
+	assert.Equal(t, "/var/log/sameline.log", entries[1].Path)
+}
+
+// Several paths on the line before a lone brace: none of them may leak, and
+// the block must still claim all of them.
+func TestParseContentLoneBraceMultiplePaths(t *testing.T) {
+	content := `su root adm
+
+/var/log/a.log /var/log/b.log
+{
+    rotate 3
+}
+`
+
+	global, entries := ParseContent("/etc/logrotate.conf", content)
+
+	assert.Equal(t, map[string]string{"su": "root adm"}, global)
+	assert.NotContains(t, global, "/var/log/a.log")
+
+	// One entry per path in the block.
+	assert.Len(t, entries, 2)
+	assert.Equal(t, "/var/log/a.log", entries[0].Path)
+	assert.Equal(t, "/var/log/b.log", entries[1].Path)
+}
+
+// A comment or blank line between the paths and the brace is still the same
+// block, so the path must not leak there either.
+func TestParseContentLoneBraceWithInterveningComment(t *testing.T) {
+	content := `compress
+
+/var/log/commented.log
+# rotate this one aggressively
+
+{
+    rotate 1
+}
+`
+
+	global, entries := ParseContent("/etc/logrotate.conf", content)
+
+	assert.Equal(t, map[string]string{"compress": ""}, global)
+	assert.NotContains(t, global, "/var/log/commented.log")
+
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "/var/log/commented.log", entries[0].Path)
+}
+
+// A real global directive that merely precedes a block on a later line must
+// still be recorded.
+func TestParseContentGlobalsBeforeBlocksSurvive(t *testing.T) {
+	content := `dateext
+maxage 30
+
+/var/log/keep.log {
+    rotate 5
+}
+`
+
+	global, entries := ParseContent("/etc/logrotate.conf", content)
+
+	assert.Equal(t, map[string]string{"dateext": "", "maxage": "30"}, global)
+	assert.Len(t, entries, 1)
+}


### PR DESCRIPTION
## The bug

logrotate accepts the log path and its opening brace on separate lines — a common style, and what `logrotate.d` fragments often use:

```
/var/log/app.log
{
    rotate 9
}
```

`ParseContent` walks the file line by line, so the path line is reached while still *outside any block* and falls through to the global-directive branch. The brace handler only claims it on the **next** iteration — by which point `globalConfig` already holds an entry keyed on the log path:

```go
globalConfig["/var/log/app.log"] = ""
```

With two paths on the line it is worse, because the second becomes the *value* of the first:

```go
globalConfig["/var/log/a.log"] = "/var/log/b.log"
```

Anything reading `logrotate.globalConfig` as the set of global directives saw log paths mixed in among `weekly`, `rotate` and `compress`.

## The fix

A line is skipped when the next significant line is a lone `{`, leaving it to the brace handler that already parses it correctly. Blank lines and comments between the paths and the brace are handled, matching `findPathsBackward`, which scans backward over exactly the same lines.

Entries are unaffected — the blocks parsed correctly before and still do. This only removes the spurious `globalConfig` keys.

## Verification

New tests fail on `main`:

```
map[string]string{"/var/log/lonebrace.log":"", "rotate":"4", "weekly":""}
    should not contain "/var/log/lonebrace.log"

map[string]string{"/var/log/a.log":"/var/log/b.log", "su":"root adm"}
    should not contain "/var/log/a.log"
```

and pass here. Coverage: single path, multiple paths on one line, a comment between the paths and the brace, and a regression test that genuine globals preceding a block are still recorded. All 10 existing logrotate tests stay green.

Found while running an exhaustive config-parser sweep of the os provider across 15 Linux distros.