### PR TITLE
🐛 os: stop reading the apk build timestamp as a package epoch

### DIFF
--- a/providers/os/resources/packages/apk_packages.go
+++ b/providers/os/resources/packages/apk_packages.go
@@ -52,21 +52,14 @@ func ParseApkDbPackages(pf *inventory.Platform, input io.Reader) []Package {
 	pkgs := []Package{}
 
 	var pkgVersion string
-	var pkgEpoch string
 
 	add := func(pkg Package) {
-		// merge version and epoch
-		if pkgEpoch == "0" || pkgEpoch == "" {
-			pkg.Version = pkgVersion
-		} else {
-			pkg.Version = pkgEpoch + ":" + pkgVersion
-			pkg.Epoch = pkgEpoch
-		}
+		// apk has no epoch, so the version is the `V:` field verbatim.
+		pkg.Version = pkgVersion
 
 		pkg.Format = AlpinePkgFormat
 		pkg.PUrl = purl.NewPackageURL(pf, purl.TypeApk, pkg.Name, pkg.Version,
 			purl.WithArch(pkg.Arch),
-			purl.WithEpoch(pkg.Epoch),
 		).String()
 
 		cpes, _ := cpe2.NewPackage2Cpe(pkg.Vendor, pkg.Name, pkg.Version, "", pf.Arch)
@@ -101,7 +94,6 @@ func ParseApkDbPackages(pf *inventory.Platform, input io.Reader) []Package {
 		if len(line) == 0 {
 			add(pkg)
 			// reset values
-			pkgEpoch = ""
 			pkgVersion = ""
 			pkg = Package{}
 		}
@@ -112,7 +104,9 @@ func ParseApkDbPackages(pf *inventory.Platform, input io.Reader) []Package {
 			continue
 		}
 
-		// Parse the package name or version.
+		// Parse the package name or version. The lowercase `t:` field is the
+		// build timestamp of the package, not an epoch, and apk has no epoch
+		// concept at all, so we do not read it.
 		switch key {
 		case 'P':
 			pkg.Name = string(value) // package name
@@ -120,8 +114,6 @@ func ParseApkDbPackages(pf *inventory.Platform, input io.Reader) []Package {
 			pkgVersion = string(value) // package version
 		case 'A':
 			pkg.Arch = string(value) // architecture
-		case 't':
-			pkgEpoch = string(value) // epoch
 		case 'o':
 			pkg.Origin = string(value) // origin
 		case 'T':

--- a/providers/os/resources/packages/apk_packages_test.go
+++ b/providers/os/resources/packages/apk_packages_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/providers/os/connection/mock"
 )
@@ -40,13 +41,12 @@ func TestAlpineApkdbParser(t *testing.T) {
 
 	p := Package{
 		Name:        "musl",
-		Version:     "1510953106:1.1.18-r2",
-		Epoch:       "1510953106",
+		Version:     "1.1.18-r2",
 		Arch:        "x86_64",
 		Description: "the musl c library (libc) implementation",
 		License:     "MIT",
 		Origin:      "musl",
-		PUrl:        "pkg:apk/alpine/musl@1510953106:1.1.18-r2?arch=x86_64&distro=alpine-3.7.0&epoch=1510953106",
+		PUrl:        "pkg:apk/alpine/musl@1.1.18-r2?arch=x86_64&distro=alpine-3.7.0",
 		CPEs: []string{
 			"cpe:2.3:a:*:musl:1.1.18-r2:*:*:*:*:*:x86_64:*",
 		},
@@ -63,12 +63,11 @@ func TestAlpineApkdbParser(t *testing.T) {
 	p = Package{
 		Name:        "libressl2.6-libcrypto",
 		License:     "custom",
-		Version:     "1510257703:2.6.3-r0",
-		Epoch:       "1510257703",
+		Version:     "2.6.3-r0",
 		Arch:        "x86_64",
 		Description: "libressl libcrypto library",
 		Origin:      "libressl",
-		PUrl:        "pkg:apk/alpine/libressl2.6-libcrypto@1510257703:2.6.3-r0?arch=x86_64&distro=alpine-3.7.0&epoch=1510257703",
+		PUrl:        "pkg:apk/alpine/libressl2.6-libcrypto@2.6.3-r0?arch=x86_64&distro=alpine-3.7.0",
 		CPEs: []string{
 			"cpe:2.3:a:*:libressl2.6-libcrypto:2.6.3-r0:*:*:*:*:*:x86_64:*",
 		},
@@ -85,12 +84,11 @@ func TestAlpineApkdbParser(t *testing.T) {
 	p = Package{
 		Name:        "libressl2.6-libssl",
 		License:     "custom",
-		Version:     "1510257703:2.6.3-r0",
-		Epoch:       "1510257703",
+		Version:     "2.6.3-r0",
 		Arch:        "x86_64",
 		Description: "libressl libssl library",
 		Origin:      "libressl",
-		PUrl:        "pkg:apk/alpine/libressl2.6-libssl@1510257703:2.6.3-r0?arch=x86_64&distro=alpine-3.7.0&epoch=1510257703",
+		PUrl:        "pkg:apk/alpine/libressl2.6-libssl@2.6.3-r0?arch=x86_64&distro=alpine-3.7.0",
 		CPEs: []string{
 			"cpe:2.3:a:*:libressl2.6-libssl:2.6.3-r0:*:*:*:*:*:x86_64:*",
 		},
@@ -107,12 +105,11 @@ func TestAlpineApkdbParser(t *testing.T) {
 	p = Package{
 		Name:        "apk-tools",
 		License:     "GPL2",
-		Version:     "1515485577:2.8.2-r0",
-		Epoch:       "1515485577",
+		Version:     "2.8.2-r0",
 		Arch:        "x86_64",
 		Description: "Alpine Package Keeper - package manager for alpine",
 		Origin:      "apk-tools",
-		PUrl:        "pkg:apk/alpine/apk-tools@1515485577:2.8.2-r0?arch=x86_64&distro=alpine-3.7.0&epoch=1515485577",
+		PUrl:        "pkg:apk/alpine/apk-tools@2.8.2-r0?arch=x86_64&distro=alpine-3.7.0",
 		CPEs: []string{
 			"cpe:2.3:a:*:apk-tools:2.8.2-r0:*:*:*:*:*:x86_64:*",
 		},
@@ -129,12 +126,11 @@ func TestAlpineApkdbParser(t *testing.T) {
 	p = Package{
 		Name:        "busybox",
 		License:     "GPL2",
-		Version:     "1513075346:1.27.2-r7",
-		Epoch:       "1513075346",
+		Version:     "1.27.2-r7",
 		Arch:        "x86_64",
 		Description: "Size optimized toolbox of many common UNIX utilities",
 		Origin:      "busybox",
-		PUrl:        "pkg:apk/alpine/busybox@1513075346:1.27.2-r7?arch=x86_64&distro=alpine-3.7.0&epoch=1513075346",
+		PUrl:        "pkg:apk/alpine/busybox@1.27.2-r7?arch=x86_64&distro=alpine-3.7.0",
 		CPEs: []string{
 			"cpe:2.3:a:*:busybox:1.27.2-r7:*:*:*:*:*:x86_64:*",
 		},
@@ -151,12 +147,11 @@ func TestAlpineApkdbParser(t *testing.T) {
 	p = Package{
 		Name:        "alpine-baselayout",
 		License:     "GPL2",
-		Version:     "1510075862:3.0.5-r2",
-		Epoch:       "1510075862",
+		Version:     "3.0.5-r2",
 		Arch:        "x86_64",
 		Description: "Alpine base dir structure and init scripts",
 		Origin:      "alpine-baselayout",
-		PUrl:        "pkg:apk/alpine/alpine-baselayout@1510075862:3.0.5-r2?arch=x86_64&distro=alpine-3.7.0&epoch=1510075862",
+		PUrl:        "pkg:apk/alpine/alpine-baselayout@3.0.5-r2?arch=x86_64&distro=alpine-3.7.0",
 		CPEs: []string{
 			"cpe:2.3:a:*:alpine-baselayout:3.0.5-r2:*:*:*:*:*:x86_64:*",
 		},
@@ -167,6 +162,70 @@ func TestAlpineApkdbParser(t *testing.T) {
 		},
 	}
 	assert.Equal(t, p, findPkg(m, p.Name), p.Name)
+}
+
+// TestApkBuildTimestampIsNotAnEpoch pins the lowercase `t:` field of the apk
+// database as the package build timestamp rather than an epoch. apk has no
+// epoch concept, so `t:` must never reach the version, the epoch or the package
+// URL. The records below are taken from an Alpine 3.23.5 host, where every one
+// of the 235 installed packages reported a timestamp-prefixed version.
+func TestApkBuildTimestampIsNotAnEpoch(t *testing.T) {
+	pf := &inventory.Platform{
+		Name:    "alpine",
+		Version: "3.23.5",
+		Arch:    "x86_64",
+		Family:  []string{"linux", "unix", "os"},
+		Labels: map[string]string{
+			"distro-id": "alpine",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		version   string
+		timestamp string
+	}{
+		{"busybox", "1.37.0-r30", "1765894768"},
+		{"musl", "1.2.5-r23", "1775835052"},
+		{"apk-tools", "3.0.6-r0", "1776175586"},
+		{"nginx", "1.28.3-r7", "1784813488"},
+	}
+
+	var db bytes.Buffer
+	for _, test := range tests {
+		db.WriteString("P:" + test.name + "\n")
+		db.WriteString("V:" + test.version + "\n")
+		db.WriteString("A:x86_64\n")
+		db.WriteString("o:" + test.name + "\n")
+		db.WriteString("t:" + test.timestamp + "\n")
+		db.WriteString("\n")
+	}
+
+	pkgs := ParseApkDbPackages(pf, bytes.NewReader(db.Bytes()))
+	require.Len(t, pkgs, len(tests))
+
+	for i, test := range tests {
+		pkg := pkgs[i]
+		require.Equal(t, test.name, pkg.Name)
+
+		// the version is the `V:` field verbatim, with no timestamp prefix
+		assert.Equal(t, test.version, pkg.Version, "version of %s", test.name)
+
+		// apk has no epoch, so nothing may be reported as one
+		assert.Empty(t, pkg.Epoch, "epoch of %s", test.name)
+
+		// and neither the timestamp nor an epoch qualifier reaches the purl
+		assert.Equal(t,
+			"pkg:apk/alpine/"+test.name+"@"+test.version+"?arch=x86_64&distro=alpine-3.23.5",
+			pkg.PUrl, "purl of %s", test.name)
+		assert.NotContains(t, pkg.PUrl, test.timestamp, "purl of %s carries the build timestamp", test.name)
+		assert.NotContains(t, pkg.PUrl, "epoch=", "purl of %s carries an epoch qualifier", test.name)
+
+		// the cpe is built from the same version
+		assert.Equal(t,
+			[]string{"cpe:2.3:a:*:" + test.name + ":" + test.version + ":*:*:*:*:*:x86_64:*"},
+			pkg.CPEs, "cpes of %s", test.name)
+	}
 }
 
 func TestApkUpdateParser(t *testing.T) {


### PR DESCRIPTION
## The bug

The apk installed database (`/lib/apk/db/installed`) uses the lowercase `t:` field for the **build timestamp** of a package, a unix seconds value. **apk has no epoch concept at all** — uppercase `T:` is the description and `V:` is the version.

`ParseApkDbPackages` read `t:` into `pkgEpoch`:

```go
case 't':
    pkgEpoch = string(value) // epoch
```

and the `add()` closure then took its `pkgEpoch != "" && pkgEpoch != "0"` branch and prefixed the timestamp onto the version. Practically every record in a modern apk database carries a `t:` field, so this fired for **every package on every Alpine, Wolfi and Chainguard asset**.

`add()` sets `pkg.Version` *before* deriving the identifiers, so the damage reached the package URL and the epoch field too.

## Confirmed live on Alpine 3.23.5 (EC2)

All 235 installed packages were affected.

| package | truth (`apk info -v`) | mql `version` before | mql `version` after |
|---|---|---|---|
| busybox | `1.37.0-r30` | `1765894768:1.37.0-r30` | `1.37.0-r30` |
| musl | `1.2.5-r23` | `1775835052:1.2.5-r23` | `1.2.5-r23` |
| apk-tools | `3.0.6-r0` | `1776175586:3.0.6-r0` | `3.0.6-r0` |
| nginx | `1.28.3-r7` | `1784813488:1.28.3-r7` | `1.28.3-r7` |

The raw record confirms the source: `P:nginx`, `V:1.28.3-r7`, `t:1784813488`. The distinct `t:` values are plainly timestamps (`1583171707` = 2020-03-02).

Blast radius per package:

| field | before | after |
|---|---|---|
| `version` | `1784813488:1.28.3-r7` | `1.28.3-r7` |
| `epoch` | `1784813488` | empty |
| `purl` | `pkg:apk/alpine/nginx@1784813488:1.28.3-r7?arch=x86_64&distro=alpine-3.23.5&epoch=1784813488` | `pkg:apk/alpine/nginx@1.28.3-r7?arch=x86_64&distro=alpine-3.23.5` |
| `cpes` | already correct | unchanged |

## Impact on vulnerability matching

Advisory matching for apk keys off the **version**, the **purl** and the **epoch**, and all three were wrong for every package on every Alpine, Wolfi and Chainguard asset. A purl of `pkg:apk/alpine/nginx@1784813488:1.28.3-r7` does not equal the `pkg:apk/alpine/nginx@1.28.3-r7` an advisory carries, and a version comparison against a range such as `< 1.28.3-r7` is being handed a ten-digit epoch that dominates the ordering. Because the timestamp is per-package and monotonically recent, the corrupted version sorts *above* essentially every advisory bound — so the failure mode is a **false negative**: vulnerable apk packages silently reported as unaffected.

The **CPEs escaped**. `cpe.NewPackage2Cpe` strips a leading `\d+:` epoch before building the WFN, so the CPE was generated from the bare version. That is also why the pre-existing test's CPE assertions were the only ones that were right.

## The fix

`pkg.Version` is now the `V:` field verbatim, `Epoch` stays empty, no `epoch=` purl qualifier is emitted, and `t:` is no longer read at all.

`t:` is **not** mapped anywhere else. The `Package` struct has no build-time field, and `InstallDate` would be the wrong home for it — a build time is not an install time, and its doc comment already lists apk as a backend that does not surface install time. Adding a schema field is out of scope for a bugfix.

## Other package managers

I audited every parser in `providers/os/resources/packages/` for the same shape of defect — a source field mapped onto a semantically different `Package` field, a timestamp read into a non-time field, or a build time read into `InstallDate`. **apk was the only one.** rpm takes a real `%{EPOCH}` and normalizes `0`/`(none)`; dpkg, opkg and pacman carry the epoch inside the version string as the format intends; `InstallDate` is only ever set from genuine install times (`%{INSTALLTIME}` on rpm, the MSI `InstallDate` on Windows).

One adjacent, *inverse-shape* observation, left alone here as out of scope: `dpkg_packages.go` feeds `pkg.Epoch` into the purl and both CPE builds, but nothing ever assigns it — so deb epochs stay baked into the version literal while the purl reports none. That is a deliberate-decision question rather than a regression, and it does not corrupt anything the way this did.

## Tests

The **existing fixture test asserted the bug**. `TestAlpineApkdbParser` pinned `Version: "1510953106:1.1.18-r2"`, `Epoch: "1510953106"` and an `&epoch=1510953106` purl qualifier for all six of its packages. Those assertions were wrong and are corrected here — the fixture's `t:` values were already realistic, so it reproduced the regression faithfully all along.

Added `TestApkBuildTimestampIsNotAnEpoch`, built from the four live Alpine 3.23.5 records above so the test documents the actual regression. It asserts, per package, that the version is the bare `V:` value, that `Epoch` is empty, that the purl carries neither the timestamp nor an `epoch=` qualifier, and that the CPE uses the same bare version.

Verified the new test fails against the pre-fix parser with exactly the live symptom:

```
Error: Not equal:
       expected: "1.37.0-r30"
       actual  : "1765894768:1.37.0-r30"
Error: Should be empty, but was 1765894768
Error: Not equal:
       expected: "pkg:apk/alpine/busybox@1.37.0-r30?arch=x86_64&distro=alpine-3.23.5"
       actual  : "pkg:apk/alpine/busybox@1765894768:1.37.0-r30?arch=x86_64&distro=alpine-3.23.5&epoch=1765894768"
```

`cd providers/os && go test ./resources/packages/... -count=1` passes.

## Provenance

Long-standing. It predates the #9879 regexp refactor, which only moved the `case "t"` line.
