### PR TITLE
🐛 os: read /proc/mounts when the mount command cannot answer

### DIFF
--- a/providers/os/resources/mount/manager.go
+++ b/providers/os/resources/mount/manager.go
@@ -5,6 +5,7 @@ package mount
 
 import (
 	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/providers/os/connection/shared"
 )
 
@@ -50,25 +51,44 @@ func (s *LinuxMountManager) Name() string {
 }
 
 func (s *LinuxMountManager) List() ([]MountPoint, error) {
-	// TODO: not working via docker yet
-	// // try /proc
-	// f, err := s.motor.Provider.File("/proc/mount")
-	// if err == nil {
-	// 	defer f.Close()
-	// 	return ParseLinuxProcMount(f), nil
-	// }
-
+	// `mount` carries the richest output, but plenty of hosts have a command
+	// capability and no util-linux to answer with: the immutable and distroless
+	// images in particular. /proc/mounts lists the same mounts, so reach for it
+	// when the command cannot answer rather than failing the whole resource.
 	if s.conn.Capabilities().Has(shared.Capability_RunCommand) {
-		cmd, err := s.conn.RunCommand("mount")
-		if err != nil {
-			return nil, errors.Wrap(err, "could not read mounts")
+		mounts, err := s.mountsFromCommand()
+		if err == nil {
+			return mounts, nil
 		}
-		return ParseLinuxMountCmd(cmd.Stdout), nil
-	} else if s.conn.Capabilities().Has(shared.Capability_File) {
+		if !s.conn.Capabilities().Has(shared.Capability_File) {
+			return nil, err
+		}
+		log.Debug().Err(err).Msg("mql[mount]> could not read mounts with the mount command, reading them from the filesystem")
+	}
+
+	if s.conn.Capabilities().Has(shared.Capability_File) {
 		return mountsFromFSLinux(s.conn.FileSystem())
 	}
 
 	return nil, errors.New("mount not supported for provided transport")
+}
+
+func (s *LinuxMountManager) mountsFromCommand() ([]MountPoint, error) {
+	cmd, err := s.conn.RunCommand("mount")
+	if err != nil {
+		return nil, errors.Wrap(err, "could not run the mount command")
+	}
+	if cmd.ExitStatus != 0 {
+		return nil, errors.Newf("the mount command exited with %d", cmd.ExitStatus)
+	}
+
+	mounts := ParseLinuxMountCmd(cmd.Stdout)
+	// A running Linux host always has at least a root mount, so an empty result
+	// means the command did not answer, not that nothing is mounted.
+	if len(mounts) == 0 {
+		return nil, errors.New("the mount command reported no mounts")
+	}
+	return mounts, nil
 }
 
 type UnixMountManager struct {
@@ -83,6 +103,11 @@ func (s *UnixMountManager) List() ([]MountPoint, error) {
 	cmd, err := s.conn.RunCommand("mount")
 	if err != nil {
 		return nil, errors.Wrap(err, "could not run mount command")
+	}
+	// Without this the stderr of a failed mount command parses to an empty list
+	// and reports as "nothing is mounted".
+	if cmd.ExitStatus != 0 {
+		return nil, errors.Newf("the mount command exited with %d", cmd.ExitStatus)
 	}
 
 	return ParseUnixMountCmd(cmd.Stdout), nil

--- a/providers/os/resources/mount/manager_test.go
+++ b/providers/os/resources/mount/manager_test.go
@@ -54,3 +54,65 @@ func TestManagerFreebsd(t *testing.T) {
 
 	assert.Equal(t, 2, len(mounts))
 }
+
+// A host with a command capability but no `mount` binary is not a host with
+// nothing mounted. Before the fallback, the missing command's empty stdout
+// parsed to an empty list and the resource reported that as fact.
+func TestManagerFallsBackToProcMountsWhenCommandIsMissing(t *testing.T) {
+	mock, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{Family: []string{"linux"}},
+	}, mock.WithPath("./testdata/no-mount-command.toml"))
+	require.NoError(t, err)
+
+	mm, err := mount.ResolveManager(mock)
+	require.NoError(t, err)
+	mounts, err := mm.List()
+	require.NoError(t, err)
+
+	require.Len(t, mounts, 7, "the mounts must come from /proc/mounts")
+
+	byPath := map[string]mount.MountPoint{}
+	for _, m := range mounts {
+		byPath[m.MountPoint] = m
+	}
+	root, ok := byPath["/"]
+	require.True(t, ok, "the root mount must be reported")
+	assert.Equal(t, "/dev/nvme0n1p1", root.Device)
+	assert.Equal(t, "ext4", root.FSType)
+	assert.Contains(t, root.Options, "rw")
+}
+
+// Same when the binary exists but refuses to answer.
+func TestManagerFallsBackToProcMountsWhenCommandFails(t *testing.T) {
+	mock, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{Family: []string{"linux"}},
+	}, mock.WithPath("./testdata/failing-mount-command.toml"))
+	require.NoError(t, err)
+
+	mm, err := mount.ResolveManager(mock)
+	require.NoError(t, err)
+	mounts, err := mm.List()
+	require.NoError(t, err)
+
+	require.Len(t, mounts, 3)
+	assert.Equal(t, "/", mounts[1].MountPoint)
+	assert.Equal(t, "ext4", mounts[1].FSType)
+}
+
+// The command stays the preferred source: a host where it answers must not
+// start reading /proc/mounts instead.
+func TestManagerPrefersTheMountCommand(t *testing.T) {
+	mock, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{Family: []string{"linux"}},
+	}, mock.WithPath("./testdata/debian.toml"))
+	require.NoError(t, err)
+
+	mm, err := mount.ResolveManager(mock)
+	require.NoError(t, err)
+	mounts, err := mm.List()
+	require.NoError(t, err)
+
+	// debian.toml carries no /proc/mounts at all, so 25 entries can only have
+	// come from the command.
+	assert.Equal(t, 25, len(mounts))
+}

--- a/providers/os/resources/mount/testdata/failing-mount-command.toml
+++ b/providers/os/resources/mount/testdata/failing-mount-command.toml
@@ -1,0 +1,14 @@
+# A host where the `mount` binary exists but refuses to answer. Pre-fix its
+# stderr parsed to an empty list, so the resource reported "nothing is mounted".
+
+[commands."mount"]
+stdout = ""
+stderr = "mount: failed to read mtab: Permission denied"
+exit_status = 1
+
+[files."/proc/mounts"]
+content = """
+proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+/dev/nvme0n1p1 / ext4 rw,relatime,discard 0 0
+tmpfs /run tmpfs rw,nosuid,nodev,size=799604k,mode=755 0 0
+"""

--- a/providers/os/resources/mount/testdata/no-mount-command.toml
+++ b/providers/os/resources/mount/testdata/no-mount-command.toml
@@ -1,0 +1,17 @@
+# A host with a command capability but no `mount` binary, which is how the
+# immutable and distroless images ship. /proc/mounts is still there and still
+# lists every mount, so the resource has a correct answer available to it.
+#
+# There is deliberately no [commands."mount"] entry: the mock answers an unknown
+# command the way a real host does, with a non-zero exit and empty stdout.
+
+[files."/proc/mounts"]
+content = """
+proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
+devtmpfs /dev devtmpfs rw,nosuid,size=4096k,nr_inodes=498365,mode=755 0 0
+/dev/nvme0n1p1 / ext4 rw,relatime,discard 0 0
+tmpfs /run tmpfs rw,nosuid,nodev,size=799604k,mode=755 0 0
+tmpfs /dev/shm tmpfs rw,nosuid,nodev 0 0
+cgroup2 /sys/fs/cgroup cgroup2 rw,nosuid,nodev,noexec,relatime,nsdelegate 0 0
+"""


### PR DESCRIPTION
## The bug

`LinuxMountManager.List` picked its source by **capability** rather than by **result**:

```go
if s.conn.Capabilities().Has(shared.Capability_RunCommand) {
    cmd, err := s.conn.RunCommand("mount")
    if err != nil {
        return nil, errors.Wrap(err, "could not read mounts")
    }
    return ParseLinuxMountCmd(cmd.Stdout), nil
} else if s.conn.Capabilities().Has(shared.Capability_File) {
    return mountsFromFSLinux(s.conn.FileSystem())   // only reachable with NO command capability
}
```

`mountsFromFSLinux` already knows how to read `/proc/mounts` (and `/etc/fstab` after it). It was gated behind the *absence* of a command capability, so a host that has both never got there.

On a host with a shell but no util-linux — the immutable and distroless images — `RunCommand` succeeds, `mount` exits non-zero with empty stdout, and `ParseLinuxMountCmd` turns that into an empty slice. **`mount.list` then reports "nothing is mounted" with no error at all.** `/proc/mounts` was sitting right there with the full answer.

`nfs.mounts` resolves through the same manager (`nfs.go` → `mount.ResolveManager` → `mm.List()`), so it was reporting no NFS mounts on those hosts for the same reason.

## Changes

- Try `mount` first, and fall back to the filesystem when it cannot answer: a transport error, a non-zero exit status, or an empty parse. A running Linux host always has at least a root mount, so zero entries means the command did not answer rather than that nothing is mounted.
- A connection with no file capability still gets the command's error, not a silent empty list.
- `UnixMountManager` had the same missing exit-status check and no fallback available to it, so a failed `mount` parsed its stderr into an empty list. It now reports the failure.
- Dropped a commented-out `/proc/mount` block that referenced a `s.motor.Provider` API that no longer exists — and had the path wrong (`/proc/mount`, not `/proc/mounts`).

## Tests

Two fixtures, both modelling a real shape:

- `no-mount-command.toml` — no `[commands."mount"]` entry at all, so the mock answers it the way a real host does (non-zero exit, empty stdout), plus a populated `/proc/mounts`.
- `failing-mount-command.toml` — the binary exists and refuses (`failed to read mtab: Permission denied`).

Both new tests were verified to **fail against the pre-fix code**, with exactly the reported symptom:

```
--- FAIL: TestManagerFallsBackToProcMountsWhenCommandIsMissing
        Error: "[]" should have 7 item(s), but has 0
--- FAIL: TestManagerFallsBackToProcMountsWhenCommandFails
        Error: "[]" should have 3 item(s), but has 0
```

Note the failure mode: `[]` and **no error**.

A third test pins that the command stays the preferred source — `debian.toml` carries no `/proc/mounts`, so its 25 entries can only have come from the command.

`go build ./...`, `go vet`, and `go test ./resources/mount/... -count=1` all pass.