### PR TITLE
🐛 os: read config from /usr/etc on openSUSE Leap 16 and SLE 16

### DIFF
--- a/providers/os/resources/limits.go
+++ b/providers/os/resources/limits.go
@@ -9,8 +9,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/spf13/afero"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/connection/shared"
 	"go.mondoo.com/mql/providers/os/resources/limits"
 )
 
@@ -41,9 +43,15 @@ func (le *mqlLimitsEntry) id() (string, error) {
 func (l *mqlLimits) files() ([]any, error) {
 	var allFiles []any
 
-	// Add main limits file
+	var fs afero.Fs
+	if conn, ok := l.MqlRuntime.Connection.(shared.Connection); ok {
+		fs = conn.FileSystem()
+	}
+
+	// Add main limits file. On distributions that ship packaged defaults under
+	// /usr/etc (openSUSE Leap 16, SLE 16) this is where the file actually is.
 	mainFile, err := CreateResource(l.MqlRuntime, "file", map[string]*llx.RawData{
-		"path": llx.StringData(defaultLimitsFile),
+		"path": llx.StringData(resolveVendorConfigPath(fs, defaultLimitsFile)),
 	})
 	if err != nil {
 		return nil, err
@@ -58,23 +66,11 @@ func (l *mqlLimits) files() ([]any, error) {
 		allFiles = append(allFiles, f)
 	}
 
-	// Check if limits.d directory exists
-	dirFile, err := CreateResource(l.MqlRuntime, "file", map[string]*llx.RawData{
-		"path": llx.StringData(defaultLimitsDir),
-	})
-	if err != nil {
-		return nil, err
-	}
-	dir := dirFile.(*mqlFile)
-	dirExists := dir.GetExists()
-	if dirExists.Error != nil {
-		return nil, dirExists.Error
-	}
-
-	if dirExists.Data {
-		// Get all files from limits.d directory
+	// Drop-ins merge across both trees, with /etc shadowing a same-named file
+	// in /usr/etc.
+	for _, dir := range vendorConfigDirs(fs, defaultLimitsDir) {
 		files, err := CreateResource(l.MqlRuntime, "files.find", map[string]*llx.RawData{
-			"from": llx.StringData(defaultLimitsDir),
+			"from": llx.StringData(dir),
 			"type": llx.StringData("file"),
 		})
 		if err != nil {
@@ -96,9 +92,13 @@ func (l *mqlLimits) files() ([]any, error) {
 			}
 
 			// Only include .conf files
-			if strings.HasSuffix(basename.Data, ".conf") {
-				allFiles = append(allFiles, file)
+			if !strings.HasSuffix(basename.Data, ".conf") {
+				continue
 			}
+			if vendorConfigShadowed(fs, file.Path.Data) {
+				continue
+			}
+			allFiles = append(allFiles, file)
 		}
 	}
 

--- a/providers/os/resources/logindefs.go
+++ b/providers/os/resources/logindefs.go
@@ -9,6 +9,7 @@ import (
 
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/connection/shared"
 	"go.mondoo.com/mql/providers/os/resources/logindefs"
 )
 
@@ -43,8 +44,13 @@ func (s *mqlLogindefs) id() (string, error) {
 }
 
 func (s *mqlLogindefs) file() (*mqlFile, error) {
+	path := defaultLoginDefsConfig
+	if conn, ok := s.MqlRuntime.Connection.(shared.Connection); ok {
+		path = resolveVendorConfigPath(conn.FileSystem(), defaultLoginDefsConfig)
+	}
+
 	f, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
-		"path": llx.StringData(defaultLoginDefsConfig),
+		"path": llx.StringData(path),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/os/resources/logrotate.go
+++ b/providers/os/resources/logrotate.go
@@ -9,8 +9,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/spf13/afero"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/connection/shared"
 	"go.mondoo.com/mql/providers/os/resources/logrotate"
 	"go.mondoo.com/mql/types"
 )
@@ -39,9 +41,16 @@ func (le *mqlLogrotateEntry) id() (string, error) {
 func (l *mqlLogrotate) files() ([]any, error) {
 	var allFiles []any
 
-	// Add main logrotate.conf
+	var fs afero.Fs
+	if conn, ok := l.MqlRuntime.Connection.(shared.Connection); ok {
+		fs = conn.FileSystem()
+	}
+
+	// Add main logrotate.conf. Distributions that ship packaged defaults under
+	// /usr/etc (openSUSE Leap 16, SLE 16) keep it there unless an administrator
+	// overrode it in /etc.
 	mainFile, err := CreateResource(l.MqlRuntime, "file", map[string]*llx.RawData{
-		"path": llx.StringData(defaultLogrotateConf),
+		"path": llx.StringData(resolveVendorConfigPath(fs, defaultLogrotateConf)),
 	})
 	if err != nil {
 		return nil, err
@@ -56,22 +65,11 @@ func (l *mqlLogrotate) files() ([]any, error) {
 		allFiles = append(allFiles, f)
 	}
 
-	// Check logrotate.d directory
-	dirFile, err := CreateResource(l.MqlRuntime, "file", map[string]*llx.RawData{
-		"path": llx.StringData(defaultLogrotateDir),
-	})
-	if err != nil {
-		return nil, err
-	}
-	dir := dirFile.(*mqlFile)
-	dirExists := dir.GetExists()
-	if dirExists.Error != nil {
-		return nil, dirExists.Error
-	}
-
-	if dirExists.Data {
+	// Drop-ins merge across both trees, with /etc shadowing a same-named file
+	// in /usr/etc.
+	for _, dir := range vendorConfigDirs(fs, defaultLogrotateDir) {
 		files, err := CreateResource(l.MqlRuntime, "files.find", map[string]*llx.RawData{
-			"from":  llx.StringData(defaultLogrotateDir),
+			"from":  llx.StringData(dir),
 			"type":  llx.StringData("file"),
 			"depth": llx.IntData(1),
 		})
@@ -98,6 +96,9 @@ func (l *mqlLogrotate) files() ([]any, error) {
 				strings.HasSuffix(name, ".rpmsave") || strings.HasSuffix(name, ".rpmorig") ||
 				strings.HasSuffix(name, ".dpkg-old") || strings.HasSuffix(name, ".dpkg-new") ||
 				strings.HasSuffix(name, ".dpkg-dist") || strings.HasSuffix(name, "~") {
+				continue
+			}
+			if vendorConfigShadowed(fs, file.Path.Data) {
 				continue
 			}
 

--- a/providers/os/resources/sshd.go
+++ b/providers/os/resources/sshd.go
@@ -65,8 +65,13 @@ func (s *mqlSshdConfig) id() (string, error) {
 }
 
 func (s *mqlSshdConfig) file() (*mqlFile, error) {
+	path := defaultSshdConfig
+	if conn, ok := s.MqlRuntime.Connection.(shared.Connection); ok {
+		path = resolveVendorConfigPath(conn.FileSystem(), defaultSshdConfig)
+	}
+
 	f, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
-		"path": llx.StringData(defaultSshdConfig),
+		"path": llx.StringData(path),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/os/resources/sudoers.go
+++ b/providers/os/resources/sudoers.go
@@ -20,6 +20,8 @@ import (
 // sudoersPaths lists the sudoers file paths to check per platform.
 // Most systems use /etc/sudoers. BSD variants and AIX install sudo via
 // package managers to non-default prefixes, so /etc/sudoers does not exist.
+const defaultSudoersFile = "/etc/sudoers"
+
 var sudoersPaths = map[string][]string{
 	"freebsd":      {"/usr/local/etc/sudoers"},
 	"dragonflybsd": {"/usr/local/etc/sudoers"},
@@ -95,7 +97,7 @@ func sudoersPathsForPlatform(conn shared.Connection) []string {
 			return paths
 		}
 	}
-	return []string{"/etc/sudoers"}
+	return []string{resolveVendorConfigPath(conn.FileSystem(), defaultSudoersFile)}
 }
 
 // files returns the list of sudoers configuration files

--- a/providers/os/resources/vendorconfig.go
+++ b/providers/os/resources/vendorconfig.go
@@ -1,0 +1,83 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"path"
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+// vendorConfigRoot is the vendor configuration tree that ships distribution
+// defaults outside of /etc. openSUSE Leap 16 and SUSE Linux Enterprise 16 moved
+// their packaged defaults there: /etc holds only what an administrator changed,
+// while the shipped file lives at the same relative path under /usr/etc. A host
+// that never customized sshd_config therefore has no /etc/ssh/sshd_config at
+// all, only /usr/etc/ssh/sshd_config.
+//
+// The precedence is the one systemd documents for its split configuration
+// trees: /etc wins when it has the file, /usr/etc supplies it otherwise.
+const vendorConfigRoot = "/usr/etc"
+
+// vendorConfigCandidates expands an /etc path into the locations it may be
+// readable at, most specific first. Paths outside /etc are returned unchanged,
+// so callers can pass any configured path without special-casing.
+func vendorConfigCandidates(p string) []string {
+	if p != "/etc" && !strings.HasPrefix(p, "/etc/") {
+		return []string{p}
+	}
+	return []string{p, vendorConfigRoot + strings.TrimPrefix(p, "/etc")}
+}
+
+// resolveVendorConfigPath returns the first candidate for p that exists on fs.
+// When none exists it returns p unchanged, so a "file not found" error still
+// names the canonical location rather than the fallback.
+func resolveVendorConfigPath(fs afero.Fs, p string) string {
+	if fs == nil {
+		return p
+	}
+	for _, candidate := range vendorConfigCandidates(p) {
+		if _, err := fs.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return p
+}
+
+// vendorConfigDirs returns every candidate for dir that exists on fs and is a
+// directory, /etc first. Drop-in directories merge across the two trees rather
+// than shadowing each other wholesale, which is why this returns a list where
+// resolveVendorConfigPath returns one path.
+func vendorConfigDirs(fs afero.Fs, dir string) []string {
+	if fs == nil {
+		return nil
+	}
+	var dirs []string
+	for _, candidate := range vendorConfigCandidates(dir) {
+		fi, err := fs.Stat(candidate)
+		if err != nil || !fi.IsDir() {
+			continue
+		}
+		dirs = append(dirs, candidate)
+	}
+	return dirs
+}
+
+// vendorConfigShadowed reports whether a drop-in read from a /usr/etc directory
+// is overridden by a file of the same name in the matching /etc directory. Only
+// the file name matters: sshd, sudo and logrotate all resolve a drop-in by its
+// basename, so /etc/ssh/sshd_config.d/50-foo.conf replaces the /usr/etc copy
+// instead of being read in addition to it.
+func vendorConfigShadowed(fs afero.Fs, filePath string) bool {
+	if fs == nil || !strings.HasPrefix(filePath, vendorConfigRoot+"/") {
+		return false
+	}
+	etcPath := "/etc" + strings.TrimPrefix(filePath, vendorConfigRoot)
+	if path.Clean(etcPath) != etcPath {
+		return false
+	}
+	_, err := fs.Stat(etcPath)
+	return err == nil
+}

--- a/providers/os/resources/vendorconfig_test.go
+++ b/providers/os/resources/vendorconfig_test.go
@@ -1,0 +1,156 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVendorConfigCandidates(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want []string
+	}{
+		{
+			name: "etc file",
+			path: "/etc/login.defs",
+			want: []string{"/etc/login.defs", "/usr/etc/login.defs"},
+		},
+		{
+			name: "nested etc file",
+			path: "/etc/ssh/sshd_config",
+			want: []string{"/etc/ssh/sshd_config", "/usr/etc/ssh/sshd_config"},
+		},
+		{
+			name: "etc directory",
+			path: "/etc/security/limits.d",
+			want: []string{"/etc/security/limits.d", "/usr/etc/security/limits.d"},
+		},
+		{
+			name: "bare etc",
+			path: "/etc",
+			want: []string{"/etc", "/usr/etc"},
+		},
+		{
+			name: "path outside etc is untouched",
+			path: "/usr/local/etc/sudoers",
+			want: []string{"/usr/local/etc/sudoers"},
+		},
+		{
+			name: "etc prefix without separator is not an etc path",
+			path: "/etcetera/conf",
+			want: []string{"/etcetera/conf"},
+		},
+		{
+			name: "relative path is untouched",
+			path: "sshd_config",
+			want: []string{"sshd_config"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, vendorConfigCandidates(test.path))
+		})
+	}
+}
+
+func TestResolveVendorConfigPath(t *testing.T) {
+	t.Run("etc wins when both exist", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/etc/login.defs", []byte("UMASK 077\n"), 0o644))
+		require.NoError(t, afero.WriteFile(fs, "/usr/etc/login.defs", []byte("UMASK 022\n"), 0o644))
+
+		assert.Equal(t, "/etc/login.defs", resolveVendorConfigPath(fs, "/etc/login.defs"))
+	})
+
+	t.Run("falls back to usr etc", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/usr/etc/ssh/sshd_config", []byte("UsePAM yes\n"), 0o644))
+
+		assert.Equal(t, "/usr/etc/ssh/sshd_config", resolveVendorConfigPath(fs, "/etc/ssh/sshd_config"))
+	})
+
+	t.Run("keeps the canonical path when nothing exists", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+
+		assert.Equal(t, "/etc/sudoers", resolveVendorConfigPath(fs, "/etc/sudoers"))
+	})
+
+	t.Run("nil filesystem keeps the canonical path", func(t *testing.T) {
+		assert.Equal(t, "/etc/sudoers", resolveVendorConfigPath(nil, "/etc/sudoers"))
+	})
+}
+
+func TestVendorConfigDirs(t *testing.T) {
+	t.Run("returns both trees with etc first", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, fs.MkdirAll("/etc/logrotate.d", 0o755))
+		require.NoError(t, fs.MkdirAll("/usr/etc/logrotate.d", 0o755))
+
+		assert.Equal(t,
+			[]string{"/etc/logrotate.d", "/usr/etc/logrotate.d"},
+			vendorConfigDirs(fs, "/etc/logrotate.d"))
+	})
+
+	t.Run("returns only the tree that exists", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, fs.MkdirAll("/usr/etc/security/limits.d", 0o755))
+
+		assert.Equal(t,
+			[]string{"/usr/etc/security/limits.d"},
+			vendorConfigDirs(fs, "/etc/security/limits.d"))
+	})
+
+	t.Run("ignores a regular file with the directory name", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, "/etc/logrotate.d", []byte("not a dir"), 0o644))
+
+		assert.Empty(t, vendorConfigDirs(fs, "/etc/logrotate.d"))
+	})
+
+	t.Run("no directory anywhere", func(t *testing.T) {
+		assert.Empty(t, vendorConfigDirs(afero.NewMemMapFs(), "/etc/logrotate.d"))
+	})
+
+	t.Run("nil filesystem", func(t *testing.T) {
+		assert.Empty(t, vendorConfigDirs(nil, "/etc/logrotate.d"))
+	})
+}
+
+func TestVendorConfigShadowed(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/etc/logrotate.d/nginx", []byte("admin copy\n"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/usr/etc/logrotate.d/nginx", []byte("vendor copy\n"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/usr/etc/logrotate.d/chrony", []byte("vendor copy\n"), 0o644))
+
+	t.Run("vendor drop-in overridden in etc", func(t *testing.T) {
+		assert.True(t, vendorConfigShadowed(fs, "/usr/etc/logrotate.d/nginx"))
+	})
+
+	t.Run("vendor drop-in with no override", func(t *testing.T) {
+		assert.False(t, vendorConfigShadowed(fs, "/usr/etc/logrotate.d/chrony"))
+	})
+
+	t.Run("etc drop-in is never shadowed", func(t *testing.T) {
+		assert.False(t, vendorConfigShadowed(fs, "/etc/logrotate.d/nginx"))
+	})
+
+	t.Run("path outside the vendor tree", func(t *testing.T) {
+		assert.False(t, vendorConfigShadowed(fs, "/opt/logrotate.d/nginx"))
+	})
+
+	t.Run("traversal is not resolved into an etc lookup", func(t *testing.T) {
+		assert.False(t, vendorConfigShadowed(fs, "/usr/etc/logrotate.d/../logrotate.d/nginx"))
+	})
+
+	t.Run("nil filesystem", func(t *testing.T) {
+		assert.False(t, vendorConfigShadowed(nil, "/usr/etc/logrotate.d/nginx"))
+	})
+}


### PR DESCRIPTION
## What

openSUSE Leap 16 and SUSE Linux Enterprise 16 split packaged configuration out of `/etc`. The file a package ships lives at the same relative path under `/usr/etc`, and `/etc` holds only what an administrator changed. A stock Leap 16 host has **no** `/etc/ssh/sshd_config`, `/etc/login.defs`, `/etc/sudoers`, `/etc/security/limits.conf` or `/etc/logrotate.conf` at all.

Five resolvers hardcode the `/etc` path, so on Leap 16 they report an error or nothing.

## Observed on openSUSE Leap 16.0 (`ami-03a316f2d7f5f31b2`), before

```
sshd.config { file { path } permitRootLogin }
  -> permitRootLogin: "Error: file '/etc/ssh/sshd_config' not found"

logindefs { params }              -> {}
sudoers { files defaults }        -> files: [], defaults: []
sudoers.userSpecs                 -> []
limits { files }                  -> []
logrotate { globalConfig }        -> {}
```

The sudoers case is the sharpest. This host's `/usr/etc/sudoers` pulls in `/etc/sudoers.d`, which grants `ec2-user ALL=(ALL) NOPASSWD: ALL` — invisible to any audit reading `sudoers`. `sshd.config` was just as blind, missing the `/etc/ssh/sshd_config.d/90-disable-passwd-auth.conf` drop-in that turns `PasswordAuthentication` off.

## After

```
sshd.config  file /usr/etc/ssh/sshd_config, PasswordAuthentication "no",
             KbdInteractiveAuthentication "no", UsePAM "yes"
sshd.config.files
             /usr/etc/ssh/sshd_config
             /usr/etc/ssh/sshd_config.d/40-suse-crypto-policies.conf
             /etc/ssh/sshd_config.d/90-disable-kbd-auth.conf
             /etc/ssh/sshd_config.d/90-disable-passwd-auth.conf
             /etc/crypto-policies/back-ends/opensshserver.config
logindefs    PASS_MAX_DAYS 99999, UMASK 022, ENCRYPT_METHOD SHA512
sudoers      /usr/etc/sudoers + /etc/sudoers.d/90-cloud-init-users,
             userSpec ec2-user ALL=(ALL) NOPASSWD: ALL
limits       /usr/etc/security/limits.conf
logrotate    global directives from /usr/etc/logrotate.conf, 13 config files
```

## How

A shared helper resolves an `/etc` path by preferring `/etc` and falling back to `/usr/etc` — the precedence systemd documents for split configuration trees. Drop-in directories are read from **both** trees, with a file in `/etc` shadowing the same-named vendor copy.

When neither tree has the file the canonical `/etc` path is kept, so error messages still name the location a user expects. Hosts without `/usr/etc` behave exactly as before — one extra failed `Stat` per config resource.

## Tests

`providers/os/resources/vendorconfig_test.go` covers the pure-Go path logic against an in-memory filesystem: `/etc` precedence, `/usr/etc` fallback, the no-match case, paths outside `/etc`, the `/etcetera` near-miss, directory merging, a regular file wearing a directory name, drop-in shadowing, and path traversal.

Verified live on openSUSE Leap 16.0.
