### PR TITLE
⭐ os: detect Red Hat Enterprise Linux CoreOS

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -462,6 +462,56 @@ var elxr = &PlatformResolver{
 	},
 }
 
+// rhcos is Red Hat Enterprise Linux CoreOS, the immutable rpm-ostree based RHEL
+// variant that OpenShift runs its nodes on. Its os-release carries ID="rhcos"
+// with ID_LIKE="rhel fedora", and /etc/redhat-release reads like stock RHEL
+// ("Red Hat Enterprise Linux release 9.6 (Plow)"), so os-release ID is the only
+// thing that tells the two apart. It has to be resolved before rhel: the RHCOS
+// PRETTY_NAME starts with "Red Hat", which is enough for the rhel resolver to
+// claim the host and report it as plain redhat.
+var rhcos = &PlatformResolver{
+	Name:     "rhcos",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		if pf.Name != "rhcos" {
+			return false, nil
+		}
+
+		osrd := NewOSReleaseDetector(conn)
+		osr, err := osrd.osrelease()
+		if err != nil {
+			log.Debug().Err(err).Msg("platform> cannot parse os-release on this rhcos system")
+			return true, nil
+		}
+
+		if len(osr["NAME"]) > 0 {
+			// PRETTY_NAME carries the build string too, e.g.
+			// "Red Hat Enterprise Linux CoreOS 9.6.20250523-0"
+			pf.Title = osr["NAME"]
+		}
+
+		// VERSION_ID is the RHCOS image build, not the RHEL release the packages
+		// are cut from. RHEL_VERSION is what package versions and advisories line
+		// up with, so it wins where the image ships it. Without it we keep what
+		// the family already read out of /etc/redhat-release, which is the same
+		// RHEL release.
+		if len(osr["RHEL_VERSION"]) > 0 {
+			pf.Version = osr["RHEL_VERSION"]
+		}
+
+		// the image build is still worth keeping, RHCOS does not ship BUILD_ID
+		if len(osr["OSTREE_VERSION"]) > 0 {
+			pf.Build = osr["OSTREE_VERSION"]
+		}
+
+		if len(osr["OPENSHIFT_VERSION"]) > 0 {
+			pf.Metadata["openshift/version"] = osr["OPENSHIFT_VERSION"]
+		}
+
+		return true, nil
+	},
+}
+
 // rhel PlatformResolver only detects redhat and no derivatives
 var rhel = &PlatformResolver{
 	Name:     "redhat",
@@ -1217,8 +1267,10 @@ var redhatFamily = &PlatformResolver{
 	Name:     "redhat",
 	IsFamily: true,
 	// NOTE: oracle pretends to be redhat with /etc/redhat-release and Red Hat Linux, therefore we
-	// want to check that platform before redhat
-	Children: []*PlatformResolver{oracle, rhel, centos, fedora, scientific, eurolinux, nobara, qubes},
+	// want to check that platform before redhat. rhcos has the same problem: its
+	// /etc/redhat-release is stock RHEL and its PRETTY_NAME starts with "Red Hat",
+	// so it also has to be resolved before redhat.
+	Children: []*PlatformResolver{oracle, rhcos, rhel, centos, fedora, scientific, eurolinux, nobara, qubes},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		f, err := conn.FileSystem().Open("/etc/redhat-release")
 		if err != nil {

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -246,6 +246,32 @@ func TestEuroLinux9OSDetector(t *testing.T) {
 	assert.Equal(t, []string{"redhat", "linux", "unix", "os"}, di.Family)
 }
 
+func TestRhcosDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-rhcos.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "rhcos", di.Name, "os name should be identified")
+	assert.Equal(t, "Red Hat Enterprise Linux CoreOS", di.Title, "os title should be identified")
+	assert.Equal(t, "9.6", di.Version, "os version should be the rhel release, not the image build")
+	assert.Equal(t, "9.6.20250523-0", di.Build, "image build should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"redhat", "linux", "unix", "os"}, di.Family)
+	assert.Equal(t, "4.19", di.Metadata["openshift/version"], "openshift version should be identified")
+}
+
+// rpm-ostree systems ship the real file at /usr/lib/os-release and symlink
+// /etc/os-release at it. Scanning the raw root partition can leave the symlink
+// unresolved, so detection has to work off the /usr/lib copy alone.
+func TestRhcosUsrLibOsReleaseDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-rhcos-usrlib.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "rhcos", di.Name, "os name should be identified")
+	assert.Equal(t, "Red Hat Enterprise Linux CoreOS", di.Title, "os title should be identified")
+	assert.Equal(t, "9.6", di.Version, "os version should be the rhel release, not the image build")
+	assert.Equal(t, []string{"redhat", "linux", "unix", "os"}, di.Family)
+}
+
 func TestUbuntu1204Detector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-ubuntu1204.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/testdata/detect-rhcos-usrlib.toml
+++ b/providers/os/detector/testdata/detect-rhcos-usrlib.toml
@@ -1,0 +1,36 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "5.14.0-570.21.1.el9_6.x86_64"
+
+[files."/etc/redhat-release"]
+content = "Red Hat Enterprise Linux release 9.6 (Plow)"
+
+[files."/usr/lib/os-release"]
+content = """
+NAME="Red Hat Enterprise Linux CoreOS"
+ID="rhcos"
+ID_LIKE="rhel fedora"
+VERSION="9.6.20250523-0"
+VERSION_ID="9.6.20250523-0"
+VARIANT="CoreOS"
+VARIANT_ID=coreos
+PLATFORM_ID="platform:el9"
+PRETTY_NAME="Red Hat Enterprise Linux CoreOS 9.6.20250523-0"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/a:redhat:enterprise_linux:9::coreos"
+HOME_URL="https://www.redhat.com/"
+DOCUMENTATION_URL="https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/"
+BUG_REPORT_URL="https://access.redhat.com/labs/rhir/"
+REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
+REDHAT_BUGZILLA_PRODUCT_VERSION="4.19"
+REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"
+REDHAT_SUPPORT_PRODUCT_VERSION="4.19"
+OPENSHIFT_VERSION="4.19"
+RHEL_VERSION="9.6"
+OSTREE_VERSION="9.6.20250523-0"
+"""

--- a/providers/os/detector/testdata/detect-rhcos.toml
+++ b/providers/os/detector/testdata/detect-rhcos.toml
@@ -1,0 +1,62 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "5.14.0-570.21.1.el9_6.x86_64"
+
+[files."/etc/redhat-release"]
+content = "Red Hat Enterprise Linux release 9.6 (Plow)"
+
+# /etc/os-release is a symlink to ../usr/lib/os-release on rpm-ostree systems
+[files."/etc/os-release"]
+content = """
+NAME="Red Hat Enterprise Linux CoreOS"
+ID="rhcos"
+ID_LIKE="rhel fedora"
+VERSION="9.6.20250523-0"
+VERSION_ID="9.6.20250523-0"
+VARIANT="CoreOS"
+VARIANT_ID=coreos
+PLATFORM_ID="platform:el9"
+PRETTY_NAME="Red Hat Enterprise Linux CoreOS 9.6.20250523-0"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/a:redhat:enterprise_linux:9::coreos"
+HOME_URL="https://www.redhat.com/"
+DOCUMENTATION_URL="https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/"
+BUG_REPORT_URL="https://access.redhat.com/labs/rhir/"
+REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
+REDHAT_BUGZILLA_PRODUCT_VERSION="4.19"
+REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"
+REDHAT_SUPPORT_PRODUCT_VERSION="4.19"
+OPENSHIFT_VERSION="4.19"
+RHEL_VERSION="9.6"
+OSTREE_VERSION="9.6.20250523-0"
+"""
+
+[files."/usr/lib/os-release"]
+content = """
+NAME="Red Hat Enterprise Linux CoreOS"
+ID="rhcos"
+ID_LIKE="rhel fedora"
+VERSION="9.6.20250523-0"
+VERSION_ID="9.6.20250523-0"
+VARIANT="CoreOS"
+VARIANT_ID=coreos
+PLATFORM_ID="platform:el9"
+PRETTY_NAME="Red Hat Enterprise Linux CoreOS 9.6.20250523-0"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/a:redhat:enterprise_linux:9::coreos"
+HOME_URL="https://www.redhat.com/"
+DOCUMENTATION_URL="https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/"
+BUG_REPORT_URL="https://access.redhat.com/labs/rhir/"
+REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
+REDHAT_BUGZILLA_PRODUCT_VERSION="4.19"
+REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"
+REDHAT_SUPPORT_PRODUCT_VERSION="4.19"
+OPENSHIFT_VERSION="4.19"
+RHEL_VERSION="9.6"
+OSTREE_VERSION="9.6.20250523-0"
+"""


### PR DESCRIPTION
Found during a live EC2 validation sweep on RHCOS.

## What's wrong today

Red Hat Enterprise Linux CoreOS is the immutable, rpm-ostree based RHEL variant that OpenShift runs its nodes on. The detector has no resolver for it, so an RHCOS host resolves as plain `redhat`:

- `/etc/redhat-release` on RHCOS reads `Red Hat Enterprise Linux release 9.6 (Plow)` — it never says CoreOS.
- `PRETTY_NAME` starts with `Red Hat`, and the `rhel` resolver matches on exactly that.

The only field that separates the two is os-release `ID="rhcos"` (with `ID_LIKE="rhel fedora"`), so that's what the new resolver keys on.

## Ordering

`rhcos` is registered in `redhatFamily.Children` **before** `rhel`, for the same reason `oracle` already is. `rhel` claims anything whose title contains `Red Hat`, so if it runs first RHCOS is never identified. Flipping the two in the slice locally makes the new test fail with `expected: "rhcos" / actual: "redhat"`, plus an empty `Build` and no `openshift/version` metadata — the resolver is only reachable when it precedes `rhel`.

## Version field

`Version` reports **`RHEL_VERSION`**, not `VERSION_ID`.

On RHCOS `VERSION_ID` is the image build (`9.6.20250523-0`). That string doesn't line up with package NEVRAs or with RHEL advisories, so using it as the platform version would break every version comparison a redhat-family policy makes. `RHEL_VERSION` (`9.6`) is the release the packages are actually cut from, and it agrees with what `redhatFamily` already parses out of `/etc/redhat-release` — so when an older image ships no `RHEL_VERSION`, the value the family read stays in place and is still correct.

The image build isn't discarded: it goes to `Build` (RHCOS ships no `BUILD_ID`, so `OSTREE_VERSION` fills that slot), and `OPENSHIFT_VERSION` lands in metadata as `openshift/version`, which is the fact you actually want when auditing a cluster's nodes.

`Title` comes from `NAME` (`Red Hat Enterprise Linux CoreOS`) rather than `PRETTY_NAME`, which carries the build string — same treatment `flatcar` and `azurelinux` give it.

## os-release on an ostree system

`/etc/os-release` is a symlink to `/usr/lib/os-release` on rpm-ostree systems. `OSReleaseDetector.osrelease()` already falls back to `/usr/lib/os-release` when the `/etc` path can't be opened (added for Bottlerocket), so this works either way. There's a second fixture, `detect-rhcos-usrlib.toml`, that ships only the `/usr/lib` copy to pin that path down.

## Tests

Two fixtures and two tests asserting Name / Title / Version / Build / Arch / Family / metadata.

```
$ cd providers/os && go test ./detector/... -count=1
ok  	go.mondoo.com/mql/providers/os/detector	1.139s
ok  	go.mondoo.com/mql/providers/os/detector/windows	1.277s
```
