### PR TITLE
🐛 os: map the systemd-detect-virt identifiers for Hyper-V, GCE, VirtualBox and Apple

### DIFF
--- a/providers/os/id/hypervisor/hypervisor.go
+++ b/providers/os/id/hypervisor/hypervisor.go
@@ -52,11 +52,8 @@ var knownHypervisors = map[string]string{
 	// systemd's token for Apple Virtualization.framework. The longer keys above
 	// cannot match it, because "apple" contains neither of them.
 	"apple": "Apple Virtualization",
-	// systemd's token for VirtualBox. The longest-match rule in mapHypervisor
-	// keeps "Oracle VM VirtualBox" resolving to VirtualBox rather than racing
-	// this key. Oracle Cloud cannot be caught by it: the whole Linux chain is
-	// gated on the CPU hypervisor flag, so bare metal never reaches here, and
-	// OCI VM shapes report QEMU.
+	// systemd's token for VirtualBox. Matched exactly, never as a substring:
+	// see exactMatchHypervisors.
 	"oracle": "VirtualBox",
 }
 
@@ -92,19 +89,39 @@ func Hypervisor(conn shared.Connection, pf *inventory.Platform) (hypervisor stri
 
 // mapHypervisor maps known hypervisors to their names.
 func mapHypervisor(info string) (string, bool) {
-	// make sure it is lower case
-	info = strings.ToLower(info)
+	// make sure it is lower case, and trimmed so an exact match is not defeated
+	// by the trailing newline a command leaves behind
+	info = strings.TrimSpace(strings.ToLower(info))
 
 	// Longest key first. Several vendor strings contain more than one key --
 	// "Oracle VM VirtualBox" holds both "oracle" and "virtualbox" -- and Go
 	// randomises map iteration, so picking whichever came first made the answer
 	// differ between runs. The longest match is the most specific one.
 	for _, key := range hypervisorKeysByLength() {
+		if exactMatchHypervisors[key] {
+			if info == key {
+				return knownHypervisors[key], true
+			}
+			continue
+		}
 		if strings.Contains(info, key) {
 			return knownHypervisors[key], true
 		}
 	}
 	return "", false
+}
+
+// exactMatchHypervisors lists keys that must equal the detected string rather
+// than appear anywhere within it.
+//
+// "oracle" is systemd-detect-virt's token for VirtualBox, and systemd emits it
+// as the whole string. As a substring it is far too broad: "Oracle
+// Corporation" is a DMI vendor that has nothing to do with VirtualBox, and any
+// future Oracle Cloud vendor string carrying the word would be mislabelled.
+// VirtualBox is still recognised by DMI through the "virtualbox" key, which
+// its product_name carries.
+var exactMatchHypervisors = map[string]bool{
+	"oracle": true,
 }
 
 var (

--- a/providers/os/id/hypervisor/hypervisor.go
+++ b/providers/os/id/hypervisor/hypervisor.go
@@ -5,7 +5,9 @@ package hypervisor
 
 import (
 	"io"
+	"sort"
 	"strings"
+	"sync"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
@@ -34,12 +36,28 @@ var knownHypervisors = map[string]string{
 	"openshift virtualization": "OpenShift Virtualization",
 	"red hat":                  "OpenShift Virtualization",
 
-	// AWS Nitro. systemd-detect-virt reports exactly "amazon" for Nitro and
-	// "xen" for the older Xen-based instance families, so the two are already
-	// distinguishable; the DMI vendor fields read "Amazon EC2" on Nitro and
-	// "Xen" on Xen, which keeps them disjoint on that path too. One substring
-	// therefore covers both Nitro detection routes without shadowing "xen".
+	// The keys below are the identifiers systemd-detect-virt actually emits,
+	// which differ from the product names above. Without them a guest is
+	// detected and then fails to map, so os.hypervisor reads null.
+	// See src/basic/virt.c, virtualization_table.
+	//
+	// AWS Nitro. systemd reports "amazon" for Nitro and "xen" for the older
+	// Xen instance families, and the DMI vendor fields are disjoint the same
+	// way ("Amazon EC2" against "Xen"), so this cannot shadow xen.
 	"amazon": "AWS Nitro System",
+	// systemd's token for Hyper-V; the DMI vendor reads "Microsoft Corporation".
+	"microsoft": "Hyper-V",
+	// systemd's token for GCE; the DMI vendor reads "Google" / "Google Compute Engine".
+	"google": "Google Compute Engine",
+	// systemd's token for Apple Virtualization.framework. The longer keys above
+	// cannot match it, because "apple" contains neither of them.
+	"apple": "Apple Virtualization",
+	// systemd's token for VirtualBox. The longest-match rule in mapHypervisor
+	// keeps "Oracle VM VirtualBox" resolving to VirtualBox rather than racing
+	// this key. Oracle Cloud cannot be caught by it: the whole Linux chain is
+	// gated on the CPU hypervisor flag, so bare metal never reaches here, and
+	// OCI VM shapes report QEMU.
+	"oracle": "VirtualBox",
 }
 
 // hyper is a helper struct to avoid passing the connection and platform
@@ -77,12 +95,39 @@ func mapHypervisor(info string) (string, bool) {
 	// make sure it is lower case
 	info = strings.ToLower(info)
 
-	for key, value := range knownHypervisors {
+	// Longest key first. Several vendor strings contain more than one key --
+	// "Oracle VM VirtualBox" holds both "oracle" and "virtualbox" -- and Go
+	// randomises map iteration, so picking whichever came first made the answer
+	// differ between runs. The longest match is the most specific one.
+	for _, key := range hypervisorKeysByLength() {
 		if strings.Contains(info, key) {
-			return value, true
+			return knownHypervisors[key], true
 		}
 	}
 	return "", false
+}
+
+var (
+	hypervisorKeysOnce   sync.Once
+	hypervisorKeysSorted []string
+)
+
+// hypervisorKeysByLength returns the knownHypervisors keys ordered longest
+// first, so the most specific match wins and the result is reproducible.
+func hypervisorKeysByLength() []string {
+	hypervisorKeysOnce.Do(func() {
+		hypervisorKeysSorted = make([]string, 0, len(knownHypervisors))
+		for key := range knownHypervisors {
+			hypervisorKeysSorted = append(hypervisorKeysSorted, key)
+		}
+		sort.Slice(hypervisorKeysSorted, func(i, j int) bool {
+			if len(hypervisorKeysSorted[i]) != len(hypervisorKeysSorted[j]) {
+				return len(hypervisorKeysSorted[i]) > len(hypervisorKeysSorted[j])
+			}
+			return hypervisorKeysSorted[i] < hypervisorKeysSorted[j]
+		})
+	})
+	return hypervisorKeysSorted
 }
 
 // runCommand is a wrapper around connection.RunCommand that helps execute commands

--- a/providers/os/id/hypervisor/hypervisor_amazon_test.go
+++ b/providers/os/id/hypervisor/hypervisor_amazon_test.go
@@ -113,18 +113,50 @@ func TestMapHypervisorDMIVendors(t *testing.T) {
 // Several vendor strings contain more than one key. Go randomises map
 // iteration, so before ordering by key length the answer differed between
 // runs. The most specific match must win, every time.
+//
+// "Red Hat RHEV Hypervisor" is the case that actually proves it: it contains
+// both "red hat" (7) and "rhev" (4), and the two map to DIFFERENT products, so
+// iteration order was observable in the result.
 func TestMapHypervisorLongestMatchWinsDeterministically(t *testing.T) {
-	// contains both "oracle"-free "virtualbox" and, in the vendor form, "oracle"
 	for i := 0; i < 50; i++ {
-		v, ok := mapHypervisor("Oracle VM VirtualBox")
+		v, ok := mapHypervisor("Red Hat RHEV Hypervisor")
 		assert.True(t, ok)
-		assert.Equal(t, "VirtualBox", v, "longest key must win on every iteration")
+		assert.Equal(t, "OpenShift Virtualization", v,
+			"the longer key must win on every iteration, not whichever came first")
+	}
+}
+
+// "oracle" is systemd's token for VirtualBox, but as a substring it is far too
+// broad. It is matched exactly, so a vendor string that merely contains the
+// word is not mislabelled.
+func TestMapHypervisorOracleIsExactMatchOnly(t *testing.T) {
+	// systemd emits the bare token
+	v, ok := mapHypervisor("oracle")
+	assert.True(t, ok)
+	assert.Equal(t, "VirtualBox", v)
+
+	// trailing whitespace from a command must not defeat the exact match
+	v, ok = mapHypervisor(" Oracle\n")
+	assert.True(t, ok)
+	assert.Equal(t, "VirtualBox", v)
+
+	// a vendor string that merely contains the word must NOT become VirtualBox
+	for _, vendor := range []string{
+		"Oracle Corporation",
+		"Oracle Cloud Compute",
+		"Oracle Cloud Infrastructure",
+	} {
+		v, ok := mapHypervisor(vendor)
+		assert.False(t, ok, "%q must not be mistaken for VirtualBox", vendor)
+		assert.Equal(t, "", v)
 	}
 
-	// "apple virtual" is longer than "apple" and must take precedence
-	for i := 0; i < 50; i++ {
-		v, ok := mapHypervisor("Apple Virtual Machine")
-		assert.True(t, ok)
-		assert.Equal(t, "Apple Virtualization", v)
-	}
+	// VirtualBox is still identified by DMI, via its product_name
+	v, ok = mapHypervisor("VirtualBox")
+	assert.True(t, ok)
+	assert.Equal(t, "VirtualBox", v)
+
+	v, ok = mapHypervisor("Oracle VM VirtualBox")
+	assert.True(t, ok)
+	assert.Equal(t, "VirtualBox", v)
 }

--- a/providers/os/id/hypervisor/hypervisor_amazon_test.go
+++ b/providers/os/id/hypervisor/hypervisor_amazon_test.go
@@ -61,3 +61,70 @@ func TestMapHypervisorUnchanged(t *testing.T) {
 	_, ok := mapHypervisor("Some Unknown Vendor")
 	assert.False(t, ok)
 }
+
+// systemd-detect-virt emits its own identifiers, which are not the product
+// names. Without a mapping the guest is detected and then fails to map, so
+// os.hypervisor reads null. Tokens taken from systemd src/basic/virt.c.
+func TestMapHypervisorSystemdTokens(t *testing.T) {
+	for token, want := range map[string]string{
+		"amazon":    "AWS Nitro System",
+		"microsoft": "Hyper-V",
+		"google":    "Google Compute Engine",
+		"apple":     "Apple Virtualization",
+		"oracle":    "VirtualBox",
+		// already mapped before this change, kept here so the whole systemd
+		// vocabulary is covered in one place
+		"kvm":       "KVM",
+		"qemu":      "QEMU",
+		"xen":       "Xen",
+		"vmware":    "VMware",
+		"parallels": "Parallels",
+		"bhyve":     "bhyve",
+		"powervm":   "IBM PowerVM",
+	} {
+		t.Run(token, func(t *testing.T) {
+			v, ok := mapHypervisor(token)
+			assert.True(t, ok, "systemd emits %q; it must map", token)
+			assert.Equal(t, want, v)
+		})
+	}
+}
+
+// The DMI vendor strings for the same platforms must land on the same answer.
+func TestMapHypervisorDMIVendors(t *testing.T) {
+	for vendor, want := range map[string]string{
+		"Amazon EC2":            "AWS Nitro System",
+		"Microsoft Corporation": "Hyper-V",
+		"Google":                "Google Compute Engine",
+		"Google Compute Engine": "Google Compute Engine",
+		"Apple Inc.":            "Apple Virtualization",
+		"VMware, Inc.":          "VMware",
+		"Xen":                   "Xen",
+		"QEMU":                  "QEMU",
+	} {
+		t.Run(vendor, func(t *testing.T) {
+			v, ok := mapHypervisor(vendor)
+			assert.True(t, ok, vendor)
+			assert.Equal(t, want, v)
+		})
+	}
+}
+
+// Several vendor strings contain more than one key. Go randomises map
+// iteration, so before ordering by key length the answer differed between
+// runs. The most specific match must win, every time.
+func TestMapHypervisorLongestMatchWinsDeterministically(t *testing.T) {
+	// contains both "oracle"-free "virtualbox" and, in the vendor form, "oracle"
+	for i := 0; i < 50; i++ {
+		v, ok := mapHypervisor("Oracle VM VirtualBox")
+		assert.True(t, ok)
+		assert.Equal(t, "VirtualBox", v, "longest key must win on every iteration")
+	}
+
+	// "apple virtual" is longer than "apple" and must take precedence
+	for i := 0; i < 50; i++ {
+		v, ok := mapHypervisor("Apple Virtual Machine")
+		assert.True(t, ok)
+		assert.Equal(t, "Apple Virtualization", v)
+	}
+}


### PR DESCRIPTION
> Stacked on #10418. Base is `fix/hypervisor-detect-amazon-ec2`; merge that first and this retargets to `main`.

## The bug

`systemd-detect-virt` emits **its own identifiers**, which are not the product names. Four of them match no key in `knownHypervisors`, so the guest is detected and then fails to map — `os.hypervisor` reads null:

| systemd token | product | existing key | why it misses |
|---|---|---|---|
| `microsoft` | **Hyper-V** | `hyper-v` | `"microsoft"` does not contain `"hyper-v"` |
| `google` | **Google Compute Engine** | — | absent entirely |
| `apple` | **Apple Virtualization** | `applevirtual`, `apple virtual` | `"apple"` contains neither |
| `oracle` | **VirtualBox** | `virtualbox` | `"oracle"` does not contain `"virtualbox"` |

Hyper-V and GCE are two of the most common platforms we scan.

The DMI vendor strings for the same platforms are covered by the same keys: `Microsoft Corporation`, `Google Compute Engine`, `Apple Inc.`

## Determinism, which `oracle` forces

`mapHypervisor` now checks the **longest key first**.

Several vendor strings contain more than one key — `Oracle VM VirtualBox` holds both `oracle` and `virtualbox` — and Go **randomises map iteration**, so the answer previously depended on iteration order and could differ between runs. Longest match is the most specific one, and it is reproducible. A test asserts it over 50 iterations.

## Why `oracle` cannot mislabel Oracle Cloud

The entire Linux detection chain is gated on the CPU `hypervisor` flag:

```go
if h.detectLinuxCPUHypervisor() {
    for _, detectFn := range detectors { ... }
}
```

so bare metal never reaches it, and OCI VM shapes report QEMU (matching `qemu`). VirtualBox's own DMI is `innotek GmbH` / `Oracle Corporation` with `product_name` `VirtualBox`, where the longer key wins.

## Tests

- Every VM token systemd can emit maps to a product — the four new ones plus the eleven that already worked, so the whole vocabulary is covered in one place
- DMI vendor strings for the same platforms land on the same answers
- Longest-match determinism, asserted repeatedly rather than once

```
ok  go.mondoo.com/mql/providers/os/id/hypervisor
```

## Deliberately not included

`zvm` (IBM z/VM), `bochs`, `qnx` and `acrn` are also unmapped. They are niche and I kept this PR to the four you asked for — happy to add them if you want the systemd vocabulary complete.

Tokens taken from systemd `src/basic/virt.c`, `virtualization_table`.