### PR TITLE
🛑 os: drop busybox's v prefix from the reported version

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -877,7 +877,9 @@ var busybox = &PlatformResolver{
 			return false, nil
 		}
 
-		releaseRegex := regexp.MustCompile(`^(.+)\s(v[\d\.]+)\s*\((.*)\).*$`)
+		// busybox prints its version as "BusyBox v1.34.1 (...)"; the v is part of
+		// its banner, not the version, and every other platform reports a bare one.
+		releaseRegex := regexp.MustCompile(`^(.+)\sv([\d\.]+)\s*\((.*)\).*$`)
 		for _, rodataByteString := range rodataByteStrings {
 			rodataString := string(rodataByteString)
 			m := releaseRegex.FindStringSubmatch(rodataString)

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -823,7 +823,7 @@ func TestBusyboxLinuxDetector(t *testing.T) {
 
 	assert.Equal(t, "busybox", di.Name, "os name should be identified")
 	assert.Equal(t, "BusyBox", di.Title, "os title should be identified")
-	assert.Equal(t, "v1.34.1", di.Version, "os version should be identified")
+	assert.Equal(t, "1.34.1", di.Version, "os version should not carry busybox's v prefix")
 	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
 	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
 }


### PR DESCRIPTION
busybox reported its version as **`v1.34.1`**. Every other platform reports a bare version (`3.21.7`, `24.04`), so any comparison written against `platform.version` had to special-case busybox.

The `v` belongs to busybox's own banner — `BusyBox v1.34.1 (...)` — not to the version. The regex captured it inside the group:

```diff
-releaseRegex := regexp.MustCompile(`^(.+)\s(v[\d\.]+)\s*\((.*)\).*$`)
+releaseRegex := regexp.MustCompile(`^(.+)\sv([\d\.]+)\s*\((.*)\).*$`)
```

## Breaking

This changes a reported value. A policy pinning `platform.version == "v1.38.0"` on a busybox asset needs updating to `"1.38.0"`.

The old value was pinned by `TestBusyboxLinuxDetector`, so the test change is the contract change, made first.

Confirmed live: `busybox:latest` now reports `1.38.0` (was `v1.38.0`) across the `latest`, `musl`, `glibc` and `uclibc` variants.