### PR TITLE
🐛 os: detect redhat-family release files that omit the "release" keyword

### DIFF
--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -1484,3 +1484,19 @@ func TestSles16Detector(t *testing.T) {
 	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
 	assert.Equal(t, []string{"suse", "linux", "unix", "os"}, di.Family)
 }
+
+// Fedora ELN's /etc/redhat-release reads "Fedora ELN 11", with no "release"
+// keyword. The redhat family resolver treats an unparseable release file as
+// "not a redhat host", so before this was handled ELN skipped the whole redhat
+// subtree and landed in defaultLinux as name "eln" with no redhat family,
+// which killed every resource gated on IsFamily("redhat").
+func TestFedoraELNDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-fedora-eln.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "fedora", di.Name, "os name should be identified")
+	assert.Equal(t, "Fedora ELN 11", di.Title, "os title should be identified")
+	assert.Equal(t, "11", di.Version, "os version should be identified")
+	assert.Equal(t, "aarch64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"redhat", "linux", "unix", "os"}, di.Family)
+}

--- a/providers/os/detector/parser_linux_version.go
+++ b/providers/os/detector/parser_linux_version.go
@@ -6,6 +6,7 @@ package detector
 import (
 	"errors"
 	"regexp"
+	"strings"
 )
 
 var (
@@ -13,6 +14,10 @@ var (
 	LSB_RELEASE_REGEX   = regexp.MustCompile(`(?m)^\s*(.+?)\s*=["']?(.+?)["']?$`)
 	RHEL_PLATFORM_REGEX = regexp.MustCompile(`^(.+)\srelease`)
 	RHEL_RELEASE_REGEX  = regexp.MustCompile(`release ([\d\.]+)`)
+
+	// Some redhat-family release files name the product and version without the
+	// "release" keyword at all. Fedora ELN writes "Fedora ELN 11".
+	RHEL_NO_KEYWORD_REGEX = regexp.MustCompile(`^(.+?)\s+(\d+(?:\.\d+)*)\s*(?:\(.*\))?$`)
 )
 
 func ParseImageRelease(content string) (map[string]string, error) {
@@ -37,19 +42,26 @@ func parseKeyValue(content string, regex *regexp.Regexp) map[string]string {
 }
 
 func ParseRhelVersion(releaseDescription string) (string, string, error) {
-	// extract platform name
+	releaseDescription = strings.TrimSpace(releaseDescription)
+
+	// The conventional form carries the keyword:
+	//   Red Hat Enterprise Linux release 9.2 (Plow)
+	//   CentOS Stream release 9
 	m := RHEL_PLATFORM_REGEX.FindStringSubmatch(releaseDescription)
-	if len(m) < 1 {
-		return "", "", errors.New("could not parse rhel version")
-	}
-	name := m[1]
-
-	// extract release
 	n := RHEL_RELEASE_REGEX.FindStringSubmatch(releaseDescription)
-	if len(n) < 2 {
-		return "", "", errors.New("could not parse rhel version")
+	if len(m) > 1 && len(n) > 1 {
+		return m[1], n[1], nil
 	}
-	release := n[1]
 
-	return name, release, nil
+	// Fedora ELN omits it: "Fedora ELN 11". Failing here is not cosmetic. The
+	// redhat family resolver treats an error from this function as "not a
+	// redhat host", which skips the entire subtree (rhel, centos, fedora,
+	// oracle, ...) and drops the asset into defaultLinux without the redhat
+	// family. Every resource gated on IsFamily("redhat") then goes dead:
+	// packages, yum, kernel.installed and os.rebootpending among them.
+	if k := RHEL_NO_KEYWORD_REGEX.FindStringSubmatch(releaseDescription); len(k) > 2 {
+		return k[1], k[2], nil
+	}
+
+	return "", "", errors.New("could not parse rhel version")
 }

--- a/providers/os/detector/testdata/detect-fedora-eln.toml
+++ b/providers/os/detector/testdata/detect-fedora-eln.toml
@@ -1,0 +1,50 @@
+# Fedora ELN (Enterprise Linux Next), Fedora's rolling RHEL-next branch.
+#
+# Captured from a live aarch64 EC2 instance built from
+# Fedora-Cloud-Base-AmazonEC2.aarch64-ELN-20260512.2.
+#
+# The interesting part is /etc/redhat-release: it reads "Fedora ELN 11", with no
+# "release" keyword. Every other redhat-family release file has one
+# ("Fedora release 29", "CentOS Stream release 9"), and the family resolver used
+# to require it, so ELN failed the redhat gate entirely and fell through to
+# defaultLinux.
+
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "aarch64"
+
+[commands."uname -r"]
+stdout = "7.1.0-0.rc3.260512g50897c955902.24.eln156.aarch64"
+
+[files."/etc/os-release"]
+content = """
+NAME="Fedora ELN"
+VERSION="11"
+RELEASE_TYPE=development
+ID=eln
+ID_LIKE="rhel centos fedora"
+VERSION_ID=11
+PLATFORM_ID="platform:eln"
+PRETTY_NAME="Fedora ELN 11"
+ANSI_COLOR="0;38;2;60;110;180"
+LOGO=fedora-logo-icon
+CPE_NAME="cpe:/o:fedoraproject:fedora-eln:11"
+DEFAULT_HOSTNAME="localhost"
+HOME_URL="https://docs.fedoraproject.org/en-US/eln/"
+DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/eln/"
+SUPPORT_URL="https://fedoraproject.org/wiki/Eln"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+VARIANT="ELN"
+VARIANT_ID=eln
+"""
+
+[files."/etc/redhat-release"]
+content = "Fedora ELN 11"
+
+[files."/etc/fedora-release"]
+content = "Fedora ELN 11"
+
+[files."/etc/system-release"]
+content = "Fedora ELN 11"


### PR DESCRIPTION
## The bug

`ParseRhelVersion` requires the literal word **"release"** in `/etc/redhat-release`:

```go
RHEL_PLATFORM_REGEX = regexp.MustCompile(`^(.+)\srelease`)
RHEL_RELEASE_REGEX  = regexp.MustCompile(`release ([\d\.]+)`)
```

Fedora ELN writes its release file without one:

```
Fedora ELN 11
```

So parsing fails — and the redhat family resolver treats an error from this function as *"not a redhat host"*:

```go
title, release, err := ParseRhelVersion(content)
if err == nil { ... return true, nil }
return false, nil
```

Returning false skips the **entire subtree**: `oracle, rhel, centos, fedora, scientific, eurolinux, nobara, qubes` are never evaluated. Detection falls through to `defaultLinux`, keeping the raw os-release `ID`, so the asset reports:

| field | before | expected |
|---|---|---|
| name | `eln` | `fedora` |
| family | `[linux unix os]` | `[redhat linux unix os]` |

## Why it matters

Every resource gated on `IsFamily("redhat")` goes dead. Confirmed on a live Fedora ELN 11 instance carrying **571 rpms**:

| resource | reported | ground truth |
|---|---|---|
| `packages` | *"could not detect suitable package manager for platform"* | **571 rpms** |
| `yum.repos` | *"only supported on redhat-based platforms"* | 4 enabled repos |
| `kernel.installed` | *"could not detect suitable package manager"* | 1 kernel |
| `os.rebootpending` | *"your platform is not supported by reboot resource"* | — |

A scan of an ELN host silently sees **zero packages**.

## The fix

The keyword form is tried **first**, so every existing release file parses exactly as before. Only when that fails does a second pattern accept `<product name> <version>`, which is what ELN emits.

Nothing else needed changing: the `fedora` child resolver already matches on a title containing "Fedora", so once the family gate passes, ELN resolves to `fedora` with the redhat family.

## Verification

New fixture captured verbatim from a live **aarch64** Fedora ELN 11 EC2 instance (`Fedora-Cloud-Base-AmazonEC2.aarch64-ELN-20260512.2`).

The test **fails on `main`** and passes here:

```
name="fedora" title="Fedora ELN 11" version="11" arch="aarch64"
family=[redhat linux unix os]
```

All **120** existing detector fixtures pass unchanged, so the keyword path is untouched.

Found while running a live provider validation across Linux distributions.