### PR TITLE
📄 os: document that pam.conf.serviceEntry.lineNumber counts from zero

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -1087,7 +1087,13 @@ private pam.conf.serviceEntry @defaults("service module") {
   // The `/etc/pam.d/<service>` file path the line came from, or the service
   // name in the first column when read from the single-file `/etc/pam.conf`.
   service string
-  // Line number in service file (used for ID)
+  // Line number the entry was read from
+  //
+  // Zero-based: the first line of the file is 0. Every other lineNumber in
+  // this provider counts from 1, including limits.entry, logrotate.entry,
+  // crontab.entry, sudoers and modprobe, so subtract nothing here and add
+  // nothing there when comparing against a text editor. The value forms part
+  // of the entry's identity, so it is kept as it is rather than renumbered.
   lineNumber int
   // PAM entry type (e.g., auth, account, password, session)
   pamType string


### PR DESCRIPTION
## What

`pam.conf.serviceEntry.lineNumber` is **zero-based**. Its doc comment said only:

```
// Line number in service file (used for ID)
```

so nothing told you the first line is `0`.

## Why it matters

Every other `lineNumber` in this provider counts from **1**:

| resource | source |
|---|---|
| `limits.entry` | parser `LineNumber` |
| `logrotate.entry` | `lineNum := i + 1` |
| `crontab.entry` | `lineNumber := 0; lineNumber++` before use |
| `sudoers` (spec / default / alias) | `actualLineNum` |
| `modprobe` | `actualLineNum := lineNum + 1` |

`pam.go` is the only one that hands the raw loop index straight to the field:

```go
log.Warn()....Int("line", i+1).Msg("skipping malformed PAM line")   // 1-based
...
"lineNumber": llx.IntData(int64(i)),                                // 0-based
```

Those two lines are a few apart in the same function, disagreeing with each other. Anyone lining an entry up against a text editor, or comparing a pam entry's `lineNumber` against a limits or logrotate one, was off by one with nothing to warn them.

## Why documented, not renumbered

`lineNumber` forms part of the entry's identity, so changing the values would be a breaking change for anyone matching on them. The comment now states the base and points at the inconsistency, which is the safe fix.

Doc-comment only — regenerating produces no code diff.

Found while running an exhaustive config-parser sweep of the os provider across 15 Linux distros.