### PR TITLE
🐛 os: stop reporting SUSE kernel subpackages as installed kernels

### DIFF
--- a/providers/os/resources/kernel.go
+++ b/providers/os/resources/kernel.go
@@ -113,6 +113,61 @@ func suseKernelMatchesRunning(pkgVersion, pkgName, runningKernelVersion string) 
 	return strings.HasPrefix(stripRPMEpoch(pkgVersion), versionPrefix)
 }
 
+// suseKernelName reports the flavor a SUSE kernel package carries, and whether
+// the package holds a bootable kernel at all.
+//
+// SUSE names its bootable kernels "kernel-<flavor>" (kernel-default,
+// kernel-azure, kernel-rt, kernel-kvmsmall), plus the stripped
+// "kernel-<flavor>-base" variant that MicroOS boots. Everything else shipped
+// under the kernel- prefix is a subpackage that contains no kernel:
+// kernel-firmware-*, kernel-devel, kernel-macros, kernel-source, kernel-syms,
+// kernel-docs, kernel-install-tools, kernel-obs-build, kernel-livepatch-*, and
+// the per-flavor -devel/-extra/-optional/-vdso builds.
+//
+// Listing those invents installed kernels that are not on disk, and their
+// versions are unrelated to any kernel release: a stock host with
+// kernel-firmware-network and kernel-macros installed reported three
+// "installed kernels", one of them at a higher version than the running one,
+// which reads as a pending kernel upgrade that does not exist.
+//
+// A bootable name is therefore one flavor segment, optionally followed by
+// "-base", and the flavor is not one of the subpackage words. A flavor SUSE
+// adds later still resolves; a subpackage never does.
+func suseKernelName(pkgName string) (string, bool) {
+	flavor, ok := strings.CutPrefix(pkgName, "kernel-")
+	if !ok || flavor == "" {
+		return "", false
+	}
+
+	// kernel-default-base is bootable; kernel-default-devel and
+	// kernel-firmware-network are not.
+	flavor = strings.TrimSuffix(flavor, "-base")
+	if strings.Contains(flavor, "-") {
+		return "", false
+	}
+
+	if suseKernelSubpackages[flavor] {
+		return "", false
+	}
+
+	return pkgName, true
+}
+
+// suseKernelSubpackages are the single-segment kernel-* packages that are not
+// kernels. Multi-segment subpackages (kernel-firmware-network,
+// kernel-obs-build, kernel-default-devel) are already excluded by shape.
+// "base" only appears as a suffix on a real flavor (kernel-default-base); on
+// its own it is not a kernel.
+var suseKernelSubpackages = map[string]bool{
+	"base":     true,
+	"devel":    true,
+	"docs":     true,
+	"firmware": true,
+	"macros":   true,
+	"source":   true,
+	"syms":     true,
+}
+
 // debianImageKernelName reports the kernel release a linux-image package
 // carries, and whether the package holds a kernel at all.
 //
@@ -341,14 +396,15 @@ func photonKernelVersion(pkg kernelPackage, runningKernelVersion string) (Kernel
 //	cat /proc/version
 //	Linux version 4.12.14-122.23-default (geeko@buildhost)
 func suseKernelVersion(pkg kernelPackage, runningKernelVersion string) (KernelVersion, bool) {
-	if !strings.HasPrefix(pkg.Name, "kernel-") {
+	name, ok := suseKernelName(pkg.Name)
+	if !ok {
 		return KernelVersion{}, false
 	}
 
 	return KernelVersion{
-		Name:    pkg.Name,
-		Version: pkg.Version + strings.TrimPrefix(pkg.Name, "kernel"),
-		Running: suseKernelMatchesRunning(pkg.Version, pkg.Name, runningKernelVersion),
+		Name:    name,
+		Version: pkg.Version + strings.TrimPrefix(name, "kernel"),
+		Running: suseKernelMatchesRunning(pkg.Version, name, runningKernelVersion),
 	}, true
 }
 

--- a/providers/os/resources/kernel_suse_test.go
+++ b/providers/os/resources/kernel_suse_test.go
@@ -1,0 +1,97 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSuseKernelName(t *testing.T) {
+	tests := []struct {
+		pkg      string
+		wantName string
+		wantOK   bool
+		why      string
+	}{
+		// Bootable kernels, as named in the openSUSE Leap 16.0 and SLE 16 repos.
+		{"kernel-default", "kernel-default", true, "the stock flavor"},
+		{"kernel-azure", "kernel-azure", true, "cloud flavor"},
+		{"kernel-rt", "kernel-rt", true, "realtime flavor"},
+		{"kernel-kvmsmall", "kernel-kvmsmall", true, "virtualization flavor"},
+		{"kernel-default-base", "kernel-default-base", true, "stripped kernel MicroOS boots"},
+		{"kernel-64kb", "kernel-64kb", true, "flavor not in any list still resolves"},
+		{"kernel-longterm", "kernel-longterm", true, "flavor not in any list still resolves"},
+
+		// Subpackages that carry no kernel. These are what a stock SUSE host
+		// actually has installed alongside the kernel, and listing them invents
+		// installed kernels.
+		{"kernel-firmware-network", "", false, "firmware, installed on stock hosts"},
+		{"kernel-firmware-all", "", false, "firmware meta package"},
+		{"kernel-macros", "", false, "rpm macros, version tracks a newer kernel"},
+		{"kernel-devel", "", false, "headers"},
+		{"kernel-devel-azure", "", false, "per-flavor headers"},
+		{"kernel-source", "", false, "sources"},
+		{"kernel-source-vanilla", "", false, "sources"},
+		{"kernel-syms", "", false, "module symbols"},
+		{"kernel-syms-azure", "", false, "per-flavor module symbols"},
+		{"kernel-docs", "", false, "documentation"},
+		{"kernel-docs-html", "", false, "documentation"},
+		{"kernel-install-tools", "", false, "tooling"},
+		{"kernel-obs-build", "", false, "build service helper"},
+		{"kernel-obs-qa", "", false, "build service helper"},
+		{"kernel-default-devel", "", false, "per-flavor headers"},
+		{"kernel-default-extra", "", false, "extra modules, not a kernel"},
+		{"kernel-default-optional", "", false, "optional modules, not a kernel"},
+		{"kernel-azure-vdso", "", false, "vdso build"},
+		{"kernel-livepatch-6_12_0-160000_37-default", "", false, "livepatch"},
+
+		// Not a kernel package at all.
+		{"kernel", "", false, "no flavor suffix, not used by SUSE"},
+		{"kernel-", "", false, "empty flavor"},
+		{"kernel-base", "", false, "-base with no flavor in front"},
+		{"linux-image-6.12.0-default", "", false, "debian naming"},
+		{"bash", "", false, "unrelated package"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.pkg, func(t *testing.T) {
+			name, ok := suseKernelName(test.pkg)
+			assert.Equal(t, test.wantOK, ok, test.why)
+			assert.Equal(t, test.wantName, name, test.why)
+		})
+	}
+}
+
+// The live openSUSE Leap 16.0 host this came from ran 6.12.0-160000.35-default
+// with kernel-default 6.12.0-160000.35.1 installed, plus kernel-macros at the
+// higher 6.12.0-160000.37.1 and kernel-firmware-network at 20250717-160000.1.2.
+// Only the first is a kernel, and only it is running.
+func TestSuseKernelNameWithRunningMatch(t *testing.T) {
+	running := "6.12.0-160000.35-default"
+
+	tests := []struct {
+		pkg         string
+		version     string
+		wantKernel  bool
+		wantRunning bool
+	}{
+		{"kernel-default", "6.12.0-160000.35.1", true, true},
+		{"kernel-macros", "6.12.0-160000.37.1", false, false},
+		{"kernel-firmware-network", "20250717-160000.1.2", false, false},
+		{"kernel-default", "6.12.0-160000.37.1", true, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.pkg+"@"+test.version, func(t *testing.T) {
+			name, ok := suseKernelName(test.pkg)
+			assert.Equal(t, test.wantKernel, ok)
+			if !ok {
+				return
+			}
+			assert.Equal(t, test.wantRunning, suseKernelMatchesRunning(test.version, name, running))
+		})
+	}
+}


### PR DESCRIPTION
## What

`kernel.installed` matches every rpm named `kernel-*` on the suse family. SUSE ships a lot of packages under that prefix that contain no kernel: `kernel-firmware-*`, `kernel-devel`, `kernel-macros`, `kernel-source`, `kernel-syms`, `kernel-docs`, `kernel-install-tools`, `kernel-obs-build`, `kernel-livepatch-*`, and the per-flavor `-devel`/`-extra`/`-optional`/`-vdso` builds. `kernel-firmware-*` in particular is installed on stock SUSE hosts.

## Observed on openSUSE Leap 16.0 running `6.12.0-160000.35-default`

```
kernel.installed
[{name: "kernel-firmware-network", running: false, version: "20250717-160000.1.2-firmware-network"},
 {name: "kernel-default",          running: true,  version: "6.12.0-160000.35.1-default"},
 {name: "kernel-macros",           running: false, version: "6.12.0-160000.37.1-macros"}]
```

Two of the three are not kernels. The `kernel-macros` entry is worse than noise: its version tracks the newest kernel in the repo, not the installed one, so it reads as a newer kernel sitting on disk waiting for a reboot that nothing is waiting for. **Any check comparing the running kernel against the newest installed one fires on a host that is fully up to date.**

## After

```
kernel.installed
[{name: "kernel-default", running: true, version: "6.12.0-160000.35.1-default"}]
```

## How

Match SUSE's actual naming: a bootable kernel is `kernel-<flavor>`, optionally with the `-base` suffix MicroOS boots, where the flavor is a single segment and not one of the subpackage words. A flavor SUSE adds later (`kernel-64kb`, `kernel-longterm`) still resolves; a subpackage never does.

This mirrors `debianImageKernelName`, which fixed the same class of bug for the Debian `linux-image-*` metapackage.

## Tests

`providers/os/resources/kernel_suse_test.go` tables every `kernel-*` package name in the openSUSE Leap 16.0 repos — 7 bootable, 19 subpackages, plus non-kernel names — and pins the running-kernel match against the live host's real versions.

Verified live on openSUSE Leap 16.0 (`ami-03a316f2d7f5f31b2`) with `kernel-firmware-network` and `kernel-macros` installed alongside `kernel-default`.
