### PR TITLE
🧹 azure: drop the stale subscription.go permission entry

### DIFF
--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.36.0",
-  "generated_at": "2026-08-23T20:23:17-07:00",
+  "generated_at": "2026-08-25T10:25:48-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.ApiManagement/service/apis/policies/read",
@@ -1943,12 +1943,6 @@
       "service": "Microsoft.Resources",
       "action": "NewListLocationsPager",
       "source_file": "recoveryservices.go"
-    },
-    {
-      "permission": "Microsoft.Resources/subscriptions/read",
-      "service": "Microsoft.Resources",
-      "action": "Get",
-      "source_file": "subscription.go"
     },
     {
       "permission": "Microsoft.Resources/subscriptions/resourceGroups/read",


### PR DESCRIPTION
## Summary

`Microsoft.Resources/subscriptions/read` was attributed to `providers/azure/resources/subscription.go`, but #10353 moved that `Get` call to `providers/azure/connection/client_subscriptions.go`. The file now has no Azure SDK imports and no `Get` call, so the extractor correctly stops emitting the entry. This regenerates the manifest to match.

## No permission is lost

The permission stays in the top-level `permissions` array and keeps two live provenance entries:

| action | source_file |
|---|---|
| `Get` | `connection/client_subscriptions.go` |
| `NewListLocationsPager` | `recoveryservices.go` |

The extractor reports **343 permissions (unchanged)** — this is provenance cleanup, not a scope change. No customer needs to adjust their role.

## How it was regenerated

```
go run providers-sdk/v1/util/permissions/permissions.go providers/azure
```

(the `providers/permissions` make target — note `make providers/build/<provider>` does **not** regenerate this file)

## Test plan

- [x] `go run providers-sdk/v1/util/permissions/permissions.go providers/azure` reports `343 permissions (unchanged)`
- [x] `Microsoft.Resources/subscriptions/read` still present in the top-level `permissions` array
- [x] `providers/azure/resources/subscription.go` confirmed to contain no `.Get(` call and no Azure SDK imports
