### PR TITLE
:star: os: detect CloudLinux OS as a redhat-family platform

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -557,6 +557,28 @@ var eurolinux = &PlatformResolver{
 	},
 }
 
+// CloudLinux OS is a RHEL rebuild (os-release carries ID=cloudlinux,
+// ID_LIKE="rhel fedora centos"). Without a resolver here no child of the redhat
+// family claims it, the family gate is abandoned, and everything keyed on
+// IsFamily("redhat") goes dead: packages, updates, yum and services among them.
+var cloudlinux = &PlatformResolver{
+	Name:     "cloudlinux",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		if pf.Name == "cloudlinux" {
+			return true, nil
+		}
+
+		// fallback for images that ship no os-release, only /etc/redhat-release
+		if strings.Contains(pf.Title, "CloudLinux") {
+			pf.Name = "cloudlinux"
+			return true, nil
+		}
+
+		return false, nil
+	},
+}
+
 // The centos platform resolver finds CentOS and CentOS-like platforms like alma and rocky
 var centos = &PlatformResolver{
 	Name:     "centos",
@@ -1270,7 +1292,9 @@ var redhatFamily = &PlatformResolver{
 	// want to check that platform before redhat. rhcos has the same problem: its
 	// /etc/redhat-release is stock RHEL and its PRETTY_NAME starts with "Red Hat",
 	// so it also has to be resolved before redhat.
-	Children: []*PlatformResolver{oracle, rhcos, rhel, centos, fedora, scientific, eurolinux, nobara, qubes},
+	// NOTE: cloudlinux runs before centos, whose last resort is the mere existence of
+	// /etc/centos-release, which a rebuild may ship for compatibility
+	Children: []*PlatformResolver{oracle, rhcos, rhel, cloudlinux, centos, fedora, scientific, eurolinux, nobara, qubes},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		f, err := conn.FileSystem().Open("/etc/redhat-release")
 		if err != nil {

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -272,6 +272,28 @@ func TestRhcosUsrLibOsReleaseDetector(t *testing.T) {
 	assert.Equal(t, []string{"redhat", "linux", "unix", "os"}, di.Family)
 }
 
+func TestCloudLinux9OSDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-cloudlinux-9.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "cloudlinux", di.Name, "os name should be identified")
+	assert.Equal(t, "CloudLinux 9.6 (Vladimir Lyakhov)", di.Title, "os title should be identified")
+	assert.Equal(t, "9.6", di.Version, "os version should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"redhat", "linux", "unix", "os"}, di.Family)
+}
+
+// A host with no /etc/os-release still reaches the resolver with the title the
+// redhat family parsed out of /etc/redhat-release ("CloudLinux release 9.6
+// (Vladimir Lyakhov)" yields the title "CloudLinux").
+func TestCloudLinuxDetectFromReleaseTitle(t *testing.T) {
+	pf := &inventory.Platform{Title: "CloudLinux"}
+	detected, err := cloudlinux.Detect(cloudlinux, pf, nil)
+	assert.NoError(t, err)
+	assert.True(t, detected, "cloudlinux should be detected from the release title")
+	assert.Equal(t, "cloudlinux", pf.Name, "os name should be set")
+}
+
 func TestUbuntu1204Detector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-ubuntu1204.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/device_type_test.go
+++ b/providers/os/detector/device_type_test.go
@@ -819,6 +819,8 @@ func TestDetectDeviceType_EnterpriseLinux(t *testing.T) {
 	}{
 		// detect-eurolinux-9.toml
 		{"eurolinux 9", "eurolinux", "EuroLinux 9.1 (Stockholm)", []string{"redhat", "linux", "unix", "os"}},
+		// detect-cloudlinux-9.toml
+		{"cloudlinux 9", "cloudlinux", "CloudLinux 9.6 (Vladimir Lyakhov)", []string{"redhat", "linux", "unix", "os"}},
 		// detect-scientific.toml
 		{"scientific linux", "scientific", "Scientific Linux CERN SLC", []string{"redhat", "linux", "unix", "os"}},
 		// detect-centos-9-stream.toml

--- a/providers/os/detector/testdata/detect-cloudlinux-9.toml
+++ b/providers/os/detector/testdata/detect-cloudlinux-9.toml
@@ -1,0 +1,23 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[files."/etc/redhat-release"]
+content = "CloudLinux release 9.6 (Vladimir Lyakhov)"
+
+[files."/etc/os-release"]
+content = """
+NAME="CloudLinux"
+VERSION="9.6 (Vladimir Lyakhov)"
+ID="cloudlinux"
+ID_LIKE="rhel fedora centos"
+VERSION_ID="9.6"
+PLATFORM_ID="platform:el9"
+PRETTY_NAME="CloudLinux 9.6 (Vladimir Lyakhov)"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:cloudlinux:cloudlinux:9.6:GA:server"
+HOME_URL="https://www.cloudlinux.com/"
+BUG_REPORT_URL="https://cloudlinux.zendesk.com/"
+"""


### PR DESCRIPTION
## Symptom

On a live CloudLinux 9 EC2 host (AMI `ami-077bd2c471aad1b78`):

```
$ mql run local -c "packages.length"
0
```

The host has roughly 4250 rpms installed.

## Cause

CloudLinux OS is a RHEL-family rebuild, but `providers/os/detector/detector_all.go`
had no resolver that matched it. `redhatFamily` detects the host correctly from
`/etc/redhat-release`, but none of its children claimed it, so
`resolvePlatform` abandoned the family subtree and the asset landed on the
generic linux platform without `redhat` in its family chain.

Everything gated on `IsFamily("redhat")` goes dead with it. The package manager
switch in `providers/os/resources/packages/packages.go` selects `RpmPkgManager`
off that family, which is why `packages` came back empty; `updates`, `yum` and
the systemd service manager selection key off the same family.

The family assumption is already baked in elsewhere:
`providers/os/resources/services/manager_test.go` has a platform named
`cloudlinux` that expects redhat-family behaviour. Only the resolver was
missing.

## Fix

A `cloudlinux` resolver keyed on the os-release `ID`, with a fallback on the
title the family already parsed out of `/etc/redhat-release` for images that
ship no os-release (the same shape `rhel`, `fedora` and `scientific` use).

It is registered as `{oracle, rhel, cloudlinux, centos, ...}`. `oracle` and
`rhel` cannot fire on CloudLinux (`/etc/oracle-release` is absent and neither
the title nor `/etc/redhat-release` mentions "Red Hat"), but it has to precede
`centos`, whose last resort is the mere existence of `/etc/centos-release`, a
file a rebuild may ship for compatibility.

## Verification

`providers/os/detector/testdata/detect-cloudlinux-9.toml` is captured from that
host's real `/etc/os-release` and `/etc/redhat-release`
(`CloudLinux release 9.6 (Vladimir Lyakhov)`, `ID="cloudlinux"`,
`ID_LIKE="rhel fedora centos"`).

```
$ cd providers/os && go test ./detector/... -count=1
ok  	go.mondoo.com/mql/providers/os/detector	1.372s
ok  	go.mondoo.com/mql/providers/os/detector/windows	1.320s
```

Detection now yields name `cloudlinux`, title `CloudLinux 9.6 (Vladimir Lyakhov)`,
version `9.6`, family `[redhat linux unix os]`.
