### PR TITLE
🐛 os: stop postgresql.conf inventing defaults when no config file exists

### DIFF
--- a/providers/os/resources/postgresql.go
+++ b/providers/os/resources/postgresql.go
@@ -212,7 +212,25 @@ func (s *mqlPostgresqlConf) params(file *mqlFile) (map[string]any, error) {
 // Convenience views into specific directives. They all derive from `params`
 // so they share the same parse cycle (single file read, single tokenisation).
 
+// confAbsent reports that no postgresql.conf was found anywhere on the host.
+//
+// The convenience accessors below fall back to PostgreSQL's documented
+// defaults when a directive is missing from the file, which is correct when
+// the file exists and simply omits it. With no file at all there is nothing to
+// default from: reporting port 5432, listenAddresses ["localhost"] or
+// sslEnabled false describes a posture nobody ever configured. Worse, it reads
+// as a real finding, and a check asserting "does not listen on *" passes
+// against a host where PostgreSQL was never set up.
+func (s *mqlPostgresqlConf) confAbsent() bool {
+	return s.File.State&plugin.StateIsNull != 0
+}
+
 func (s *mqlPostgresqlConf) listenAddresses(params map[string]any) ([]any, error) {
+	if s.confAbsent() {
+		s.ListenAddresses.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
 	v := paramString(params, "listen_addresses")
 	if v == "" {
 		// Default per PostgreSQL: 'localhost' if unset.
@@ -227,6 +245,11 @@ func (s *mqlPostgresqlConf) listenAddresses(params map[string]any) ([]any, error
 }
 
 func (s *mqlPostgresqlConf) port(params map[string]any) (int64, error) {
+	if s.confAbsent() {
+		s.Port.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+
 	v := paramString(params, "port")
 	if v == "" {
 		return 5432, nil
@@ -239,66 +262,146 @@ func (s *mqlPostgresqlConf) port(params map[string]any) (int64, error) {
 }
 
 func (s *mqlPostgresqlConf) sslEnabled(params map[string]any) (bool, error) {
+	if s.confAbsent() {
+		s.SslEnabled.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
+
 	return postgresql.IsTruthy(paramString(params, "ssl")), nil
 }
 
 func (s *mqlPostgresqlConf) sslCertFile(params map[string]any) (string, error) {
+	if s.confAbsent() {
+		s.SslCertFile.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
+
 	return paramString(params, "ssl_cert_file"), nil
 }
 
 func (s *mqlPostgresqlConf) sslKeyFile(params map[string]any) (string, error) {
+	if s.confAbsent() {
+		s.SslKeyFile.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
+
 	return paramString(params, "ssl_key_file"), nil
 }
 
 func (s *mqlPostgresqlConf) sslCaFile(params map[string]any) (string, error) {
+	if s.confAbsent() {
+		s.SslCaFile.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
+
 	return paramString(params, "ssl_ca_file"), nil
 }
 
 func (s *mqlPostgresqlConf) sslMinProtocolVersion(params map[string]any) (string, error) {
+	if s.confAbsent() {
+		s.SslMinProtocolVersion.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
+
 	return paramString(params, "ssl_min_protocol_version"), nil
 }
 
 func (s *mqlPostgresqlConf) sslCiphers(params map[string]any) (string, error) {
+	if s.confAbsent() {
+		s.SslCiphers.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
+
 	return paramString(params, "ssl_ciphers"), nil
 }
 
 func (s *mqlPostgresqlConf) passwordEncryption(params map[string]any) (string, error) {
+	if s.confAbsent() {
+		s.PasswordEncryption.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
+
 	return paramString(params, "password_encryption"), nil
 }
 
 func (s *mqlPostgresqlConf) dataDirectory(params map[string]any) (string, error) {
+	if s.confAbsent() {
+		s.DataDirectory.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
+
 	return paramString(params, "data_directory"), nil
 }
 
 func (s *mqlPostgresqlConf) hbaFile(params map[string]any) (string, error) {
+	if s.confAbsent() {
+		s.HbaFile.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
+
 	return paramString(params, "hba_file"), nil
 }
 
 func (s *mqlPostgresqlConf) identFile(params map[string]any) (string, error) {
+	if s.confAbsent() {
+		s.IdentFile.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
+
 	return paramString(params, "ident_file"), nil
 }
 
 func (s *mqlPostgresqlConf) logDestination(params map[string]any) (string, error) {
+	if s.confAbsent() {
+		s.LogDestination.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
+
 	return paramString(params, "log_destination"), nil
 }
 
 func (s *mqlPostgresqlConf) loggingCollector(params map[string]any) (bool, error) {
+	if s.confAbsent() {
+		s.LoggingCollector.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
+
 	return postgresql.IsTruthy(paramString(params, "logging_collector")), nil
 }
 
 func (s *mqlPostgresqlConf) logConnections(params map[string]any) (bool, error) {
+	if s.confAbsent() {
+		s.LogConnections.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
+
 	return postgresql.IsTruthy(paramString(params, "log_connections")), nil
 }
 
 func (s *mqlPostgresqlConf) logDisconnections(params map[string]any) (bool, error) {
+	if s.confAbsent() {
+		s.LogDisconnections.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
+
 	return postgresql.IsTruthy(paramString(params, "log_disconnections")), nil
 }
 
 func (s *mqlPostgresqlConf) logStatement(params map[string]any) (string, error) {
+	if s.confAbsent() {
+		s.LogStatement.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
+
 	return paramString(params, "log_statement"), nil
 }
 
 func (s *mqlPostgresqlConf) sharedPreloadLibraries(params map[string]any) ([]any, error) {
+	if s.confAbsent() {
+		s.SharedPreloadLibraries.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
 	parts := postgresql.SplitListParam(paramString(params, "shared_preload_libraries"))
 	out := make([]any, len(parts))
 	for i, p := range parts {

--- a/providers/os/resources/postgresql_nofile_test.go
+++ b/providers/os/resources/postgresql_nofile_test.go
@@ -1,0 +1,129 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// confNotFound builds the state file() leaves behind when no postgresql.conf
+// exists anywhere on the host: File marked set+null.
+func confNotFound() *mqlPostgresqlConf {
+	s := &mqlPostgresqlConf{}
+	s.File = plugin.TValue[*mqlFile]{State: plugin.StateIsSet | plugin.StateIsNull}
+	return s
+}
+
+// confPresent builds the state for a config file that exists but omits every
+// directive. PostgreSQL's documented defaults DO apply here, so the accessors
+// must keep returning them.
+func confPresent() *mqlPostgresqlConf {
+	s := &mqlPostgresqlConf{}
+	s.File = plugin.TValue[*mqlFile]{Data: &mqlFile{}, State: plugin.StateIsSet}
+	return s
+}
+
+// With no config file at all there is nothing to default from. Reporting
+// port 5432 / listenAddresses ["localhost"] / sslEnabled false describes a
+// posture nobody configured, and lets a "does not listen on *" assertion pass
+// against a host where PostgreSQL was never set up.
+func TestPostgresqlConfNoFileReturnsNull(t *testing.T) {
+	empty := map[string]any{}
+
+	t.Run("port", func(t *testing.T) {
+		s := confNotFound()
+		v, err := s.port(empty)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), v)
+		assert.True(t, s.Port.State&plugin.StateIsNull != 0, "port must be null, not 5432")
+	})
+
+	t.Run("listenAddresses", func(t *testing.T) {
+		s := confNotFound()
+		v, err := s.listenAddresses(empty)
+		assert.NoError(t, err)
+		assert.Nil(t, v)
+		assert.True(t, s.ListenAddresses.State&plugin.StateIsNull != 0,
+			"listenAddresses must be null, not [localhost]")
+	})
+
+	t.Run("sslEnabled", func(t *testing.T) {
+		s := confNotFound()
+		v, err := s.sslEnabled(empty)
+		assert.NoError(t, err)
+		assert.False(t, v)
+		assert.True(t, s.SslEnabled.State&plugin.StateIsNull != 0,
+			"sslEnabled must be null; false reads as a real finding")
+	})
+
+	t.Run("loggingCollector", func(t *testing.T) {
+		s := confNotFound()
+		_, err := s.loggingCollector(empty)
+		assert.NoError(t, err)
+		assert.True(t, s.LoggingCollector.State&plugin.StateIsNull != 0)
+	})
+
+	t.Run("logConnections", func(t *testing.T) {
+		s := confNotFound()
+		_, err := s.logConnections(empty)
+		assert.NoError(t, err)
+		assert.True(t, s.LogConnections.State&plugin.StateIsNull != 0)
+	})
+
+	t.Run("dataDirectory", func(t *testing.T) {
+		s := confNotFound()
+		v, err := s.dataDirectory(empty)
+		assert.NoError(t, err)
+		assert.Equal(t, "", v)
+		assert.True(t, s.DataDirectory.State&plugin.StateIsNull != 0)
+	})
+
+	t.Run("sharedPreloadLibraries", func(t *testing.T) {
+		s := confNotFound()
+		v, err := s.sharedPreloadLibraries(empty)
+		assert.NoError(t, err)
+		assert.Nil(t, v)
+		assert.True(t, s.SharedPreloadLibraries.State&plugin.StateIsNull != 0)
+	})
+}
+
+// The documented defaults are still correct when the file exists and simply
+// does not mention the directive. This is the behaviour the guard must not
+// break.
+func TestPostgresqlConfPresentButEmptyKeepsDefaults(t *testing.T) {
+	empty := map[string]any{}
+
+	s := confPresent()
+	port, err := s.port(empty)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(5432), port, "a present file with no port directive still defaults")
+	assert.True(t, s.Port.State&plugin.StateIsNull == 0, "and is not null")
+
+	s = confPresent()
+	addrs, err := s.listenAddresses(empty)
+	assert.NoError(t, err)
+	assert.Equal(t, []any{"localhost"}, addrs)
+
+	s = confPresent()
+	ssl, err := s.sslEnabled(empty)
+	assert.NoError(t, err)
+	assert.False(t, ssl, "ssl is genuinely off when the file omits it")
+	assert.True(t, s.SslEnabled.State&plugin.StateIsNull == 0)
+}
+
+// A directive that IS present must win regardless.
+func TestPostgresqlConfPresentWithValues(t *testing.T) {
+	s := confPresent()
+	port, err := s.port(map[string]any{"port": "6543"})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(6543), port)
+
+	s = confPresent()
+	ssl, err := s.sslEnabled(map[string]any{"ssl": "on"})
+	assert.NoError(t, err)
+	assert.True(t, ssl)
+}


### PR DESCRIPTION
## The bug

`file()` already handles a host with no `postgresql.conf` — it marks `File` set+null, and `setConfEmpty` leaves `params` as an empty map. But the convenience accessors then applied PostgreSQL's documented defaults to that empty map, so the resource reported a configuration nobody had written:

```
postgresql.conf { file }    → {"file": null}      ← knows it read nothing
postgresql.conf { params }  → {"params": {}}      ← knows it read nothing
postgresql.conf { port sslEnabled listenAddresses }
                            → {"port":5432,"sslEnabled":false,
                               "listenAddresses":["localhost"]}   ← confident values
```

Observed on CentOS Stream 9 with `postgresql` installed but never `initdb`'d, so no `postgresql.conf` existed anywhere on disk (`/var/lib/pgsql/data` was empty).

## Why it matters

The fabricated values point in the **unsafe** direction:

- `sslEnabled: false` reads as *"PostgreSQL has SSL disabled"* — a reportable finding — on a host where PostgreSQL was never configured
- `listenAddresses: ["localhost"]` contains no wildcard, so a *"does not listen on `*`"* assertion **passes** against a posture nobody ever verified
- `loggingCollector` / `logConnections` / `logDisconnections` all read `false`, i.e. "logging is off"

This is the invented-defaults pattern CLAUDE.md warns about: the resource knows it read nothing (`file` is null, `params` is `{}`) yet its siblings answer confidently.

## The fix

All 18 accessors return **null** when no config file was found, via a single `confAbsent()` guard keyed on the same `File` state `file()` already sets.

The file-exists path is **untouched**. Defaults still apply when the file exists and simply omits a directive — which is correct, because PostgreSQL really would use them.

## Tests

Three cases, so the distinction can't silently regress:

| scenario | expectation |
|---|---|
| no config file | every accessor null — `port` not 5432, `listenAddresses` not `["localhost"]`, `sslEnabled` not `false` |
| file exists, directive absent | defaults still returned and **not** null |
| file exists, directive present | the configured value wins |

```
ok  go.mondoo.com/mql/providers/os/resources
```

Found while running a live provider validation across Linux distributions.