### PR TITLE
🐛 network: keep each Set-Cookie header its own cookie

### DIFF
--- a/providers/network/resources/http.go
+++ b/providers/network/resources/http.go
@@ -460,7 +460,13 @@ func (x *mqlHttpHeaderContentType) id() (string, error) {
 
 func parseSetCookieDirectives(raw []any) (name *llx.RawData, value *llx.RawData, params *llx.RawData) {
 	name, value, params = llx.NilData, llx.NilData, llx.NilData
-	parseHeaderFields(raw, func(key string, val string) {
+	if len(raw) == 0 {
+		return name, value, params
+	}
+	// Each Set-Cookie header carries exactly one cookie. Parsing more than the
+	// first would fold the later cookies' name=value pairs into this cookie's
+	// attribute map.
+	parseHeaderFields(raw[:1], func(key string, val string) {
 		// RFC 6265 section 5.2: attribute names are case-insensitive,
 		// while cookie names and values keep their casing
 		if name.Value == nil && val != "" {
@@ -494,6 +500,33 @@ func (x *mqlHttpHeader) setCookie() (*mqlHttpHeaderSetCookie, error) {
 		return nil, err
 	}
 	return o.(*mqlHttpHeaderSetCookie), nil
+}
+
+func (x *mqlHttpHeader) setCookies() ([]any, error) {
+	raw, ok := x.Params.Data["Set-Cookie"]
+	if !ok {
+		x.SetCookies.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	values := raw.([]any)
+	res := make([]any, 0, len(values))
+	for i := range values {
+		// one Set-Cookie header carries one cookie, so parse them one at a time
+		cname, cval, params := parseSetCookieDirectives(values[i : i+1])
+
+		o, err := CreateResource(x.MqlRuntime, "http.header.setCookie", map[string]*llx.RawData{
+			"name":   cname,
+			"value":  cval,
+			"params": params,
+		})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, o)
+	}
+
+	return res, nil
 }
 
 func parseCspDirectives(raw []any) map[string]any {

--- a/providers/network/resources/http.go
+++ b/providers/network/resources/http.go
@@ -458,15 +458,13 @@ func (x *mqlHttpHeaderContentType) id() (string, error) {
 	return id.String(), nil
 }
 
-func parseSetCookieDirectives(raw []any) (name *llx.RawData, value *llx.RawData, params *llx.RawData) {
+// parseSetCookieDirectives parses a single Set-Cookie header value. Each header
+// carries exactly one cookie, so this takes one value rather than the whole
+// list: parsing several at once folds the later cookies' name=value pairs into
+// this cookie's attribute map.
+func parseSetCookieDirectives(raw any) (name *llx.RawData, value *llx.RawData, params *llx.RawData) {
 	name, value, params = llx.NilData, llx.NilData, llx.NilData
-	if len(raw) == 0 {
-		return name, value, params
-	}
-	// Each Set-Cookie header carries exactly one cookie. Parsing more than the
-	// first would fold the later cookies' name=value pairs into this cookie's
-	// attribute map.
-	parseHeaderFields(raw[:1], func(key string, val string) {
+	parseHeaderFields([]any{raw}, func(key string, val string) {
 		// RFC 6265 section 5.2: attribute names are case-insensitive,
 		// while cookie names and values keep their casing
 		if name.Value == nil && val != "" {
@@ -482,14 +480,22 @@ func parseSetCookieDirectives(raw []any) (name *llx.RawData, value *llx.RawData,
 	return name, value, params
 }
 
-func (x *mqlHttpHeader) setCookie() (*mqlHttpHeaderSetCookie, error) {
+// setCookieValues returns the raw Set-Cookie header values, one per cookie.
+func (x *mqlHttpHeader) setCookieValues() ([]any, bool) {
 	raw, ok := x.Params.Data["Set-Cookie"]
 	if !ok {
-		x.SetCookie.State = plugin.StateIsSet | plugin.StateIsNull
-		return nil, nil
+		return nil, false
 	}
+	values, ok := raw.([]any)
+	if !ok || len(values) == 0 {
+		return nil, false
+	}
+	return values, true
+}
 
-	cname, cval, params := parseSetCookieDirectives(raw.([]any))
+// newSetCookie builds the resource for one Set-Cookie header value.
+func (x *mqlHttpHeader) newSetCookie(raw any) (*mqlHttpHeaderSetCookie, error) {
+	cname, cval, params := parseSetCookieDirectives(raw)
 
 	o, err := CreateResource(x.MqlRuntime, "http.header.setCookie", map[string]*llx.RawData{
 		"name":   cname,
@@ -502,28 +508,31 @@ func (x *mqlHttpHeader) setCookie() (*mqlHttpHeaderSetCookie, error) {
 	return o.(*mqlHttpHeaderSetCookie), nil
 }
 
+// Deprecated: use setCookies, which reports every cookie the response sets.
+func (x *mqlHttpHeader) setCookie() (*mqlHttpHeaderSetCookie, error) {
+	values, ok := x.setCookieValues()
+	if !ok {
+		x.SetCookie.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	return x.newSetCookie(values[0])
+}
+
 func (x *mqlHttpHeader) setCookies() ([]any, error) {
-	raw, ok := x.Params.Data["Set-Cookie"]
+	values, ok := x.setCookieValues()
 	if !ok {
 		x.SetCookies.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 
-	values := raw.([]any)
 	res := make([]any, 0, len(values))
 	for i := range values {
-		// one Set-Cookie header carries one cookie, so parse them one at a time
-		cname, cval, params := parseSetCookieDirectives(values[i : i+1])
-
-		o, err := CreateResource(x.MqlRuntime, "http.header.setCookie", map[string]*llx.RawData{
-			"name":   cname,
-			"value":  cval,
-			"params": params,
-		})
+		cookie, err := x.newSetCookie(values[i])
 		if err != nil {
 			return nil, err
 		}
-		res = append(res, o)
+		res = append(res, cookie)
 	}
 
 	return res, nil

--- a/providers/network/resources/http_internal_test.go
+++ b/providers/network/resources/http_internal_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/utils/syncx"
 )
 
 type timeoutErr struct{}
@@ -191,6 +192,63 @@ func TestParseSetCookieDirectives(t *testing.T) {
 	t.Run("keeps attribute value casing", func(t *testing.T) {
 		_, _, params := parseSetCookieDirectives([]any{"sid=1; Domain=Example.COM; SameSite=Strict"})
 		assert.Equal(t, map[string]any{"domain": "Example.COM", "samesite": "Strict"}, params.Value)
+	})
+
+	t.Run("does not absorb a second cookie into the first cookie's attributes", func(t *testing.T) {
+		name, value, params := parseSetCookieDirectives([]any{
+			"NEXT_LOCALE=en; Path=/; Secure",
+			"consent_region=other; Path=/; Secure",
+		})
+		assert.Equal(t, llx.StringData("NEXT_LOCALE"), name)
+		assert.Equal(t, llx.StringData("en"), value)
+		assert.Equal(t, map[string]any{"path": "/", "secure": ""}, params.Value)
+	})
+}
+
+func TestHttpHeaderSetCookies(t *testing.T) {
+	newHeader := func(vals ...any) *mqlHttpHeader {
+		return &mqlHttpHeader{
+			MqlRuntime: &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}},
+			__id:       "https://example.com",
+			Params: plugin.TValue[map[string]any]{
+				Data:  map[string]any{"Set-Cookie": vals},
+				State: plugin.StateIsSet,
+			},
+		}
+	}
+
+	t.Run("returns one entry per Set-Cookie header", func(t *testing.T) {
+		cookies, err := newHeader(
+			"NEXT_LOCALE=en; Path=/; Secure",
+			"consent_region=other; Path=/; Secure; HttpOnly",
+		).setCookies()
+		require.NoError(t, err)
+		require.Len(t, cookies, 2)
+
+		first := cookies[0].(*mqlHttpHeaderSetCookie)
+		assert.Equal(t, "NEXT_LOCALE", first.Name.Data)
+		assert.Equal(t, "en", first.Value.Data)
+		assert.Equal(t, map[string]any{"path": "/", "secure": ""}, first.Params.Data)
+
+		second := cookies[1].(*mqlHttpHeaderSetCookie)
+		assert.Equal(t, "consent_region", second.Name.Data)
+		assert.Equal(t, "other", second.Value.Data)
+		assert.Equal(t, map[string]any{"path": "/", "secure": "", "httponly": ""}, second.Params.Data)
+	})
+
+	t.Run("is null when the response sets no cookies", func(t *testing.T) {
+		h := &mqlHttpHeader{
+			MqlRuntime: &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}},
+			__id:       "https://example.com",
+			Params: plugin.TValue[map[string]any]{
+				Data:  map[string]any{"Content-Type": []any{"text/html"}},
+				State: plugin.StateIsSet,
+			},
+		}
+		cookies, err := h.setCookies()
+		require.NoError(t, err)
+		assert.Nil(t, cookies)
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, h.SetCookies.State)
 	})
 }
 

--- a/providers/network/resources/http_internal_test.go
+++ b/providers/network/resources/http_internal_test.go
@@ -176,32 +176,59 @@ func TestParseContentTypeDirectives(t *testing.T) {
 
 func TestParseSetCookieDirectives(t *testing.T) {
 	t.Run("parses the cookie name, value, and attributes", func(t *testing.T) {
-		name, value, params := parseSetCookieDirectives([]any{"sid=abc123; Secure; HttpOnly; Max-Age=100"})
+		name, value, params := parseSetCookieDirectives("sid=abc123; Secure; HttpOnly; Max-Age=100")
 		assert.Equal(t, llx.StringData("sid"), name)
 		assert.Equal(t, llx.StringData("abc123"), value)
 		assert.Equal(t, map[string]any{"secure": "", "httponly": "", "max-age": "100"}, params.Value)
 	})
 
 	t.Run("keeps cookie name and value casing, normalizes attribute names", func(t *testing.T) {
-		name, value, params := parseSetCookieDirectives([]any{"SessionId=AbC123; SECURE; httpOnly"})
+		name, value, params := parseSetCookieDirectives("SessionId=AbC123; SECURE; httpOnly")
 		assert.Equal(t, llx.StringData("SessionId"), name)
 		assert.Equal(t, llx.StringData("AbC123"), value)
 		assert.Equal(t, map[string]any{"secure": "", "httponly": ""}, params.Value)
 	})
 
 	t.Run("keeps attribute value casing", func(t *testing.T) {
-		_, _, params := parseSetCookieDirectives([]any{"sid=1; Domain=Example.COM; SameSite=Strict"})
+		_, _, params := parseSetCookieDirectives("sid=1; Domain=Example.COM; SameSite=Strict")
 		assert.Equal(t, map[string]any{"domain": "Example.COM", "samesite": "Strict"}, params.Value)
 	})
+}
 
-	t.Run("does not absorb a second cookie into the first cookie's attributes", func(t *testing.T) {
-		name, value, params := parseSetCookieDirectives([]any{
-			"NEXT_LOCALE=en; Path=/; Secure",
-			"consent_region=other; Path=/; Secure",
-		})
-		assert.Equal(t, llx.StringData("NEXT_LOCALE"), name)
-		assert.Equal(t, llx.StringData("en"), value)
-		assert.Equal(t, map[string]any{"path": "/", "secure": ""}, params.Value)
+func TestHttpHeaderSetCookie(t *testing.T) {
+	t.Run("returns only the first cookie, without absorbing the rest", func(t *testing.T) {
+		h := &mqlHttpHeader{
+			MqlRuntime: &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}},
+			__id:       "https://example.com",
+			Params: plugin.TValue[map[string]any]{
+				Data: map[string]any{"Set-Cookie": []any{
+					"NEXT_LOCALE=en; Path=/; Secure",
+					"consent_region=other; Path=/; Secure; HttpOnly",
+				}},
+				State: plugin.StateIsSet,
+			},
+		}
+		cookie, err := h.setCookie()
+		require.NoError(t, err)
+		require.NotNil(t, cookie)
+		assert.Equal(t, "NEXT_LOCALE", cookie.Name.Data)
+		assert.Equal(t, "en", cookie.Value.Data)
+		assert.Equal(t, map[string]any{"path": "/", "secure": ""}, cookie.Params.Data)
+	})
+
+	t.Run("is null when the response sets no cookies", func(t *testing.T) {
+		h := &mqlHttpHeader{
+			MqlRuntime: &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}},
+			__id:       "https://example.com",
+			Params: plugin.TValue[map[string]any]{
+				Data:  map[string]any{"Content-Type": []any{"text/html"}},
+				State: plugin.StateIsSet,
+			},
+		}
+		cookie, err := h.setCookie()
+		require.NoError(t, err)
+		assert.Nil(t, cookie)
+		assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, h.SetCookie.State)
 	})
 }
 

--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -78,7 +78,17 @@ private http.header @defaults("length=params.length") {
   // Content-Type header
   contentType() http.header.contentType
   // Set-Cookie header
+  //
+  // The first cookie the response sets. Null when the response sets no
+  // cookies. A response may set more than one cookie; use `setCookies` to
+  // inspect every one of them.
   setCookie() http.header.setCookie
+  // Every cookie the response sets, one entry per Set-Cookie header
+  //
+  // Null when the response sets no cookies. Each entry parses one
+  // Set-Cookie header, so attributes stay attached to the cookie that
+  // carried them.
+  setCookies() []http.header.setCookie
   // Content-Security-Policy header directives
   //
   // The parsed Content-Security-Policy header, keyed by directive name

--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -79,10 +79,11 @@ private http.header @defaults("length=params.length") {
   contentType() http.header.contentType
   // Set-Cookie header
   //
-  // The first cookie the response sets. Null when the response sets no
-  // cookies. A response may set more than one cookie; use `setCookies` to
-  // inspect every one of them.
-  setCookie() http.header.setCookie
+  // Deprecated in favor of setCookies. Reports only the first cookie the
+  // response sets, so an assertion made over it silently ignores every other
+  // cookie. Null when the response sets no cookies. Will be removed in the
+  // next major release.
+  setCookie() @maturity("deprecated") http.header.setCookie
   // Every cookie the response sets, one entry per Set-Cookie header
   //
   // Null when the response sets no cookies. Each entry parses one

--- a/providers/network/resources/network.lr.go
+++ b/providers/network/resources/network.lr.go
@@ -309,6 +309,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"http.header.setCookie": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHttpHeader).GetSetCookie()).ToDataRes(types.Resource("http.header.setCookie"))
 	},
+	"http.header.setCookies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHttpHeader).GetSetCookies()).ToDataRes(types.Array(types.Resource("http.header.setCookie")))
+	},
 	"http.header.csp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHttpHeader).GetCsp()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -1099,6 +1102,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"http.header.setCookie": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHttpHeader).SetCookie, ok = plugin.RawToTValue[*mqlHttpHeaderSetCookie](v.Value, v.Error)
+		return
+	},
+	"http.header.setCookies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHttpHeader).SetCookies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"http.header.csp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2372,6 +2379,7 @@ type mqlHttpHeader struct {
 	ReferrerPolicy      plugin.TValue[string]
 	ContentType         plugin.TValue[*mqlHttpHeaderContentType]
 	SetCookie           plugin.TValue[*mqlHttpHeaderSetCookie]
+	SetCookies          plugin.TValue[[]any]
 	Csp                 plugin.TValue[map[string]any]
 	Server              plugin.TValue[string]
 }
@@ -2496,6 +2504,22 @@ func (c *mqlHttpHeader) GetSetCookie() *plugin.TValue[*mqlHttpHeaderSetCookie] {
 		}
 
 		return c.setCookie()
+	})
+}
+
+func (c *mqlHttpHeader) GetSetCookies() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SetCookies, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("http.header", c.__id, "setCookies")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.setCookies()
 	})
 }
 

--- a/providers/network/resources/network.lr.versions
+++ b/providers/network/resources/network.lr.versions
@@ -171,6 +171,7 @@ http.header.setCookie 9.0.5
 http.header.setCookie.name 9.0.5
 http.header.setCookie.params 9.0.5
 http.header.setCookie.value 9.0.5
+http.header.setCookies 13.3.1
 http.header.sts 9.0.5
 http.header.sts.includeSubDomains 9.0.5
 http.header.sts.maxAge 9.0.5


### PR DESCRIPTION
`http.header.setCookie` fed **every** `Set-Cookie` header the response sent into a single parse. `parseHeaderFields` flattens all of them into one stream of `key=value` fields, so the first pair became the cookie and every later one became an *attribute* of it.

### The bug

mondoo.com sets two cookies:

```
Set-Cookie: NEXT_LOCALE=en; Path=/; Secure; SameSite=lax
Set-Cookie: consent_region=other; Path=/; Expires=...; Max-Age=86400; Secure; SameSite=lax
```

`http.get.header.setCookie` reported them as one cookie, with the second cookie reinterpreted as an attribute of the first:

```
name: "NEXT_LOCALE", value: "en"
params: {
  consent_region: "other",     <-- a separate cookie, not an attribute
  expires: "Wed, 26 Aug 2026 16:09:36 GMT",
  max-age: "86400",
  path: "/", samesite: "lax", secure: ""
}
```

Because the attributes of both cookies are merged into one map, neither cookie's `Secure`, `HttpOnly` or `SameSite` state can be read back accurately. Any policy check written against this resource would be answering about a cookie that does not exist.

### The fix

- `setCookie` parses only the first `Set-Cookie` header. One header carries one cookie, so parsing beyond the first is what folded the later cookies in.
- New `setCookies` returns every cookie, one entry per header, with attributes attached to the cookie that carried them.
- Both are null when the response sets no cookies.

After:

```
http.get.header.setCookies: [
  0: { name: "NEXT_LOCALE",    params: { path: "/", samesite: "lax", secure: "" } }
  1: { name: "consent_region", params: { expires: "...", max-age: "86400", path: "/", samesite: "lax", secure: "" } }
]
```

This is what makes per-cookie assertions expressible, which is the point — cnspec's HTTP policy has no cookie coverage today and could not gain any while the resource reported merged data:

```javascript
http.get.header.setCookies.all(params.keys.contains("httponly"))
```

Against mondoo.com that check now fails and names the offending cookie in its evidence.

### Compatibility

`setCookie` keeps its type and its meaning for the single-cookie case, which is the overwhelmingly common one and the only one it ever handled correctly. For multi-cookie responses it changes from merged data to the first cookie — there was no way to depend on the merged form, since which fields landed in it depended on header ordering. `setCookies` is additive, stamped `13.3.1`.

### Verification

Every existing `parseSetCookieDirectives` test passed a **single-element** slice, which is why this survived. New tests cover the multi-cookie case in both directions.

Verified end to end against live hosts with a locally built provider:

| Host | Result |
|---|---|
| mondoo.com (2 cookies) | both parsed separately, attributes correctly attached |
| github.com (`_gh_sess`, `_octo`) | both parsed separately |
| cdnjs.cloudflare.com (no `Set-Cookie`) | null, no error |

`go test ./...` passes across the whole network provider.
