### PR TITLE
🐛 os: decode linux route flags with linux constants, not BSD ones

### DIFF
--- a/providers/os/resources/networkinterface/darwin_routes.go
+++ b/providers/os/resources/networkinterface/darwin_routes.go
@@ -75,7 +75,7 @@ func (d *darwinRouteDetector) fetchDarwinRoutes(af int) ([]Route, error) {
 		routes = append(routes, Route{
 			Destination: dest,
 			Gateway:     gateway,
-			Flags:       parseRouteFlags(int64(routeMsg.Flags)),
+			Flags:       parseBSDRouteFlags(int64(routeMsg.Flags)),
 			Interface:   iface,
 		})
 	}

--- a/providers/os/resources/networkinterface/linux_route_flags_test.go
+++ b/providers/os/resources/networkinterface/linux_route_flags_test.go
@@ -1,0 +1,110 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package networkinterface
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Linux and BSD agree only up to RTF_HOST. Everything above it means something
+// different on each, so decoding a Linux route with the BSD table renames most
+// of the flags and invents a REJECT that is not there.
+func TestLinuxAndBsdRouteFlagsDiverge(t *testing.T) {
+	tests := []struct {
+		name  string
+		flags int64
+		linux []string
+		bsd   []string
+	}{
+		{"up", 0x0001, []string{"UP"}, []string{"UP"}},
+		{"up+gateway", 0x0003, []string{"GATEWAY", "UP"}, []string{"GATEWAY", "UP"}},
+		{"host", 0x0004, []string{"HOST"}, []string{"HOST"}},
+		// from here the two tables disagree
+		{"reinstate is not reject", 0x0008, []string{"REINSTATE"}, []string{"REJECT"}},
+		{"mtu is not done", 0x0040, []string{"MTU"}, []string{"DONE"}},
+		{"window is not mask", 0x0080, []string{"WINDOW"}, []string{"MASK"}},
+		{"irtt is not cloning", 0x0100, []string{"IRTT"}, []string{"CLONING"}},
+		{"reject is not xresolve", 0x0200, []string{"REJECT"}, []string{"XRESOLVE"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.linux, parseLinuxRouteFlags(tc.flags))
+			assert.Equal(t, tc.bsd, parseBSDRouteFlags(tc.flags))
+		})
+	}
+}
+
+// Captured from /proc/net/ipv6_route on Arch Linux 2026.08 in EC2: 0x00200200
+// is RTF_NONEXTHOP|RTF_REJECT, the unreachable ::/0 the kernel installs on a
+// host with no IPv6 default route.
+func TestLinuxIPv6RouteFlags(t *testing.T) {
+	flags := parseLinuxIPv6RouteFlags(0x00200200)
+	assert.Equal(t, []string{"NONEXTHOP", "REJECT"}, flags)
+	assert.True(t, routeFlagsRejected(flags))
+
+	// a real router-advertised default carries no REJECT
+	ra := parseLinuxIPv6RouteFlags(0x00040003)
+	assert.Equal(t, []string{"ADDRCONF", "GATEWAY", "UP"}, ra)
+	assert.False(t, routeFlagsRejected(ra))
+
+	// the IPv6 table must still carry the IPv4 bits it shares
+	assert.Equal(t, []string{"UP"}, parseLinuxIPv6RouteFlags(0x0001))
+
+	// the top bit must not be lost to sign extension
+	assert.Contains(t, parseLinuxIPv6RouteFlags(0x80000000), "LOCAL")
+}
+
+// The whole point: an unreachable ::/0 must not be reported as a default route.
+func TestParseLinuxIPv6RoutesSkipsRejectRoutes(t *testing.T) {
+	// dest prefixlen src srcprefixlen nexthop metric ref use flags device
+	const procIPv6Route = `fe800000000000000000000000000000 40 00000000000000000000000000000000 00 00000000000000000000000000000000 00000100 00000000 00000000 00000001     eth0
+00000000000000000000000000000000 00 00000000000000000000000000000000 00 00000000000000000000000000000000 ffffffff 00000001 00000000 00200200       lo
+00000000000000000000000000000000 00 00000000000000000000000000000000 00 00000000000000000000000000000000 ffffffff 00000001 00000000 00200200       lo
+`
+	l := &linuxRouteDetector{}
+	routes, err := l.parseLinuxIPv6RoutesFromProc(procIPv6Route)
+	require.NoError(t, err)
+
+	require.Len(t, routes, 1, "the two unreachable ::/0 entries must not be reported")
+	assert.Equal(t, "fe80::/64", routes[0].Destination)
+	assert.Equal(t, "eth0", routes[0].Interface)
+	assert.Equal(t, []string{"UP"}, routes[0].Flags, "flags must come from the flags column, not be left empty")
+}
+
+// A genuine IPv6 default route must survive.
+func TestParseLinuxIPv6RoutesKeepsRealDefault(t *testing.T) {
+	const procIPv6Route = `00000000000000000000000000000000 00 00000000000000000000000000000000 00 fe800000000000000000000000000001 00000400 00000000 00000000 00040003     eth0
+`
+	l := &linuxRouteDetector{}
+	routes, err := l.parseLinuxIPv6RoutesFromProc(procIPv6Route)
+	require.NoError(t, err)
+
+	require.Len(t, routes, 1)
+	assert.Equal(t, "::/0", routes[0].Destination)
+	assert.Equal(t, "fe80::1", routes[0].Gateway)
+	assert.Equal(t, []string{"ADDRCONF", "GATEWAY", "UP"}, routes[0].Flags)
+}
+
+// `ip route show table all` reports the discard entries with a type. The struct
+// has always parsed the field; nothing read it.
+func TestIpRouteJSONSkipsDiscardRoutes(t *testing.T) {
+	const output = `[
+  {"dst":"default","gateway":"172.31.0.1","dev":"eth0","flags":[]},
+  {"type":"unreachable","dst":"default","dev":"lo","flags":[]},
+  {"type":"blackhole","dst":"10.0.0.0/8","dev":"lo","flags":[]},
+  {"type":"prohibit","dst":"192.168.5.0/24","dev":"lo","flags":[]},
+  {"dst":"172.31.0.0/20","dev":"eth0","prefsrc":"172.31.1.5","flags":[]}
+]`
+	l := &linuxRouteDetector{}
+	routes, err := l.parseIpRouteJSON(output)
+	require.NoError(t, err)
+
+	require.Len(t, routes, 2)
+	assert.Equal(t, "0.0.0.0", routes[0].Destination)
+	assert.Equal(t, "172.31.0.1", routes[0].Gateway)
+	assert.Equal(t, "172.31.0.0/20", routes[1].Destination)
+}

--- a/providers/os/resources/networkinterface/linux_route_flags_test.go
+++ b/providers/os/resources/networkinterface/linux_route_flags_test.go
@@ -89,6 +89,47 @@ func TestParseLinuxIPv6RoutesKeepsRealDefault(t *testing.T) {
 	assert.Equal(t, []string{"ADDRCONF", "GATEWAY", "UP"}, routes[0].Flags)
 }
 
+// /proc/net/route is the primary IPv4 source, and it reports unreachable and
+// prohibit entries with RTF_REJECT just as the IPv6 table does. Without the
+// same guard the two sources disagree: `ip route` skips them by type while
+// /proc reports them as ordinary routes.
+//
+// Fixture captured from a Linux host carrying all three discard types:
+//
+//	ip route add unreachable 10.99.0.0/16
+//	ip route add blackhole   10.98.0.0/16
+//	ip route add prohibit    10.97.0.0/16
+func TestParseLinuxRoutesFromProcSkipsRejectRoutes(t *testing.T) {
+	const procRoute = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
+eth0	00000000	010011AC	0003	0	0	0	00000000	0	0	0
+*	0000610A	00000000	0201	0	0	0	0000FFFF	0	0	0
+*	0000620A	00000000	0001	0	0	0	0000FFFF	0	0	0
+*	0000630A	00000000	0201	0	0	0	0000FFFF	0	0	0
+eth0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0
+`
+	l := &linuxRouteDetector{}
+	routes, err := l.parseLinuxRoutesFromProc(procRoute)
+	require.NoError(t, err)
+
+	var dests []string
+	for _, r := range routes {
+		dests = append(dests, r.Destination)
+	}
+
+	assert.NotContains(t, dests, "10.99.0.0/16", "unreachable route must not be reported")
+	assert.NotContains(t, dests, "10.97.0.0/16", "prohibit route must not be reported")
+
+	assert.Contains(t, dests, "0.0.0.0/0", "the real default route must survive")
+	assert.Contains(t, dests, "172.17.0.0/16", "the real link route must survive")
+
+	// The kernel's fib_flag_trans maps only RTN_UNREACHABLE and RTN_PROHIBIT to
+	// RTF_REJECT, so a blackhole route reaches /proc with flags 0001 and is
+	// indistinguishable from a live one here. `ip route show table all` filters
+	// it by type instead.
+	assert.Contains(t, dests, "10.98.0.0/16",
+		"blackhole carries no REJECT bit in /proc/net/route; only the JSON path can filter it")
+}
+
 // `ip route show table all` reports the discard entries with a type. The struct
 // has always parsed the field; nothing read it.
 func TestIpRouteJSONSkipsDiscardRoutes(t *testing.T) {

--- a/providers/os/resources/networkinterface/linux_routes.go
+++ b/providers/os/resources/networkinterface/linux_routes.go
@@ -47,7 +47,7 @@ func (l *linuxRouteDetector) List() ([]Route, error) {
 		if err == nil {
 			return routes, nil
 		}
-		log.Debug().Err(err).Msg("Failed to parse ip route JSON output, falling back to /proc/net/route and /proc/net/ipv6_route")
+		log.Debug().Err(err).Msg("Failed to parse ip route JSON output")
 	}
 
 	return nil, errors.New("failed to get network routes")
@@ -97,6 +97,15 @@ func (l *linuxRouteDetector) parseIpRouteJSON(output string) ([]Route, error) {
 
 // convertJSONRouteToRoute converts an ipRouteJSON to a Route
 func (l *linuxRouteDetector) convertJSONRouteToRoute(jsonRoute ipRouteJSON) *Route {
+	// `ip route show table all` includes the entries the kernel installs to
+	// discard traffic. They are not paths anything travels over, and counting
+	// an unreachable ::/0 as a default route makes a host without IPv6
+	// connectivity look like it has some.
+	switch jsonRoute.Type {
+	case "unreachable", "blackhole", "prohibit", "throw":
+		return nil
+	}
+
 	route := &Route{
 		Interface: jsonRoute.Dev,
 		Gateway:   jsonRoute.Gateway,
@@ -185,8 +194,7 @@ func (l *linuxRouteDetector) parseLinuxRoutesFromProc(output string) ([]Route, e
 			flagsInt = 0
 		}
 
-		// Convert flags to strings using BSD-style route flags (RTF_*)
-		flags := parseRouteFlags(int64(flagsInt))
+		flags := parseLinuxRouteFlags(int64(flagsInt))
 
 		// Handle gateway
 		gatewayStr := gateway.String()
@@ -223,6 +231,7 @@ func (l *linuxRouteDetector) parseLinuxIPv6RoutesFromProc(output string) ([]Rout
 		destHex := fields[0]
 		prefixLenHex := fields[1] // Destination prefix length (stored as hex string representing decimal)
 		nextHopHex := fields[4]   // Next hop is at index 4
+		flagsHex := fields[8]
 		device := fields[9]
 
 		// Parse destination IPv6 address (32 hex chars = 128 bits)
@@ -260,10 +269,24 @@ func (l *linuxRouteDetector) parseLinuxIPv6RoutesFromProc(output string) ([]Rout
 			continue
 		}
 
+		flagsInt, err := strconv.ParseUint(flagsHex, 16, 64)
+		if err != nil {
+			flagsInt = 0
+		}
+		flags := parseLinuxIPv6RouteFlags(int64(flagsInt))
+
+		// The kernel installs a reject route for every destination it knows is
+		// unreachable, including a ::/0 one on hosts with no IPv6 default
+		// route. Those discard traffic rather than carry it, so reporting them
+		// makes a host look like it has a default route when it does not.
+		if routeFlagsRejected(flags) {
+			continue
+		}
+
 		routes = append(routes, Route{
 			Destination: destStr,
 			Gateway:     gatewayStr,
-			Flags:       []string{}, // /proc/net/ipv6_route doesn't provide flags in a simple format
+			Flags:       flags,
 			Interface:   device,
 		})
 	}

--- a/providers/os/resources/networkinterface/linux_routes.go
+++ b/providers/os/resources/networkinterface/linux_routes.go
@@ -196,6 +196,14 @@ func (l *linuxRouteDetector) parseLinuxRoutesFromProc(output string) ([]Route, e
 
 		flags := parseLinuxRouteFlags(int64(flagsInt))
 
+		// Same discard entries the IPv6 table and `ip route` paths drop. The
+		// kernel's fib_flag_trans sets RTF_REJECT for unreachable and prohibit
+		// routes; blackhole carries no flag of its own here, so only the JSON
+		// path can tell that one apart.
+		if routeFlagsRejected(flags) {
+			continue
+		}
+
 		// Handle gateway
 		gatewayStr := gateway.String()
 		if gateway.Equal(net.IPv4zero) {

--- a/providers/os/resources/networkinterface/linux_routes_test.go
+++ b/providers/os/resources/networkinterface/linux_routes_test.go
@@ -371,9 +371,11 @@ func Test_parseLinuxIPv6RoutesFromProc(t *testing.T) {
 	l := &linuxRouteDetector{}
 	alpineRoutes, err := l.parseLinuxIPv6RoutesFromProc(alpineIPv6ProcOutput)
 	require.NoError(t, err)
-	// The test data has 3 lines: 2 default routes (::/0) and 1 localhost route (::1/128)
-	// So we expect 3 routes, but 2 are duplicates in the map
-	require.GreaterOrEqual(t, len(alpineRoutes), 2, "Should parse at least 2 routes from /proc/net/ipv6_route")
+	// The test data has 3 lines. Two are the unreachable ::/0 the kernel installs
+	// on a host with no IPv6 connectivity (flags 00200200 = RTF_NONEXTHOP|RTF_REJECT);
+	// they discard traffic and must not be reported as default routes. Only the
+	// ::1/128 localhost route is real.
+	require.Len(t, alpineRoutes, 1, "the unreachable ::/0 entries must not be reported")
 
 	// Test data from Debian machine /proc/net/ipv6_route
 	debianIPv6ProcOutput := `2a02810a0983f3000000000000000000 40 00000000000000000000000000000000 00 00000000000000000000000000000000 00000258 00000005 00000000 00000001     wlo1
@@ -433,6 +435,19 @@ func Test_parseLinuxIPv6RoutesFromProc(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, len(debianRoutes), 10, "Should parse many routes from /proc/net/ipv6_route (excluding multicast)")
 
+	// This host carries both a real default route via wlo1 (flags 00000003) and
+	// the unreachable one on lo (flags 00200200). Only the first is a route
+	// traffic travels over, so network.routes.defaults must see exactly one.
+	defaults := 0
+	for _, r := range debianRoutes {
+		if r.Destination == "::/0" {
+			defaults++
+			assert.Equal(t, "wlo1", r.Interface)
+			assert.Equal(t, "fe80::b2f2:8ff:fe4c:9c41", r.Gateway)
+		}
+	}
+	assert.Equal(t, 1, defaults, "the unreachable ::/0 on lo must not be counted as a default route")
+
 	alpineRouteMap := make(map[string]*Route, len(alpineRoutes))
 	for i := range alpineRoutes {
 		key := alpineRoutes[i].Destination + "|" + alpineRoutes[i].Gateway + "|" + alpineRoutes[i].Interface
@@ -453,18 +468,11 @@ func Test_parseLinuxIPv6RoutesFromProc(t *testing.T) {
 		expectedFlags []string
 	}{
 		{
-			name:          "IPv6 default route",
-			destination:   "::/0",
-			gateway:       "::",
-			interfaceName: "lo",
-			expectedFlags: []string{},
-		},
-		{
 			name:          "IPv6 localhost route",
 			destination:   "::1/128",
 			gateway:       "::",
 			interfaceName: "lo",
-			expectedFlags: []string{},
+			expectedFlags: []string{"LOCAL", "NONEXTHOP", "UP"},
 		},
 	}
 
@@ -494,7 +502,7 @@ func Test_parseLinuxIPv6RoutesFromProc(t *testing.T) {
 			destination:   "::1/128",
 			gateway:       "::",
 			interfaceName: "lo",
-			expectedFlags: []string{},
+			expectedFlags: []string{"LOCAL", "NONEXTHOP", "UP"},
 		},
 		// wlo1 interface
 		{
@@ -502,35 +510,35 @@ func Test_parseLinuxIPv6RoutesFromProc(t *testing.T) {
 			destination:   "::/0",
 			gateway:       "fe80::b2f2:8ff:fe4c:9c41",
 			interfaceName: "wlo1",
-			expectedFlags: []string{},
+			expectedFlags: []string{"GATEWAY", "UP"},
 		},
 		{
 			name:          "IPv6 link-local route on wlo1",
 			destination:   "fe80::/64",
 			gateway:       "::",
 			interfaceName: "wlo1",
-			expectedFlags: []string{},
+			expectedFlags: []string{"UP"},
 		},
 		{
 			name:          "IPv6 network route 2a02:810a:983:f300::/64 on wlo1",
 			destination:   "2a02:810a:983:f300::/64",
 			gateway:       "::",
 			interfaceName: "wlo1",
-			expectedFlags: []string{},
+			expectedFlags: []string{"UP"},
 		},
 		{
 			name:          "IPv6 ULA network route fdad:a22e:9f09::/64 on wlo1",
 			destination:   "fdad:a22e:9f09::/64",
 			gateway:       "::",
 			interfaceName: "wlo1",
-			expectedFlags: []string{},
+			expectedFlags: []string{"UP"},
 		},
 		{
 			name:          "IPv6 host route on wlo1",
 			destination:   "fe80::e0e1:af0:8971:6498/128",
 			gateway:       "::",
 			interfaceName: "wlo1",
-			expectedFlags: []string{},
+			expectedFlags: []string{"LOCAL", "NONEXTHOP", "UP"},
 		},
 		// br-01ca4fc8136f interface
 		{
@@ -538,14 +546,14 @@ func Test_parseLinuxIPv6RoutesFromProc(t *testing.T) {
 			destination:   "fe80::/64",
 			gateway:       "::",
 			interfaceName: "br-01ca4fc8136f",
-			expectedFlags: []string{},
+			expectedFlags: []string{"UP"},
 		},
 		{
 			name:          "IPv6 host route on br-01ca4fc8136f",
 			destination:   "fe80::42:36ff:fe7d:ca5/128",
 			gateway:       "::",
 			interfaceName: "br-01ca4fc8136f",
-			expectedFlags: []string{},
+			expectedFlags: []string{"LOCAL", "NONEXTHOP", "UP"},
 		},
 		// docker0 interface
 		{
@@ -553,14 +561,14 @@ func Test_parseLinuxIPv6RoutesFromProc(t *testing.T) {
 			destination:   "fe80::/64",
 			gateway:       "::",
 			interfaceName: "docker0",
-			expectedFlags: []string{},
+			expectedFlags: []string{"UP"},
 		},
 		{
 			name:          "IPv6 host route on docker0",
 			destination:   "fe80::42:74ff:fe55:e6ae/128",
 			gateway:       "::",
 			interfaceName: "docker0",
-			expectedFlags: []string{},
+			expectedFlags: []string{"LOCAL", "NONEXTHOP", "UP"},
 		},
 		// br-573cc74a8612 interface
 		{
@@ -568,14 +576,14 @@ func Test_parseLinuxIPv6RoutesFromProc(t *testing.T) {
 			destination:   "fe80::/64",
 			gateway:       "::",
 			interfaceName: "br-573cc74a8612",
-			expectedFlags: []string{},
+			expectedFlags: []string{"UP"},
 		},
 		{
 			name:          "IPv6 host route on br-573cc74a8612",
 			destination:   "fe80::42:1fff:feda:c5e0/128",
 			gateway:       "::",
 			interfaceName: "br-573cc74a8612",
-			expectedFlags: []string{},
+			expectedFlags: []string{"LOCAL", "NONEXTHOP", "UP"},
 		},
 		// veth13dad49 interface
 		{
@@ -583,14 +591,14 @@ func Test_parseLinuxIPv6RoutesFromProc(t *testing.T) {
 			destination:   "fe80::/64",
 			gateway:       "::",
 			interfaceName: "veth13dad49",
-			expectedFlags: []string{},
+			expectedFlags: []string{"UP"},
 		},
 		{
 			name:          "IPv6 host route on veth13dad49",
 			destination:   "fe80::6843:81ff:fe73:9c89/128",
 			gateway:       "::",
 			interfaceName: "veth13dad49",
-			expectedFlags: []string{},
+			expectedFlags: []string{"LOCAL", "NONEXTHOP", "UP"},
 		},
 		// vethce143da interface
 		{
@@ -598,14 +606,14 @@ func Test_parseLinuxIPv6RoutesFromProc(t *testing.T) {
 			destination:   "fe80::/64",
 			gateway:       "::",
 			interfaceName: "vethce143da",
-			expectedFlags: []string{},
+			expectedFlags: []string{"UP"},
 		},
 		{
 			name:          "IPv6 host route on vethce143da",
 			destination:   "fe80::ac61:28ff:fef4:319a/128",
 			gateway:       "::",
 			interfaceName: "vethce143da",
-			expectedFlags: []string{},
+			expectedFlags: []string{"LOCAL", "NONEXTHOP", "UP"},
 		},
 		// vethc4f5eec interface
 		{
@@ -613,14 +621,14 @@ func Test_parseLinuxIPv6RoutesFromProc(t *testing.T) {
 			destination:   "fe80::/64",
 			gateway:       "::",
 			interfaceName: "vethc4f5eec",
-			expectedFlags: []string{},
+			expectedFlags: []string{"UP"},
 		},
 		{
 			name:          "IPv6 host route on vethc4f5eec",
 			destination:   "fe80::2019:9cff:fe49:50a1/128",
 			gateway:       "::",
 			interfaceName: "vethc4f5eec",
-			expectedFlags: []string{},
+			expectedFlags: []string{"LOCAL", "NONEXTHOP", "UP"},
 		},
 		// veth303a5c2 interface
 		{
@@ -628,14 +636,14 @@ func Test_parseLinuxIPv6RoutesFromProc(t *testing.T) {
 			destination:   "fe80::/64",
 			gateway:       "::",
 			interfaceName: "veth303a5c2",
-			expectedFlags: []string{},
+			expectedFlags: []string{"UP"},
 		},
 		{
 			name:          "IPv6 host route on veth303a5c2",
 			destination:   "fe80::d43e:f5ff:fe24:dc2c/128",
 			gateway:       "::",
 			interfaceName: "veth303a5c2",
-			expectedFlags: []string{},
+			expectedFlags: []string{"LOCAL", "NONEXTHOP", "UP"},
 		},
 		// veth61d447b interface
 		{
@@ -643,14 +651,14 @@ func Test_parseLinuxIPv6RoutesFromProc(t *testing.T) {
 			destination:   "fe80::/64",
 			gateway:       "::",
 			interfaceName: "veth61d447b",
-			expectedFlags: []string{},
+			expectedFlags: []string{"UP"},
 		},
 		{
 			name:          "IPv6 host route on veth61d447b",
 			destination:   "fe80::5082:1eff:fed5:990a/128",
 			gateway:       "::",
 			interfaceName: "veth61d447b",
-			expectedFlags: []string{},
+			expectedFlags: []string{"LOCAL", "NONEXTHOP", "UP"},
 		},
 	}
 

--- a/providers/os/resources/networkinterface/routes.go
+++ b/providers/os/resources/networkinterface/routes.go
@@ -97,9 +97,13 @@ func (r *Route) IsIPv6() bool {
 	return ip.To4() == nil && ip.To16() != nil
 }
 
-// routeFlagsMap maps route flag bits to their human-readable names
-// Based on sys/route.h constants (RTF_*) common across BSD-style systems (Linux, macOS, etc.)
-var routeFlagsMap = map[int64]string{
+// bsdRouteFlagsMap maps route flag bits to their human-readable names on
+// BSD-derived systems, per sys/route.h. macOS uses these.
+//
+// Linux does NOT: its RTF_* values in include/uapi/linux/route.h agree only up
+// to RTF_HOST (0x4) and diverge from 0x8 onwards, so Linux routes must be
+// decoded with linuxRouteFlagsMap instead.
+var bsdRouteFlagsMap = map[int64]string{
 	0x1:       "UP",        // RTF_UP - route is up
 	0x2:       "GATEWAY",   // RTF_GATEWAY - route has a gateway
 	0x4:       "HOST",      // RTF_HOST - host route (not a network route)
@@ -124,9 +128,76 @@ var routeFlagsMap = map[int64]string{
 	0x8000000: "MULTICAST", // RTF_MULTICAST - route represents a multicast address
 }
 
-// parseRouteFlags converts route flags integer to an array of flag strings
-func parseRouteFlags(flags int64) []string {
-	return parseFlags(flags, routeFlagsMap)
+// linuxRouteFlagsMap maps the RTF_* bits of /proc/net/route to their names, per
+// include/uapi/linux/route.h. These are the IPv4 flags; the IPv6 table below
+// builds on them.
+var linuxRouteFlagsMap = map[int64]string{
+	0x0001: "UP",        // RTF_UP - route is usable
+	0x0002: "GATEWAY",   // RTF_GATEWAY - destination is a gateway
+	0x0004: "HOST",      // RTF_HOST - host entry, network otherwise
+	0x0008: "REINSTATE", // RTF_REINSTATE - reinstate route after timeout
+	0x0010: "DYNAMIC",   // RTF_DYNAMIC - created dynamically by a redirect
+	0x0020: "MODIFIED",  // RTF_MODIFIED - modified dynamically by a redirect
+	0x0040: "MTU",       // RTF_MTU - route carries a specific MTU
+	0x0080: "WINDOW",    // RTF_WINDOW - per route window clamping
+	0x0100: "IRTT",      // RTF_IRTT - initial round trip time
+	0x0200: "REJECT",    // RTF_REJECT - packets to this destination are rejected
+}
+
+// linuxIPv6RouteFlagsMap maps the flag bits of /proc/net/ipv6_route. IPv6 reuses
+// the low bits above and adds its own from include/uapi/linux/ipv6_route.h.
+var linuxIPv6RouteFlagsMap = map[int64]string{
+	0x00010000: "DEFAULT",   // RTF_DEFAULT - learned via router discovery
+	0x00020000: "ALLONLINK", // RTF_ALLONLINK - no routers on link
+	0x00040000: "ADDRCONF",  // RTF_ADDRCONF - installed from a router advertisement
+	0x00080000: "PREFIX_RT", // RTF_PREFIX_RT - prefix-only route
+	0x00100000: "ANYCAST",   // RTF_ANYCAST - anycast
+	0x00200000: "NONEXTHOP", // RTF_NONEXTHOP - route with no next hop
+	0x00400000: "EXPIRES",   // RTF_EXPIRES - route expires
+	0x00800000: "ROUTEINFO", // RTF_ROUTEINFO - route information from an RA
+	0x01000000: "CACHE",     // RTF_CACHE - cache entry
+	0x02000000: "FLOW",      // RTF_FLOW - flow significant route
+	0x04000000: "POLICY",    // RTF_POLICY - policy route
+	0x40000000: "PCPU",      // RTF_PCPU - per-cpu, read only
+	0x80000000: "LOCAL",     // RTF_LOCAL - route to a local address
+}
+
+func init() {
+	// IPv6 routes carry the IPv4 bits too, so fold them in rather than
+	// restating them and letting the two lists drift apart.
+	for bit, name := range linuxRouteFlagsMap {
+		linuxIPv6RouteFlagsMap[bit] = name
+	}
+}
+
+// parseBSDRouteFlags converts the route flags of a BSD-derived system into an
+// array of flag strings.
+func parseBSDRouteFlags(flags int64) []string {
+	return parseFlags(flags, bsdRouteFlagsMap)
+}
+
+// parseLinuxRouteFlags converts the flags column of /proc/net/route into an
+// array of flag strings.
+func parseLinuxRouteFlags(flags int64) []string {
+	return parseFlags(flags, linuxRouteFlagsMap)
+}
+
+// parseLinuxIPv6RouteFlags converts the flags column of /proc/net/ipv6_route
+// into an array of flag strings.
+func parseLinuxIPv6RouteFlags(flags int64) []string {
+	return parseFlags(flags, linuxIPv6RouteFlagsMap)
+}
+
+// routeFlagsRejected reports whether the route discards traffic rather than
+// carrying it, which is what the kernel installs for an unreachable
+// destination.
+func routeFlagsRejected(flags []string) bool {
+	for _, f := range flags {
+		if f == "REJECT" || f == "BLACKHOLE" {
+			return true
+		}
+	}
+	return false
 }
 
 // parseFlags converts route flags integer to an array of flag strings using the provided flags map


### PR DESCRIPTION
## The bug

`routeFlagsMap` in `providers/os/resources/networkinterface/routes.go` was documented as:

> Based on sys/route.h constants (RTF_*) common across BSD-style systems (Linux, macOS, etc.)

Linux is not a BSD-style system for this purpose. `include/uapi/linux/route.h` agrees with `sys/route.h` only up to `RTF_HOST` (0x4) and diverges from 0x8 onwards. Every Linux route flag above `HOST` was therefore reported under the wrong name:

| bit | Linux | reported as |
|---|---|---|
| 0x0008 | `RTF_REINSTATE` | `REJECT` |
| 0x0040 | `RTF_MTU` | `DONE` |
| 0x0080 | `RTF_WINDOW` | `MASK` |
| 0x0100 | `RTF_IRTT` | `CLONING` |
| 0x0200 | `RTF_REJECT` | `XRESOLVE` |

Note the first row in particular: a route that merely reinstates after a timeout was reported with a `REJECT` flag it does not have, while a route that genuinely rejects traffic was not.

`/proc/net/route` is the **primary** source on Linux (`ip route` is only the fallback), so this affected every Linux asset. The existing tests missed it entirely because their fixtures only carry flags `0001` and `0003` — the two values where the two tables happen to agree.

## IPv6 flags were never read at all

`parseLinuxIPv6RoutesFromProc` hardcoded an empty list:

```go
Flags: []string{}, // /proc/net/ipv6_route doesn't provide flags in a simple format
```

The comment is not correct. The flags are field 8, in the same hex form as IPv4 — the function's own doc comment above it already lists `flags` in the format string.

## Unreachable routes reported as real ones

With the flags readable, the routes that discard traffic can be told apart from the ones that carry it. The kernel installs an unreachable `::/0` on any host without an IPv6 default route, and reporting it made such hosts look like they had one.

Confirmed live on Arch Linux in EC2: `network.routes.defaults` returned **three** entries — the real `0.0.0.0/0`, plus two identical `::/0 via :: dev lo` — on a host where `ip -6 route show` lists only `fe80::/64`. The two phantoms are flags `00200200` = `RTF_NONEXTHOP|RTF_REJECT`.

The `ip -json route show table all` path had the same hole from the other direction: `ipRouteJSON.Type` has always been parsed into the struct and never read, so `unreachable`, `blackhole` and `prohibit` entries came through as ordinary routes there too. Worse, an unreachable IPv6 default has no gateway and no prefsrc, so the family sniffing in `convertJSONRouteToRoute` fell through to `v4` and reported it as `0.0.0.0`.

## Changes

- Split the flag table: `bsdRouteFlagsMap` (macOS, unchanged values), `linuxRouteFlagsMap` (`include/uapi/linux/route.h`), and `linuxIPv6RouteFlagsMap` (the base flags plus the high bits from `include/uapi/linux/ipv6_route.h`).
- `parseLinuxRoutesFromProc` and `parseLinuxIPv6RoutesFromProc` use the Linux tables; `darwin_routes.go` uses the BSD one.
- The IPv6 parser reads field 8 instead of hardcoding an empty list.
- Both Linux paths skip routes that discard traffic — `REJECT`/`BLACKHOLE` flags in procfs, `unreachable`/`blackhole`/`prohibit`/`throw` types in the JSON.
- Fixed a log line that claimed a fallback to `/proc/net/route` that does not exist at that point.

## Tests

The Alpine IPv6 fixture in the existing test was itself an instance of this bug — its comment reads *"2 default routes (::/0) and 1 localhost route"*, but both of those `::/0` lines are `00200200`, the unreachable pair. That container has no IPv6 default route. Corrected, along with the 23 `expectedFlags: []string{}` assertions that only passed because flags were never populated.

New coverage in `linux_route_flags_test.go`:

- a table pinning each bit where Linux and BSD disagree, asserting both decodings side by side
- the live Arch `00200200` decoding to `NONEXTHOP|REJECT`
- an unreachable `::/0` filtered while a real router-advertised default survives
- the `0x80000000` top bit surviving without sign extension
- `unreachable`/`blackhole`/`prohibit` skipped in the JSON path

The Debian fixture makes the sharpest guard: it carries **both** a real default via `wlo1` and the unreachable one on `lo`, so the test asserts exactly one `::/0` survives.

`go build ./...`, `go vet`, and the full `go test ./resources/... -count=1` for the os provider all pass.