### PR TITLE
🐛 os: report the architecture on container image scans

### DIFF
--- a/providers/os/connection/docker/container_connection.go
+++ b/providers/os/connection/docker/container_connection.go
@@ -308,7 +308,8 @@ func NewContainerImageConnection(id uint32, conf *inventory.Config, asset *inven
 		imageRef = conf.Host
 	}
 
-	tarConn, err := tar.NewConnection(
+	var tarConn *tar.Connection
+	tarConn, err = tar.NewConnection(
 		id,
 		conf,
 		asset,
@@ -316,6 +317,14 @@ func NewContainerImageConnection(id uint32, conf *inventory.Config, asset *inven
 			img, err := image.LoadImageFromDockerEngine(imageRef, disableInmemoryCache)
 			if err != nil {
 				return filename, err
+			}
+
+			// Carry the architecture over from the image config, the same way the
+			// registry path does. A tar connection has no command capability to ask
+			// `uname -m`, so without this the asset reports an empty architecture.
+			// This runs before platform detection reads the field back.
+			if imgConfig, cfgErr := img.ConfigFile(); cfgErr == nil && imgConfig != nil {
+				tarConn.PlatformArchitecture = imgConfig.Architecture
 			}
 
 			err = tar.StreamToTmpFile(mutate.Extract(img), tmpFile)

--- a/providers/os/connection/tar/file.go
+++ b/providers/os/connection/tar/file.go
@@ -48,8 +48,18 @@ func (f *File) Read(b []byte) (n int, err error) {
 	return f.reader.Read(b)
 }
 
+// ReadAt gives random access to the entry, which platform detection needs to
+// parse an ELF header. The tar entry is already extracted into memory, so the
+// underlying reader supports it directly.
 func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
-	return 0, errors.New("not implemented yet")
+	if f.reader == nil {
+		return 0, errors.New("no tar data available")
+	}
+	ra, ok := f.reader.(io.ReaderAt)
+	if !ok {
+		return 0, errors.New("tar entry does not support random access")
+	}
+	return ra.ReadAt(b, off)
 }
 
 func (f *File) Readdir(n int) ([]os.FileInfo, error) {

--- a/providers/os/connection/tar/fs_test.go
+++ b/providers/os/connection/tar/fs_test.go
@@ -4,6 +4,7 @@
 package tar_test
 
 import (
+	"debug/elf"
 	"io"
 	"regexp"
 	"sort"
@@ -171,5 +172,52 @@ func TestTarFileAlpine(t *testing.T) {
 		assert.Equal(t, 5, len(names))
 		sort.Strings(names)
 		assert.Equal(t, []string{"arch", "keys", "protected_paths.d", "repositories", "world"}, names)
+	})
+}
+
+// Platform detection falls back to reading the ELF header of a binary on the
+// target when there is no command capability to ask `uname -m`, which is every
+// container image scan. elf.NewFile needs io.ReaderAt, so the tar filesystem
+// has to provide one.
+func TestTarFileReadAt(t *testing.T) {
+	err := cacheAlpine()
+	require.NoError(t, err, "should create tar without error")
+
+	c, err := tar.NewConnection(0, &inventory.Config{
+		Type: "tar",
+		Options: map[string]string{
+			tar.OPTION_FILE: alpineContainerPath,
+		},
+	}, &inventory.Asset{})
+	require.NoError(t, err)
+
+	t.Run("reads the bytes at an offset", func(t *testing.T) {
+		f, err := c.FileSystem().Open("/etc/alpine-release")
+		require.NoError(t, err)
+		full, err := io.ReadAll(f)
+		require.NoError(t, err)
+		require.Greater(t, len(full), 6)
+
+		f2, err := c.FileSystem().Open("/etc/alpine-release")
+		require.NoError(t, err)
+		ra, ok := f2.(io.ReaderAt)
+		require.True(t, ok, "tar file must implement io.ReaderAt")
+
+		buf := make([]byte, 4)
+		n, err := ra.ReadAt(buf, 2)
+		require.NoError(t, err)
+		assert.Equal(t, 4, n)
+		assert.Equal(t, full[2:6], buf)
+	})
+
+	t.Run("an ELF binary parses over the tar filesystem", func(t *testing.T) {
+		f, err := c.FileSystem().Open("/bin/busybox")
+		require.NoError(t, err)
+		ra, ok := f.(io.ReaderAt)
+		require.True(t, ok, "tar file must implement io.ReaderAt")
+
+		ef, err := elf.NewFile(ra)
+		require.NoError(t, err, "elf.NewFile must work over the tar filesystem")
+		assert.NotEqual(t, elf.EM_NONE, ef.Machine, "ELF machine type must be readable")
 	})
 }


### PR DESCRIPTION
Container image scans reported an empty architecture. The same image as a **running** container reported it correctly:

```
running container →  arch: "arm64"   ✓
image scan        →  arch: ""        ✗   (all 51 images in a 60-image sweep)
```

Two independent defects had to line up.

**The engine path never sets it.** The docker-engine-image path builds a `tar.Connection` and never assigns `PlatformArchitecture`. The registry path does (`conn.PlatformArchitecture = imgConfig.Architecture`) — which is why the same image scanned through a remote daemon reported `amd64` while the local one reported nothing.

**The ELF fallback could never run.** `archFromELF` parses `/bin/ls`, `/usr/bin/ls`, `/bin/busybox` and is documented as the path "for command-less scans where `uname -m` is not available". The candidates are present (`/usr/bin/ls`, 199464 bytes on `ubuntu:24.04`) and the debug log showed it firing, but `elf.NewFile` needs `io.ReaderAt`:

```go
func (f *File) ReadAt(b []byte, off int64) (n int, err error) {
	return 0, errors.New("not implemented yet")
}
```

### Why both, and not just the stub

`elfMachineToArch` deliberately returns uname-style `x86_64`/`aarch64`; the image config gives OCI-style `amd64`/`arm64`. Fixing only the stub would make the fallback answer a **different dialect** than the registry path for the same image — trading an empty field for an inconsistent one. So the engine path carries the image config's architecture, and the ELF fallback stays the last resort for a scan with neither commands nor an image config.

`ReadAt` itself is a delegation: the tar entry is already buffered in a `*bytes.Reader`, which implements `io.ReaderAt` natively.

### Verification

Test-first; the failing test reported `cannot read ELF identifier 'not implemented yet'`, the production error exactly.

| image | before | arm64 daemon | x86_64 daemon |
|---|---|---|---|
| `alpine:3.21` | `""` | `arm64` | `amd64` |
| `ubuntu:24.04` | `""` | `arm64` | — |
| `busybox:latest` | `""` | `arm64` | — |

Both image paths now agree on OCI-style naming. `go test ./connection/tar/... ./connection/docker/... ./detector/...` pass.