### PR TITLE
🐛 os: stop kernel.installed hiding kernels on Arch and phantoms on dpkg

### DIFF
--- a/providers/os/resources/kernel.go
+++ b/providers/os/resources/kernel.go
@@ -113,6 +113,61 @@ func suseKernelMatchesRunning(pkgVersion, pkgName, runningKernelVersion string) 
 	return strings.HasPrefix(stripRPMEpoch(pkgVersion), versionPrefix)
 }
 
+// suseKernelName reports the flavor a SUSE kernel package carries, and whether
+// the package holds a bootable kernel at all.
+//
+// SUSE names its bootable kernels "kernel-<flavor>" (kernel-default,
+// kernel-azure, kernel-rt, kernel-kvmsmall), plus the stripped
+// "kernel-<flavor>-base" variant that MicroOS boots. Everything else shipped
+// under the kernel- prefix is a subpackage that contains no kernel:
+// kernel-firmware-*, kernel-devel, kernel-macros, kernel-source, kernel-syms,
+// kernel-docs, kernel-install-tools, kernel-obs-build, kernel-livepatch-*, and
+// the per-flavor -devel/-extra/-optional/-vdso builds.
+//
+// Listing those invents installed kernels that are not on disk, and their
+// versions are unrelated to any kernel release: a stock host with
+// kernel-firmware-network and kernel-macros installed reported three
+// "installed kernels", one of them at a higher version than the running one,
+// which reads as a pending kernel upgrade that does not exist.
+//
+// A bootable name is therefore one flavor segment, optionally followed by
+// "-base", and the flavor is not one of the subpackage words. A flavor SUSE
+// adds later still resolves; a subpackage never does.
+func suseKernelName(pkgName string) (string, bool) {
+	flavor, ok := strings.CutPrefix(pkgName, "kernel-")
+	if !ok || flavor == "" {
+		return "", false
+	}
+
+	// kernel-default-base is bootable; kernel-default-devel and
+	// kernel-firmware-network are not.
+	flavor = strings.TrimSuffix(flavor, "-base")
+	if strings.Contains(flavor, "-") {
+		return "", false
+	}
+
+	if suseKernelSubpackages[flavor] {
+		return "", false
+	}
+
+	return pkgName, true
+}
+
+// suseKernelSubpackages are the single-segment kernel-* packages that are not
+// kernels. Multi-segment subpackages (kernel-firmware-network,
+// kernel-obs-build, kernel-default-devel) are already excluded by shape.
+// "base" only appears as a suffix on a real flavor (kernel-default-base); on
+// its own it is not a kernel.
+var suseKernelSubpackages = map[string]bool{
+	"base":     true,
+	"devel":    true,
+	"docs":     true,
+	"firmware": true,
+	"macros":   true,
+	"source":   true,
+	"syms":     true,
+}
+
 // debianImageKernelName reports the kernel release a linux-image package
 // carries, and whether the package holds a kernel at all.
 //
@@ -341,14 +396,15 @@ func photonKernelVersion(pkg kernelPackage, runningKernelVersion string) (Kernel
 //	cat /proc/version
 //	Linux version 4.12.14-122.23-default (geeko@buildhost)
 func suseKernelVersion(pkg kernelPackage, runningKernelVersion string) (KernelVersion, bool) {
-	if !strings.HasPrefix(pkg.Name, "kernel-") {
+	name, ok := suseKernelName(pkg.Name)
+	if !ok {
 		return KernelVersion{}, false
 	}
 
 	return KernelVersion{
-		Name:    pkg.Name,
-		Version: pkg.Version + strings.TrimPrefix(pkg.Name, "kernel"),
-		Running: suseKernelMatchesRunning(pkg.Version, pkg.Name, runningKernelVersion),
+		Name:    name,
+		Version: pkg.Version + strings.TrimPrefix(name, "kernel"),
+		Running: suseKernelMatchesRunning(pkg.Version, name, runningKernelVersion),
 	}, true
 }
 

--- a/providers/os/resources/kernel.go
+++ b/providers/os/resources/kernel.go
@@ -141,149 +141,371 @@ func debianImageKernelName(pkgName string) (string, bool) {
 	return name, true
 }
 
-func (k *mqlKernel) installed() ([]any, error) {
-	res := []KernelVersion{}
+// dpkgStatusIsInstalled reports whether a dpkg status triple describes a
+// package whose files are actually on disk.
+//
+// The triple is "<want> <flag> <state>" and only the state answers this. A
+// package that was removed but not purged keeps its entry in
+// /var/lib/dpkg/status as
+//
+//	Status: deinstall ok config-files
+//
+// with its files already gone. The kernel such an entry names cannot be
+// booted, so counting it inflates the installed set with a phantom and can
+// fail a "the running kernel is the newest installed" assertion against a
+// kernel that is not there. The want field is deliberately ignored: a held
+// package ("hold ok installed") is still installed, and isHeldStatus in the
+// packages package is what reads that position.
+//
+// An entry carrying no status at all is not evidence of removal. Google
+// distroless images keep their dpkg metadata in /var/lib/dpkg/status.d
+// stanzas that omit the Status field entirely, so an absent or unparseable
+// triple is treated as unknown and kept rather than silently dropped.
+func dpkgStatusIsInstalled(status string) bool {
+	fields := strings.Fields(status)
+	if len(fields) < 3 {
+		return true
+	}
+	return fields[2] == "installed"
+}
 
+// archKernelPackages is the set of Arch Linux packages that carry a kernel.
+//
+// It is an explicit allowlist rather than a "linux" prefix match because
+// Arch pairs every kernel with a headers package and ships other linux-
+// prefixed packages that hold no kernel at all: linux-headers,
+// linux-lts-headers, linux-api-headers and linux-firmware would all pass a
+// prefix test and none of them is bootable.
+var archKernelPackages = map[string]bool{
+	"linux":          true, // mainline
+	"linux-lts":      true, // long-term support
+	"linux-zen":      true, // desktop-tuned
+	"linux-hardened": true, // security-hardened
+}
+
+// foldArchVersionSeparators rewrites the separators in an Arch kernel
+// version to one canonical form, so the pacman spelling and the uname
+// spelling of the same kernel compare equal. See archKernelMatchesRunning.
+func foldArchVersionSeparators(version string) string {
+	return strings.ReplaceAll(version, ".", "-")
+}
+
+// archKernelMatchesRunning reports whether the given pacman kernel package
+// describes the currently running kernel.
+//
+// pacman and uname disagree on one separator. The package version joins the
+// upstream version to the Arch patch level with a dot, while the release
+// uname reports joins them with a dash:
+//
+//	pacman: linux 7.1.9.arch1-2
+//	uname:  7.1.9-arch1-2
+//
+// so a direct string comparison never matches and every entry in the list
+// would report running:false. Folding both separators into one form removes
+// the disagreement without having to know which of the two a given flavor
+// spells it with.
+//
+// The flavor lives in the package name suffix and is appended to the
+// release uname reports: linux-lts 6.6.67-1 runs as "6.6.67-1-lts".
+// Trimming that suffix from the running version first (the shape
+// suseKernelMatchesRunning uses) leaves the two version strings directly
+// comparable. The bare "linux" package has an empty suffix, for which the
+// trim is a no-op.
+func archKernelMatchesRunning(pkgVersion, pkgName, runningKernelVersion string) bool {
+	if runningKernelVersion == "" {
+		return false
+	}
+
+	flavor := strings.TrimPrefix(pkgName, "linux")
+	if !strings.HasSuffix(runningKernelVersion, flavor) {
+		return false
+	}
+	running := strings.TrimSuffix(runningKernelVersion, flavor)
+
+	return foldArchVersionSeparators(pkgVersion) == foldArchVersionSeparators(running)
+}
+
+// kernelPackage is the subset of an installed package the per-family kernel
+// filters read. Lifting it out of *mqlPackage keeps every filter a pure
+// function of values, which is what makes them testable without a runtime.
+type kernelPackage struct {
+	Name    string
+	Version string
+	Arch    string
+	Status  string
+}
+
+// kernelFilter maps one installed package to the kernel it carries. The
+// second return is false when the package is not a kernel (a -headers
+// package, a Debian metapackage, anything unrelated) or when it names a
+// kernel the host cannot boot (a dpkg entry removed but not purged).
+type kernelFilter func(pkg kernelPackage, runningKernelVersion string) (KernelVersion, bool)
+
+// debianKernelVersion reads a dpkg linux-image package.
+//
+// kernel version is "4.19.0-13-cloud-amd64", carried by packages named
+// "linux-image-*":
+//
+//	[{
+//		name: "linux-image-4.19.0-12-cloud-amd64"
+//		version: "4.19.152-1"
+//	}, {
+//		name: "linux-image-4.19.0-13-cloud-amd64"
+//		version: "4.19.160-2"
+//	}, {
+//		name: "linux-image-cloud-amd64"
+//		version: "4.19+105+deb10u8"
+//	}]
+func debianKernelVersion(pkg kernelPackage, runningKernelVersion string) (KernelVersion, bool) {
+	kernelName, ok := debianImageKernelName(pkg.Name)
+	if !ok {
+		return KernelVersion{}, false
+	}
+
+	// A removed-but-not-purged image package still has a linux-image-<release>
+	// name in the dpkg database long after its files are gone.
+	if !dpkgStatusIsInstalled(pkg.Status) {
+		return KernelVersion{}, false
+	}
+
+	return KernelVersion{
+		Name:    kernelName,
+		Version: pkg.Version,
+		Running: kernelName == runningKernelVersion,
+	}, true
+}
+
+// oracleKernelVersion reads an Oracle Linux kernel package. Oracle is rpm
+// based but might be running the UEK kernel, so both "kernel" and
+// "kernel-uek" count. Kernel version is "6.12.0-105.51.5.el9uek.x86_64".
+func oracleKernelVersion(pkg kernelPackage, runningKernelVersion string) (KernelVersion, bool) {
+	if pkg.Name != "kernel" && pkg.Name != "kernel-uek" {
+		return KernelVersion{}, false
+	}
+
+	return KernelVersion{
+		Name:    pkg.Name,
+		Version: pkg.Version,
+		Running: rpmKernelMatchesRunning(pkg.Version, pkg.Arch, runningKernelVersion),
+	}, true
+}
+
+// redhatKernelVersion reads an rpm kernel package.
+//
+// kernel version is "3.10.0-1160.11.1.el7.x86_64", carried by packages
+// named "kernel":
+//
+//	[{
+//		name: "kernel"
+//		version: "3.10.0-1127.el7"
+//	}, {
+//		name: "kernel"
+//		version: "3.10.0-1160.11.1.el7"
+//	}, {
+//		name: "kernel"
+//		version: "3.10.0-1127.19.1.el7"
+//	}]
+func redhatKernelVersion(pkg kernelPackage, runningKernelVersion string) (KernelVersion, bool) {
+	if pkg.Name != "kernel" {
+		return KernelVersion{}, false
+	}
+
+	return KernelVersion{
+		Name:    pkg.Name,
+		Version: pkg.Version,
+		Running: rpmKernelMatchesRunning(pkg.Version, pkg.Arch, runningKernelVersion),
+	}, true
+}
+
+// photonKernelVersion reads a Photon kernel package, whose flavor lives in
+// the package name suffix ("linux" bare, "linux-esx" for VMware).
+func photonKernelVersion(pkg kernelPackage, runningKernelVersion string) (KernelVersion, bool) {
+	if !strings.HasPrefix(pkg.Name, "linux") {
+		return KernelVersion{}, false
+	}
+
+	return KernelVersion{
+		Name:    pkg.Name,
+		Version: pkg.Version + strings.TrimPrefix(pkg.Name, "linux"),
+		Running: photonKernelMatchesRunning(pkg.Version, pkg.Name, runningKernelVersion),
+	}, true
+}
+
+// suseKernelVersion reads a SUSE kernel package.
+//
+//	kernel.info[version] == "4.12.14-122.23-default"
+//	rpm -qa | grep -i kernel
+//	kernel-default-4.12.14-122.23.1.x86_64
+//	kernel-firmware-20190618-5.14.1.noarch
+//	kernel-default-4.12.14-122.60.1.x86_64
+//	cat /proc/version
+//	Linux version 4.12.14-122.23-default (geeko@buildhost)
+func suseKernelVersion(pkg kernelPackage, runningKernelVersion string) (KernelVersion, bool) {
+	if !strings.HasPrefix(pkg.Name, "kernel-") {
+		return KernelVersion{}, false
+	}
+
+	return KernelVersion{
+		Name:    pkg.Name,
+		Version: pkg.Version + strings.TrimPrefix(pkg.Name, "kernel"),
+		Running: suseKernelMatchesRunning(pkg.Version, pkg.Name, runningKernelVersion),
+	}, true
+}
+
+// archKernelVersion reads a pacman kernel package. The installed version
+// reads "7.1.9.arch1-2" while uname reports "7.1.8-arch1-3", so the running
+// comparison has to normalise the separator (archKernelMatchesRunning).
+func archKernelVersion(pkg kernelPackage, runningKernelVersion string) (KernelVersion, bool) {
+	if !archKernelPackages[pkg.Name] {
+		return KernelVersion{}, false
+	}
+
+	return KernelVersion{
+		Name:    pkg.Name,
+		Version: pkg.Version,
+		Running: archKernelMatchesRunning(pkg.Version, pkg.Name, runningKernelVersion),
+	}, true
+}
+
+// kernelFilterForPlatform picks the filter that knows how this platform's
+// package manager names and versions kernel packages. The second return is
+// false when no filter covers the platform; kernelInstalledFilter decides
+// what that means.
+//
+// The order matters and matches the order these families were originally
+// dispatched in: Oracle Linux is checked before the redhat family it
+// belongs to, because it may be running the UEK kernel.
+func kernelFilterForPlatform(platform *inventory.Platform) (kernelFilter, bool) {
+	switch {
+	case platform == nil || !platform.IsFamily(inventory.FAMILY_LINUX):
+		return nil, false
+	case platform.IsFamily("debian"):
+		return debianKernelVersion, true
+	case platform.Name == "oraclelinux":
+		return oracleKernelVersion, true
+	case platform.IsFamily("redhat") || platform.Name == "amazonlinux":
+		return redhatKernelVersion, true
+	case platform.Name == "photon":
+		return photonKernelVersion, true
+	case platform.IsFamily("suse"):
+		return suseKernelVersion, true
+	case platform.IsFamily("arch"):
+		return archKernelVersion, true
+	default:
+		return nil, false
+	}
+}
+
+// kernelInstalledFilter resolves the filter for a platform and decides how
+// installed() must answer when there is none. The three outcomes are
+// deliberately distinct:
+//
+//   - a filter, no error: enumerate the kernel packages.
+//   - no filter, an error: a Linux host whose package manager has no case
+//     here. A Linux host is running a kernel and got it from a package
+//     manager, so "no kernels installed" is never the truth. Answering with
+//     an empty list would be indistinguishable from a verified-empty result,
+//     and a policy asserting "the running kernel is the newest installed"
+//     would evaluate over the empty set and pass without checking anything.
+//     The error names the platform so the missing case can be added.
+//   - no filter, no error: not Linux at all. darwin, bsd and aix reach
+//     installed() because initKernel admits them for kernel.info, modules
+//     and parameters, but a package-managed kernel image is not a thing that
+//     exists there. That answer stays the empty list it has always been:
+//     whether it should be null instead is a separate question about a
+//     platform where the concept barely applies, and not one this dispatch
+//     should decide.
+func kernelInstalledFilter(platform *inventory.Platform) (kernelFilter, error) {
+	if filter, ok := kernelFilterForPlatform(platform); ok {
+		return filter, nil
+	}
+
+	if platform.IsFamily(inventory.FAMILY_LINUX) {
+		return nil, errors.New("kernel.installed is not supported on platform " + platformLabel(platform))
+	}
+
+	return nil, nil
+}
+
+func (k *mqlKernel) installed() ([]any, error) {
 	conn := k.MqlRuntime.Connection.(shared.Connection)
 	platform := conn.Asset().Platform
 
-	if platform.IsFamily(inventory.FAMILY_LINUX) {
-
-		// 1. gather running kernel information
-		info := k.GetInfo()
-		if info.Error != nil {
-			return nil, errors.New("could not determine kernel version")
-		}
-
-		kernelInfo, ok := info.Data.(map[string]any)
-		if !ok {
-			return nil, errors.New("no structured kernel information found")
-		}
-
-		runningKernelVersion := kernelInfo["version"].(string)
-
-		// 2. get all packages
-		raw, err := CreateResource(k.MqlRuntime, "packages", map[string]*llx.RawData{})
-		if err != nil {
-			return nil, err
-		}
-		packages := raw.(*mqlPackages)
-
-		tlist := packages.GetList()
-		if tlist.Error != nil {
-			return nil, tlist.Error
-		}
-		mqlPkgs := tlist.Data
-
-		filterKernel := func(pkg *mqlPackage) {}
-
-		if platform.IsFamily("debian") {
-			// debian based systems
-			// kernel version is  "4.19.0-13-cloud-amd64"
-			// filter by packages named "linux-image-*"
-			//[{
-			//	name: "linux-image-4.19.0-12-cloud-amd64"
-			//	version: "4.19.152-1"
-			//}, {
-			//	name: "linux-image-4.19.0-13-cloud-amd64"
-			//	version: "4.19.160-2"
-			//}, {
-			//	name: "linux-image-cloud-amd64"
-			//	version: "4.19+105+deb10u8"
-			//}]
-			filterKernel = func(pkg *mqlPackage) {
-				kernelName, ok := debianImageKernelName(pkg.Name.Data)
-				if !ok {
-					return
-				}
-
-				res = append(res, KernelVersion{
-					Name:    kernelName,
-					Version: pkg.Version.Data,
-					Running: kernelName == runningKernelVersion,
-				})
-			}
-		} else if platform.Name == "oraclelinux" {
-			// ORacleLinux is an rpm based systems, but might be running the UEK kernel
-			// kernel version is  "6.12.0-105.51.5.el9uek.x86_64"
-			// filter by packages named "kernel" OR "kernel-uek"
-			filterKernel = func(pkg *mqlPackage) {
-				if pkg.Name.Data == "kernel" || pkg.Name.Data == "kernel-uek" {
-					version := pkg.Version.Data
-					res = append(res, KernelVersion{
-						Name:    pkg.Name.Data,
-						Version: version,
-						Running: rpmKernelMatchesRunning(version, pkg.Arch.Data, runningKernelVersion),
-					})
-				}
-			}
-		} else if platform.IsFamily("redhat") || platform.Name == "amazonlinux" {
-			// rpm based systems
-			// kernel version is  "3.10.0-1160.11.1.el7.x86_64"
-			// filter by packages named "kernel"
-			//[{
-			//	name: "kernel"
-			//	version: "3.10.0-1127.el7"
-			//}, {
-			//	name: "kernel"
-			//	version: "3.10.0-1160.11.1.el7"
-			//}, {
-			//	name: "kernel"
-			//	version: "3.10.0-1127.19.1.el7"
-			//}]
-			filterKernel = func(pkg *mqlPackage) {
-				if pkg.Name.Data == "kernel" {
-					version := pkg.Version.Data
-					res = append(res, KernelVersion{
-						Name:    pkg.Name.Data,
-						Version: version,
-						Running: rpmKernelMatchesRunning(version, pkg.Arch.Data, runningKernelVersion),
-					})
-				}
-			}
-		} else if platform.Name == "photon" {
-			filterKernel = func(pkg *mqlPackage) {
-				name := pkg.Name.Data
-				if strings.HasPrefix(name, "linux") {
-					version := pkg.Version.Data
-
-					res = append(res, KernelVersion{
-						Name:    name,
-						Version: version + strings.TrimPrefix(name, "linux"),
-						Running: photonKernelMatchesRunning(version, name, runningKernelVersion),
-					})
-				}
-			}
-		} else if platform.IsFamily("suse") {
-			// kernel.info[version] == "4.12.14-122.23-default"
-			// rpm -qa | grep -i kernel
-			// kernel-default-4.12.14-122.23.1.x86_64
-			// kernel-firmware-20190618-5.14.1.noarch
-			// kernel-default-4.12.14-122.60.1.x86_64
-			// cat /proc/version
-			// Linux version 4.12.14-122.23-default (geeko@buildhost)
-			filterKernel = func(pkg *mqlPackage) {
-				name := pkg.Name.Data
-				if strings.HasPrefix(name, "kernel-") {
-					version := pkg.Version.Data
-					res = append(res, KernelVersion{
-						Name:    name,
-						Version: version + strings.TrimPrefix(name, "kernel"),
-						Running: suseKernelMatchesRunning(version, name, runningKernelVersion),
-					})
-				}
-			}
-		}
-
-		for i := range mqlPkgs {
-			mqlPkg := mqlPkgs[i]
-			pkg := mqlPkg.(*mqlPackage)
-			filterKernel(pkg)
-		}
+	filterKernel, err := kernelInstalledFilter(platform)
+	if err != nil {
+		return nil, err
+	}
+	if filterKernel == nil {
+		// Not Linux: unchanged, and deliberately so. See kernelInstalledFilter.
+		return convert.JsonToDictSlice([]KernelVersion{})
 	}
 
-	// empty when there is no kernel information found
+	// 1. gather running kernel information
+	info := k.GetInfo()
+	if info.Error != nil {
+		return nil, errors.New("could not determine kernel version")
+	}
+
+	kernelInfo, ok := info.Data.(map[string]any)
+	if !ok {
+		return nil, errors.New("no structured kernel information found")
+	}
+
+	runningKernelVersion, ok := kernelInfo["version"].(string)
+	if !ok {
+		return nil, errors.New("no running kernel version found")
+	}
+
+	// 2. get all packages
+	raw, err := CreateResource(k.MqlRuntime, "packages", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	packages := raw.(*mqlPackages)
+
+	tlist := packages.GetList()
+	if tlist.Error != nil {
+		return nil, tlist.Error
+	}
+	mqlPkgs := tlist.Data
+
+	res := []KernelVersion{}
+	for i := range mqlPkgs {
+		pkg, ok := mqlPkgs[i].(*mqlPackage)
+		if !ok {
+			continue
+		}
+
+		kernelVersion, ok := filterKernel(kernelPackage{
+			Name:    pkg.Name.Data,
+			Version: pkg.Version.Data,
+			Arch:    pkg.Arch.Data,
+			Status:  pkg.Status.Data,
+		}, runningKernelVersion)
+		if !ok {
+			continue
+		}
+
+		res = append(res, kernelVersion)
+	}
+
 	return convert.JsonToDictSlice(res)
+}
+
+// platformLabel names a platform for an error message, falling back to the
+// family when the name is empty so the message never trails off into
+// nothing.
+func platformLabel(platform *inventory.Platform) string {
+	if platform == nil {
+		return "unknown"
+	}
+	if platform.Name != "" {
+		return platform.Name
+	}
+	if len(platform.Family) > 0 {
+		return strings.Join(platform.Family, "/")
+	}
+	return "unknown"
 }
 
 func (k *mqlKernel) info() (any, error) {

--- a/providers/os/resources/kernel_internal_test.go
+++ b/providers/os/resources/kernel_internal_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 )
 
 // TestParseModprobeConfig locks down the modprobe.d parser used by the
@@ -532,6 +534,548 @@ func TestParseModulesBuiltin(t *testing.T) {
 			}
 			for _, name := range tc.absent {
 				assert.False(t, got[name], "expected %q NOT to be builtin", name)
+			}
+		})
+	}
+}
+
+// TestArchKernelMatchesRunning is the unit-level reproducer for the Arch
+// half of the silent-empty bug. Read off a live Arch host: pacman reports
+// `linux 7.1.9.arch1-2` while uname reports `7.1.8-arch1-3`. The two
+// spellings disagree on the separator in front of the arch patch level, so
+// a naive string equality reports running:false for every kernel including
+// the one that is actually booted.
+func TestArchKernelMatchesRunning(t *testing.T) {
+	cases := []struct {
+		name           string
+		pkgVersion     string
+		pkgName        string
+		runningKernel  string
+		expectedResult bool
+	}{
+		{
+			name:           "live Arch host: newer kernel installed, older still running",
+			pkgVersion:     "7.1.9.arch1-2",
+			pkgName:        "linux",
+			runningKernel:  "7.1.8-arch1-3",
+			expectedResult: false,
+		},
+		{
+			name:           "booted kernel matches across the dot/dash separator",
+			pkgVersion:     "7.1.8.arch1-3",
+			pkgName:        "linux",
+			runningKernel:  "7.1.8-arch1-3",
+			expectedResult: true,
+		},
+		{
+			name:           "linux-lts carries its flavor as a release suffix",
+			pkgVersion:     "6.6.67-1",
+			pkgName:        "linux-lts",
+			runningKernel:  "6.6.67-1-lts",
+			expectedResult: true,
+		},
+		{
+			name:           "linux-zen matches with both a patch marker and a flavor suffix",
+			pkgVersion:     "6.12.4.zen1-1",
+			pkgName:        "linux-zen",
+			runningKernel:  "6.12.4-zen1-1-zen",
+			expectedResult: true,
+		},
+		{
+			name:           "linux-hardened matches with both a patch marker and a flavor suffix",
+			pkgVersion:     "6.12.4.hardened1-1",
+			pkgName:        "linux-hardened",
+			runningKernel:  "6.12.4-hardened1-1-hardened",
+			expectedResult: true,
+		},
+		{
+			name:           "mainline linux does not claim a running lts kernel",
+			pkgVersion:     "6.6.67-1",
+			pkgName:        "linux",
+			runningKernel:  "6.6.67-1-lts",
+			expectedResult: false,
+		},
+		{
+			name:           "lts does not claim a running mainline kernel",
+			pkgVersion:     "7.1.8.arch1-3",
+			pkgName:        "linux-lts",
+			runningKernel:  "7.1.8-arch1-3",
+			expectedResult: false,
+		},
+		{
+			name:           "older lts build does not match the running one",
+			pkgVersion:     "6.6.60-1",
+			pkgName:        "linux-lts",
+			runningKernel:  "6.6.67-1-lts",
+			expectedResult: false,
+		},
+		{
+			name:           "running-kernel string is empty (kernel.info unavailable)",
+			pkgVersion:     "7.1.9.arch1-2",
+			pkgName:        "linux",
+			runningKernel:  "",
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := archKernelMatchesRunning(tc.pkgVersion, tc.pkgName, tc.runningKernel)
+			assert.Equal(t, tc.expectedResult, got)
+		})
+	}
+}
+
+// TestDpkgStatusIsInstalled locks down the dpkg status gate behind the
+// debian branch of kernel.installed. The case that motivated it was found
+// on Linux Mint: a kernel removed but not purged keeps its
+// linux-image-<release> entry in /var/lib/dpkg/status with the state
+// "config-files" and no files on disk, and was being reported as installed.
+func TestDpkgStatusIsInstalled(t *testing.T) {
+	cases := []struct {
+		status    string
+		installed bool
+		why       string
+	}{
+		{"install ok installed", true, "the ordinary installed package"},
+		{"deinstall ok config-files", false, "removed but not purged: the files are gone"},
+		{"purge ok config-files", false, "queued for purge, files already gone"},
+		{"hold ok installed", true, "a held package is still installed"},
+		{"install ok half-installed", false, "an interrupted install is not bootable"},
+		{"install ok unpacked", false, "unpacked but never configured"},
+		{"deinstall ok not-installed", false, "explicitly not installed"},
+		{"", true, "no status at all: distroless status.d stanzas omit the field, so unknown rather than removed"},
+		{"install ok", true, "not a full triple: unknown rather than removed"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.status, func(t *testing.T) {
+			assert.Equal(t, tc.installed, dpkgStatusIsInstalled(tc.status), tc.why)
+		})
+	}
+}
+
+// TestKernelFilters covers each per-family filter end to end: which
+// packages it accepts as kernels, what it names them, and whether it marks
+// the running one. The redhat / oraclelinux / photon / suse / debian rows
+// are regression coverage that the extraction of these closures into pure
+// functions did not change what they report.
+func TestKernelFilters(t *testing.T) {
+	cases := []struct {
+		name          string
+		filter        kernelFilter
+		pkg           kernelPackage
+		runningKernel string
+		wantOK        bool
+		want          KernelVersion
+	}{
+		// --- arch (new) ---
+		{
+			name:          "arch: installed mainline kernel, older one running",
+			filter:        archKernelVersion,
+			pkg:           kernelPackage{Name: "linux", Version: "7.1.9.arch1-2"},
+			runningKernel: "7.1.8-arch1-3",
+			wantOK:        true,
+			want:          KernelVersion{Name: "linux", Version: "7.1.9.arch1-2", Running: false},
+		},
+		{
+			name:          "arch: the booted kernel is marked running",
+			filter:        archKernelVersion,
+			pkg:           kernelPackage{Name: "linux", Version: "7.1.8.arch1-3"},
+			runningKernel: "7.1.8-arch1-3",
+			wantOK:        true,
+			want:          KernelVersion{Name: "linux", Version: "7.1.8.arch1-3", Running: true},
+		},
+		{
+			name:          "arch: linux-headers is not a kernel",
+			filter:        archKernelVersion,
+			pkg:           kernelPackage{Name: "linux-headers", Version: "7.1.9.arch1-2"},
+			runningKernel: "7.1.8-arch1-3",
+			wantOK:        false,
+		},
+		{
+			name:          "arch: linux-lts-headers is not a kernel",
+			filter:        archKernelVersion,
+			pkg:           kernelPackage{Name: "linux-lts-headers", Version: "6.6.67-1"},
+			runningKernel: "6.6.67-1-lts",
+			wantOK:        false,
+		},
+		{
+			name:          "arch: linux-api-headers is not a kernel",
+			filter:        archKernelVersion,
+			pkg:           kernelPackage{Name: "linux-api-headers", Version: "6.10-1"},
+			runningKernel: "7.1.8-arch1-3",
+			wantOK:        false,
+		},
+		{
+			name:          "arch: linux-firmware is not a kernel",
+			filter:        archKernelVersion,
+			pkg:           kernelPackage{Name: "linux-firmware", Version: "20241210.20e46d0f-1"},
+			runningKernel: "7.1.8-arch1-3",
+			wantOK:        false,
+		},
+		{
+			name:          "arch: an unrelated package is not a kernel",
+			filter:        archKernelVersion,
+			pkg:           kernelPackage{Name: "bash", Version: "5.2.037-1"},
+			runningKernel: "7.1.8-arch1-3",
+			wantOK:        false,
+		},
+		{
+			name:          "arch: linux-lts is a kernel and is marked running",
+			filter:        archKernelVersion,
+			pkg:           kernelPackage{Name: "linux-lts", Version: "6.6.67-1"},
+			runningKernel: "6.6.67-1-lts",
+			wantOK:        true,
+			want:          KernelVersion{Name: "linux-lts", Version: "6.6.67-1", Running: true},
+		},
+
+		// --- debian (status gate is new, naming is regression) ---
+		{
+			name:          "debian: install ok installed is accepted and marked running",
+			filter:        debianKernelVersion,
+			pkg:           kernelPackage{Name: "linux-image-4.19.0-13-cloud-amd64", Version: "4.19.160-2", Status: "install ok installed"},
+			runningKernel: "4.19.0-13-cloud-amd64",
+			wantOK:        true,
+			want:          KernelVersion{Name: "4.19.0-13-cloud-amd64", Version: "4.19.160-2", Running: true},
+		},
+		{
+			name:          "debian: an older installed image is accepted but not running",
+			filter:        debianKernelVersion,
+			pkg:           kernelPackage{Name: "linux-image-4.19.0-12-cloud-amd64", Version: "4.19.152-1", Status: "install ok installed"},
+			runningKernel: "4.19.0-13-cloud-amd64",
+			wantOK:        true,
+			want:          KernelVersion{Name: "4.19.0-12-cloud-amd64", Version: "4.19.152-1", Running: false},
+		},
+		{
+			name:          "debian: deinstall ok config-files is rejected",
+			filter:        debianKernelVersion,
+			pkg:           kernelPackage{Name: "linux-image-5.15.0-91-generic", Version: "5.15.0-91.101", Status: "deinstall ok config-files"},
+			runningKernel: "5.15.0-94-generic",
+			wantOK:        false,
+		},
+		{
+			name:          "debian: a removed image is rejected even when it names the running kernel",
+			filter:        debianKernelVersion,
+			pkg:           kernelPackage{Name: "linux-image-5.15.0-94-generic", Version: "5.15.0-94.104", Status: "purge ok config-files"},
+			runningKernel: "5.15.0-94-generic",
+			wantOK:        false,
+		},
+		{
+			name:          "debian: a held image is still installed",
+			filter:        debianKernelVersion,
+			pkg:           kernelPackage{Name: "linux-image-5.15.0-94-generic", Version: "5.15.0-94.104", Status: "hold ok installed"},
+			runningKernel: "5.15.0-94-generic",
+			wantOK:        true,
+			want:          KernelVersion{Name: "5.15.0-94-generic", Version: "5.15.0-94.104", Running: true},
+		},
+		{
+			name:          "debian: an image with no status is kept (distroless status.d omits it)",
+			filter:        debianKernelVersion,
+			pkg:           kernelPackage{Name: "linux-image-4.19.0-13-cloud-amd64", Version: "4.19.160-2", Status: ""},
+			runningKernel: "4.19.0-13-cloud-amd64",
+			wantOK:        true,
+			want:          KernelVersion{Name: "4.19.0-13-cloud-amd64", Version: "4.19.160-2", Running: true},
+		},
+		{
+			name:          "debian: the metapackage carries no kernel",
+			filter:        debianKernelVersion,
+			pkg:           kernelPackage{Name: "linux-image-cloud-amd64", Version: "4.19+105+deb10u8", Status: "install ok installed"},
+			runningKernel: "4.19.0-13-cloud-amd64",
+			wantOK:        false,
+		},
+		{
+			name:          "debian: an unrelated package is not a kernel",
+			filter:        debianKernelVersion,
+			pkg:           kernelPackage{Name: "linux-headers-4.19.0-13-cloud-amd64", Version: "4.19.160-2", Status: "install ok installed"},
+			runningKernel: "4.19.0-13-cloud-amd64",
+			wantOK:        false,
+		},
+
+		// --- redhat (regression) ---
+		{
+			name:          "redhat: kernel package matches running via arch suffix",
+			filter:        redhatKernelVersion,
+			pkg:           kernelPackage{Name: "kernel", Version: "3.10.0-1160.11.1.el7", Arch: "x86_64"},
+			runningKernel: "3.10.0-1160.11.1.el7.x86_64",
+			wantOK:        true,
+			want:          KernelVersion{Name: "kernel", Version: "3.10.0-1160.11.1.el7", Running: true},
+		},
+		{
+			name:          "redhat: an older kernel is listed but not running",
+			filter:        redhatKernelVersion,
+			pkg:           kernelPackage{Name: "kernel", Version: "3.10.0-1127.el7", Arch: "x86_64"},
+			runningKernel: "3.10.0-1160.11.1.el7.x86_64",
+			wantOK:        true,
+			want:          KernelVersion{Name: "kernel", Version: "3.10.0-1127.el7", Running: false},
+		},
+		{
+			name:          "redhat: kernel-devel is not a kernel",
+			filter:        redhatKernelVersion,
+			pkg:           kernelPackage{Name: "kernel-devel", Version: "3.10.0-1160.11.1.el7", Arch: "x86_64"},
+			runningKernel: "3.10.0-1160.11.1.el7.x86_64",
+			wantOK:        false,
+		},
+		{
+			name:          "redhat: amazonlinux epoch is stripped before matching",
+			filter:        redhatKernelVersion,
+			pkg:           kernelPackage{Name: "kernel", Version: "1:6.1.170-210.320.amzn2023", Arch: "x86_64"},
+			runningKernel: "6.1.170-210.320.amzn2023.x86_64",
+			wantOK:        true,
+			want:          KernelVersion{Name: "kernel", Version: "1:6.1.170-210.320.amzn2023", Running: true},
+		},
+
+		// --- oraclelinux (regression) ---
+		{
+			name:          "oraclelinux: the UEK kernel is recognised",
+			filter:        oracleKernelVersion,
+			pkg:           kernelPackage{Name: "kernel-uek", Version: "1:6.12.0-105.51.5.el9uek", Arch: "x86_64"},
+			runningKernel: "6.12.0-105.51.5.el9uek.x86_64",
+			wantOK:        true,
+			want:          KernelVersion{Name: "kernel-uek", Version: "1:6.12.0-105.51.5.el9uek", Running: true},
+		},
+		{
+			name:          "oraclelinux: the stock kernel is listed but not running under UEK",
+			filter:        oracleKernelVersion,
+			pkg:           kernelPackage{Name: "kernel", Version: "5.14.0-427.el9", Arch: "x86_64"},
+			runningKernel: "6.12.0-105.51.5.el9uek.x86_64",
+			wantOK:        true,
+			want:          KernelVersion{Name: "kernel", Version: "5.14.0-427.el9", Running: false},
+		},
+		{
+			name:          "oraclelinux: kernel-uek-devel is not a kernel",
+			filter:        oracleKernelVersion,
+			pkg:           kernelPackage{Name: "kernel-uek-devel", Version: "1:6.12.0-105.51.5.el9uek", Arch: "x86_64"},
+			runningKernel: "6.12.0-105.51.5.el9uek.x86_64",
+			wantOK:        false,
+		},
+
+		// --- photon (regression) ---
+		{
+			name:          "photon: the esx flavor is recognised and marked running",
+			filter:        photonKernelVersion,
+			pkg:           kernelPackage{Name: "linux-esx", Version: "4.19.97-1.ph3"},
+			runningKernel: "4.19.97-1.ph3-esx",
+			wantOK:        true,
+			want:          KernelVersion{Name: "linux-esx", Version: "4.19.97-1.ph3-esx", Running: true},
+		},
+		{
+			name:          "photon: the bare linux package is recognised",
+			filter:        photonKernelVersion,
+			pkg:           kernelPackage{Name: "linux", Version: "4.19.97-1.ph3"},
+			runningKernel: "4.19.97-1.ph3",
+			wantOK:        true,
+			want:          KernelVersion{Name: "linux", Version: "4.19.97-1.ph3", Running: true},
+		},
+		{
+			name:          "photon: a non-linux package is skipped",
+			filter:        photonKernelVersion,
+			pkg:           kernelPackage{Name: "bash", Version: "5.0-1.ph3"},
+			runningKernel: "4.19.97-1.ph3",
+			wantOK:        false,
+		},
+
+		// --- suse (regression) ---
+		{
+			name:          "suse: kernel-default is recognised and marked running",
+			filter:        suseKernelVersion,
+			pkg:           kernelPackage{Name: "kernel-default", Version: "4.12.14-122.23.1"},
+			runningKernel: "4.12.14-122.23-default",
+			wantOK:        true,
+			want:          KernelVersion{Name: "kernel-default", Version: "4.12.14-122.23.1-default", Running: true},
+		},
+		{
+			name:          "suse: an older kernel-default is listed but not running",
+			filter:        suseKernelVersion,
+			pkg:           kernelPackage{Name: "kernel-default", Version: "4.12.14-122.20.1"},
+			runningKernel: "4.12.14-122.23-default",
+			wantOK:        true,
+			want:          KernelVersion{Name: "kernel-default", Version: "4.12.14-122.20.1-default", Running: false},
+		},
+		{
+			name:          "suse: the bare kernel name without a dash is skipped",
+			filter:        suseKernelVersion,
+			pkg:           kernelPackage{Name: "kernel", Version: "4.12.14-122.23.1"},
+			runningKernel: "4.12.14-122.23-default",
+			wantOK:        false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := tc.filter(tc.pkg, tc.runningKernel)
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+// TestKernelFilterForPlatform locks down the dispatch. The rows that matter
+// are the ones returning false: before this changed, a platform with no
+// filter fell through a no-op closure and kernel.installed answered with an
+// empty list and no error, which reads as "no kernels installed" on a host
+// that is demonstrably running one.
+func TestKernelFilterForPlatform(t *testing.T) {
+	cases := []struct {
+		name      string
+		platform  *inventory.Platform
+		supported bool
+	}{
+		{
+			name:      "arch linux is now supported",
+			platform:  &inventory.Platform{Name: "arch", Family: []string{"arch", "linux", "unix", "os"}},
+			supported: true,
+		},
+		{
+			name:      "manjaro rides the arch family",
+			platform:  &inventory.Platform{Name: "manjaro", Family: []string{"arch", "linux", "unix", "os"}},
+			supported: true,
+		},
+		{
+			name:      "debian",
+			platform:  &inventory.Platform{Name: "debian", Family: []string{"debian", "linux", "unix", "os"}},
+			supported: true,
+		},
+		{
+			name:      "ubuntu rides the debian family",
+			platform:  &inventory.Platform{Name: "ubuntu", Family: []string{"ubuntu", "debian", "linux", "unix", "os"}},
+			supported: true,
+		},
+		{
+			name:      "oraclelinux",
+			platform:  &inventory.Platform{Name: "oraclelinux", Family: []string{"redhat", "linux", "unix", "os"}},
+			supported: true,
+		},
+		{
+			name:      "redhat",
+			platform:  &inventory.Platform{Name: "redhat", Family: []string{"redhat", "linux", "unix", "os"}},
+			supported: true,
+		},
+		{
+			name:      "amazonlinux",
+			platform:  &inventory.Platform{Name: "amazonlinux", Family: []string{"linux", "unix", "os"}},
+			supported: true,
+		},
+		{
+			name:      "photon",
+			platform:  &inventory.Platform{Name: "photon", Family: []string{"linux", "unix", "os"}},
+			supported: true,
+		},
+		{
+			name:      "suse",
+			platform:  &inventory.Platform{Name: "sles", Family: []string{"suse", "linux", "unix", "os"}},
+			supported: true,
+		},
+		{
+			name:      "alpine has no kernel-package filter and must not answer with an empty list",
+			platform:  &inventory.Platform{Name: "alpine", Family: []string{"linux", "unix", "os"}},
+			supported: false,
+		},
+		{
+			name:      "gentoo has no kernel-package filter and must not answer with an empty list",
+			platform:  &inventory.Platform{Name: "gentoo", Family: []string{"linux", "unix", "os"}},
+			supported: false,
+		},
+		{
+			name:      "macos is not linux",
+			platform:  &inventory.Platform{Name: "macos", Family: []string{"darwin", "bsd", "unix", "os"}},
+			supported: false,
+		},
+		{
+			name:      "a nil platform is not supported and does not panic",
+			platform:  nil,
+			supported: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			filter, ok := kernelFilterForPlatform(tc.platform)
+			assert.Equal(t, tc.supported, ok)
+			if tc.supported {
+				assert.NotNil(t, filter)
+			} else {
+				assert.Nil(t, filter)
+			}
+		})
+	}
+}
+
+// TestPlatformLabel confirms the unsupported-platform error always names
+// something: the platform name when there is one, the family when the name
+// is empty, so the message never trails off.
+func TestPlatformLabel(t *testing.T) {
+	assert.Equal(t, "arch", platformLabel(&inventory.Platform{Name: "arch", Family: []string{"arch", "linux"}}))
+	assert.Equal(t, "linux/unix", platformLabel(&inventory.Platform{Family: []string{"linux", "unix"}}))
+	assert.Equal(t, "unknown", platformLabel(&inventory.Platform{}))
+	assert.Equal(t, "unknown", platformLabel(nil))
+}
+
+// kernelFilterForPlatform returns false for two very different situations, and
+// kernelInstalledFilter is what tells them apart. Pin the distinction so the
+// non-Linux contract cannot be widened into an error by accident: an SBOM run
+// on macOS has always recorded an empty list here, and changing that is a
+// separate decision about a platform where a package-managed kernel image is
+// not a thing that exists.
+func TestKernelInstalledFilterSeparatesUnsupportedFromNotLinux(t *testing.T) {
+	cases := []struct {
+		name     string
+		platform *inventory.Platform
+		// exactly one of these holds
+		wantFilter bool
+		wantErr    bool
+	}{
+		{
+			name:       "a supported linux gets a filter",
+			platform:   &inventory.Platform{Name: "debian", Family: []string{"debian", "linux", "unix", "os"}},
+			wantFilter: true,
+		},
+		{
+			name:     "a linux with no filter is an error, not an empty answer",
+			platform: &inventory.Platform{Name: "alpine", Family: []string{"linux", "unix", "os"}},
+			wantErr:  true,
+		},
+		{
+			name:     "gentoo likewise",
+			platform: &inventory.Platform{Name: "gentoo", Family: []string{"linux", "unix", "os"}},
+			wantErr:  true,
+		},
+		{
+			name:     "macos keeps answering with an empty list",
+			platform: &inventory.Platform{Name: "macos", Family: []string{"darwin", "bsd", "unix", "os"}},
+		},
+		{
+			name:     "freebsd likewise",
+			platform: &inventory.Platform{Name: "freebsd", Family: []string{"bsd", "unix", "os"}},
+		},
+		{
+			name:     "aix likewise",
+			platform: &inventory.Platform{Name: "aix", Family: []string{"unix", "os"}},
+		},
+		{
+			name:     "a nil platform does not panic and is not an error",
+			platform: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			filter, err := kernelInstalledFilter(tc.platform)
+
+			if tc.wantErr {
+				require.Error(t, err, "a linux host is running a kernel it got from a package manager")
+				assert.Contains(t, err.Error(), tc.platform.Name, "the error must name the platform")
+				assert.Nil(t, filter)
+				return
+			}
+
+			require.NoError(t, err)
+			if tc.wantFilter {
+				assert.NotNil(t, filter)
+			} else {
+				assert.Nil(t, filter, "a nil filter with a nil error is how installed() knows to answer []")
 			}
 		})
 	}

--- a/providers/os/resources/kernel_suse_test.go
+++ b/providers/os/resources/kernel_suse_test.go
@@ -1,0 +1,97 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSuseKernelName(t *testing.T) {
+	tests := []struct {
+		pkg      string
+		wantName string
+		wantOK   bool
+		why      string
+	}{
+		// Bootable kernels, as named in the openSUSE Leap 16.0 and SLE 16 repos.
+		{"kernel-default", "kernel-default", true, "the stock flavor"},
+		{"kernel-azure", "kernel-azure", true, "cloud flavor"},
+		{"kernel-rt", "kernel-rt", true, "realtime flavor"},
+		{"kernel-kvmsmall", "kernel-kvmsmall", true, "virtualization flavor"},
+		{"kernel-default-base", "kernel-default-base", true, "stripped kernel MicroOS boots"},
+		{"kernel-64kb", "kernel-64kb", true, "flavor not in any list still resolves"},
+		{"kernel-longterm", "kernel-longterm", true, "flavor not in any list still resolves"},
+
+		// Subpackages that carry no kernel. These are what a stock SUSE host
+		// actually has installed alongside the kernel, and listing them invents
+		// installed kernels.
+		{"kernel-firmware-network", "", false, "firmware, installed on stock hosts"},
+		{"kernel-firmware-all", "", false, "firmware meta package"},
+		{"kernel-macros", "", false, "rpm macros, version tracks a newer kernel"},
+		{"kernel-devel", "", false, "headers"},
+		{"kernel-devel-azure", "", false, "per-flavor headers"},
+		{"kernel-source", "", false, "sources"},
+		{"kernel-source-vanilla", "", false, "sources"},
+		{"kernel-syms", "", false, "module symbols"},
+		{"kernel-syms-azure", "", false, "per-flavor module symbols"},
+		{"kernel-docs", "", false, "documentation"},
+		{"kernel-docs-html", "", false, "documentation"},
+		{"kernel-install-tools", "", false, "tooling"},
+		{"kernel-obs-build", "", false, "build service helper"},
+		{"kernel-obs-qa", "", false, "build service helper"},
+		{"kernel-default-devel", "", false, "per-flavor headers"},
+		{"kernel-default-extra", "", false, "extra modules, not a kernel"},
+		{"kernel-default-optional", "", false, "optional modules, not a kernel"},
+		{"kernel-azure-vdso", "", false, "vdso build"},
+		{"kernel-livepatch-6_12_0-160000_37-default", "", false, "livepatch"},
+
+		// Not a kernel package at all.
+		{"kernel", "", false, "no flavor suffix, not used by SUSE"},
+		{"kernel-", "", false, "empty flavor"},
+		{"kernel-base", "", false, "-base with no flavor in front"},
+		{"linux-image-6.12.0-default", "", false, "debian naming"},
+		{"bash", "", false, "unrelated package"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.pkg, func(t *testing.T) {
+			name, ok := suseKernelName(test.pkg)
+			assert.Equal(t, test.wantOK, ok, test.why)
+			assert.Equal(t, test.wantName, name, test.why)
+		})
+	}
+}
+
+// The live openSUSE Leap 16.0 host this came from ran 6.12.0-160000.35-default
+// with kernel-default 6.12.0-160000.35.1 installed, plus kernel-macros at the
+// higher 6.12.0-160000.37.1 and kernel-firmware-network at 20250717-160000.1.2.
+// Only the first is a kernel, and only it is running.
+func TestSuseKernelNameWithRunningMatch(t *testing.T) {
+	running := "6.12.0-160000.35-default"
+
+	tests := []struct {
+		pkg         string
+		version     string
+		wantKernel  bool
+		wantRunning bool
+	}{
+		{"kernel-default", "6.12.0-160000.35.1", true, true},
+		{"kernel-macros", "6.12.0-160000.37.1", false, false},
+		{"kernel-firmware-network", "20250717-160000.1.2", false, false},
+		{"kernel-default", "6.12.0-160000.37.1", true, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.pkg+"@"+test.version, func(t *testing.T) {
+			name, ok := suseKernelName(test.pkg)
+			assert.Equal(t, test.wantKernel, ok)
+			if !ok {
+				return
+			}
+			assert.Equal(t, test.wantRunning, suseKernelMatchesRunning(test.version, name, running))
+		})
+	}
+}


### PR DESCRIPTION
Two defects in the `filterKernel` dispatch of `kernel.installed`
(`providers/os/resources/kernel.go`), both found on live hosts. They live in
the same dispatch, so they ship together.

## Defect 1: silent empty on every unsupported package manager

The dispatch opened with a no-op default:

```go
filterKernel := func(pkg *mqlPackage) {}
```

so a platform matching none of the `debian` / `oraclelinux` / `redhat` /
`photon` / `suse` cases ran the loop over every installed package doing
nothing and returned `[]` with a **nil error**.

**Live evidence (Arch Linux, pacman):**

| query | result |
|---|---|
| `kernel { installed }` | `[]` |
| `packages.where(name == "linux")` | `linux 7.1.9.arch1-2` |
| `kernel.info` | resolves fine |

No entry ever carried `running: true`, so a policy asserting *"the running
kernel is the newest installed"* evaluated over an empty set and **passed
vacuously**. On that same host the running kernel was `7.1.8-arch1-3` against
an installed `7.1.9.arch1-2` — a genuine pending-reboot drift this resource
exists to catch, and silently could not.

### (a) Arch / pacman is now a supported family

Keyed on the `arch` platform *family*, so Manjaro and SteamOS come along
rather than only `platform.Name == "arch"`.

Kernel packages are an **explicit allowlist** — `linux`, `linux-lts`,
`linux-zen`, `linux-hardened` — rather than a `linux` prefix match, which
would also swallow `linux-headers`, `linux-lts-headers`, `linux-api-headers`
and `linux-firmware`, none of which contains a bootable kernel.

**The `Running` comparison.** pacman and uname disagree on one separator: the
package version joins the upstream version to the Arch patch level with a
dot, the release uname reports joins them with a dash.

```
pacman: linux 7.1.9.arch1-2
uname:  7.1.9-arch1-2
```

A naive string equality therefore never matches and every entry would report
`running:false` — the same class of bug `rpmKernelMatchesRunning` (epoch) and
`debianImageKernelName` (metapackage) already solve for their families. The
fix folds both separators to one canonical form, which removes the
disagreement without having to know which of the two a given flavor spells it
with. The flavor lives in the package name suffix and is appended to the
release uname reports (`linux-lts 6.6.67-1` runs as `6.6.67-1-lts`), so that
suffix is trimmed from the running version first — the same shape
`suseKernelMatchesRunning` uses. The bare `linux` package has an empty suffix,
for which the trim is a no-op.

This is honest about its confidence: the mainline `linux` mapping is pinned
directly by the live evidence above. The `-lts` / `-zen` / `-hardened` rows
follow the same documented Arch scheme and are covered by unit tests, but were
not observed on a live host — the separator-folding was chosen precisely
because it does not depend on knowing which separator each flavor uses. If a
flavor ever deviates, the effect is a `false` on that flavor's `Running` only;
the kernel still appears in `installed`, which is the primary fix.

### (b) Unsupported families no longer answer with `[]`

**Decision: return an error naming the platform.** Justification:

1. `[]` + nil is indistinguishable from a *verified-empty* answer. It reads as
   "no kernels are installed", which is never true of a host that is running
   one.
2. Both alternatives to an error let an assertion pass without checking
   anything. `[]` passes an `.all()` vacuously, and per CLAUDE.md §5 a null
   field passes a `{ a && b }` chain via three-valued logic. An error is the
   only outcome a caller cannot mistake for a result — it fails loudly and
   attributably.
3. It matches what `installed()` already does for its other unanswerable
   conditions in the same function (`could not determine kernel version`,
   `no structured kernel information found`).

The error names the platform so the missing case can be added.

**Non-Linux behaviour is deliberately unchanged.** darwin/bsd/aix reach
`installed()` because `initKernel` permits them for `kernel.info` / `modules` /
`parameters`, and they keep answering `[]` exactly as they do today. The bug
being fixed here is a Linux host that demonstrably has kernel packages
installed and reports none; whether macOS should answer null rather than an
empty list is a separate question about a platform where a package-managed
kernel image is not a thing that exists, and changing it here would alter
existing SBOM output for an unrelated reason. `kernelInstalledFilter` is the
single place that draws the line, and `TestKernelInstalledFilterSeparatesUnsupportedFromNotLinux`
pins both sides of it so the non-Linux contract cannot be widened by accident.

Also in this area: `kernelInfo["version"].(string)` was an unchecked type
assertion that would **panic** if `kernel.info` ever returned no `version` key.
Per CLAUDE.md §5 a panic in this path takes down the whole scan, so it is now
a comma-ok returning an error.

## Defect 2: removed-but-not-purged kernels reported as installed

The debian branch keyed only on the package name via `debianImageKernelName`
and **never checked `pkg.Status`**. On dpkg systems a package removed but not
purged stays in `/var/lib/dpkg/status` as

```
Status: deinstall ok config-files
```

Its files are gone, but `kernel.installed` still listed it. That inflates the
installed set with kernels that are not on disk and cannot be booted, and can
fail a "running kernel is the newest installed" assertion against a phantom.
**Found on Linux Mint.**

`pkg.Status` **is** available. `status` is declared on the `package` resource
in `os.lr` and, although the `status()` computed method is a `return "", nil`
stub, `fillPackageArgs` in `packages.go` populates it eagerly for every
package that comes through `packages.GetList()`
(`args["status"] = llx.StringData(osPkg.Status)`), and the dpkg parser fills
`pkg.Status` from the `Status:` control field. No schema change was needed.

The branch now requires the **state** field of the dpkg triple
(`<want> <flag> <state>`) to read `installed`. The *want* field is
deliberately ignored so a held kernel (`hold ok installed`) is still counted —
that position is what `isHeldStatus` reads for `pinned`.

**An absent triple is treated as unknown and kept.** Google distroless images
keep their dpkg metadata in `/var/lib/dpkg/status.d` stanzas that omit the
`Status` field entirely (confirmed against
`resources/packages/testdata/packages_dpkg_statusd.toml`, which contains zero
`Status:` lines), so a strict check would have dropped every package on an
image scan. Absence of a status is not evidence of removal.

## Refactor

The per-family closures captured `res` and `runningKernelVersion`, which made
them untestable. They are lifted into pure functions over a `kernelPackage`
value returning `(KernelVersion, bool)` — the seam CLAUDE.md §3.6 asks for.
Dispatch moves to `kernelFilterForPlatform`, preserving the original ordering
(Oracle Linux is still checked before the redhat family it belongs to, because
it may be running UEK). Behaviour for the existing families is unchanged and
pinned by regression tests.

## Tests

`providers/os/resources/kernel_internal_test.go`, following the existing
table-test style in that file. 60 subtests, all new:

- `TestArchKernelMatchesRunning` — the live Arch case (installed
  `7.1.9.arch1-2` vs running `7.1.8-arch1-3` → not running), the matching
  case across the dot/dash separator, the lts/zen/hardened flavor suffixes,
  cross-flavor false positives, and the empty running-kernel string.
- `TestDpkgStatusIsInstalled` — `install ok installed` accepted;
  `deinstall ok config-files`, `purge ok config-files`, `half-installed`,
  `unpacked`, `not-installed` rejected; `hold ok installed` still installed;
  absent/partial triple kept as unknown.
- `TestKernelFilters` — every filter end to end. Arch accepts `linux` and
  `linux-lts` and rejects `linux-headers`, `linux-lts-headers`,
  `linux-api-headers`, `linux-firmware`. Debian accepts `install ok installed`
  and `hold ok installed`, rejects `deinstall ok config-files` and
  `purge ok config-files` (including one that names the *running* kernel), and
  still rejects the metapackage. Regression rows pin redhat, amazonlinux
  epoch, oraclelinux UEK, photon and suse unchanged.
- `TestKernelFilterForPlatform` — arch/manjaro/debian/ubuntu/oraclelinux/
  redhat/amazonlinux/photon/suse resolve; alpine and gentoo (Linux, no filter),
  macos, and a nil platform do not.
- `TestPlatformLabel` — the error always names something.

Both new assertions are genuine reproducers: the arch match case fails under
the old naive equality, and the `config-files` case returned "installed" before
the status gate.

```
$ cd providers/os && go test ./resources/... -count=1
ok  	go.mondoo.com/mql/providers/os/resources	1.618s
... all packages ok, no failures

$ go test ./resources/ -run 'TestArchKernelMatchesRunning|TestDpkgStatusIsInstalled|TestKernelFilters|TestKernelFilterForPlatform|TestPlatformLabel' -count=1 -v
--- PASS: TestArchKernelMatchesRunning (0.00s)
--- PASS: TestDpkgStatusIsInstalled (0.00s)
--- PASS: TestKernelFilters (0.00s)
--- PASS: TestKernelFilterForPlatform (0.00s)
--- PASS: TestPlatformLabel (0.00s)
```

`gofmt`, `go vet` and `typos` clean. No schema change, so no codegen or
`.lr.versions` entry.

