### PR TITLE
🐛 os: read sshd_config Include paths that are quoted

### DIFF
--- a/providers/os/resources/sshd/params.go
+++ b/providers/os/resources/sshd/params.go
@@ -6,6 +6,7 @@ package sshd
 import (
 	"strings"
 
+	shellquote "github.com/kballard/go-shellquote"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/utils/sortx"
@@ -266,6 +267,32 @@ func ParseBlocksWithGlob(rootPath string, fileContent fileContentFunc, globExpan
 }
 
 // ParseBlocksWithGlobRecursive parses a single file and recursively handles Include directives.
+// splitIncludeArgs splits an Include directive's arguments into paths.
+//
+// sshd_config permits a path to be quoted, which is how a path containing
+// spaces is written, and some distributions quote unconditionally. Flatcar
+// ships exactly one effective line:
+//
+//	Include "/etc/ssh/sshd_config.d/*.conf"
+//
+// Splitting on spaces alone left the quote characters inside the pattern, so
+// the glob matched nothing, the miss was swallowed by a log.Warn, and the
+// entire included configuration was dropped without any error reaching the
+// caller. sshd.config.ciphers then returned an empty list, which makes a
+// "no weak ciphers" denylist pass vacuously.
+//
+// Quote-aware splitting also fixes the case quoting exists for: a path that
+// contains a space is now one argument rather than two broken ones.
+func splitIncludeArgs(args string) []string {
+	if fields, err := shellquote.Split(args); err == nil {
+		return fields
+	}
+
+	// Unbalanced quoting is malformed sshd_config. Fall back to the plain
+	// split rather than dropping the directive entirely.
+	return strings.Split(args, " ")
+}
+
 func ParseBlocksWithGlobRecursive(filePath string, content string, fileContent fileContentFunc, globExpand globExpandFunc) (MatchBlocks, error) {
 	curBlock := &MatchBlock{
 		Criteria: "",
@@ -298,8 +325,7 @@ func ParseBlocksWithGlobRecursive(filePath string, content string, fileContent f
 		}
 
 		if key == "Include" {
-			// FIXME: parse multi-keys properly
-			includePaths := strings.Split(l.args, " ")
+			includePaths := splitIncludeArgs(l.args)
 
 			for _, includePath := range includePaths {
 				// Expand glob pattern if present

--- a/providers/os/resources/sshd/params_include_quoted_test.go
+++ b/providers/os/resources/sshd/params_include_quoted_test.go
@@ -1,0 +1,73 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sshd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sshd_config permits a quoted Include path, and some distributions quote
+// unconditionally. Flatcar's entire config is one line:
+//
+//	Include "/etc/ssh/sshd_config.d/*.conf"
+//
+// Splitting on spaces left the quotes inside the glob, so it matched nothing
+// and the whole included config was dropped silently.
+func TestSplitIncludeArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+		want []string
+	}{
+		{
+			name: "unquoted, the common form",
+			args: "/etc/ssh/sshd_config.d/*.conf",
+			want: []string{"/etc/ssh/sshd_config.d/*.conf"},
+		},
+		{
+			// the reported case
+			name: "double quoted",
+			args: `"/etc/ssh/sshd_config.d/*.conf"`,
+			want: []string{"/etc/ssh/sshd_config.d/*.conf"},
+		},
+		{
+			name: "single quoted",
+			args: `'/etc/ssh/sshd_config.d/*.conf'`,
+			want: []string{"/etc/ssh/sshd_config.d/*.conf"},
+		},
+		{
+			name: "multiple unquoted paths",
+			args: "/etc/ssh/a.conf /etc/ssh/b.conf",
+			want: []string{"/etc/ssh/a.conf", "/etc/ssh/b.conf"},
+		},
+		{
+			name: "mixed quoted and unquoted",
+			args: `"/etc/ssh/a.conf" /etc/ssh/b.conf`,
+			want: []string{"/etc/ssh/a.conf", "/etc/ssh/b.conf"},
+		},
+		{
+			// the reason quoting exists in the first place
+			name: "quoted path containing a space stays one argument",
+			args: `"/etc/ssh/my configs/*.conf"`,
+			want: []string{"/etc/ssh/my configs/*.conf"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, splitIncludeArgs(tc.args))
+		})
+	}
+}
+
+// Malformed quoting must not drop the directive entirely; fall back to the
+// plain split so behaviour is no worse than before.
+func TestSplitIncludeArgsUnbalancedQuote(t *testing.T) {
+	got := splitIncludeArgs(`"/etc/ssh/unterminated.conf`)
+	require.NotEmpty(t, got)
+	assert.Equal(t, []string{`"/etc/ssh/unterminated.conf`}, got)
+}


### PR DESCRIPTION
## The bug

The `Include` handler split its arguments on spaces:

```go
// FIXME: parse multi-keys properly
includePaths := strings.Split(l.args, " ")
```

`sshd_config` permits a **quoted** path, and some distributions quote unconditionally. Flatcar's `/etc/ssh/sshd_config` is a single effective line:

```
Include "/etc/ssh/sshd_config.d/*.conf"
```

The quote characters stayed inside the pattern, so the glob matched nothing — and the miss was swallowed by a `log.Warn` + `continue`, so **no error reached the caller**. The entire included configuration was dropped:

```
sshd.config.params            {}
sshd.config.ciphers           []
sshd.config.macs              []
sshd.config.hostkeyalgorithms []
```

on a host whose hardening lives entirely in that drop-in.

## Why it matters

The failure points the wrong way. An empty cipher list makes a *"no weak ciphers"* denylist **pass vacuously**, and `params["PermitRootLogin"]` reads null on a config that was never opened. Silent, and in the direction of a clean report.

## Isolated, not inferred

A/B on the same host with the same drop-in, changing **only** the quoting:

| `Include` line | result |
|---|---|
| `Include /var/tmp/sshtest/sshd_config.d/*.conf` | ciphers[6], macs[6] ✅ |
| `Include "/var/tmp/sshtest/sshd_config.d/*.conf"` | ciphers[], macs[] ❌ |

## The fix

Splitting is now quote-aware via `shellquote`, already a dependency of this module. That also fixes the case quoting exists for in the first place: a path containing a space becomes one argument rather than two broken ones. Unbalanced quoting falls back to the previous plain split, so malformed config is no worse off than before.

Not distro-specific — this affects any host that quotes its `Include`.

## Scope

`effectiveCiphers` / `effectiveMacs` / `effectiveKexs` were **unaffected** throughout, because they come from `sshd -T` rather than this parser. Only the raw-parse family was blind.

## Tests

Unquoted, double-quoted, single-quoted, multiple paths, mixed quoting, a quoted path containing a space, and the unbalanced-quote fallback.

```
ok  go.mondoo.com/mql/providers/os/resources/sshd
```

Found while running a live provider validation across Linux distributions.