### PR TITLE
🐛 os: read the repositories under /etc/apt/sources.list.d

### DIFF
--- a/providers/os/resources/apt.go
+++ b/providers/os/resources/apt.go
@@ -84,10 +84,15 @@ func (a *mqlApt) sourceFiles() ([]*mqlFile, error) {
 		out = append(out, mainFile)
 	}
 
+	// No name filter here. files.find's `name` becomes `find -name`, an fnmatch
+	// glob, so the regex this used to pass matched nothing and every fragment
+	// under sources.list.d was silently dropped. `regex` would reach
+	// `find -regex`, but that matches the whole path and its dialect differs
+	// between GNU and BSD find, so the extension check is done here instead
+	// where it behaves the same everywhere.
 	o, err := CreateResource(a.MqlRuntime, "files.find", map[string]*llx.RawData{
 		"from":  llx.StringData(aptSourcesListD),
 		"type":  llx.StringData("file"),
-		"name":  llx.StringData(`\.(list|sources)$`),
 		"depth": llx.IntData(1),
 	})
 	if err != nil {
@@ -96,13 +101,26 @@ func (a *mqlApt) sourceFiles() ([]*mqlFile, error) {
 	list := o.(*mqlFilesFind).GetList()
 	if list.Error == nil {
 		for _, item := range list.Data {
-			if mf, ok := item.(*mqlFile); ok {
-				out = append(out, mf)
+			mf, ok := item.(*mqlFile)
+			if !ok {
+				continue
 			}
+			if !isAptSourceFile(mf.Path.Data) {
+				continue
+			}
+			out = append(out, mf)
 		}
 	}
 
 	return out, nil
+}
+
+// isAptSourceFile reports whether a path under sources.list.d is one apt would
+// read. apt honours exactly two extensions: .list for the one-line format and
+// .sources for deb822. Everything else in the directory, notably the .save and
+// .distUpgrade backups apt itself leaves behind, is ignored.
+func isAptSourceFile(path string) bool {
+	return strings.HasSuffix(path, ".list") || strings.HasSuffix(path, ".sources")
 }
 
 func (a *mqlApt) newRepo(file *mqlFile, repo aptRepo) (*mqlAptRepo, error) {

--- a/providers/os/resources/apt_sourcefiles_test.go
+++ b/providers/os/resources/apt_sourcefiles_test.go
@@ -1,0 +1,49 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// apt reads exactly two extensions out of sources.list.d. The previous filter
+// passed a regex to files.find's `name`, which is an fnmatch glob, so it
+// matched nothing and every fragment was dropped -- including the deb822
+// .sources files that are the norm on Debian 12+ and Ubuntu 24.04+.
+func TestIsAptSourceFile(t *testing.T) {
+	included := []string{
+		"/etc/apt/sources.list.d/debian.list",
+		"/etc/apt/sources.list.d/kali.sources",
+		"/etc/apt/sources.list.d/ubuntu.sources",
+		"/etc/apt/sources.list.d/docker.list",
+	}
+	for _, p := range included {
+		t.Run("include/"+p, func(t *testing.T) {
+			assert.True(t, isAptSourceFile(p), "apt reads this file")
+		})
+	}
+
+	excluded := []string{
+		// apt's own backups, which must not be parsed as live config
+		"/etc/apt/sources.list.d/debian.list.save",
+		"/etc/apt/sources.list.d/debian.list.distUpgrade",
+		"/etc/apt/sources.list.d/kali.sources.bak",
+		// unrelated files that share the directory
+		"/etc/apt/sources.list.d/README",
+		"/etc/apt/sources.list.d/deadsnakes.gpg",
+		"/etc/apt/sources.list.d/",
+		"",
+	}
+	for _, p := range excluded {
+		name := p
+		if name == "" {
+			name = "empty"
+		}
+		t.Run("exclude/"+name, func(t *testing.T) {
+			assert.False(t, isAptSourceFile(p), "apt ignores this file")
+		})
+	}
+}


### PR DESCRIPTION
## The bug

`sourceFiles` passed a **regex** to `files.find`'s `name` parameter:

```go
"name": llx.StringData(`\.(list|sources)$`),
```

`name` becomes `find -name` — an **fnmatch glob**. `regex` is the separate parameter that reaches `find -regex`. So the pattern never matched, and **every fragment under `/etc/apt/sources.list.d/` was silently dropped**.

Proven on a live host:

```
name:  "\.(list|sources)$"  → []                                    glob, never matches
regex: "\.(list|sources)$"  → []                                    find's own dialect, also fails
name:  "*.sources"          → /etc/apt/sources.list.d/kali.sources  ✓
no name filter              → /etc/apt/sources.list.d/kali.sources  ✓
```

## Why it matters

`sources.list.d` is where repositories actually live on a modern system, and deb822 `.sources` files are the norm on **Debian 12+ and Ubuntu 24.04+**, so this gets worse over time.

Confirmed independently on two distributions:

| host | `apt.repos` returned | reality |
|---|---|---|
| **Kali** | `[]` — completely empty | one active repo in `kali.sources` |
| **Linux Mint 22** | 1 entry | **5** real repos, and the one entry was fictitious |

Mint is the worse case. Its `/etc/apt/sources.list` still carries a commented-out `deb cdrom:` line from the image's Mint 20.2 lineage, and that is the only thing the resource found:

```json
{"url":"cdrom:[Linux", "distribution":"Mint",
 "components":["20.2","_Uma_","-","Release","amd64","20210703]/","focal","contrib","main"],
 "enabled":false}
```

So `apt.repos` returned **one fictitious repository and none of the five real ones**.

## The fix

The extension check moves into Go. `regex` would reach `find -regex`, but that matches the **whole path** and its dialect differs between GNU and BSD find, so doing it here behaves the same on every target.

It also correctly skips the `.save` and `.distUpgrade` backups apt leaves behind, which a bare `*.list` glob would have picked up as live configuration.

## Tests

`sourceFiles` had **no test**, which is why this shipped — both parsers (`parseAptOneLine`, `parseAptDeb822`) were already correct and covered. The new test pins the file selection itself: `.list` and `.sources` included, `.save` / `.distUpgrade` / `.bak` / `README` / `.gpg` excluded.

```
ok  go.mondoo.com/mql/providers/os/resources
```

Found while running a live provider validation across Linux distributions.