### PR TITLE
🐛 os: grub.config.passwordProtected trusted a template as a password

### DIFF
--- a/providers/os/resources/grub.go
+++ b/providers/os/resources/grub.go
@@ -5,8 +5,10 @@ package resources
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"io"
+	"path"
 	"regexp"
 	"strings"
 	"sync"
@@ -51,6 +53,7 @@ var grubCfgPaths = []string{
 type mqlGrubConfigInternal struct {
 	lock              sync.Mutex
 	fetched           bool
+	cachedGrubFound   bool
 	cachedEntries     []GrubEntry
 	cachedPwProtected bool
 }
@@ -106,8 +109,8 @@ func (g *mqlGrubConfig) id() (string, error) {
 }
 
 func (g *mqlGrubConfig) params() (map[string]any, error) {
-	path := g.GetDefaultsPath().Data
-	if path == "" {
+	defaultsPath := g.GetDefaultsPath().Data
+	if defaultsPath == "" {
 		return map[string]any{}, nil
 	}
 
@@ -120,7 +123,7 @@ func (g *mqlGrubConfig) params() (map[string]any, error) {
 		return nil, errors.New("filesystem not available")
 	}
 
-	f, err := fs.Open(path)
+	f, err := fs.Open(defaultsPath)
 	if err != nil {
 		return nil, err
 	}
@@ -150,8 +153,8 @@ func (g *mqlGrubConfig) fetchGrubCfg() error {
 		return nil
 	}
 
-	path := g.GetGrubPath().Data
-	if path == "" {
+	cfgPath := g.GetGrubPath().Data
+	if cfgPath == "" {
 		g.fetched = true
 		return nil
 	}
@@ -165,7 +168,7 @@ func (g *mqlGrubConfig) fetchGrubCfg() error {
 		return errors.New("filesystem not available")
 	}
 
-	f, err := fs.Open(path)
+	f, err := fs.Open(cfgPath)
 	if err != nil {
 		return err
 	}
@@ -181,8 +184,20 @@ func (g *mqlGrubConfig) fetchGrubCfg() error {
 		return err
 	}
 
+	pwCfg := ParseGrubPasswordConfig(content)
+	protected := pwCfg.Protected()
+	// RHEL-family grub.cfg files carry a templated 01_users block whose
+	// credential is read from ${prefix}/user.cfg at boot. When grub.cfg only
+	// references those variables, the credential itself lives in user.cfg.
+	if !protected && pwCfg.ReferencesVars() {
+		if vars := readGrubUserCfg(fs, cfgPath); vars != nil {
+			protected = pwCfg.ProtectedWith(vars)
+		}
+	}
+
 	g.cachedEntries = entries
-	g.cachedPwProtected = ParseGrubPasswordProtected(content)
+	g.cachedPwProtected = protected
+	g.cachedGrubFound = true
 	g.fetched = true
 	return nil
 }
@@ -214,6 +229,14 @@ func (g *mqlGrubConfig) entries() ([]any, error) {
 func (g *mqlGrubConfig) passwordProtected() (bool, error) {
 	if err := g.fetchGrubCfg(); err != nil {
 		return false, err
+	}
+	if !g.cachedGrubFound {
+		// No grub.cfg exists in any known location, so the host either boots
+		// with a different bootloader or keeps its configuration somewhere we
+		// cannot see. Reporting false there would read as "GRUB is installed
+		// and has no password", which is a finding we have not made.
+		g.PasswordProtected.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
 	}
 	return g.cachedPwProtected, nil
 }
@@ -361,13 +384,152 @@ func ParseGrubCfgEntries(r io.Reader) ([]GrubEntry, error) {
 }
 
 var (
-	reSuperusers = regexp.MustCompile(`(?m)^\s*set\s+superusers\s*=`)
-	rePassword   = regexp.MustCompile(`(?m)^\s*password(?:_pbkdf2)?\s+`)
+	reSuperusers = regexp.MustCompile(`^set\s+superusers\s*=\s*(.*)$`)
+	rePassword   = regexp.MustCompile(`^password(?:_pbkdf2)?\s+(.*)$`)
+	// reShellVar matches an unexpanded shell variable reference, such as
+	// ${GRUB2_PASSWORD} or $GRUB2_PASSWORD.
+	reShellVar = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)`)
 )
 
+// GrubPasswordConfig captures what a grub.cfg states about password protection.
+// The distinction that matters is whether the superuser list and the credential
+// are literal values or unexpanded shell variables: every RHEL-family grub.cfg
+// carries a templated `password_pbkdf2 root ${GRUB2_PASSWORD}` block emitted by
+// /etc/grub.d/01_users, and on a host without a GRUB password that variable is
+// never defined.
+type GrubPasswordConfig struct {
+	// SuperusersLiteral is true when a `set superusers=` directive assigns a
+	// literal, non-empty user list.
+	SuperusersLiteral bool
+	// SuperusersVars holds the variable names a `set superusers=` directive
+	// reads its value from.
+	SuperusersVars []string
+	// PasswordLiteral is true when a `password` or `password_pbkdf2` directive
+	// carries a literal, non-empty credential.
+	PasswordLiteral bool
+	// PasswordVars holds the variable names a password directive reads its
+	// credential from.
+	PasswordVars []string
+}
+
+// ParseGrubPasswordConfig scans grub.cfg for superuser and password directives.
+func ParseGrubPasswordConfig(content []byte) GrubPasswordConfig {
+	var cfg GrubPasswordConfig
+
+	scanner := bufio.NewScanner(bytes.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || line[0] == '#' {
+			continue
+		}
+
+		if m := reSuperusers.FindStringSubmatch(line); m != nil {
+			value := stripQuotes(strings.TrimSpace(m[1]))
+			if vars := shellVarNames(value); len(vars) > 0 {
+				cfg.SuperusersVars = append(cfg.SuperusersVars, vars...)
+			} else if value != "" {
+				cfg.SuperusersLiteral = true
+			}
+			continue
+		}
+
+		if m := rePassword.FindStringSubmatch(line); m != nil {
+			// `password <user> <cleartext>` and
+			// `password_pbkdf2 <user> <hash>` both carry the credential as the
+			// second argument. Anything shorter states no credential at all.
+			fields := strings.Fields(m[1])
+			if len(fields) < 2 {
+				continue
+			}
+			credential := stripQuotes(fields[1])
+			if vars := shellVarNames(credential); len(vars) > 0 {
+				cfg.PasswordVars = append(cfg.PasswordVars, vars...)
+			} else if credential != "" {
+				cfg.PasswordLiteral = true
+			}
+		}
+	}
+
+	return cfg
+}
+
+// Protected reports whether grub.cfg on its own proves a password is set, which
+// requires a literal superuser list and a literal credential.
+func (c GrubPasswordConfig) Protected() bool {
+	return c.SuperusersLiteral && c.PasswordLiteral
+}
+
+// ReferencesVars reports whether any directive takes its value from a shell
+// variable that grub.cfg does not define, in which case the credential has to be
+// resolved from user.cfg before the config can be judged.
+func (c GrubPasswordConfig) ReferencesVars() bool {
+	return len(c.SuperusersVars) > 0 || len(c.PasswordVars) > 0
+}
+
+// ProtectedWith reports whether the config is password protected once the
+// variables it references are resolved from the given assignments, typically the
+// contents of ${prefix}/user.cfg.
+func (c GrubPasswordConfig) ProtectedWith(vars map[string]string) bool {
+	superusers := c.SuperusersLiteral || anyVarSet(c.SuperusersVars, vars)
+	password := c.PasswordLiteral || anyVarSet(c.PasswordVars, vars)
+	return superusers && password
+}
+
+// anyVarSet reports whether any of the named variables has a non-empty value.
+func anyVarSet(names []string, vars map[string]string) bool {
+	for _, name := range names {
+		if strings.TrimSpace(vars[name]) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// shellVarNames returns the names of every unexpanded shell variable in value.
+func shellVarNames(value string) []string {
+	matches := reShellVar.FindAllStringSubmatch(value, -1)
+	if matches == nil {
+		return nil
+	}
+	names := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if m[1] != "" {
+			names = append(names, m[1])
+		} else if m[2] != "" {
+			names = append(names, m[2])
+		}
+	}
+	return names
+}
+
 // ParseGrubPasswordProtected checks grub.cfg content for password protection.
-// GRUB password protection requires both 'set superusers=' and a 'password' or
-// 'password_pbkdf2' directive.
+// GRUB password protection requires both a `set superusers=` directive and a
+// `password` or `password_pbkdf2` directive, and both have to carry literal
+// values. A credential that is still an unexpanded shell variable, as in the
+// `password_pbkdf2 root ${GRUB2_PASSWORD}` block that /etc/grub.d/01_users emits
+// on every RHEL-family host, is a template rather than a password.
 func ParseGrubPasswordProtected(content []byte) bool {
-	return reSuperusers.Match(content) && rePassword.Match(content)
+	return ParseGrubPasswordConfig(content).Protected()
+}
+
+// readGrubUserCfg reads user.cfg next to grub.cfg. That is the ${prefix}/user.cfg
+// the 01_users block sources, and where grub2-setpassword stores GRUB2_PASSWORD
+// on RHEL-family systems. A missing or unreadable file is the normal case and
+// returns a nil map rather than an error.
+func readGrubUserCfg(fs afero.Fs, grubCfgPath string) map[string]string {
+	if grubCfgPath == "" {
+		return nil
+	}
+
+	f, err := fs.Open(path.Join(path.Dir(grubCfgPath), "user.cfg"))
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	vars, err := ParseGrubDefaults(f)
+	if err != nil {
+		return nil
+	}
+	return vars
 }

--- a/providers/os/resources/grub_test.go
+++ b/providers/os/resources/grub_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -286,4 +287,212 @@ func TestStripQuotes(t *testing.T) {
 	assert.Equal(t, "", stripQuotes(`""`))
 	assert.Equal(t, "", stripQuotes(`''`))
 	assert.Equal(t, "a", stripQuotes("a"))
+}
+
+// stockRhelUsersBlock is the block /etc/grub.d/01_users writes into grub.cfg on
+// every RHEL-family host, whether or not a GRUB password was ever set. It is
+// dead code unless ${prefix}/user.cfg defines GRUB2_PASSWORD.
+const stockRhelUsersBlock = `### BEGIN /etc/grub.d/01_users ###
+if [ -f ${prefix}/user.cfg ]; then
+  source ${prefix}/user.cfg
+  if [ -n "${GRUB2_PASSWORD}" ]; then
+    set superusers="root"
+    export superusers
+    password_pbkdf2 root ${GRUB2_PASSWORD}
+  fi
+fi
+### END /etc/grub.d/01_users ###
+`
+
+func TestParseGrubPasswordProtectedTemplates(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "stock RHEL 01_users block is a template, not a password",
+			content: stockRhelUsersBlock,
+			want:    false,
+		},
+		{
+			name: "stock RHEL block inside a full grub.cfg",
+			content: `set pager=1
+` + stockRhelUsersBlock + `### BEGIN /etc/grub.d/10_linux ###
+menuentry 'Red Hat Enterprise Linux (5.14.0) 9.4' {
+	linux /vmlinuz-5.14.0 root=/dev/mapper/rhel-root ro
+	initrd /initramfs-5.14.0.img
+}
+### END /etc/grub.d/10_linux ###
+`,
+			want: false,
+		},
+		{
+			name: "configured pbkdf2 password",
+			content: `set superusers="root"
+password_pbkdf2 root grub.pbkdf2.sha512.10000.ABC123.DEF456
+`,
+			want: true,
+		},
+		{
+			name: "configured plaintext password",
+			content: `set superusers="root"
+password root hunter2
+`,
+			want: true,
+		},
+		{
+			name: "superusers without a password directive",
+			content: `set superusers="root"
+export superusers
+`,
+			want: false,
+		},
+		{
+			name: "password directive without superusers",
+			content: `password_pbkdf2 root grub.pbkdf2.sha512.10000.ABC123.DEF456
+`,
+			want: false,
+		},
+		{
+			name:    "empty content",
+			content: "",
+			want:    false,
+		},
+		{
+			name: "braceless shell variable credential",
+			content: `set superusers="root"
+password_pbkdf2 root $GRUB2_PASSWORD
+`,
+			want: false,
+		},
+		{
+			name: "templated superuser list",
+			content: `set superusers="${GRUB2_SUPERUSER}"
+password_pbkdf2 root grub.pbkdf2.sha512.10000.ABC123.DEF456
+`,
+			want: false,
+		},
+		{
+			name: "empty superusers assignment",
+			content: `set superusers=""
+password_pbkdf2 root grub.pbkdf2.sha512.10000.ABC123.DEF456
+`,
+			want: false,
+		},
+		{
+			name: "password directive with no credential argument",
+			content: `set superusers="root"
+password_pbkdf2 root
+`,
+			want: false,
+		},
+		{
+			name: "indented directives inside a conditional",
+			content: `if [ -n "${x}" ]; then
+    set superusers="admin"
+    password_pbkdf2 admin grub.pbkdf2.sha512.10000.ABC123.DEF456
+fi
+`,
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, ParseGrubPasswordProtected([]byte(test.content)))
+		})
+	}
+}
+
+func TestParseGrubPasswordConfig(t *testing.T) {
+	t.Run("stock RHEL block records the variable it depends on", func(t *testing.T) {
+		cfg := ParseGrubPasswordConfig([]byte(stockRhelUsersBlock))
+		assert.True(t, cfg.SuperusersLiteral)
+		assert.False(t, cfg.PasswordLiteral)
+		assert.Equal(t, []string{"GRUB2_PASSWORD"}, cfg.PasswordVars)
+		assert.True(t, cfg.ReferencesVars())
+		assert.False(t, cfg.Protected())
+	})
+
+	t.Run("configured host references no variables", func(t *testing.T) {
+		cfg := ParseGrubPasswordConfig([]byte(`set superusers="root"
+password_pbkdf2 root grub.pbkdf2.sha512.10000.ABC123.DEF456
+`))
+		assert.True(t, cfg.Protected())
+		assert.False(t, cfg.ReferencesVars())
+	})
+}
+
+func TestGrubPasswordConfigProtectedWith(t *testing.T) {
+	cfg := ParseGrubPasswordConfig([]byte(stockRhelUsersBlock))
+
+	t.Run("user.cfg with a password", func(t *testing.T) {
+		vars, err := ParseGrubDefaults(strings.NewReader("GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.ABC123.DEF456\n"))
+		require.NoError(t, err)
+		assert.True(t, cfg.ProtectedWith(vars))
+	})
+
+	t.Run("user.cfg with an empty password", func(t *testing.T) {
+		vars, err := ParseGrubDefaults(strings.NewReader("GRUB2_PASSWORD=\n"))
+		require.NoError(t, err)
+		assert.False(t, cfg.ProtectedWith(vars))
+	})
+
+	t.Run("user.cfg without the variable", func(t *testing.T) {
+		vars, err := ParseGrubDefaults(strings.NewReader("GRUB2_SOMETHING_ELSE=1\n"))
+		require.NoError(t, err)
+		assert.False(t, cfg.ProtectedWith(vars))
+	})
+
+	t.Run("absent user.cfg", func(t *testing.T) {
+		assert.False(t, cfg.ProtectedWith(map[string]string{}))
+	})
+
+	t.Run("templated superusers resolved from user.cfg", func(t *testing.T) {
+		templated := ParseGrubPasswordConfig([]byte(`set superusers="${GRUB2_SUPERUSER}"
+password_pbkdf2 root ${GRUB2_PASSWORD}
+`))
+		assert.False(t, templated.ProtectedWith(map[string]string{
+			"GRUB2_PASSWORD": "grub.pbkdf2.sha512.10000.ABC123.DEF456",
+		}))
+		assert.True(t, templated.ProtectedWith(map[string]string{
+			"GRUB2_SUPERUSER": "root",
+			"GRUB2_PASSWORD":  "grub.pbkdf2.sha512.10000.ABC123.DEF456",
+		}))
+	})
+}
+
+func TestReadGrubUserCfg(t *testing.T) {
+	t.Run("reads user.cfg beside grub.cfg", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/boot/grub2/grub.cfg", []byte(stockRhelUsersBlock), 0o644))
+		require.NoError(t, afero.WriteFile(fs, "/boot/grub2/user.cfg",
+			[]byte("GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.ABC123.DEF456\n"), 0o600))
+
+		vars := readGrubUserCfg(fs, "/boot/grub2/grub.cfg")
+		require.NotNil(t, vars)
+		assert.Equal(t, "grub.pbkdf2.sha512.10000.ABC123.DEF456", vars["GRUB2_PASSWORD"])
+	})
+
+	t.Run("reads user.cfg from an EFI directory", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/boot/efi/EFI/redhat/user.cfg",
+			[]byte("GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.ABC123.DEF456\n"), 0o600))
+
+		vars := readGrubUserCfg(fs, "/boot/efi/EFI/redhat/grub.cfg")
+		require.NotNil(t, vars)
+		assert.NotEmpty(t, vars["GRUB2_PASSWORD"])
+	})
+
+	t.Run("missing user.cfg is not an error", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/boot/grub2/grub.cfg", []byte(stockRhelUsersBlock), 0o644))
+
+		assert.Nil(t, readGrubUserCfg(fs, "/boot/grub2/grub.cfg"))
+	})
+
+	t.Run("empty grub.cfg path", func(t *testing.T) {
+		assert.Nil(t, readGrubUserCfg(afero.NewMemMapFs(), ""))
+	})
 }

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -7400,7 +7400,14 @@ grub.config @defaults("defaultsPath grubPath") {
   params() map[string]string
   // Menu entries defined in grub.cfg
   entries() []grub.config.entry
-  // Whether GRUB password protection is enabled (superusers + password_pbkdf2)
+  // Whether GRUB password protection is enabled
+  //
+  // True when grub.cfg names a superuser and carries a matching password or
+  // password_pbkdf2 credential, including a credential kept in the user.cfg
+  // file beside grub.cfg. A credential that is still an unexpanded shell
+  // variable, such as the templated block many distributions emit
+  // unconditionally, does not count. Null when no grub.cfg exists, since a
+  // host that does not use GRUB is neither protected nor unprotected.
   passwordProtected() bool
 }
 


### PR DESCRIPTION
## The bug

`grub.config.passwordProtected` returns **true on every RHEL-family host**, whether or not a GRUB password was ever set.

The check was two independent regex matches over the whole file:

```go
reSuperusers = regexp.MustCompile(`(?m)^\s*set\s+superusers\s*=`)
rePassword   = regexp.MustCompile(`(?m)^\s*password(?:_pbkdf2)?\s+`)
return reSuperusers.Match(content) && rePassword.Match(content)
```

Both match the block `/etc/grub.d/01_users` writes into `grub.cfg` on every RHEL-family install, password or not:

```sh
### BEGIN /etc/grub.d/01_users ###
if [ -f ${prefix}/user.cfg ]; then
  source ${prefix}/user.cfg
  if [ -n "${GRUB2_PASSWORD}" ]; then
    set superusers="root"
    export superusers
    password_pbkdf2 root ${GRUB2_PASSWORD}
  fi
fi
### END /etc/grub.d/01_users ###
```

That block is dead code unless `${prefix}/user.cfg` defines `GRUB2_PASSWORD`. The old check saw `set superusers=` and `password_pbkdf2`, matched both, and reported the host protected. It is a **false negative for the auditor**: the one control this field exists to detect silently passes everywhere.

## A template is not a password

Parsing now distinguishes a literal value from an unexpanded shell variable. `GrubPasswordConfig` records, for the superuser list and the credential separately, whether the value is literal or read from a variable (`${GRUB2_PASSWORD}` or `$GRUB2_PASSWORD`). `Protected()` requires **both** to be literal, so the templated block alone no longer counts.

## Credentials really do live in user.cfg

Requiring literals would be a false positive in the other direction, because `grub2-setpassword` writes the real credential to `${prefix}/user.cfg` and leaves `grub.cfg` templated. So when `grub.cfg` only references variables, the config is resolved against `user.cfg` read from beside `grub.cfg`, and a non-empty assignment there counts as protection. A missing or unreadable `user.cfg` is the normal case and is not an error.

## No grub.cfg is now null, not false

`passwordProtected` previously returned `false` when no `grub.cfg` existed in any known location. That reads as "GRUB is installed and has no password" — a finding that was never made. A host with a different bootloader now returns **null** via `StateIsSet | StateIsNull`.

> Note for policy authors: MQL's three-valued logic means a null field passes an `&&` assertion, so a check that relied on `passwordProtected == false` firing on non-GRUB hosts will now skip them instead.

## Tests

`grub_test.go` gains table tests over the real shapes: the stock RHEL `01_users` block, a literal `password_pbkdf2` credential, `${VAR}` and `$VAR` forms, quoted values, a `password` directive with too few fields, and resolution against `user.cfg` present, absent, and empty.

## Test plan

- [ ] `go test ./providers/os/resources/ -run Grub`
- [ ] RHEL-family host **without** a GRUB password: `grub.config.passwordProtected` is `false` (was `true`)
- [ ] RHEL-family host **with** `grub2-setpassword` run: `true`
- [ ] Debian/Ubuntu host with a literal `password_pbkdf2` in `grub.cfg`: `true`
- [ ] Host with no `grub.cfg`: null, not `false`
