### PR TITLE
🟢 os: pin openSUSE Leap 16 platform detection

### DIFF
--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -465,6 +465,21 @@ func TestOpenSuseLeap15Detector(t *testing.T) {
 	assert.Equal(t, []string{"suse", "linux", "unix", "os"}, di.Family)
 }
 
+// Leap 16 is a full rebase onto the SLE 16 codebase: it drops YaST, moves
+// packaged configuration to /usr/etc, and ships an /etc/os-release whose
+// ID_LIKE now also names SLE. It still has to resolve as opensuse-leap and
+// not fall through to the sles resolver or read as a Leap 15 point release.
+func TestOpenSuseLeap16Detector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-opensuse-leap-16.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "opensuse-leap", di.Name, "os name should be identified")
+	assert.Equal(t, "openSUSE Leap 16.0", di.Title, "os title should be identified")
+	assert.Equal(t, "16.0", di.Version, "os version should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"suse", "linux", "unix", "os"}, di.Family)
+}
+
 func TestOpenSuseTumbleweedDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-opensuse-tumbleweed.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/testdata/detect-opensuse-leap-16.toml
+++ b/providers/os/detector/testdata/detect-opensuse-leap-16.toml
@@ -1,0 +1,24 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "6.12.0-160000.35-default"
+
+[files."/etc/os-release"]
+content = """
+NAME="openSUSE Leap"
+VERSION="16.0"
+ID="opensuse-leap"
+ID_LIKE="suse opensuse"
+VERSION_ID="16.0"
+PRETTY_NAME="openSUSE Leap 16.0"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:leap:16.0"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://www.opensuse.org/"
+DOCUMENTATION_URL="https://en.opensuse.org/Portal:Leap"
+LOGO="distributor-logo-Leap"
+"""


### PR DESCRIPTION
## What

openSUSE Leap 16 is a full rebase onto the SLE 16 codebase rather than another 15.x point release: it drops YaST, moves packaged configuration to `/usr/etc`, and ships a rewritten `/etc/os-release`. Nothing in the detector table covered it, so a regression that made it resolve as `sles` or as a Leap 15 point release would have shipped unnoticed, taking every suse-family resource with it.

## How

Capture the `/etc/os-release` and `uname` output from a live openSUSE Leap 16.0 host (`ami-03a316f2d7f5f31b2`) as a fixture and assert the resolution the host actually produces today:

| field | value |
|---|---|
| name | `opensuse-leap` |
| title | `openSUSE Leap 16.0` |
| version | `16.0` |
| arch | `x86_64` |
| family | `suse`, `linux`, `unix`, `os` |

The host has no `/etc/SuSE-release`, matching the existing Leap 15 fixture's shape.

**Detection is already correct — this only pins it.** It sits next to the existing `detect-opensuse-leap-15.toml` and `detect-suse-sles-16.toml` cases, closing the gap between them.
