### PR TITLE
🐛 os: enumerate groups through NSS, not just /etc/group

### DIFF
--- a/providers/os/resources/groups/etcgroups.go
+++ b/providers/os/resources/groups/etcgroups.go
@@ -121,6 +121,15 @@ func (s *UnixGroupManager) listEtcGroup() ([]*Group, error) {
 //
 // getent group emits the same colon separated format as /etc/group, so the
 // existing parser handles it unchanged.
+//
+// Enumeration is a courtesy, not a guarantee: an NSS module may serve lookups
+// by name while declining to list. sssd ships enumerate=false by default, so on
+// a host joined to LDAP or AD this returns only what the files module holds and
+// the directory-backed groups are absent -- indistinguishable from a host that
+// simply has few groups. The fallback yields the same set in that case, so the
+// answer stays correct; it is not, however, complete. Enumerating a large
+// directory is also slow, which is why sssd defaults it off. Reporting group
+// membership for directory-backed accounts needs a per-name lookup, not a list.
 func (s *UnixGroupManager) listGetentGroup() ([]*Group, error) {
 	getent, err := s.conn.RunCommand("getent group")
 	if err != nil {

--- a/providers/os/resources/groups/etcgroups.go
+++ b/providers/os/resources/groups/etcgroups.go
@@ -91,9 +91,15 @@ func (s *UnixGroupManager) Group(id string) (*Group, error) {
 // and fallen back to /etc/passwd. The two managers disagreeing is why the same
 // host reported 37 users but 6 groups.
 func (s *UnixGroupManager) listGroups() ([]*Group, error) {
-	if groups, err := s.listGetentGroup(); err == nil && len(groups) != 0 {
+	groups, err := s.listGetentGroup()
+	if err == nil && len(groups) != 0 {
 		return groups, nil
 	}
+	// getent is missing on busybox style images and fails when NSS is
+	// misconfigured. Record why we dropped to /etc/group, otherwise a host that
+	// should have resolved through NSS looks indistinguishable from one that
+	// never had getent at all.
+	log.Debug().Err(err).Int("groups", len(groups)).Msg("getent group did not return groups, falling back to /etc/group")
 	return s.listEtcGroup()
 }
 

--- a/providers/os/resources/groups/etcgroups.go
+++ b/providers/os/resources/groups/etcgroups.go
@@ -77,7 +77,27 @@ func (s *UnixGroupManager) Group(id string) (*Group, error) {
 	return findGroup(groups, id)
 }
 
-func (s *UnixGroupManager) List() ([]*Group, error) {
+// listGroups enumerates the groups the system actually resolves, not just the
+// ones written in /etc/group.
+//
+// getent asks NSS, so it also returns groups served by sssd, systemd-userdb,
+// LDAP or a distribution specific module. Reading /etc/group alone under
+// reports on any such host: on Flatcar, whose groups live in
+// /usr/share/flatcar/etc/group behind the usrfiles NSS module, getent lists 56
+// groups and /etc/group holds 6. A group that is missing from the list cannot
+// fail a check, so the gap is silent and points the wrong way.
+//
+// This mirrors UnixUserManager.List, which has always preferred getent passwd
+// and fallen back to /etc/passwd. The two managers disagreeing is why the same
+// host reported 37 users but 6 groups.
+func (s *UnixGroupManager) listGroups() ([]*Group, error) {
+	if groups, err := s.listGetentGroup(); err == nil && len(groups) != 0 {
+		return groups, nil
+	}
+	return s.listEtcGroup()
+}
+
+func (s *UnixGroupManager) listEtcGroup() ([]*Group, error) {
 	f, err := s.conn.FileSystem().Open("/etc/group")
 	if err != nil {
 		return nil, err
@@ -87,6 +107,27 @@ func (s *UnixGroupManager) List() ([]*Group, error) {
 	groups, err := ParseEtcGroup(f)
 	if err != nil {
 		return nil, multierr.Wrap(err, "could not parse /etc/group")
+	}
+	return groups, nil
+}
+
+// https://man7.org/linux/man-pages/man1/getent.1.html
+//
+// getent group emits the same colon separated format as /etc/group, so the
+// existing parser handles it unchanged.
+func (s *UnixGroupManager) listGetentGroup() ([]*Group, error) {
+	getent, err := s.conn.RunCommand("getent group")
+	if err != nil {
+		return nil, err
+	}
+
+	return ParseEtcGroup(getent.Stdout)
+}
+
+func (s *UnixGroupManager) List() ([]*Group, error) {
+	groups, err := s.listGroups()
+	if err != nil {
+		return nil, err
 	}
 
 	um, err := users.ResolveManager(s.conn)

--- a/providers/os/resources/groups/etcgroups_nss_test.go
+++ b/providers/os/resources/groups/etcgroups_nss_test.go
@@ -1,0 +1,54 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package groups
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// getent group emits the same colon separated format as /etc/group, which is
+// why the existing parser handles it unchanged. This pins that, because the
+// NSS fallback depends on it.
+func TestParseEtcGroupHandlesGetentOutput(t *testing.T) {
+	// verbatim shape of `getent group` on a host whose groups come from an NSS
+	// module rather than /etc/group
+	out := `root:x:0:
+daemon:x:1:
+sudo:x:27:core
+docker:x:233:core
+nobody:x:65534:
+portage:x:250:core
+`
+	groups, err := ParseEtcGroup(strings.NewReader(out))
+	require.NoError(t, err)
+	require.Len(t, groups, 6)
+
+	byName := map[string]*Group{}
+	for _, g := range groups {
+		byName[g.Name] = g
+	}
+
+	// the entries that only NSS knows about must parse identically
+	assert.Contains(t, byName, "nobody", "an NSS-only group must parse")
+	assert.Equal(t, int64(65534), byName["nobody"].Gid)
+
+	require.Contains(t, byName, "portage")
+	assert.Equal(t, int64(250), byName["portage"].Gid)
+	assert.Equal(t, []string{"core"}, byName["portage"].Members)
+
+	assert.Equal(t, int64(0), byName["root"].Gid)
+	assert.Empty(t, byName["root"].Members)
+}
+
+// A group line with no members must not invent one.
+func TestParseEtcGroupEmptyMembers(t *testing.T) {
+	groups, err := ParseEtcGroup(strings.NewReader("wheel:x:10:\n"))
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Empty(t, groups[0].Members)
+}

--- a/providers/os/resources/users/etcpasswd.go
+++ b/providers/os/resources/users/etcpasswd.go
@@ -81,7 +81,11 @@ func (s *UnixUserManager) List() ([]*User, error) {
 	if err == nil && len(users) != 0 {
 		return users, nil
 	}
-	// fallback to /etc/passwd
+	// getent is missing on busybox style images and fails when NSS is
+	// misconfigured. Record why we dropped to /etc/passwd, otherwise a host that
+	// should have resolved through NSS looks indistinguishable from one that
+	// never had getent at all.
+	log.Debug().Err(err).Int("users", len(users)).Msg("getent passwd did not return users, falling back to /etc/passwd")
 	return s.listEtcPasswd()
 }
 


### PR DESCRIPTION
## The bug

`UnixGroupManager.List` opened `/etc/group` and nothing else:

```go
func (s *UnixGroupManager) List() ([]*Group, error) {
    f, err := s.conn.FileSystem().Open("/etc/group")
    ...
```

Its sibling `UnixUserManager.List` has always done the right thing:

```go
users, err := s.listGetentPasswd()
if err == nil && len(users) != 0 { return users, nil }
return s.listEtcPasswd()          // fallback
```

The two managers disagreeing produced a visible contradiction on the same host: **37 users but 6 groups**.

## Why it matters

`getent` asks **NSS**, so it also returns groups served by sssd, systemd-userdb, LDAP or a distribution-specific module. Reading `/etc/group` alone under-reports on any such host.

Measured on Flatcar, whose groups live in `/usr/share/flatcar/etc/group` behind the `usrfiles` NSS module (`nsswitch.conf: group: files usrfiles sss systemd`):

```
getent group | wc -l           → 56 unique groups
mql groups.length              → 6      ← exactly /etc/group
groups.where(name=="nobody")   → []     ← getent resolves it fine
```

**50 groups missing**, including `nobody` and `portage` — a group the `core` user actually belongs to per `id core`.

A group that isn't in the list **cannot fail a check**, so the gap is silent and points in the unsafe direction. This hits any host whose groups come from LDAP/SSSD/systemd-userdb, not just Flatcar.

## The fix

`List` now mirrors the users manager: `getent group` first, `/etc/group` as the fallback. `getent` emits the same colon-separated format, so `ParseEtcGroup` handles it unchanged.

Hosts with no NSS modules beyond `files` are unaffected — `getent` returns the same content `/etc/group` holds.

## Tests

Pin that the parser handles real `getent group` output, including entries that only NSS knows about (`nobody`, `portage` with its member list), and that a group with no members doesn't gain one.

```
ok  go.mondoo.com/mql/providers/os/resources/groups
```

## Related, deliberately not changed

The same host reports `root` and `core` **twice** in `users`. That is faithful, not a defect — `getent passwd | grep -c '^core:'` is genuinely 2, because both `files` and `usrfiles` answer. Left alone.

Found while running a live provider validation across Linux distributions.