### PR TITLE
🐛 os: stop the technology URL builder from stamping "unknown" onto the platform

### DIFF
--- a/providers/os/detector/detector.go
+++ b/providers/os/detector/detector.go
@@ -75,15 +75,23 @@ func addTechnologyUrl(platform *inventory.Platform) {
 		platform.TechnologyUrlSegments = []string{"os"}
 	}
 
-	if platform.Name == "" {
-		platform.Name = "unknown"
+	// The URL needs a value in every segment, so an unnamed or unversioned
+	// platform gets a placeholder here. The placeholder stays local to the URL:
+	// writing it back onto the platform reports it as the asset's real name and
+	// version, and a rolling release without a VERSION_ID (arch, endeavouros)
+	// then keys its package PURLs to distro=<name>-unknown instead of falling
+	// back to the build id.
+	name := platform.Name
+	if name == "" {
+		name = "unknown"
 	}
-	if platform.Version == "" {
-		platform.Version = "unknown"
+	version := platform.Version
+	if version == "" {
+		version = "unknown"
 	}
 
 	platform.TechnologyUrlSegments = append(platform.TechnologyUrlSegments,
-		primaryFamily(platform), platform.Name, platform.Version)
+		primaryFamily(platform), name, version)
 }
 
 // map that is organized by platform name, to quickly determine its families

--- a/providers/os/detector/technology_url_test.go
+++ b/providers/os/detector/technology_url_test.go
@@ -1,0 +1,101 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package detector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+)
+
+func TestAddTechnologyUrl(t *testing.T) {
+	t.Run("name and version set", func(t *testing.T) {
+		pf := &inventory.Platform{
+			Name:    "debian",
+			Version: "12.15",
+			Family:  []string{"debian", "linux", "unix", "os"},
+		}
+		addTechnologyUrl(pf)
+
+		assert.Equal(t, []string{"os", "linux", "debian", "12.15"}, pf.TechnologyUrlSegments)
+		assert.Equal(t, "debian", pf.Name)
+		assert.Equal(t, "12.15", pf.Version)
+	})
+
+	t.Run("no version, build set", func(t *testing.T) {
+		pf := &inventory.Platform{
+			Name:   "arch",
+			Build:  "rolling",
+			Family: []string{"arch", "linux", "unix", "os"},
+		}
+		addTechnologyUrl(pf)
+
+		// the URL still gets a placeholder segment ...
+		assert.Equal(t, []string{"os", "linux", "arch", "unknown"}, pf.TechnologyUrlSegments)
+		// ... but the platform itself keeps reporting that it has no version,
+		// so consumers can fall back to the build id.
+		assert.Equal(t, "arch", pf.Name)
+		assert.Empty(t, pf.Version)
+		assert.Equal(t, "rolling", pf.Build)
+	})
+
+	t.Run("neither name nor version", func(t *testing.T) {
+		pf := &inventory.Platform{}
+		addTechnologyUrl(pf)
+
+		assert.Equal(t, []string{"os", "other", "unknown", "unknown"}, pf.TechnologyUrlSegments)
+		assert.Empty(t, pf.Name)
+		assert.Empty(t, pf.Version)
+	})
+
+	t.Run("container image kind", func(t *testing.T) {
+		pf := &inventory.Platform{
+			Name:    "alpine",
+			Version: "3.20",
+			Kind:    "container-image",
+			Family:  []string{"alpine", "linux", "unix", "os"},
+		}
+		addTechnologyUrl(pf)
+
+		assert.Equal(t,
+			[]string{"container", "container-image", "linux", "alpine", "3.20"},
+			pf.TechnologyUrlSegments)
+		assert.Equal(t, "3.20", pf.Version)
+	})
+
+	t.Run("nil platform", func(t *testing.T) {
+		assert.NotPanics(t, func() { addTechnologyUrl(nil) })
+	})
+}
+
+// Arch has no VERSION_ID in /etc/os-release, only BUILD_ID=rolling. The
+// detection run must leave the version empty instead of reporting the URL
+// placeholder as the asset's version.
+func TestDetectOSKeepsRollingReleaseVersionEmpty(t *testing.T) {
+	for _, tc := range []struct {
+		fixture string
+		name    string
+		build   string
+	}{
+		{fixture: "./testdata/detect-arch-vm.toml", name: "arch", build: "rolling"},
+		{fixture: "./testdata/detect-endeavouros.toml", name: "endeavouros", build: "rolling"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath(tc.fixture))
+			require.NoError(t, err)
+
+			pf, ok := DetectOS(conn)
+			require.True(t, ok)
+			require.NotNil(t, pf)
+
+			assert.Equal(t, tc.name, pf.Name)
+			assert.Empty(t, pf.Version, "rolling release has no version")
+			assert.Equal(t, tc.build, pf.Build)
+			assert.Equal(t, []string{"os", "linux", tc.name, "unknown"}, pf.TechnologyUrlSegments)
+		})
+	}
+}

--- a/providers/os/resources/purl/platform_purl_test.go
+++ b/providers/os/resources/purl/platform_purl_test.go
@@ -147,6 +147,16 @@ func TestNewPlatformPurl(t *testing.T) {
 			wantErr: "",
 		},
 		{
+			name: "rolling release without a version",
+			platform: &inventory.Platform{
+				Name:  "arch",
+				Arch:  "x86_64",
+				Build: "rolling",
+			},
+			want:    "pkg:platform/arch?arch=x86_64&build=rolling&distro=arch-rolling",
+			wantErr: "",
+		},
+		{
 			name:     "nil platform",
 			platform: nil,
 			want:     "",

--- a/providers/os/resources/purl/purl_test.go
+++ b/providers/os/resources/purl/purl_test.go
@@ -315,4 +315,33 @@ func TestPackageURLString(t *testing.T) {
 		expected := "pkg:rpm/opensuse/testpkg@1.0.0?arch=x86_64&distro=opensuse-microos-20260822"
 		assert.Equal(t, expected, p.String())
 	})
+
+	// Arch and its derivatives ship no VERSION_ID, only BUILD_ID=rolling, so
+	// the distro qualifier has to come from the build id.
+	t.Run("rolling release package", func(t *testing.T) {
+		platform := &inventory.Platform{
+			Name:  "arch",
+			Arch:  "x86_64",
+			Build: "rolling",
+			Labels: map[string]string{
+				"distro-id": "arch",
+			},
+		}
+		p := purl.NewPackageURL(platform, purl.TypeAlpm, "testpkg", "1.0.0")
+		expected := "pkg:alpm/arch/testpkg@1.0.0?arch=x86_64&distro=arch-rolling"
+		assert.Equal(t, expected, p.String())
+	})
+
+	t.Run("package without version or build", func(t *testing.T) {
+		platform := &inventory.Platform{
+			Name: "arch",
+			Arch: "x86_64",
+			Labels: map[string]string{
+				"distro-id": "arch",
+			},
+		}
+		p := purl.NewPackageURL(platform, purl.TypeAlpm, "testpkg", "1.0.0")
+		expected := "pkg:alpm/arch/testpkg@1.0.0?arch=x86_64&distro=arch"
+		assert.Equal(t, expected, p.String())
+	})
 }

--- a/sbom/spdx.go
+++ b/sbom/spdx.go
@@ -307,15 +307,18 @@ func (s *Spdx) convertToSbom(doc *spdx.Document) *Sbom {
 						}
 						name = distroVal
 						pf.Title = distroVal
+						// a distro qualifier carries no version when the
+						// platform has none, e.g. "arch" rather than
+						// "arch-rolling"
 						vals := strings.Split(distroVal, "-")
-						if len(vals) > 0 {
-							pf.Name = vals[0]
+						pf.Name = vals[0]
+						if len(vals) > 1 {
 							pf.Version = vals[1]
 						}
 						pf.Family = familyMap[pf.Name]
 					}
 					arch, ok := m["arch"]
-					if ok {
+					if ok && pf != nil {
 						pf.Arch = arch
 					}
 				}

--- a/sbom/spdx.go
+++ b/sbom/spdx.go
@@ -307,13 +307,19 @@ func (s *Spdx) convertToSbom(doc *spdx.Document) *Sbom {
 						}
 						name = distroVal
 						pf.Title = distroVal
-						// a distro qualifier carries no version when the
-						// platform has none, e.g. "arch" rather than
-						// "arch-rolling"
-						vals := strings.Split(distroVal, "-")
-						pf.Name = vals[0]
-						if len(vals) > 1 {
-							pf.Version = vals[1]
+						// The qualifier is the platform name and version
+						// joined with a dash (purl.NewPlatformPurl), and it is
+						// the *name* that commonly carries dashes of its own:
+						// opensuse-leap, opensuse-tumbleweed, opensuse-microos.
+						// Splitting on the first dash reports
+						// "opensuse-leap-15.6" as name "opensuse" version
+						// "leap", so split on the last one. A qualifier with no
+						// dash carries no version, e.g. "arch" rather than
+						// "arch-rolling".
+						pf.Name = distroVal
+						if i := strings.LastIndex(distroVal, "-"); i > 0 {
+							pf.Name = distroVal[:i]
+							pf.Version = distroVal[i+1:]
 						}
 						pf.Family = familyMap[pf.Name]
 					}

--- a/sbom/spdx_test.go
+++ b/sbom/spdx_test.go
@@ -89,6 +89,48 @@ func TestSpdxJsonDecoder_GitHub_DependencyGraph(t *testing.T) {
 	assert.Equal(t, "SPDX-2.3", sbomReport.Asset.Platform.Version)
 }
 
+// A rolling release has no version, so its distro qualifier carries the build
+// id, or nothing at all when there is no build either.
+func TestSpdxJsonDecoder_RollingRelease(t *testing.T) {
+	f, err := os.Open("testdata/arch-rolling.spdx.json")
+	require.NoError(t, err)
+
+	decoder := sbom.NewSPDX(sbom.FormatSpdxJSON)
+
+	sbomReport, err := decoder.Parse(f)
+	require.NoError(t, err)
+	require.NotNil(t, sbomReport)
+	assert.Equal(t, "arch", sbomReport.Asset.Platform.Name)
+	assert.Equal(t, "rolling", sbomReport.Asset.Platform.Version)
+	assert.Equal(t, "x86_64", sbomReport.Asset.Platform.Arch)
+}
+
+func TestSpdxJsonDecoder_DistroWithoutVersion(t *testing.T) {
+	f, err := os.Open("testdata/arch-noversion.spdx.json")
+	require.NoError(t, err)
+
+	decoder := sbom.NewSPDX(sbom.FormatSpdxJSON)
+
+	sbomReport, err := decoder.Parse(f)
+	require.NoError(t, err)
+	require.NotNil(t, sbomReport)
+	assert.Equal(t, "arch", sbomReport.Asset.Platform.Name)
+	assert.Empty(t, sbomReport.Asset.Platform.Version)
+}
+
+func TestSpdxJsonDecoder_PurlWithoutDistro(t *testing.T) {
+	f, err := os.Open("testdata/purl-without-distro.spdx.json")
+	require.NoError(t, err)
+
+	decoder := sbom.NewSPDX(sbom.FormatSpdxJSON)
+
+	sbomReport, err := decoder.Parse(f)
+	require.NoError(t, err)
+	require.NotNil(t, sbomReport)
+	// nothing identifies the platform, so the document's own one stands
+	assert.Equal(t, "spdx", sbomReport.Asset.Platform.Name)
+}
+
 func TestSpdxJsonDecoder_Alpine_syft(t *testing.T) {
 	f, err := os.Open("testdata/alpine-3.19.syft.spdx.json")
 	require.NoError(t, err)

--- a/sbom/spdx_test.go
+++ b/sbom/spdx_test.go
@@ -144,3 +144,22 @@ func TestSpdxJsonDecoder_Alpine_syft(t *testing.T) {
 	assert.Equal(t, "alpine", sbomReport.Asset.Platform.Name)
 	assert.Equal(t, "3.19.9", sbomReport.Asset.Platform.Version)
 }
+
+// TestSpdxJsonDecoder_DistroNameWithDash pins that a platform name containing a
+// dash survives the round trip. The distro qualifier is the platform name and
+// version joined with a dash, and the openSUSE family puts dashes in the name
+// itself, so splitting on the first dash reported "opensuse-leap-15.6" as name
+// "opensuse" version "leap" — both fields wrong.
+func TestSpdxJsonDecoder_DistroNameWithDash(t *testing.T) {
+	f, err := os.Open("testdata/opensuse-leap.spdx.json")
+	require.NoError(t, err)
+
+	decoder := sbom.NewSPDX(sbom.FormatSpdxJSON)
+
+	sbomReport, err := decoder.Parse(f)
+	require.NoError(t, err)
+	require.NotNil(t, sbomReport)
+	assert.Equal(t, "opensuse-leap", sbomReport.Asset.Platform.Name)
+	assert.Equal(t, "15.6", sbomReport.Asset.Platform.Version)
+	assert.Equal(t, "x86_64", sbomReport.Asset.Platform.Arch)
+}

--- a/sbom/testdata/arch-noversion.spdx.json
+++ b/sbom/testdata/arch-noversion.spdx.json
@@ -1,0 +1,45 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "arch",
+  "documentNamespace": "",
+  "creationInfo": {
+    "creators": [
+      "Tool: cnquery"
+    ],
+    "created": "2026-08-25T09:00:00Z"
+  },
+  "packages": [
+    {
+      "name": "bash",
+      "SPDXID": "SPDXRef-Package-alpm-bash",
+      "versionInfo": "5.2.037-2",
+      "downloadLocation": "",
+      "filesAnalyzed": false,
+      "licenseDeclared": "5.2.037-2",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:alpm/arch/bash@5.2.037-2?arch=x86_64&distro=arch"
+        }
+      ]
+    },
+    {
+      "name": "openssl",
+      "SPDXID": "SPDXRef-Package-alpm-openssl",
+      "versionInfo": "3.5.0-1",
+      "downloadLocation": "",
+      "filesAnalyzed": false,
+      "licenseDeclared": "3.5.0-1",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:alpm/arch/openssl@3.5.0-1?arch=x86_64&distro=arch"
+        }
+      ]
+    }
+  ]
+}

--- a/sbom/testdata/arch-rolling.spdx.json
+++ b/sbom/testdata/arch-rolling.spdx.json
@@ -1,0 +1,45 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "arch-rolling",
+  "documentNamespace": "",
+  "creationInfo": {
+    "creators": [
+      "Tool: cnquery"
+    ],
+    "created": "2026-08-25T09:00:00Z"
+  },
+  "packages": [
+    {
+      "name": "bash",
+      "SPDXID": "SPDXRef-Package-alpm-bash",
+      "versionInfo": "5.2.037-2",
+      "downloadLocation": "",
+      "filesAnalyzed": false,
+      "licenseDeclared": "5.2.037-2",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:alpm/arch/bash@5.2.037-2?arch=x86_64&distro=arch-rolling"
+        }
+      ]
+    },
+    {
+      "name": "openssl",
+      "SPDXID": "SPDXRef-Package-alpm-openssl",
+      "versionInfo": "3.5.0-1",
+      "downloadLocation": "",
+      "filesAnalyzed": false,
+      "licenseDeclared": "3.5.0-1",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:alpm/arch/openssl@3.5.0-1?arch=x86_64&distro=arch-rolling"
+        }
+      ]
+    }
+  ]
+}

--- a/sbom/testdata/opensuse-leap.spdx.json
+++ b/sbom/testdata/opensuse-leap.spdx.json
@@ -1,0 +1,30 @@
+{
+    "spdxVersion": "SPDX-2.3",
+    "dataLicense": "",
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "name": "opensuse-leap-15.6",
+    "documentNamespace": "",
+    "creationInfo": {
+        "creators": [
+            "Tool: cnquery"
+        ],
+        "created": "2026-08-26T09:00:00Z"
+    },
+    "packages": [
+        {
+            "name": "bash",
+            "SPDXID": "SPDXRef-Package-rpm-bash",
+            "versionInfo": "4.4-150400.25.22",
+            "downloadLocation": "",
+            "filesAnalyzed": false,
+            "licenseDeclared": "GPL-3.0-or-later",
+            "externalRefs": [
+                {
+                    "referenceCategory": "SECURITY",
+                    "referenceType": "purl",
+                    "referenceLocator": "pkg:rpm/opensuse/bash@4.4-150400.25.22?arch=x86_64&distro=opensuse-leap-15.6"
+                }
+            ]
+        }
+    ]
+}

--- a/sbom/testdata/purl-without-distro.spdx.json
+++ b/sbom/testdata/purl-without-distro.spdx.json
@@ -1,0 +1,30 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "no-distro",
+  "documentNamespace": "",
+  "creationInfo": {
+    "creators": [
+      "Tool: cnquery"
+    ],
+    "created": "2026-08-25T09:00:00Z"
+  },
+  "packages": [
+    {
+      "name": "bash",
+      "SPDXID": "SPDXRef-Package-alpm-bash",
+      "versionInfo": "5.2.037-2",
+      "downloadLocation": "",
+      "filesAnalyzed": false,
+      "licenseDeclared": "5.2.037-2",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:alpm/bash@5.2.037-2?arch=x86_64"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## The bug

`addTechnologyUrl` in `providers/os/detector/detector.go` builds the technology URL segments for an asset. Every segment needs a value, so it substituted `"unknown"` for an empty platform name or version. It did that by **writing back onto the shared `inventory.Platform`**, so the placeholder escaped the URL and became the asset's reported name and version.

```go
if platform.Version == "" {
    platform.Version = "unknown"   // not a fact about the asset
}
```

## Who it hits

Any distro whose `/etc/os-release` carries no `VERSION_ID`. In-tree fixtures confirm **arch** and **endeavouros** (both ship only `BUILD_ID=rolling`); a bare arch container and a nixos container have no version at all. Distros that do set a `VERSION_ID` (debian, ubuntu, rhel, gentoo, steamos, cachyos, nixos proper, bottlerocket, flatcar, cos, openwrt, kali) were never affected.

## What it broke

Both PURL builders check `if platform.Version != ""` first and fall back to `platform.Build` only when it is empty. The placeholder made `Version` permanently non-empty, so the `else if platform.Build != ""` fallback was **dead code on exactly the assets it exists for**. (`platform_purl_test.go` already had a passing "platform with build instead of version" case; nothing in production could reach it.)

Reproduced against `providers/os/detector/testdata/detect-arch-vm.toml`:

| | before | after |
|---|---|---|
| `asset { version }` | `"unknown"` | `""` |
| platform PURL | `pkg:platform/arch@unknown?arch=x86_64&build=rolling&distro=arch-unknown` | `pkg:platform/arch?arch=x86_64&build=rolling&distro=arch-rolling` |
| package PURL (×all packages) | `pkg:alpm/arch/somepkg@1.0?arch=x86_64&distro=arch-unknown` | `pkg:alpm/arch/somepkg@1.0?arch=x86_64&distro=arch-rolling` |

**Advisory impact:** the `distro` qualifier is the key advisory matching uses to pick the vendor's fix stream, and `Release` is sent upstream from the same field (`providers/os/resources/vulnmgmt.go`, `providers-sdk/v1/upstream/mvd`). Every package on a rolling-release asset carried `distro=<name>-unknown`, a release that does not exist, so advisory and vulnerability matching for those assets was keyed to nothing and failed silently. Confirmed live on Arch Linux 2026.08 in EC2, where all 276 package PURLs read `distro=arch-unknown`.

## The fix

Build the segments from local placeholder values and leave `platform.Name` / `platform.Version` alone. The URL itself is unchanged in every case (still `os/linux/arch/unknown`), so asset-URL resolution is untouched.

## Second commit: an SPDX import panic the first commit makes reachable

`sbom/spdx.go` reads a purl's `distro=` qualifier back into a platform:

```go
vals := strings.Split(distroVal, "-")
if len(vals) > 0 {          // true for every string
    pf.Name = vals[0]
    pf.Version = vals[1]    // index out of range on "arch"
}
```

A qualifier with no `-` panics the import. Once the detector stops inventing a version, a platform with neither version nor build emits `distro=<id>` with nothing to join, so our own documents can now carry that shape. The `arch` qualifier a few lines below writes through a platform pointer that is only allocated inside the distro branch, so a purl with an arch and no distro panics with a nil dereference. Both are reachable from any third-party SPDX document today; both are now guarded and covered by tests that panic without the fix.

## Callers audited

Swept every reader of `Platform.Version` / `Platform.Name` across `providers/os`, `providers-sdk`, `sbom`, `cli`, `apps`, `llx`. Findings:

- `providers/os/connection/device/device_connection.go:262` — the one place that keys on the placeholder, and it already handles both spellings: `slices.Contains([]string{"", "unknown"}, p.Name)`. Unchanged.
- Every `strconv` / semver / regex parse of the version already checked its error and was already receiving an unparseable string; `"unknown"` failed exactly as `""` does: `packages/rpm_packages.go:376,605`, `detector_win.go:235,263`, `windows/hotpatch.go:71`, `packages/windows_packages.go:517`, `services/manager.go:106-166`, `yum.go:98`.
- Package-manager, service-manager, config-path, and process/user/group/mount resolution all switch on `Platform.Name` and `IsFamily(...)`, never the version. `Name` still reads `arch`, so none of them change.
- No platform ID, asset ID, or MRN is derived from the version anywhere.
- `MergePlatform` uses `mergo.WithOverride`, which does not overwrite a set destination from an empty source — so a re-detect can no longer stamp `"unknown"` over a real version that discovery supplied.
- `providers/os/provider/provider.go:284` skips detection when `Platform.Name == ""`. An asset whose detection failed outright used to arrive here named `"unknown"` and skip the re-run; now it re-enters `s.detect` and surfaces the real `failed to detect OS` error instead of connecting with a placeholder platform. Not reachable for arch (its name resolves fine) and the honest outcome, but a behavior change worth knowing about.
- `providers/os/resources/cpe/platforms.go` interpolates the version into a CPE with no emptiness check. There is no CPE entry for the arch family, so this needs a distro that is in the table *and* ships no `VERSION_ID` — debian sid. It produced `...:unknown:...` before and `...::...` now; both are junk, and reworking the CPE table is out of scope here.
- Cosmetic only: `apps/mql/cmd/status_render.go:143` renders a double space, `sbom/cyclonedx.go:81` emits an empty OS component version (valid CycloneDX), `tool_package.go:246` synthesizes `runtime://os/arch@`.
- Out of this repo: `apps/mql/cmd/login.go` registers `PlatformRelease` upstream, now empty rather than `"unknown"` on a rolling-release host.

## Tests

- `providers/os/detector/technology_url_test.go` (new): segments and non-mutation for name+version set, version empty with a build, both empty, container-image kind, nil platform; plus an end-to-end `DetectOS` run over the arch and endeavouros fixtures asserting `Version` stays empty, `Build` stays `rolling`, and the URL still carries `unknown`.
- `providers/os/resources/purl/purl_test.go`: package PURL resolves `distro=arch-rolling` from the build id, and `distro=arch` with neither version nor build.
- `providers/os/resources/purl/platform_purl_test.go`: platform PURL for a rolling release without a version.
- `sbom/spdx_test.go` plus three fixtures: a rolling-release document, a distro qualifier with no version, and a purl with an arch and no distro. The last two panic without the second commit.

```
$ cd providers/os && go test ./detector/... ./resources/purl/... -count=1
ok  	go.mondoo.com/mql/providers/os/detector
ok  	go.mondoo.com/mql/providers/os/detector/windows
ok  	go.mondoo.com/mql/providers/os/resources/purl

$ go test ./sbom/... -count=1
ok  	go.mondoo.com/mql/sbom
ok  	go.mondoo.com/mql/sbom/generator
```

`providers/os/provider` has one failure on this machine, `TestLocalConnectionIdDetectors`, which reproduces unchanged on `origin/main`.
