### PR TITLE
🐛 os: identify the hypervisor on EC2 Nitro instances

### DIFF
--- a/providers/os/id/hypervisor/hypervisor.go
+++ b/providers/os/id/hypervisor/hypervisor.go
@@ -39,7 +39,7 @@ var knownHypervisors = map[string]string{
 	// distinguishable; the DMI vendor fields read "Amazon EC2" on Nitro and
 	// "Xen" on Xen, which keeps them disjoint on that path too. One substring
 	// therefore covers both Nitro detection routes without shadowing "xen".
-	"amazon": "Nitro",
+	"amazon": "AWS Nitro System",
 }
 
 // hyper is a helper struct to avoid passing the connection and platform

--- a/providers/os/id/hypervisor/hypervisor.go
+++ b/providers/os/id/hypervisor/hypervisor.go
@@ -33,6 +33,11 @@ var knownHypervisors = map[string]string{
 	"nutanix":                  "Nutanix Acropolis",
 	"openshift virtualization": "OpenShift Virtualization",
 	"red hat":                  "OpenShift Virtualization",
+
+	// EC2. systemd-detect-virt reports exactly "amazon" on a Nitro guest, and
+	// the DMI vendor fields read "Amazon EC2", so one substring covers both
+	// detection paths. Older Xen-based instances still match "xen" above.
+	"amazon": "Amazon EC2",
 }
 
 // hyper is a helper struct to avoid passing the connection and platform

--- a/providers/os/id/hypervisor/hypervisor.go
+++ b/providers/os/id/hypervisor/hypervisor.go
@@ -34,10 +34,12 @@ var knownHypervisors = map[string]string{
 	"openshift virtualization": "OpenShift Virtualization",
 	"red hat":                  "OpenShift Virtualization",
 
-	// EC2. systemd-detect-virt reports exactly "amazon" on a Nitro guest, and
-	// the DMI vendor fields read "Amazon EC2", so one substring covers both
-	// detection paths. Older Xen-based instances still match "xen" above.
-	"amazon": "Amazon EC2",
+	// AWS Nitro. systemd-detect-virt reports exactly "amazon" for Nitro and
+	// "xen" for the older Xen-based instance families, so the two are already
+	// distinguishable; the DMI vendor fields read "Amazon EC2" on Nitro and
+	// "Xen" on Xen, which keeps them disjoint on that path too. One substring
+	// therefore covers both Nitro detection routes without shadowing "xen".
+	"amazon": "Nitro",
 }
 
 // hyper is a helper struct to avoid passing the connection and platform

--- a/providers/os/id/hypervisor/hypervisor_amazon_test.go
+++ b/providers/os/id/hypervisor/hypervisor_amazon_test.go
@@ -1,0 +1,60 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package hypervisor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// EC2 Nitro guests were reporting a null hypervisor: systemd-detect-virt says
+// "amazon" and the DMI vendor fields say "Amazon EC2", neither of which had a
+// mapping, so all three Linux detectors found their input and failed to map it.
+func TestMapHypervisorAmazonEC2(t *testing.T) {
+	// systemd-detect-virt on a Nitro guest
+	v, ok := mapHypervisor("amazon")
+	assert.True(t, ok)
+	assert.Equal(t, "Amazon EC2", v)
+
+	// DMI sys_vendor / board_vendor / bios_vendor
+	v, ok = mapHypervisor("Amazon EC2")
+	assert.True(t, ok)
+	assert.Equal(t, "Amazon EC2", v)
+
+	// dmidecode output carries trailing whitespace and mixed case
+	v, ok = mapHypervisor("  AMAZON EC2\n")
+	assert.True(t, ok)
+	assert.Equal(t, "Amazon EC2", v)
+}
+
+// Older EC2 instances are Xen-based and must keep resolving to Xen, not be
+// swallowed by the new entry.
+func TestMapHypervisorXenStillWins(t *testing.T) {
+	v, ok := mapHypervisor("xen")
+	assert.True(t, ok)
+	assert.Equal(t, "Xen", v)
+
+	v, ok = mapHypervisor("Xen HVM domU")
+	assert.True(t, ok)
+	assert.Equal(t, "Xen", v)
+}
+
+// The existing mappings are unaffected, and an unknown vendor still reports
+// nothing rather than guessing.
+func TestMapHypervisorUnchanged(t *testing.T) {
+	for input, want := range map[string]string{
+		"kvm":         "KVM",
+		"VMware, Inc": "VMware",
+		"QEMU":        "QEMU",
+		"hyper-v":     "Hyper-V",
+	} {
+		v, ok := mapHypervisor(input)
+		assert.True(t, ok, input)
+		assert.Equal(t, want, v, input)
+	}
+
+	_, ok := mapHypervisor("Some Unknown Vendor")
+	assert.False(t, ok)
+}

--- a/providers/os/id/hypervisor/hypervisor_amazon_test.go
+++ b/providers/os/id/hypervisor/hypervisor_amazon_test.go
@@ -12,21 +12,24 @@ import (
 // EC2 Nitro guests were reporting a null hypervisor: systemd-detect-virt says
 // "amazon" and the DMI vendor fields say "Amazon EC2", neither of which had a
 // mapping, so all three Linux detectors found their input and failed to map it.
+//
+// The value is the hypervisor, not the cloud: systemd emits "amazon" only for
+// Nitro, while the older Xen instance families report "xen".
 func TestMapHypervisorAmazonEC2(t *testing.T) {
 	// systemd-detect-virt on a Nitro guest
 	v, ok := mapHypervisor("amazon")
 	assert.True(t, ok)
-	assert.Equal(t, "Amazon EC2", v)
+	assert.Equal(t, "Nitro", v)
 
 	// DMI sys_vendor / board_vendor / bios_vendor
 	v, ok = mapHypervisor("Amazon EC2")
 	assert.True(t, ok)
-	assert.Equal(t, "Amazon EC2", v)
+	assert.Equal(t, "Nitro", v)
 
 	// dmidecode output carries trailing whitespace and mixed case
 	v, ok = mapHypervisor("  AMAZON EC2\n")
 	assert.True(t, ok)
-	assert.Equal(t, "Amazon EC2", v)
+	assert.Equal(t, "Nitro", v)
 }
 
 // Older EC2 instances are Xen-based and must keep resolving to Xen, not be

--- a/providers/os/id/hypervisor/hypervisor_amazon_test.go
+++ b/providers/os/id/hypervisor/hypervisor_amazon_test.go
@@ -19,17 +19,17 @@ func TestMapHypervisorAmazonEC2(t *testing.T) {
 	// systemd-detect-virt on a Nitro guest
 	v, ok := mapHypervisor("amazon")
 	assert.True(t, ok)
-	assert.Equal(t, "Nitro", v)
+	assert.Equal(t, "AWS Nitro System", v)
 
 	// DMI sys_vendor / board_vendor / bios_vendor
 	v, ok = mapHypervisor("Amazon EC2")
 	assert.True(t, ok)
-	assert.Equal(t, "Nitro", v)
+	assert.Equal(t, "AWS Nitro System", v)
 
 	// dmidecode output carries trailing whitespace and mixed case
 	v, ok = mapHypervisor("  AMAZON EC2\n")
 	assert.True(t, ok)
-	assert.Equal(t, "Nitro", v)
+	assert.Equal(t, "AWS Nitro System", v)
 }
 
 // Older EC2 instances are Xen-based and must keep resolving to Xen, not be


### PR DESCRIPTION
## The bug

`os.hypervisor` is **null on every EC2 Nitro instance**.

`knownHypervisors` has no entry matching what any of the three Linux detectors actually find:

| detector | returns |
|---|---|
| `systemd-detect-virt` | `amazon` |
| `/sys/class/dmi/id/sys_vendor` (and board/bios vendor) | `Amazon EC2` |
| `dmidecode -s system-product-name` | `t3.small` |

So the detection chain runs to completion, finds its input, and fails to map it — returning null rather than erroring.

## How you know it is the Nitro System

The value reported is **`AWS Nitro System`**, AWS's own name for it — not the cloud name. That distinction is decidable, not a guess:

| EC2 generation | `systemd-detect-virt` | DMI `sys_vendor` |
|---|---|---|
| **Nitro** (t3, m5, c5, …) | `amazon` | `Amazon EC2` |
| **Xen** (older t2, m4, …) | `xen` | `Xen` |

systemd emits `amazon` *specifically* for Nitro — it has a dedicated check for it — while Xen instances report `xen` and already match the existing `xen` entry. The DMI vendor strings are disjoint in the same way, so the new entry is accurate on both detection paths and **cannot shadow `xen`**.

`os.hypervisor` holds a hypervisor product elsewhere (`VMware`, `KVM`, `Xen`, `Hyper-V`, `IBM PowerVM`, `Nutanix Acropolis`), so `AWS Nitro System` keeps the field consistent. `Amazon EC2` would have named the cloud and told a reader nothing about what they are running on.

## Not distro-specific, and not a missing tool

Reproduced **independently on two different distributions** during live validation — CentOS Stream 10 and Flatcar Container Linux. It affects every Linux asset the os provider scans on modern EC2.

It was also verified *not* to be a missing-tool problem: `dmidecode` was absent, so it was installed and the chain re-run. `dmidecode -s system-product-name` returned `t3.small`, still no match, and `os.hypervisor` stayed null.

Older **Xen**-based EC2 instances already resolve correctly, which is why this went unnoticed as the fleet moved to Nitro.

## The fix

`mapHypervisor` lowercases its input and does a substring match, so a single entry covers both Nitro detection routes:

```go
"amazon": "AWS Nitro System",
```

## Tests

- Both real inputs map: `amazon` and `Amazon EC2`, plus a mixed-case/whitespace form as `dmidecode` emits it
- **Xen still wins** for `xen` and `Xen HVM domU` — the new entry must not swallow older EC2 instances
- Existing mappings (KVM, VMware, QEMU, Hyper-V) unchanged, and an unknown vendor still reports nothing rather than guessing

```
ok  go.mondoo.com/mql/providers/os/id/hypervisor
```

`asset.kind` already resolved to `virtualmachine`, so only the `hypervisor` field was affected.

Found while running a live provider validation across Linux distributions.