### PR TITLE
🐛 os: don't treat a # inside a quoted ini value as a comment

### DIFF
--- a/providers/os/resources/parsers/ini.go
+++ b/providers/os/resources/parsers/ini.go
@@ -10,6 +10,35 @@ type Ini struct {
 	Fields map[string]any
 }
 
+// unquotedHashIndex returns the offset of the first "#" that starts a comment,
+// or -1 when the line carries none.
+//
+// A "#" inside a quoted value is part of the value in every ini dialect, so
+// cutting the line there truncated values such as
+//
+//	proxy_password = "p@ss#word"
+//
+// down to an unterminated `"p@ss`. Inline comments on unquoted values are
+// still honoured, which is what the callers of this parser have always relied
+// on.
+func unquotedHashIndex(line string) int {
+	var quote byte
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		switch {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			}
+		case c == '\'' || c == '"':
+			quote = c
+		case c == '#':
+			return i
+		}
+	}
+	return -1
+}
+
 // ParseIni parses the raw text contents of an ini-style file
 func ParseIni(raw string, delimiter string) *Ini {
 	res := Ini{
@@ -23,7 +52,7 @@ func ParseIni(raw string, delimiter string) *Ini {
 	for i := range lines {
 		line := lines[i]
 		line = strings.TrimSpace(line)
-		if idx := strings.Index(line, "#"); idx >= 0 {
+		if idx := unquotedHashIndex(line); idx >= 0 {
 			line = line[0:idx]
 		}
 

--- a/providers/os/resources/parsers/ini_quoted_test.go
+++ b/providers/os/resources/parsers/ini_quoted_test.go
@@ -1,0 +1,91 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package parsers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func iniGroup(t *testing.T, ini *Ini, group string) map[string]any {
+	t.Helper()
+	g, ok := ini.Fields[group].(map[string]any)
+	assert.True(t, ok, "group %q should exist", group)
+	return g
+}
+
+// A "#" inside a quoted value is part of the value, not the start of a
+// comment. Cutting the line there truncated the value and left the quote
+// unterminated.
+func TestParseIniHashInsideQuotedValue(t *testing.T) {
+	raw := `[main]
+proxy_password = "p@ss#word"
+single = 'we#rd'
+tag = "a#b#c"
+`
+	g := iniGroup(t, ParseIni(raw, "="), "main")
+
+	assert.Equal(t, `"p@ss#word"`, g["proxy_password"])
+	assert.Equal(t, `'we#rd'`, g["single"])
+	assert.Equal(t, `"a#b#c"`, g["tag"])
+}
+
+// Inline comments on unquoted values keep working; callers have always relied
+// on that.
+func TestParseIniInlineCommentsStillStripped(t *testing.T) {
+	raw := `[main]
+gpgcheck = 1 # verify signatures
+installonly_limit = 3   # keep three kernels
+bare = value#nospace
+`
+	g := iniGroup(t, ParseIni(raw, "="), "main")
+
+	assert.Equal(t, "1", g["gpgcheck"])
+	assert.Equal(t, "3", g["installonly_limit"])
+	assert.Equal(t, "value", g["bare"])
+}
+
+// A comment following a quoted value is still a comment.
+func TestParseIniCommentAfterQuotedValue(t *testing.T) {
+	raw := `[main]
+key = "quoted#value" # trailing comment
+`
+	g := iniGroup(t, ParseIni(raw, "="), "main")
+	assert.Equal(t, `"quoted#value"`, g["key"])
+}
+
+// Whole-line comments and section headers are unaffected.
+func TestParseIniLineCommentsUnaffected(t *testing.T) {
+	raw := `# a leading comment
+[main]
+# another comment
+key = value
+`
+	ini := ParseIni(raw, "=")
+	g := iniGroup(t, ini, "main")
+	assert.Equal(t, "value", g["key"])
+	assert.Len(t, g, 1)
+}
+
+func TestUnquotedHashIndex(t *testing.T) {
+	tests := []struct {
+		line string
+		want int
+	}{
+		{`no hash here`, -1},
+		{`# leading`, 0},
+		{`key = value # comment`, 12},
+		{`key = "a#b"`, -1},
+		{`key = 'a#b'`, -1},
+		{`key = "a#b" # after`, 12},
+		{`key = "unterminated#`, -1},
+		{``, -1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.line, func(t *testing.T) {
+			assert.Equal(t, tc.want, unquotedHashIndex(tc.line))
+		})
+	}
+}


### PR DESCRIPTION
## The bug

`ParseIni` cut every line at the first `#`, wherever it appeared:

```go
if idx := strings.Index(line, "#"); idx >= 0 {
    line = line[0:idx]
}
```

A quoted value containing one was truncated, leaving the quote unterminated:

```
proxy_password = "p@ss#word"     ->  "p@ss
tag            = "a#b#c"         ->  "a
```

A `#` between quotes is part of the value in **every** ini dialect, so this was wrong regardless of which dialect a caller had in mind.

## Deliberately narrow

Inline comments on *unquoted* values are unchanged. There is no universal ini rule for those, and this parser backs a lot of surface:

- `auditd.config`
- `yum.config`
- the RHEL and Oracle platform detectors
- the user-facing **`parse.ini`** resource

Removing or widening comment handling would change behaviour for all of them and could break existing policies either way. Only the quoted case — which nothing can plausibly want — is corrected.

## Verification

| input | before | after |
|---|---|---|
| `proxy_password = "p@ss#word"` | `"p@ss` | `"p@ss#word"` |
| `single = 'we#rd'` | `'we` | `'we#rd'` |
| `gpgcheck = 1 # verify` | `1` | `1` (unchanged) |
| `bare = value#nospace` | `value` | `value` (unchanged) |
| `key = "quoted#value" # trailing` | `"quoted` | `"quoted#value"` |

Tests cover the quoted cases, the unquoted inline-comment cases that must not regress, whole-line comments, and a table for the `unquotedHashIndex` helper including an unterminated quote.

```
ok  go.mondoo.com/mql/providers/os/resources/parsers
ok  go.mondoo.com/mql/providers/os/detector     # 120 platform fixtures, unchanged
ok  go.mondoo.com/mql/providers/os/resources
```

Found while running an exhaustive config-parser sweep of the os provider across 15 Linux distros.