### PR TITLE
🐛 os: report an unknown rpm database location instead of zero packages

### DIFF
--- a/providers/os/resources/packages/rpm_packages.go
+++ b/providers/os/resources/packages/rpm_packages.go
@@ -428,9 +428,17 @@ func (rpm *RpmPkgManager) staticList() ([]Package, error) {
 	}
 	var tmpRpmDBFile string
 	var detectedPath string
+	// A path we cannot stat is not fatal on its own -- it just is not the
+	// database -- but if none of the candidates matched, the last failure is the
+	// best explanation we have for why, so keep it instead of dropping it.
+	var lastExistsErr error
 	for i := range files {
 		ok, err := afs.Exists(files[i])
-		if err == nil && ok {
+		if err != nil {
+			lastExistsErr = errors.Wrapf(err, "could not check %s", files[i])
+			continue
+		}
+		if ok {
 			splitPath := strings.Split(files[i], "/")
 			tmpRpmDBFile = filepath.Join(rpmTmpDir, splitPath[len(splitPath)-1])
 			detectedPath = files[i]
@@ -439,7 +447,18 @@ func (rpm *RpmPkgManager) staticList() ([]Package, error) {
 	}
 
 	if len(detectedPath) == 0 {
-		return nil, errors.Wrap(err, "could not find rpm packages location on : "+rpm.platform.Name)
+		// This must be a hard error. Returning no packages and no error reports
+		// an empty inventory for a host with thousands of packages installed,
+		// and every package-based assertion then passes against data that was
+		// never read. Name the paths that were searched so a distro with a
+		// layout we do not know yet (Bottlerocket, for one) is one log line away
+		// from being diagnosed rather than an invisible zero.
+		msg := fmt.Sprintf("could not find the rpm database on %s, searched: %s",
+			rpm.platform.Name, strings.Join(files, ", "))
+		if lastExistsErr != nil {
+			return nil, errors.Wrap(lastExistsErr, msg)
+		}
+		return nil, errors.New(msg)
 	}
 	log.Debug().Str("path", detectedPath).Msg("found rpm packages location")
 

--- a/providers/os/resources/packages/rpm_packages_test.go
+++ b/providers/os/resources/packages/rpm_packages_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
@@ -825,6 +826,80 @@ func TestRpmEpochParityAcrossCollectionPaths(t *testing.T) {
 			// The rpmdb path additionally carries the database as evidence.
 			assert.Equal(t, PkgFilesIncluded, fromDB.FilesAvailable)
 			assert.Equal(t, []FileRecord{{Path: "/var/lib/rpm/rpmdb.sqlite"}}, fromDB.Files)
+		})
+	}
+}
+
+// memFsConnection swaps out only the filesystem of an existing connection, so a
+// test can drive the static-analysis path against an in-memory image layout.
+type memFsConnection struct {
+	shared.Connection
+	fs afero.Fs
+}
+
+func (c *memFsConnection) FileSystem() afero.Fs { return c.fs }
+
+// TestRpmStaticListWithoutDatabaseErrors guards against the silent-zero bug: a
+// host whose rpm database sits at a path we do not know (Bottlerocket, for one)
+// used to come back as (nil, nil) from staticList, because the not-found branch
+// wrapped an `err` that was always nil at that point and Wrap(nil) is nil. The
+// scan then reported zero packages with no failure, and every package assertion
+// passed against an inventory that was never read.
+func TestRpmStaticListWithoutDatabaseErrors(t *testing.T) {
+	base, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/packages_redhat8.toml"))
+	require.NoError(t, err)
+
+	conn := &memFsConnection{Connection: base, fs: afero.NewMemMapFs()}
+
+	pf := &inventory.Platform{
+		Name:    "bottlerocket",
+		Version: "1.20.0",
+		Arch:    "x86_64",
+		Family:  []string{"linux", "unix", "os"},
+	}
+
+	mgr := &RpmPkgManager{conn: conn, platform: pf}
+
+	pkgs, err := mgr.staticList()
+	require.Error(t, err, "a missing rpm database must be an error, never an empty package list")
+	assert.Nil(t, pkgs)
+	assert.Contains(t, err.Error(), "bottlerocket", "the error must name the platform")
+	assert.Contains(t, err.Error(), "/var/lib/rpm/rpmdb.sqlite",
+		"the error must list the paths that were searched")
+}
+
+// TestRpmStaticListFindsDatabaseAtEveryKnownPath pins the candidate list: each
+// documented layout must still be picked up, so the not-found error above only
+// fires for a genuinely unknown one.
+func TestRpmStaticListFindsDatabaseAtEveryKnownPath(t *testing.T) {
+	knownPaths := []string{
+		"/usr/lib/sysimage/rpm/Packages",
+		"/usr/lib/sysimage/rpm/Packages.db",
+		"/usr/lib/sysimage/rpm/rpmdb.sqlite",
+		"/var/lib/rpm/rpmdb.sqlite",
+		"/var/lib/rpm/Packages",
+		"/var/lib/rpm/Packages.db",
+	}
+
+	base, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/packages_redhat8.toml"))
+	require.NoError(t, err)
+
+	pf := &inventory.Platform{Name: "redhat", Version: "8.4", Arch: "x86_64"}
+
+	for _, path := range knownPaths {
+		t.Run(path, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			// Not a real rpm database -- reaching the rpmdb parser at all is
+			// enough to prove the path was detected, since the not-found branch
+			// returns before any of that.
+			require.NoError(t, afero.WriteFile(fs, path, []byte("not-an-rpmdb"), 0o644))
+
+			mgr := &RpmPkgManager{conn: &memFsConnection{Connection: base, fs: fs}, platform: pf}
+
+			_, err := mgr.staticList()
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), "could not find the rpm database",
+				"the database at %s must be detected", path)
 		})
 	}
 }


### PR DESCRIPTION
## The bug

`RpmPkgManager.staticList()` — the static-analysis path used for container images, filesystem and device scans — returned `(nil, nil)` when the rpm database was not at one of the six hard-coded paths.

```go
var detectedPath string
for i := range files {
    ok, err := afs.Exists(files[i])   // <- declares a NEW err, scoped to the loop body
    if err == nil && ok { ...; detectedPath = files[i]; break }
}

if len(detectedPath) == 0 {
    return nil, errors.Wrap(err, "could not find rpm packages location on : "+rpm.platform.Name)
}
```

The `err` on the `errors.Wrap` line is not the loop's error. `ok, err := afs.Exists(...)` declares a fresh `err` inside the loop body; the outer `err` is the one from `os.MkdirTemp` at the top of the function, and that path already returned if it was non-nil — so it is **guaranteed nil** on every path reaching the check. `errors.Wrap(nil, msg)` returns `nil`.

**Observable symptom:** `packages.length` reports **0**, with no error surfaced anywhere. Every package-based assertion then passes on a host with thousands of packages installed, because the inventory it is asserting against was never read. A silent pass is the worst possible outcome here — a failure would at least be visible.

Found on Bottlerocket during a live EC2 validation sweep, where the rpm database is not at any of the listed paths.

## The fix

- Build a real error with `fmt.Errorf`/`errors.New` instead of wrapping a value that is always nil.
- The message names the platform **and** lists every path that was searched, so the next distro with a layout we do not model is one log line away from being diagnosed rather than an invisible zero.
- `afs.Exists` errors were previously swallowed whole (`if err == nil && ok`). A path we cannot stat is not fatal on its own, but if nothing matched it is the best explanation available — the last one is now kept and wrapped into the not-found error.

## Audit of the other `errors.Wrap` sites

`errors.Wrap(nil, ...)` returning nil is a silent-failure generator wherever it appears, so every site in `providers/os/resources/packages/` was checked:

| site | verdict |
|---|---|
| `rpm_packages.go:388` `runtimeList` | guarded by `if err != nil` — safe |
| `rpm_packages.go:403` `runtimeAvailable` | guarded — safe |
| `rpm_packages.go:411` `staticList` MkdirTemp | guarded — safe |
| `rpm_packages.go:442` **not-found branch** | **BUG — fixed here** |
| `rpm_packages.go:448` `fs.Open` | guarded — safe |
| `rpm_packages.go:454` `os.Create` | guarded — safe |
| `rpm_packages.go:561` `dbPathFileRecords` | guarded — safe |
| `windows_packages.go:738,744,757,761` | all guarded — safe |

A wider sweep over the rest of the `os` provider for the same shape (a `Wrap` not immediately preceded by a nil check) turned up no other reachable-with-nil site: `docker_engine/resolver.go:124` is only reached after an `err == nil` early return, `id/awsec2/awsec2.go:33` is inside an `if err != nil`, and `id/vmware/vmtoolsd` deliberately returns a value alongside a possibly-nil wrap.

## Tests

`TestRpmStaticListWithoutDatabaseErrors` drives `staticList` against an empty `afero.NewMemMapFs` and asserts a non-nil error whose message names the platform and the searched paths. Verified to **fail against the pre-fix code** with `An error is expected but got nil` — it reproduces exactly the silent-zero condition — and pass after.

`TestRpmStaticListFindsDatabaseAtEveryKnownPath` pins the candidate list, so the new hard error can only fire for a genuinely unknown layout.

```
$ cd providers/os && go test ./resources/packages/... -count=1
ok      go.mondoo.com/mql/providers/os/resources/packages       2.225s
```
