### PR TITLE
🐛 os: let the networkinterface package compile on BSD and other unix targets

### DIFF
--- a/providers/os/resources/networkinterface/other_unix_routes_stub.go
+++ b/providers/os/resources/networkinterface/other_unix_routes_stub.go
@@ -12,11 +12,12 @@ import (
 )
 
 // The real implementation lives in darwin_routes.go behind a darwin build tag,
-// because golang.org/x/net/route only builds on BSD-derived targets Go
-// supports it on. linux and windows each carry their own stub; without one
-// here the package does not compile at all on any other platform, since
-// routes.go assigns a *darwinRouteDetector to the operatingSystemRouteDetector
-// interface unconditionally.
+// because golang.org/x/net/route only builds on the targets Go supports it on.
+// linux and windows each carry their own stub; without one here the package
+// does not compile at all on any other platform, since routes.go references
+// *darwinRouteDetector in a switch case that is compiled on every platform.
+// The case never runs off darwin, but the method still has to exist for the
+// type to satisfy operatingSystemRouteDetector.
 func (*darwinRouteDetector) List() ([]Route, error) {
 	return nil, errors.New("Darwin route detection is not available on this platform")
 }

--- a/providers/os/resources/networkinterface/other_unix_routes_stub.go
+++ b/providers/os/resources/networkinterface/other_unix_routes_stub.go
@@ -1,0 +1,22 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !darwin && !linux && !windows
+
+// This file stubs out the Darwin route detection for every other unix build
+// (freebsd, netbsd, openbsd, dragonfly, solaris, aix).
+package networkinterface
+
+import (
+	"github.com/cockroachdb/errors"
+)
+
+// The real implementation lives in darwin_routes.go behind a darwin build tag,
+// because golang.org/x/net/route only builds on BSD-derived targets Go
+// supports it on. linux and windows each carry their own stub; without one
+// here the package does not compile at all on any other platform, since
+// routes.go assigns a *darwinRouteDetector to the operatingSystemRouteDetector
+// interface unconditionally.
+func (*darwinRouteDetector) List() ([]Route, error) {
+	return nil, errors.New("Darwin route detection is not available on this platform")
+}


### PR DESCRIPTION
## The bug

`routes.go` assigns a `*darwinRouteDetector` to the `operatingSystemRouteDetector` interface unconditionally:

```go
case pf.IsFamily(inventory.FAMILY_DARWIN):
    detector = &darwinRouteDetector{conn: conn, platform: pf}
```

but `darwinRouteDetector.List` lives in `darwin_routes.go` behind `//go:build darwin`. `linux` and `windows` each ship a stub supplying that method — nothing supplies it anywhere else:

| method | darwin | linux | windows | freebsd & co. |
|---|---|---|---|---|
| `darwinRouteDetector.List` | real | stub | stub | **missing** |
| `linuxRouteDetector.List` | ✅ untagged | ✅ | ✅ | ✅ |
| `windowsRouteDetector.List` | ✅ | ✅ | ✅ native | ✅ remote |

So the package does not compile at all on freebsd, netbsd, openbsd, dragonfly, solaris or aix:

```
routes.go:60:14: cannot use &darwinRouteDetector{…} (value of type *darwinRouteDetector)
    as operatingSystemRouteDetector value in assignment:
    *darwinRouteDetector does not implement operatingSystemRouteDetector (missing method List)
```

## The fix

One stub file tagged `!darwin && !linux && !windows`, following the shape of the existing `linux_routes_stub.go` and `windows_routes_stub.go`. linux, darwin and windows builds are unaffected — the new file is excluded from all three.

Verified with `GOOS=… go build ./...` across freebsd, linux, darwin, windows, netbsd and openbsd.

## Honest scope

This removes **our** blocker but does **not** by itself make a full freebsd provider build succeed. Once past this, the build reaches a second, independent failure in a dependency:

```
github.com/hnakamur/go-scp@v1.0.2/source.go:43:9: undefined: newFileInfoFromOS
```

That is an upstream gap, not something this repo can fix in place. FreeBSD is not currently a release target, so nothing shipping is broken today — but the repo does support FreeBSD as a *scan target* (there are `detect-freebsd12/14/15` fixtures and a `BsdKernelManager`), and this is a prerequisite for ever building natively there.

Found while auditing FreeBSD 14.4-RELEASE and 15.1-RELEASE-p2.