### PR TITLE
🐛 os: emit whole-disk filesystems from lsblk.list

### DIFF
--- a/providers/os/resources/lsblk.go
+++ b/providers/os/resources/lsblk.go
@@ -34,24 +34,50 @@ func (l *mqlLsblk) list() ([]any, error) {
 	}
 
 	mqlBlockEntries := []any{}
-	for i := range blockEntries.Blockdevices {
-		d := blockEntries.Blockdevices[i]
-		for i := range d.Children {
-			entry := d.Children[i]
-			mqlLsblkEntry, err := CreateResource(l.MqlRuntime, "lsblk.entry", map[string]*llx.RawData{
-				"name":        llx.StringData(entry.Name),
-				"fstype":      llx.StringData(entry.Fstype),
-				"label":       llx.StringData(entry.Label),
-				"uuid":        llx.StringData(entry.Uuid),
-				"mountpoints": llx.ArrayData(entry.Mountpoints, types.String),
-			})
-			if err != nil {
-				return nil, err
-			}
-			mqlBlockEntries = append(mqlBlockEntries, mqlLsblkEntry)
+	for _, entry := range filesystemDevices(blockEntries.Blockdevices) {
+		mqlLsblkEntry, err := CreateResource(l.MqlRuntime, "lsblk.entry", map[string]*llx.RawData{
+			"name":        llx.StringData(entry.Name),
+			"fstype":      llx.StringData(entry.Fstype),
+			"label":       llx.StringData(entry.Label),
+			"uuid":        llx.StringData(entry.Uuid),
+			"mountpoints": llx.ArrayData(entry.Mountpoints, types.String),
+		})
+		if err != nil {
+			return nil, err
 		}
+		mqlBlockEntries = append(mqlBlockEntries, mqlLsblkEntry)
 	}
 	return mqlBlockEntries, nil
+}
+
+// carriesFilesystem reports whether a block device holds a filesystem of its
+// own rather than only acting as a container for the devices stacked on top of
+// it. A disk that merely carries a partition table reports no fstype, no
+// mountpoint and a list of children, and is skipped in favor of its partitions.
+// A disk whose filesystem sits directly on it has no children at all, and a
+// stacking member (LVM2_member, crypto_LUKS, linux_raid_member) reports its own
+// fstype next to its children.
+func (d blockdevice) carriesFilesystem() bool {
+	return len(d.Children) == 0 || d.Fstype != "" || len(d.Mountpoints) > 0
+}
+
+// filesystemDevices walks the block device tree depth-first and returns every
+// device that carries a filesystem of its own. Walking the whole tree keeps
+// devices that sit more than one level deep (disk -> partition -> crypt -> lvm)
+// reachable.
+func filesystemDevices(devices []blockdevice) []blockdevice {
+	res := []blockdevice{}
+	var walk func(devices []blockdevice)
+	walk = func(devices []blockdevice) {
+		for i := range devices {
+			if devices[i].carriesFilesystem() {
+				res = append(res, devices[i])
+			}
+			walk(devices[i].Children)
+		}
+	}
+	walk(devices)
+	return res
 }
 
 func parseBlockEntries(data []byte) (blockdevices, error) {
@@ -60,27 +86,32 @@ func parseBlockEntries(data []byte) (blockdevices, error) {
 		return blockEntries, err
 	}
 
-	for i := range blockEntries.Blockdevices {
-		d := blockEntries.Blockdevices[i]
-		for j := range d.Children {
-			entry := d.Children[j]
-			// Some versions of the lsblk return [null] instead of empty array
-			entry.Mountpoints = slices.Collect(func(yield func(any) bool) {
-				for _, m := range entry.Mountpoints {
-					if m != nil && !yield(m) {
-						return
-					}
-				}
-			})
-			// Some versions of the lsblk return the mountpoint instead of the mountpoints array
-			if len(entry.Mountpoints) == 0 && entry.Mountpoint != "" {
-				entry.Mountpoints = append(entry.Mountpoints, entry.Mountpoint)
-			}
-			blockEntries.Blockdevices[i].Children[j] = entry
-		}
-	}
+	normalizeMountpoints(blockEntries.Blockdevices)
 
 	return blockEntries, nil
+}
+
+// normalizeMountpoints reconciles the mountpoint shapes across lsblk versions
+// for every device in the tree.
+func normalizeMountpoints(devices []blockdevice) {
+	for i := range devices {
+		entry := devices[i]
+		// Some versions of the lsblk return [null] instead of empty array
+		entry.Mountpoints = slices.Collect(func(yield func(any) bool) {
+			for _, m := range entry.Mountpoints {
+				if m != nil && !yield(m) {
+					return
+				}
+			}
+		})
+		// Some versions of the lsblk return the mountpoint instead of the mountpoints array
+		if len(entry.Mountpoints) == 0 && entry.Mountpoint != "" {
+			entry.Mountpoints = append(entry.Mountpoints, entry.Mountpoint)
+		}
+		devices[i] = entry
+
+		normalizeMountpoints(devices[i].Children)
+	}
 }
 
 func (l *mqlLsblkEntry) id() (string, error) {

--- a/providers/os/resources/lsblk_test.go
+++ b/providers/os/resources/lsblk_test.go
@@ -114,13 +114,13 @@ func TestParseBlockEntries(t *testing.T) {
 		Fstype:      "btrfs",
 		Label:       "storage01",
 		Uuid:        "6060df9a-7e53-439c-9189-ba9657161fd4",
-		Mountpoints: []any{nil},
+		Mountpoints: nil,
 	}, {
 		Name:        "sdc",
 		Fstype:      "",
 		Label:       "",
 		Uuid:        "",
-		Mountpoints: []any{nil},
+		Mountpoints: nil,
 		Children: []blockdevice{{
 			Name:        "sdc1",
 			Fstype:      "vfat",
@@ -139,7 +139,7 @@ func TestParseBlockEntries(t *testing.T) {
 		Fstype:      "btrfs",
 		Label:       "storage01",
 		Uuid:        "6060df9a-7e53-439c-9189-ba9657161fd4",
-		Mountpoints: []any{nil},
+		Mountpoints: nil,
 	}}, devices.Blockdevices)
 
 	data = `{
@@ -166,4 +166,128 @@ func TestParseBlockEntries(t *testing.T) {
 			Mountpoints: []any{"/"},
 		}},
 	}})
+}
+
+func TestParseBlockEntriesEmpty(t *testing.T) {
+	devices, err := parseBlockEntries([]byte(`{"blockdevices": []}`))
+	assert.Nil(t, err)
+	assert.Empty(t, devices.Blockdevices)
+	assert.Empty(t, filesystemDevices(devices.Blockdevices))
+}
+
+func TestFilesystemDevices(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		// expected device names, in the order they are emitted
+		expected []string
+	}{
+		{
+			// The root filesystem sits directly on an unpartitioned disk, so
+			// lsblk reports a single device with no children at all. Alpine
+			// 3.23.5 on EC2, util-linux lsblk 2.41.4.
+			name:     "filesystem on the whole disk",
+			data:     `{"blockdevices":[{"name":"nvme0n1","fstype":null,"fsavail":"17.1G","mountpoints":["/"]}]}`,
+			expected: []string{"nvme0n1"},
+		},
+		{
+			// The disk only carries a partition table, so it is skipped in
+			// favor of the partition that holds the filesystem.
+			name: "filesystem on a partition",
+			data: `{"blockdevices":[
+				{"name":"nvme0n1","fstype":null,"mountpoints":[null],"children":[
+					{"name":"nvme0n1p1","fstype":"ext4","uuid":"6c44ec5a-4727-47d4-b485-81cff72b207e","mountpoints":["/"]}
+				]}
+			]}`,
+			expected: []string{"nvme0n1p1"},
+		},
+		{
+			// disk -> partition -> crypt -> lvm. Every stacking member reports
+			// an fstype of its own, and the leaf volumes hold the filesystems.
+			name: "stacked luks and lvm volumes",
+			data: `{"blockdevices":[
+				{"name":"sda","fstype":null,"mountpoints":[null],"children":[
+					{"name":"sda1","fstype":"vfat","mountpoints":["/boot"]},
+					{"name":"sda2","fstype":"crypto_LUKS","mountpoints":[null],"children":[
+						{"name":"cryptroot","fstype":"LVM2_member","mountpoints":[null],"children":[
+							{"name":"vg-root","fstype":"ext4","mountpoints":["/"]},
+							{"name":"vg-swap","fstype":"swap","mountpoints":["[SWAP]"]}
+						]}
+					]}
+				]}
+			]}`,
+			expected: []string{"sda1", "sda2", "cryptroot", "vg-root", "vg-swap"},
+		},
+		{
+			name:     "no block devices",
+			data:     `{"blockdevices":[]}`,
+			expected: []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			devices, err := parseBlockEntries([]byte(test.data))
+			assert.Nil(t, err)
+
+			names := []string{}
+			for _, d := range filesystemDevices(devices.Blockdevices) {
+				names = append(names, d.Name)
+			}
+			assert.Equal(t, test.expected, names)
+		})
+	}
+}
+
+func TestFilesystemDevicesWholeDiskMountpoint(t *testing.T) {
+	data := `{"blockdevices":[{"name":"nvme0n1","fstype":null,"fsavail":"17.1G","mountpoints":["/"]}]}`
+
+	devices, err := parseBlockEntries([]byte(data))
+	assert.Nil(t, err)
+
+	entries := filesystemDevices(devices.Blockdevices)
+	assert.Equal(t, 1, len(entries))
+	assert.Equal(t, "nvme0n1", entries[0].Name)
+	assert.Equal(t, []any{"/"}, entries[0].Mountpoints)
+}
+
+func TestFilesystemDevicesMixedTopLevel(t *testing.T) {
+	// Unpartitioned data disks alongside a partitioned system disk: the data
+	// disks are emitted, the partition table holder is not.
+	data := `{"blockdevices":[
+		{"name":"loop0","fstype":"squashfs","mountpoints":["/var/lib/snapd/snap/core/10577"]},
+		{"name":"sda","fstype":"btrfs","label":"storage01","mountpoints":["/data"]},
+		{"name":"sdb","fstype":"btrfs","label":"storage01","mountpoints":[null]},
+		{"name":"sdc","fstype":null,"mountpoints":[null],"children":[
+			{"name":"sdc1","fstype":"vfat","mountpoints":["/boot"]},
+			{"name":"sdc2","fstype":"ext4","mountpoints":["/"]}
+		]}
+	]}`
+
+	devices, err := parseBlockEntries([]byte(data))
+	assert.Nil(t, err)
+
+	names := []string{}
+	for _, d := range filesystemDevices(devices.Blockdevices) {
+		names = append(names, d.Name)
+	}
+	assert.Equal(t, []string{"loop0", "sda", "sdb", "sdc1", "sdc2"}, names)
+}
+
+func TestNormalizeMountpointsNested(t *testing.T) {
+	// The single-mountpoint form has to be reconciled at every level of the
+	// tree, not just for the direct children of a disk.
+	data := `{"blockdevices":[
+		{"name":"sda","fstype":null,"mountpoint":null,"children":[
+			{"name":"sda1","fstype":"LVM2_member","mountpoint":null,"children":[
+				{"name":"vg-root","fstype":"xfs","mountpoint":"/"}
+			]}
+		]}
+	]}`
+
+	devices, err := parseBlockEntries([]byte(data))
+	assert.Nil(t, err)
+	assert.Empty(t, devices.Blockdevices[0].Mountpoints)
+	assert.Empty(t, devices.Blockdevices[0].Children[0].Mountpoints)
+	assert.Equal(t, []any{"/"}, devices.Blockdevices[0].Children[0].Children[0].Mountpoints)
 }

--- a/providers/os/resources/luks.go
+++ b/providers/os/resources/luks.go
@@ -34,10 +34,9 @@ func (l *mqlLuks) id() (string, error) {
 var validDevicePath = regexp.MustCompile(`^/dev/[A-Za-z0-9._/=:+@-]+$`)
 
 func (l *mqlLuks) volumes() ([]any, error) {
-	// Walk the lsblk tree ourselves instead of reusing the `lsblk`
-	// resource: `lsblk.list` only enumerates direct children of each
-	// top-level disk, so whole-disk LUKS volumes (LUKS formatted
-	// directly on `/dev/sdb`, not on `/dev/sdb1`) would be missed.
+	// Run lsblk ourselves instead of reusing the `lsblk` resource:
+	// `cryptsetup luksDump` needs a device path, and only `--paths`
+	// yields the canonical `/dev/...` form.
 	o, err := CreateResource(l.MqlRuntime, "command", map[string]*llx.RawData{
 		"command": llx.StringData("lsblk --json --fs --paths"),
 	})
@@ -166,10 +165,9 @@ func (v *mqlLuksVolume) id() (string, error) {
 }
 
 func (v *mqlLuksVolume) blockDevice() (*mqlLsblkEntry, error) {
-	// Best-effort lookup against the `lsblk` resource — works for the
-	// common LUKS-on-partition layout. For LUKS volumes that don't
-	// appear in lsblk's flattened list (whole-disk LUKS, some mapper
-	// targets), we report a null reference rather than fabricating one.
+	// Best-effort lookup against the `lsblk` resource. For LUKS volumes
+	// that don't appear in its list, we report a null reference rather
+	// than fabricating one.
 	lsblkRes, err := CreateResource(v.MqlRuntime, "lsblk", map[string]*llx.RawData{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## The bug

`lsblk.list` returns an **empty list** on any host whose filesystem sits directly on an
unpartitioned disk. No error, no warning, no log line: the query just comes back `[]`.

The accessor only ever emitted the *children* of each top-level block device:

```go
for i := range blockEntries.Blockdevices {
    d := blockEntries.Blockdevices[i]
    for i := range d.Children {   // the top-level device is never emitted
        ...
    }
}
```

When the root filesystem lives on the whole disk with no partition table, `lsblk --json --fs`
returns a single device with no `children` key at all. Confirmed live on Alpine 3.23.5 in EC2
with util-linux `lsblk` 2.41.4 (not busybox), which reports the layout correctly:

```json
{"blockdevices":[{"name":"nvme0n1","fstype":null,"fsavail":"17.1G","mountpoints":["/"]}]}
```

Every distro validated so far partitions its root disk (`nvme0n1p1`, a child), which is why this
never surfaced. It affects any whole-disk-filesystem layout, which is common on minimal cloud
images and container hosts, and it also hides unpartitioned data disks (a btrfs volume mounted
straight from `/dev/sdb`) on otherwise-working hosts.

## The emit rule

A device is emitted when it **carries a filesystem of its own**:

```go
len(d.Children) == 0 || d.Fstype != "" || len(d.Mountpoints) > 0
```

The rationale is the shape of `lsblk --fs` output. A disk that merely holds a partition table
reports `fstype: null`, no mountpoint, and a list of children, so it is skipped in favor of its
partitions and **a normal partitioned host produces byte-identical output to today**. A disk whose
filesystem sits directly on it has no children at all. A stacking member (`LVM2_member`,
`crypto_LUKS`, `linux_raid_member`) reports its own fstype alongside its children, and those rows
were already emitted before this change.

Emitting every parent unconditionally was the other option and was rejected: it would add a
spurious `nvme0n1` row to every currently-working asset and could break existing policies.

## Nested stacks were dropped too

`blockdevice.Children` is recursive (`Children []blockdevice`), but both the accessor and
`parseBlockEntries` only ever looked one level down. A `disk -> partition -> crypt -> lvm` stack
therefore lost every device below the partition, and the mountpoint normalization (the `[null]`
and singular-`mountpoint` compatibility shims for older lsblk versions) never reached them either.
Both are now depth-first walks over the whole tree, so the LVM-on-LUKS volumes that actually hold
the filesystems are reported, with their mountpoints normalized like every other row.

The `luks` resource had already worked around the one-level limitation with its own recursive
walk; its comments saying `lsblk.list` only enumerates direct children are now stale and have been
corrected. It still shells out itself, because `cryptsetup luksDump` needs the `--paths` form of
the device name.

## Also

- The inner loop shadowed the outer loop variable (`for i := range d.Children` inside
  `for i := range blockEntries.Blockdevices`). Harmless as written, gone now.

## Tests

Per CLAUDE.md §3.6, the parse plus emit rule is exactly the pure Go logic the gate targets, so the
emit rule was extracted into `filesystemDevices` / `carriesFilesystem` and tested directly, no live
connection needed:

- the real Alpine whole-disk JSON above: one entry, name `nvme0n1`, mountpoint `/` (the regression)
- a normal partitioned layout: only `nvme0n1p1`, the parent not emitted
- a `disk -> vfat + crypto_LUKS -> LVM2_member -> ext4/swap` stack: every level below the partition
  now reachable
- empty `blockdevices`: empty list, no error
- mixed top level: unpartitioned data disks emitted, the partition-table holder not
- nested mountpoint normalization: the singular `mountpoint` form reconciled at every depth

The pre-existing `TestParseBlockEntries` expectations changed in one way: top-level devices now get
the same `[null]` mountpoint normalization the children always got. That normalization is required
now that top-level devices can be emitted, otherwise a `[null]` mountpoints array would reach
`llx.ArrayData` as a null element in a string array.
