### PR TITLE
🐛 os: list FreeBSD ports with sockstat instead of lsof

### DIFF
--- a/providers/os/resources/port.go
+++ b/providers/os/resources/port.go
@@ -677,6 +677,21 @@ var freebsdPortStates = map[string]string{
 	"CLOSING":     TCP_STATES[11],
 }
 
+// freebsdPortState translates one sockstat CONN STATE token onto the canonical
+// TCP_STATES vocabulary. An unrecognised token passes through unchanged rather
+// than becoming "", so a state FreeBSD adds later is still visible instead of
+// silently reading as no state at all. udp rows carry no state and keep their
+// empty value.
+func freebsdPortState(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	if state, ok := freebsdPortStates[raw]; ok {
+		return state
+	}
+	return raw
+}
+
 // listFreebsd reads sockets from sockstat, which is part of the base system.
 func (p *mqlPorts) listFreebsd() ([]any, error) {
 	users, err := p.users()
@@ -711,11 +726,21 @@ func (p *mqlPorts) listFreebsd() ([]any, error) {
 		return nil, err
 	}
 
+	// sockstat names the owning user, while the users map is keyed by uid.
+	// Index once: scanning per socket is O(sockets x users).
+	usersByName := make(map[string]*mqlUser, len(users))
+	for uid := range users {
+		u := users[uid]
+		if u != nil {
+			usersByName[u.Name.Data] = u
+		}
+	}
+
 	res := []any{}
 	for i := range entries {
 		entry := entries[i]
 
-		state := freebsdPortStates[entry.State]
+		state := freebsdPortState(entry.State)
 
 		args := map[string]*llx.RawData{
 			"protocol":      llx.StringData(entry.Protocol),
@@ -726,7 +751,7 @@ func (p *mqlPorts) listFreebsd() ([]any, error) {
 			"remotePort":    llx.IntData(entry.RemotePort),
 		}
 
-		mqlUser := userByName(users, entry.User)
+		mqlUser := usersByName[entry.User]
 		if mqlUser != nil {
 			args["user"] = llx.ResourceData(mqlUser, "user")
 		}
@@ -753,18 +778,6 @@ func (p *mqlPorts) listFreebsd() ([]any, error) {
 	}
 
 	return res, nil
-}
-
-// userByName finds a user resource by name. sockstat reports the owning user
-// by name, while the users map is keyed by uid.
-func userByName(users map[int64]*mqlUser, name string) *mqlUser {
-	for uid := range users {
-		u := users[uid]
-		if u != nil && u.Name.Data == name {
-			return u
-		}
-	}
-	return nil
 }
 
 // AIX Implementation

--- a/providers/os/resources/port.go
+++ b/providers/os/resources/port.go
@@ -42,9 +42,13 @@ func (p *mqlPorts) list() ([]any, error) {
 	case pf.IsFamily("windows"):
 		return p.listWindows()
 
-	case pf.IsFamily("darwin") || pf.Name == "freebsd":
-		// both macOS and FreeBSD support lsof
-		// FreeBSD may need an installation via `pkg install sysutils/lsof`
+	case pf.Name == "freebsd":
+		// sockstat ships in the FreeBSD base system. lsof does not, and when it
+		// is absent the lsof path returns an empty list rather than an error,
+		// so a host with listening sockets reported none at all.
+		return p.listFreebsd()
+
+	case pf.IsFamily("darwin"):
 		return p.listMacos()
 
 	case pf.Name == "aix":
@@ -653,6 +657,114 @@ func (p *mqlPorts) listMacos() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+// freebsdPortStates maps sockstat's CONN STATE column onto the canonical
+// TCP_STATES vocabulary, so `state == "listen"` behaves the same on FreeBSD as
+// everywhere else. udp rows carry no state and keep an empty value rather than
+// having one invented for them.
+var freebsdPortStates = map[string]string{
+	"LISTEN":      TCP_STATES[10],
+	"ESTABLISHED": TCP_STATES[1],
+	"SYN_SENT":    TCP_STATES[2],
+	"SYN_RCVD":    TCP_STATES[3],
+	"FIN_WAIT_1":  TCP_STATES[4],
+	"FIN_WAIT_2":  TCP_STATES[5],
+	"TIME_WAIT":   TCP_STATES[6],
+	"CLOSED":      TCP_STATES[7],
+	"CLOSE_WAIT":  TCP_STATES[8],
+	"LAST_ACK":    TCP_STATES[9],
+	"CLOSING":     TCP_STATES[11],
+}
+
+// listFreebsd reads sockets from sockstat, which is part of the base system.
+func (p *mqlPorts) listFreebsd() ([]any, error) {
+	users, err := p.users()
+	if err != nil {
+		return nil, err
+	}
+
+	processes, err := p.processesByPid()
+	if err != nil {
+		return nil, err
+	}
+
+	conn := p.MqlRuntime.Connection.(shared.Connection)
+	executedCmd, err := conn.RunCommand("sockstat -46 -s")
+	if err != nil {
+		return nil, err
+	}
+	if executedCmd.ExitStatus != 0 {
+		// -s is not available on every release; the listing without it still
+		// carries every socket, only without the state column.
+		executedCmd, err = conn.RunCommand("sockstat -46")
+		if err != nil {
+			return nil, err
+		}
+		if executedCmd.ExitStatus != 0 {
+			return nil, errors.New("could not list ports: sockstat failed")
+		}
+	}
+
+	entries, err := ports.ParseSockstat(executedCmd.Stdout)
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	for i := range entries {
+		entry := entries[i]
+
+		state := freebsdPortStates[entry.State]
+
+		args := map[string]*llx.RawData{
+			"protocol":      llx.StringData(entry.Protocol),
+			"port":          llx.IntData(entry.LocalPort),
+			"address":       llx.StringData(entry.LocalAddress),
+			"state":         llx.StringData(state),
+			"remoteAddress": llx.StringData(entry.RemoteAddress),
+			"remotePort":    llx.IntData(entry.RemotePort),
+		}
+
+		mqlUser := userByName(users, entry.User)
+		if mqlUser != nil {
+			args["user"] = llx.ResourceData(mqlUser, "user")
+		}
+
+		mqlProcess := processes[entry.Pid]
+		if mqlProcess != nil {
+			args["process"] = llx.ResourceData(mqlProcess, "process")
+		}
+
+		obj, err := CreateResource(p.MqlRuntime, "port", args)
+		if err != nil {
+			return nil, err
+		}
+
+		portObj := obj.(*mqlPort)
+		if mqlProcess == nil {
+			portObj.Process.State = plugin.StateIsSet | plugin.StateIsNull
+		}
+		if mqlUser == nil {
+			portObj.User.State = plugin.StateIsSet | plugin.StateIsNull
+		}
+
+		res = append(res, obj)
+	}
+
+	return res, nil
+}
+
+// userByName finds a user resource by name. sockstat reports the owning user
+// by name, while the users map is keyed by uid.
+func userByName(users map[int64]*mqlUser, name string) *mqlUser {
+	for uid := range users {
+		u := users[uid]
+		if u != nil && u.Name.Data == name {
+			return u
+		}
+	}
+	return nil
 }
 
 // AIX Implementation

--- a/providers/os/resources/port_freebsd_state_test.go
+++ b/providers/os/resources/port_freebsd_state_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFreebsdPortState(t *testing.T) {
+	// mapped onto the same vocabulary the other platforms use
+	assert.Equal(t, "listen", freebsdPortState("LISTEN"))
+	assert.Equal(t, "established", freebsdPortState("ESTABLISHED"))
+	assert.Equal(t, "time wait", freebsdPortState("TIME_WAIT"))
+	assert.Equal(t, "close wait", freebsdPortState("CLOSE_WAIT"))
+
+	// udp rows carry no state at all
+	assert.Equal(t, "", freebsdPortState(""))
+
+	// a state FreeBSD adds later must stay visible rather than read as "no
+	// state", which is what a bare map lookup would have produced
+	assert.Equal(t, "SOME_FUTURE_STATE", freebsdPortState("SOME_FUTURE_STATE"))
+}

--- a/providers/os/resources/ports/sockstat.go
+++ b/providers/os/resources/ports/sockstat.go
@@ -1,0 +1,134 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package ports holds the per-platform socket listings that back the `ports`
+// resource. This file parses FreeBSD's sockstat, which ships in the base
+// system, unlike lsof.
+package ports
+
+import (
+	"bufio"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// SockstatEntry is one socket row from `sockstat -46 -s`.
+type SockstatEntry struct {
+	User          string
+	Command       string
+	Pid           int64
+	Protocol      string // tcp4, tcp6, udp4, udp6
+	LocalAddress  string
+	LocalPort     int64
+	RemoteAddress string
+	RemotePort    int64
+	State         string // CONN STATE column, empty for udp
+}
+
+// ParseSockstat reads the output of `sockstat -46 -s`.
+//
+//	USER     COMMAND    PID   FD  PROTO  LOCAL ADDRESS   FOREIGN ADDRESS  CONN STATE
+//	root     sshd       1718  7   tcp4   *:22            *:*              LISTEN
+//	ntpd     ntpd       1666  22  udp4   10.45.1.14:123  *:*
+//
+// Columns are whitespace separated and the command may be truncated, but never
+// contains a space, so splitting on fields is safe. The CONN STATE column is
+// absent for udp rows and on releases whose sockstat has no -s flag, so a row
+// is accepted with anything from 7 fields up.
+func ParseSockstat(r io.Reader) ([]SockstatEntry, error) {
+	var res []SockstatEntry
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 7 {
+			continue
+		}
+		if fields[0] == "USER" {
+			// header
+			continue
+		}
+
+		proto := fields[4]
+		if !isInetProtocol(proto) {
+			// unix domain sockets and anything else sockstat may list
+			continue
+		}
+
+		pid, err := strconv.ParseInt(fields[2], 10, 64)
+		if err != nil {
+			// a kernel socket has no pid ("?"); keep the row, report pid 0
+			pid = 0
+		}
+
+		localAddr, localPort := splitHostPort(fields[5])
+		remoteAddr, remotePort := splitHostPort(fields[6])
+
+		state := ""
+		if len(fields) > 7 {
+			state = strings.Join(fields[7:], " ")
+		}
+
+		res = append(res, SockstatEntry{
+			User:          fields[0],
+			Command:       fields[1],
+			Pid:           pid,
+			Protocol:      proto,
+			LocalAddress:  localAddr,
+			LocalPort:     localPort,
+			RemoteAddress: remoteAddr,
+			RemotePort:    remotePort,
+			State:         state,
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func isInetProtocol(p string) bool {
+	switch p {
+	case "tcp4", "tcp6", "udp4", "udp6":
+		return true
+	}
+	return false
+}
+
+// splitHostPort splits sockstat's ADDRESS:PORT, where the host may be "*", a
+// bare IPv4 address, or a bracketed IPv6 address that carries its own colons
+// and may include a zone ("[fe80::1%lo0]:123"). A wildcard or unknown port
+// yields 0.
+func splitHostPort(s string) (string, int64) {
+	if s == "" || s == "*:*" {
+		return "", 0
+	}
+
+	idx := strings.LastIndex(s, ":")
+	if idx < 0 {
+		return s, 0
+	}
+
+	host := s[:idx]
+	portStr := s[idx+1:]
+
+	// strip the brackets IPv6 literals are wrapped in
+	if len(host) > 1 && host[0] == '[' && host[len(host)-1] == ']' {
+		host = host[1 : len(host)-1]
+	}
+
+	port, err := strconv.ParseInt(portStr, 10, 64)
+	if err != nil {
+		// "*" for a wildcard port, or a service name
+		port = 0
+	}
+
+	return host, port
+}

--- a/providers/os/resources/ports/sockstat_test.go
+++ b/providers/os/resources/ports/sockstat_test.go
@@ -1,0 +1,136 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package ports
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Captured verbatim from `sockstat -46 -s` on FreeBSD 14.4-RELEASE.
+const sockstatFreeBSD14 = `USER     COMMAND    PID   FD  PROTO     LOCAL ADDRESS         FOREIGN ADDRESS       CONN STATE
+ec2-user sshd-sessi 10356 7   tcp4      10.45.1.14:22         97.115.90.143:61073   ESTABLISHED
+root     sshd        1718 6   tcp6      *:22                  *:*                   LISTEN
+root     sshd        1718 7   tcp4      *:22                  *:*                   LISTEN
+ntpd     ntpd        1666 21  udp4      *:123                 *:*
+ntpd     ntpd        1666 22  udp4      10.45.1.14:123        *:*
+ntpd     ntpd        1666 23  udp6      [::1]:123             *:*
+ntpd     ntpd        1666 24  udp6      [fe80::1%lo0]:123     *:*
+`
+
+func TestParseSockstatListeners(t *testing.T) {
+	entries, err := ParseSockstat(strings.NewReader(sockstatFreeBSD14))
+	require.NoError(t, err)
+	require.Len(t, entries, 7, "the header must not become a row")
+
+	// tcp6 listener on the wildcard address
+	e := entries[1]
+	assert.Equal(t, "root", e.User)
+	assert.Equal(t, "sshd", e.Command)
+	assert.Equal(t, int64(1718), e.Pid)
+	assert.Equal(t, "tcp6", e.Protocol)
+	assert.Equal(t, "*", e.LocalAddress)
+	assert.Equal(t, int64(22), e.LocalPort)
+	assert.Equal(t, "", e.RemoteAddress, "*:* is not a peer")
+	assert.Equal(t, int64(0), e.RemotePort)
+	assert.Equal(t, "LISTEN", e.State)
+}
+
+func TestParseSockstatEstablished(t *testing.T) {
+	entries, err := ParseSockstat(strings.NewReader(sockstatFreeBSD14))
+	require.NoError(t, err)
+
+	e := entries[0]
+	assert.Equal(t, "tcp4", e.Protocol)
+	assert.Equal(t, "10.45.1.14", e.LocalAddress)
+	assert.Equal(t, int64(22), e.LocalPort)
+	assert.Equal(t, "97.115.90.143", e.RemoteAddress)
+	assert.Equal(t, int64(61073), e.RemotePort)
+	assert.Equal(t, "ESTABLISHED", e.State)
+}
+
+// udp rows carry no CONN STATE column, and IPv6 literals bring their own
+// colons plus an optional zone.
+func TestParseSockstatUDPAndIPv6(t *testing.T) {
+	entries, err := ParseSockstat(strings.NewReader(sockstatFreeBSD14))
+	require.NoError(t, err)
+
+	udp6 := entries[5]
+	assert.Equal(t, "udp6", udp6.Protocol)
+	assert.Equal(t, "::1", udp6.LocalAddress, "brackets are stripped")
+	assert.Equal(t, int64(123), udp6.LocalPort)
+	assert.Equal(t, "", udp6.State, "udp has no connection state")
+
+	zoned := entries[6]
+	assert.Equal(t, "fe80::1%lo0", zoned.LocalAddress, "the zone is part of the address")
+	assert.Equal(t, int64(123), zoned.LocalPort)
+}
+
+// Older releases have no -s flag, so the state column is simply absent.
+func TestParseSockstatWithoutStateColumn(t *testing.T) {
+	raw := `USER     COMMAND    PID   FD  PROTO     LOCAL ADDRESS         FOREIGN ADDRESS
+root     sshd        1718 7   tcp4      *:22                  *:*
+`
+	entries, err := ParseSockstat(strings.NewReader(raw))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, int64(22), entries[0].LocalPort)
+	assert.Equal(t, "", entries[0].State)
+}
+
+// Unix domain sockets and other non-inet rows are not ports.
+func TestParseSockstatSkipsNonInet(t *testing.T) {
+	raw := `USER     COMMAND    PID   FD  PROTO     LOCAL ADDRESS         FOREIGN ADDRESS
+root     dbus        900  3   stream    /var/run/dbus/system_bus_socket  -
+root     sshd        1718 7   tcp4      *:22                  *:*
+`
+	entries, err := ParseSockstat(strings.NewReader(raw))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "tcp4", entries[0].Protocol)
+}
+
+// A kernel socket has "?" where the pid goes; the row is still a real socket.
+func TestParseSockstatKernelSocket(t *testing.T) {
+	raw := `USER     COMMAND    PID   FD  PROTO     LOCAL ADDRESS         FOREIGN ADDRESS       CONN STATE
+?        ?           ?    ?   tcp4      *:2049                *:*                   LISTEN
+`
+	entries, err := ParseSockstat(strings.NewReader(raw))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, int64(0), entries[0].Pid)
+	assert.Equal(t, int64(2049), entries[0].LocalPort)
+}
+
+func TestParseSockstatEmpty(t *testing.T) {
+	entries, err := ParseSockstat(strings.NewReader(""))
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestSplitHostPort(t *testing.T) {
+	tests := []struct {
+		in   string
+		host string
+		port int64
+	}{
+		{"*:22", "*", 22},
+		{"10.0.0.1:443", "10.0.0.1", 443},
+		{"[::1]:123", "::1", 123},
+		{"[fe80::1%lo0]:123", "fe80::1%lo0", 123},
+		{"*:*", "", 0},
+		{"", "", 0},
+		{"*:sunrpc", "*", 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			h, p := splitHostPort(tc.in)
+			assert.Equal(t, tc.host, h)
+			assert.Equal(t, tc.port, p)
+		})
+	}
+}


### PR DESCRIPTION
## The bug

FreeBSD was routed to the macOS lister:

```go
case pf.IsFamily("darwin") || pf.Name == "freebsd":
    // both macOS and FreeBSD support lsof
    // FreeBSD may need an installation via `pkg install sysutils/lsof`
    return p.listMacos()
```

`lsof` is **not** part of the FreeBSD base system, and when it is missing the lsof path yields an **empty list rather than an error**. On a stock FreeBSD 14.4 host with sshd listening:

```
$ sockstat -46 -s
root  sshd  1718  6  tcp6  *:22  *:*  LISTEN
root  sshd  1718  7  tcp4  *:22  *:*  LISTEN

mql> ports.list             => []
mql> ports.listening.length => 0
```

A check asserting that no unexpected port is listening **passed on every stock FreeBSD host**, having enumerated nothing at all. A silent empty is the worst possible shape for that question, because the answer looks like a clean bill of health.

## The fix

`sockstat` ships in the FreeBSD base system and reports the same information — owning user, pid, protocol, local and foreign address, and the connection state with `-s`. FreeBSD gets its own lister; macOS keeps using `lsof`, where it is present by default.

Handled explicitly:

- **no `-s` flag** on older releases → falls back to plain `sockstat -46`; the parser accepts a row with no state column
- **UDP rows** carry no state → left empty rather than invented
- **IPv6 literals** bring their own colons and an optional zone → `[fe80::1%lo0]:123` parses as address `fe80::1%lo0`, port 123
- **kernel sockets** report `?` for the pid → kept as a socket, with no process attached
- **non-inet rows** (unix domain sockets) → skipped
- state tokens mapped onto the canonical `TCP_STATES` vocabulary, so `state == "listen"` behaves the same as on Linux

## Verification

Live FreeBSD **14.4-RELEASE** and **15.1-RELEASE-p2**:

| | before | after |
|---|---|---|
| `ports.listening.length` | `0` | `2` |
| `ports.listening` | `[]` | tcp4 `*:22` + tcp6 `*:22`, state `listen` |
| `ports.length` | `0` | `12` — exactly the socket count sockstat reports |
| `user` / `process` | — | resolved (`ntpd`, `syslogd`, `sshd`) |

Unit tests parse real captured `sockstat -46 -s` output and cover listeners, established connections, UDP, bracketed and zoned IPv6, the no-`-s` layout, unix sockets, kernel sockets, and empty input.

```
ok  go.mondoo.com/mql/providers/os/resources/ports
```

Found while auditing FreeBSD 14 and 15.