### PR TITLE
🐛 os: stop reporting a running firewalld as "not running" when polkit denies

### DIFF
--- a/providers/os/resources/firewalld.go
+++ b/providers/os/resources/firewalld.go
@@ -103,7 +103,22 @@ func (f *mqlFirewalld) fetchStatus() error {
 	cmd := o.(*mqlCommand)
 	exitcode := cmd.GetExitcode().Data
 	state := strings.TrimSpace(cmd.GetStdout().Data)
-	if exitcode != 0 || state != "running" {
+	if exitcode != 0 {
+		// A refused question is not an answer. firewall-cmd exits non-zero both
+		// when the firewall is genuinely stopped and when polkit declines to
+		// answer an unprivileged caller. Recording the second as "not running"
+		// turns a missing permission into a clean bill of health: zones() below
+		// returns nothing whenever the status is not "running", so every zone
+		// and every rule silently disappears from the scan and an exposure
+		// check finds nothing to object to.
+		if stderr := strings.TrimSpace(cmd.GetStderr().Data); isFirewalldAuthzError(stderr) {
+			return fmt.Errorf("cannot determine firewalld state: %s", stderr)
+		}
+		f.cacheStatus = "not running"
+		f.fetched = true
+		return nil
+	}
+	if state != "running" {
 		f.cacheStatus = "not running"
 		f.fetched = true
 		return nil
@@ -125,6 +140,30 @@ func (f *mqlFirewalld) fetchStatus() error {
 
 	f.fetched = true
 	return nil
+}
+
+// isFirewalldAuthzError reports whether firewall-cmd failed because it was not
+// permitted to answer, rather than because the firewall is stopped. polkit
+// refuses an unprivileged caller with "Authorization failed" on a host where
+// firewalld is running perfectly well.
+func isFirewalldAuthzError(stderr string) bool {
+	if stderr == "" {
+		return false
+	}
+	s := strings.ToLower(stderr)
+	for _, marker := range []string{
+		"authorization failed",
+		"not authorized",
+		"not_authorized",
+		"polkit",
+		"permission denied",
+		"access denied",
+	} {
+		if strings.Contains(s, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func (f *mqlFirewalld) status() (string, error) {

--- a/providers/os/resources/firewalld_authz_test.go
+++ b/providers/os/resources/firewalld_authz_test.go
@@ -1,0 +1,51 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// firewall-cmd exits non-zero both when the firewall is stopped and when polkit
+// refuses to answer an unprivileged caller. Only the second must be treated as
+// "we could not determine"; conflating them reports a running firewall as off.
+func TestIsFirewalldAuthzError(t *testing.T) {
+	authz := []string{
+		// verbatim from an unprivileged `firewall-cmd --state` on CentOS Stream 9
+		"Authorization failed.\n    Make sure polkit agent is running or run the application as superuser.",
+		"Authorization failed.",
+		"Error: NOT_AUTHORIZED",
+		"Failed to query polkit authority",
+		"dbus.exceptions.DBusException: Permission denied",
+		"Access denied",
+		// case must not matter
+		"AUTHORIZATION FAILED",
+	}
+	for _, s := range authz {
+		t.Run("authz/"+s[:min(len(s), 28)], func(t *testing.T) {
+			assert.True(t, isFirewalldAuthzError(s), "should be recognised as an authorization failure")
+		})
+	}
+
+	notAuthz := []string{
+		// what firewall-cmd prints when the daemon really is stopped
+		"firewall-cmd: error: Failed to connect to bus: No such file or directory",
+		"FirewallD is not running",
+		"Error: COMMAND_FAILED",
+		"command not found",
+		"",
+	}
+	for _, s := range notAuthz {
+		name := s
+		if name == "" {
+			name = "empty"
+		}
+		t.Run("stopped/"+name[:min(len(name), 28)], func(t *testing.T) {
+			assert.False(t, isFirewalldAuthzError(s),
+				"a genuinely stopped firewall must still report as not running")
+		})
+	}
+}


### PR DESCRIPTION
## The bug

`fetchStatus` collapsed **every** non-zero exit from `firewall-cmd --state` into `"not running"`:

```go
if exitcode != 0 || state != "running" {
    f.cacheStatus = "not running"
    ...
}
```

`firewall-cmd` exits non-zero in two very different situations: the firewall is genuinely stopped, **or** polkit refuses to answer an unprivileged caller. The second is not an answer.

## Why this is worse than a wrong string

`zones()` gates on the same cached status:

```go
if f.cacheStatus != "running" {
    return nil, nil
}
```

So on a host where firewalld is running, an unprivileged scan reported the firewall as **off** and returned an **empty zone list**. A check that walks zones looking for over-broad rules inspected nothing and found nothing to object to — a silent pass, which is the worst outcome for a firewall audit.

Observed on CentOS Stream 9 with firewalld active the whole time:

| | `status` | `defaultZone` |
|---|---|---|
| as `ec2-user` | `"not running"` | `""` |
| as root | `"running"` | `"public"` |

Ground truth: `systemctl is-active firewalld` → `active`, `sudo firewall-cmd --state` → `running`.

Unprivileged stderr is:

```
Authorization failed.
    Make sure polkit agent is running or run the application as superuser.
```

Worth noting `defaultZone` was lost too, even though `firewall-cmd --get-default-zone` **succeeds** unprivileged — the early return meant it was never asked.

## The fix

A non-zero exit whose stderr shows an authorization failure now surfaces an error instead of a verdict. A genuinely stopped firewall still reports `"not running"` exactly as before — the stopped path is unchanged.

## Tests

`isFirewalldAuthzError` is covered both ways: real polkit/D-Bus denial strings (including the verbatim CentOS Stream 9 message, `NOT_AUTHORIZED`, and case variations) must be recognised, and genuinely-stopped signatures (`Failed to connect to bus`, `FirewallD is not running`, `COMMAND_FAILED`, empty) must **not** be — so a stopped firewall cannot start reporting as an error.

```
ok  go.mondoo.com/mql/providers/os/resources
```

Found while running a live provider validation across Linux distributions.