### PR TITLE
🛑 os: report architecture on image scans, detect ALT, drop busybox's v prefix

### DIFF
--- a/providers/os/connection/docker/container_connection.go
+++ b/providers/os/connection/docker/container_connection.go
@@ -308,7 +308,8 @@ func NewContainerImageConnection(id uint32, conf *inventory.Config, asset *inven
 		imageRef = conf.Host
 	}
 
-	tarConn, err := tar.NewConnection(
+	var tarConn *tar.Connection
+	tarConn, err = tar.NewConnection(
 		id,
 		conf,
 		asset,
@@ -316,6 +317,14 @@ func NewContainerImageConnection(id uint32, conf *inventory.Config, asset *inven
 			img, err := image.LoadImageFromDockerEngine(imageRef, disableInmemoryCache)
 			if err != nil {
 				return filename, err
+			}
+
+			// Carry the architecture over from the image config, the same way the
+			// registry path does. A tar connection has no command capability to ask
+			// `uname -m`, so without this the asset reports an empty architecture.
+			// This runs before platform detection reads the field back.
+			if imgConfig, cfgErr := img.ConfigFile(); cfgErr == nil && imgConfig != nil {
+				tarConn.PlatformArchitecture = imgConfig.Architecture
 			}
 
 			err = tar.StreamToTmpFile(mutate.Extract(img), tmpFile)

--- a/providers/os/connection/tar/file.go
+++ b/providers/os/connection/tar/file.go
@@ -48,8 +48,18 @@ func (f *File) Read(b []byte) (n int, err error) {
 	return f.reader.Read(b)
 }
 
+// ReadAt gives random access to the entry, which platform detection needs to
+// parse an ELF header. The tar entry is already extracted into memory, so the
+// underlying reader supports it directly.
 func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
-	return 0, errors.New("not implemented yet")
+	if f.reader == nil {
+		return 0, errors.New("no tar data available")
+	}
+	ra, ok := f.reader.(io.ReaderAt)
+	if !ok {
+		return 0, errors.New("tar entry does not support random access")
+	}
+	return ra.ReadAt(b, off)
 }
 
 func (f *File) Readdir(n int) ([]os.FileInfo, error) {

--- a/providers/os/connection/tar/fs_test.go
+++ b/providers/os/connection/tar/fs_test.go
@@ -4,6 +4,7 @@
 package tar_test
 
 import (
+	"debug/elf"
 	"io"
 	"regexp"
 	"sort"
@@ -171,5 +172,52 @@ func TestTarFileAlpine(t *testing.T) {
 		assert.Equal(t, 5, len(names))
 		sort.Strings(names)
 		assert.Equal(t, []string{"arch", "keys", "protected_paths.d", "repositories", "world"}, names)
+	})
+}
+
+// Platform detection falls back to reading the ELF header of a binary on the
+// target when there is no command capability to ask `uname -m`, which is every
+// container image scan. elf.NewFile needs io.ReaderAt, so the tar filesystem
+// has to provide one.
+func TestTarFileReadAt(t *testing.T) {
+	err := cacheAlpine()
+	require.NoError(t, err, "should create tar without error")
+
+	c, err := tar.NewConnection(0, &inventory.Config{
+		Type: "tar",
+		Options: map[string]string{
+			tar.OPTION_FILE: alpineContainerPath,
+		},
+	}, &inventory.Asset{})
+	require.NoError(t, err)
+
+	t.Run("reads the bytes at an offset", func(t *testing.T) {
+		f, err := c.FileSystem().Open("/etc/alpine-release")
+		require.NoError(t, err)
+		full, err := io.ReadAll(f)
+		require.NoError(t, err)
+		require.Greater(t, len(full), 6)
+
+		f2, err := c.FileSystem().Open("/etc/alpine-release")
+		require.NoError(t, err)
+		ra, ok := f2.(io.ReaderAt)
+		require.True(t, ok, "tar file must implement io.ReaderAt")
+
+		buf := make([]byte, 4)
+		n, err := ra.ReadAt(buf, 2)
+		require.NoError(t, err)
+		assert.Equal(t, 4, n)
+		assert.Equal(t, full[2:6], buf)
+	})
+
+	t.Run("an ELF binary parses over the tar filesystem", func(t *testing.T) {
+		f, err := c.FileSystem().Open("/bin/busybox")
+		require.NoError(t, err)
+		ra, ok := f.(io.ReaderAt)
+		require.True(t, ok, "tar file must implement io.ReaderAt")
+
+		ef, err := elf.NewFile(ra)
+		require.NoError(t, err, "elf.NewFile must work over the tar filesystem")
+		assert.NotEqual(t, elf.EM_NONE, ef.Machine, "ELF machine type must be readable")
 	})
 }

--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -877,7 +877,9 @@ var busybox = &PlatformResolver{
 			return false, nil
 		}
 
-		releaseRegex := regexp.MustCompile(`^(.+)\s(v[\d\.]+)\s*\((.*)\).*$`)
+		// busybox prints its version as "BusyBox v1.34.1 (...)"; the v is part of
+		// its banner, not the version, and every other platform reports a bare one.
+		releaseRegex := regexp.MustCompile(`^(.+)\sv([\d\.]+)\s*\((.*)\).*$`)
 		for _, rodataByteString := range rodataByteStrings {
 			rodataString := string(rodataByteString)
 			m := releaseRegex.FindStringSubmatch(rodataString)
@@ -906,6 +908,20 @@ var photon = &PlatformResolver{
 			return true, nil
 		}
 		return false, nil
+	},
+}
+
+// ALT Linux (BaseALT) sets ID=altlinux in os-release. It also ships
+// /etc/redhat-release, /etc/fedora-release and /etc/system-release for
+// compatibility, each carrying only "ALT Container" with no distro name and no
+// version, so nothing in the redhat family can identify it from those. Without
+// a resolver of its own the generic linux fallback claimed it, and a container
+// image claimed by that fallback is reported as "scratch".
+var altlinux = &PlatformResolver{
+	Name:     "altlinux",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		return pf.Name == "altlinux", nil
 	},
 }
 
@@ -1402,7 +1418,9 @@ var eulerFamily = &PlatformResolver{
 var linuxFamily = &PlatformResolver{
 	Name:     inventory.FAMILY_LINUX,
 	IsFamily: true,
-	Children: []*PlatformResolver{archFamily, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, wizos, alpine, wolfi, nixos, gentoo, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, flatcar, cirros, defaultLinux},
+	// NOTE: altlinux runs before the redhat family, whose members probe
+	// /etc/redhat-release and /etc/fedora-release, both of which ALT ships.
+	Children: []*PlatformResolver{archFamily, altlinux, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, wizos, alpine, wolfi, nixos, gentoo, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, flatcar, cirros, defaultLinux},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		detected := false
 		osrd := NewOSReleaseDetector(conn)

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/providers/os/connection/mock"
 )
@@ -817,13 +818,46 @@ func TestWizOSLinuxDetector(t *testing.T) {
 	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
 }
 
+// ALT Linux (BaseALT) ships /etc/redhat-release, /etc/fedora-release and
+// /etc/system-release for compatibility, all carrying just "ALT Container" with
+// no version and no distro name. Nothing claimed it, so it fell through to the
+// generic resolver and container images were reported as "scratch".
+func TestAltLinuxDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-altlinux-p10.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "altlinux", di.Name, "os name should be identified")
+	assert.Equal(t, "ALT Container", di.Title, "os title should be identified")
+	assert.Equal(t, "10", di.Version, "os version should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
+}
+
+// The name above is right even without a resolver of its own, because the
+// generic fallback leaves a name that os-release already supplied. What it does
+// not survive is a container image scan: an image whose platform was only
+// claimed by the generic resolver is reported as "scratch", which is how ALT
+// images were coming back.
+func TestAltLinuxIsClaimedByItsOwnResolver(t *testing.T) {
+	mockConn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/detect-altlinux-p10.toml"))
+	require.NoError(t, err)
+
+	pf, leaf, resolved := OperatingSystems.resolvePlatform(&inventory.Platform{}, mockConn)
+	require.True(t, resolved, "platform should resolve")
+	require.NotNil(t, leaf)
+
+	assert.NotEqual(t, defaultLinux, leaf, "ALT must not be left to the generic linux resolver")
+	assert.False(t, isUnidentifiedPlatform(pf, leaf),
+		"a container image claimed only by the generic resolver is reported as scratch")
+}
+
 func TestBusyboxLinuxDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-busybox.toml")
 	assert.Nil(t, err, "was able to create the provider")
 
 	assert.Equal(t, "busybox", di.Name, "os name should be identified")
 	assert.Equal(t, "BusyBox", di.Title, "os title should be identified")
-	assert.Equal(t, "v1.34.1", di.Version, "os version should be identified")
+	assert.Equal(t, "1.34.1", di.Version, "os version should not carry busybox's v prefix")
 	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
 	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
 }

--- a/providers/os/detector/testdata/detect-altlinux-p10.toml
+++ b/providers/os/detector/testdata/detect-altlinux-p10.toml
@@ -1,0 +1,31 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[files."/etc/altlinux-release"]
+content = "ALT Container"
+
+[files."/etc/redhat-release"]
+content = "ALT Container"
+
+[files."/etc/fedora-release"]
+content = "ALT Container"
+
+[files."/etc/system-release"]
+content = "ALT Container"
+
+[files."/etc/os-release"]
+content = """
+NAME="ALT Container"
+VERSION="10"
+ID=altlinux
+VERSION_ID=10
+PRETTY_NAME="ALT Container"
+ANSI_COLOR="1;33"
+CPE_NAME="cpe:/o:alt:container:10"
+BUILD_ID="ALT Container 10"
+ALT_BRANCH_ID="p10"
+HOME_URL="https://basealt.ru/"
+"""


### PR DESCRIPTION
Found by scanning **60 distro container images** and comparing detected platform against what each image actually is.

## 1. Container image scans reported an empty architecture

Every image scan returned `arch: ""`. The same image as a *running* container returned it correctly:

```
running container →  arch: "arm64"   ✓
image scan        →  arch: ""        ✗   (all 51 images that detected)
```

Two independent defects had to line up for this to survive:

- The **docker-engine-image path** builds a `tar.Connection` and never sets `PlatformArchitecture`. The registry path does (`conn.PlatformArchitecture = imgConfig.Architecture`), which is why the same image scanned through a remote daemon reported `amd64` while the local one reported nothing.
- The **ELF fallback** written for exactly this case could never run. `archFromELF` parses `/bin/ls`, `/usr/bin/ls`, `/bin/busybox` and is documented as the path "for command-less scans where `uname -m` is not available". The candidate binaries are present (`/usr/bin/ls`, 199464 bytes on `ubuntu:24.04`) and the debug log showed it firing, but `elf.NewFile` needs `io.ReaderAt` and the tar file's was a stub:

```go
func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
	return 0, errors.New("not implemented yet")
}
```

**Fixing only the stub would have been wrong.** `elfMachineToArch` deliberately returns uname-style `x86_64`/`aarch64`, while the image config gives OCI-style `amd64`/`arm64`. The fallback would then answer a *different dialect* than the registry path for the same image — trading an empty field for an inconsistent one. So the engine path now carries the image config's architecture, and the ELF fallback goes back to being the last resort for a scan with neither commands nor an image config. `ReadAt` is a one-line delegation: the tar entry is already buffered in a `*bytes.Reader`, which implements `io.ReaderAt` natively.

## 2. ALT Linux reported as `scratch`

`alt:p10`, `alt:p11` and `alt:sisyphus` all came back as platform `scratch`.

ALT sets `ID=altlinux` in os-release, but also ships `/etc/redhat-release`, `/etc/fedora-release` and `/etc/system-release` — each containing only `ALT Container`, with no distro name and no version — so nothing in the redhat family can identify it from those. With no resolver of its own, the generic linux fallback claimed it, and `isUnidentifiedPlatform` reports any image claimed by that fallback as `scratch`.

Worth noting the name was *already right* for command-based scans, because the generic fallback leaves the os-release name in place. Only container images were affected, so the test asserts the mechanism (`leaf != defaultLinux`) rather than the name, which would have passed either way.

ALT now has a resolver, ordered ahead of the redhat family for the same reason `cloudlinux` is ordered ahead of `centos`.

## 3. BREAKING: busybox version carried a `v` prefix

busybox reported `v1.34.1` where every other platform reports bare (`3.21.7`, `24.04`). The `v` is part of busybox's banner, not the version — the regex captured it inside the group. Any version comparison against `platform.version` had to special-case busybox.

This changes a reported value, so it is flagged breaking: a policy pinning `v1.38.0` needs updating to `1.38.0`.

## Verification

TDD throughout — each fix has a test that failed first for the right reason, including `cannot read ELF identifier 'not implemented yet'` for the `ReadAt` stub.

Validated end to end against live containers on **both** architectures, using a locally built provider:

| image | before | after (arm64) | after (amd64 daemon) |
|---|---|---|---|
| `alpine:3.21` | `arch: ""` | `arm64` | `amd64` |
| `ubuntu:24.04` | `arch: ""` | `arm64` | — |
| `busybox:latest` | `v1.38.0`, `arch: ""` | `1.38.0`, `arm64` | — |
| `alt:p10` | `scratch` | `altlinux` | `altlinux` |

Architecture reports OCI-style on both, so the two image paths agree. `go test ./detector/... ./connection/tar/... ./connection/docker/...` all pass.
