### PR TITLE
🐛 os: detect ALT Linux instead of reporting it as scratch

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -909,6 +909,20 @@ var photon = &PlatformResolver{
 	},
 }
 
+// ALT Linux (BaseALT) sets ID=altlinux in os-release. It also ships
+// /etc/redhat-release, /etc/fedora-release and /etc/system-release for
+// compatibility, each carrying only "ALT Container" with no distro name and no
+// version, so nothing in the redhat family can identify it from those. Without
+// a resolver of its own the generic linux fallback claimed it, and a container
+// image claimed by that fallback is reported as "scratch".
+var altlinux = &PlatformResolver{
+	Name:     "altlinux",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		return pf.Name == "altlinux", nil
+	},
+}
+
 var mageia = &PlatformResolver{
 	Name:     "mageia",
 	IsFamily: false,
@@ -1402,7 +1416,9 @@ var eulerFamily = &PlatformResolver{
 var linuxFamily = &PlatformResolver{
 	Name:     inventory.FAMILY_LINUX,
 	IsFamily: true,
-	Children: []*PlatformResolver{archFamily, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, wizos, alpine, wolfi, nixos, gentoo, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, flatcar, cirros, defaultLinux},
+	// NOTE: altlinux runs before the redhat family, whose members probe
+	// /etc/redhat-release and /etc/fedora-release, both of which ALT ships.
+	Children: []*PlatformResolver{archFamily, altlinux, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, wizos, alpine, wolfi, nixos, gentoo, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, flatcar, cirros, defaultLinux},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		detected := false
 		osrd := NewOSReleaseDetector(conn)

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/providers/os/connection/mock"
 )
@@ -815,6 +816,39 @@ func TestWizOSLinuxDetector(t *testing.T) {
 	assert.Equal(t, "1.0", di.Version, "os version should be identified")
 	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
 	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
+}
+
+// ALT Linux (BaseALT) ships /etc/redhat-release, /etc/fedora-release and
+// /etc/system-release for compatibility, all carrying just "ALT Container" with
+// no version and no distro name. Nothing claimed it, so it fell through to the
+// generic resolver and container images were reported as "scratch".
+func TestAltLinuxDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-altlinux-p10.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "altlinux", di.Name, "os name should be identified")
+	assert.Equal(t, "ALT Container", di.Title, "os title should be identified")
+	assert.Equal(t, "10", di.Version, "os version should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
+}
+
+// The name above is right even without a resolver of its own, because the
+// generic fallback leaves a name that os-release already supplied. What it does
+// not survive is a container image scan: an image whose platform was only
+// claimed by the generic resolver is reported as "scratch", which is how ALT
+// images were coming back.
+func TestAltLinuxIsClaimedByItsOwnResolver(t *testing.T) {
+	mockConn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/detect-altlinux-p10.toml"))
+	require.NoError(t, err)
+
+	pf, leaf, resolved := OperatingSystems.resolvePlatform(&inventory.Platform{}, mockConn)
+	require.True(t, resolved, "platform should resolve")
+	require.NotNil(t, leaf)
+
+	assert.NotEqual(t, defaultLinux, leaf, "ALT must not be left to the generic linux resolver")
+	assert.False(t, isUnidentifiedPlatform(pf, leaf),
+		"a container image claimed only by the generic resolver is reported as scratch")
 }
 
 func TestBusyboxLinuxDetector(t *testing.T) {

--- a/providers/os/detector/testdata/detect-altlinux-p10.toml
+++ b/providers/os/detector/testdata/detect-altlinux-p10.toml
@@ -1,0 +1,31 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[files."/etc/altlinux-release"]
+content = "ALT Container"
+
+[files."/etc/redhat-release"]
+content = "ALT Container"
+
+[files."/etc/fedora-release"]
+content = "ALT Container"
+
+[files."/etc/system-release"]
+content = "ALT Container"
+
+[files."/etc/os-release"]
+content = """
+NAME="ALT Container"
+VERSION="10"
+ID=altlinux
+VERSION_ID=10
+PRETTY_NAME="ALT Container"
+ANSI_COLOR="1;33"
+CPE_NAME="cpe:/o:alt:container:10"
+BUILD_ID="ALT Container 10"
+ALT_BRANCH_ID="p10"
+HOME_URL="https://basealt.ru/"
+"""


### PR DESCRIPTION
`alt:p10`, `alt:p11` and `alt:sisyphus` container images were all reported as platform **`scratch`**.

## Why

ALT Linux (BaseALT) sets `ID=altlinux` in os-release, but also ships three compatibility files:

```
/etc/redhat-release   => ALT Container
/etc/fedora-release   => ALT Container
/etc/system-release   => ALT Container
/etc/altlinux-release => ALT Container
```

No distro name, no version — so nothing in the redhat family can identify it from those. With no resolver of its own, the generic linux fallback claimed it, and `isUnidentifiedPlatform` reports any image claimed by that fallback as `scratch`.

## A note on the test

The platform name was **already correct** for command-based scans, because the generic fallback leaves the os-release name in place — `defaultLinux` only sets a name when one is missing. Only container images were affected.

So the obvious test (assert `di.Name == "altlinux"`) passes with or without the fix and proves nothing. The test here asserts the actual mechanism instead:

```go
assert.NotEqual(t, defaultLinux, leaf, "ALT must not be left to the generic linux resolver")
assert.False(t, isUnidentifiedPlatform(pf, leaf))
```

ALT is ordered ahead of the redhat family for the same reason `cloudlinux` is ordered ahead of `centos` — it ships the files that family probes.

## Verification

Fixture captured from the real `alt:p10` image. Verified live on both architectures:

| image | before | after |
|---|---|---|
| `alt:p10` | `scratch` | `altlinux` (version `10`) |

`go test ./detector/...` passes.