### PR TITLE
🐛 os: detect Manjaro ARM instead of reporting it as scratch

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -139,7 +139,13 @@ var manjaro = &PlatformResolver{
 	Name:     "manjaro",
 	IsFamily: false,
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
-		if pf.Name == "manjaro" {
+		// Manjaro ARM ships ID=manjaro-arm with ID_LIKE="manjaro arch". It is the
+		// same distribution built for ARM and belongs to the arch family just as
+		// manjaro does. Without it the arch family matched on /etc/arch-release
+		// but no child claimed the platform, so the generic fallback took it and
+		// container images were reported as "scratch". The name is left as the
+		// distribution reports it rather than folded into "manjaro".
+		if pf.Name == "manjaro" || pf.Name == "manjaro-arm" {
 			return true, nil
 		}
 		return false, nil

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -851,6 +851,33 @@ func TestAltLinuxIsClaimedByItsOwnResolver(t *testing.T) {
 		"a container image claimed only by the generic resolver is reported as scratch")
 }
 
+// Manjaro ARM sets ID=manjaro-arm, not manjaro. The arch family matched on
+// /etc/arch-release but no child claimed it, so the generic fallback took it and
+// container images were reported as "scratch".
+func TestManjaroArmDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-manjaro-arm.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "manjaro-arm", di.Name, "os name should be identified")
+	assert.Equal(t, "24.03", di.Version, "os version should come from lsb")
+	assert.Equal(t, []string{"arch", "linux", "unix", "os"}, di.Family,
+		"Manjaro ARM belongs to the arch family")
+}
+
+// A container image whose platform is only claimed by the generic resolver is
+// reported as "scratch", which is how Manjaro ARM images were coming back.
+func TestManjaroArmIsClaimedByItsOwnResolver(t *testing.T) {
+	mockConn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/detect-manjaro-arm.toml"))
+	require.NoError(t, err)
+
+	pf, leaf, resolved := OperatingSystems.resolvePlatform(&inventory.Platform{}, mockConn)
+	require.True(t, resolved, "platform should resolve")
+	require.NotNil(t, leaf)
+
+	assert.NotEqual(t, defaultLinux, leaf, "Manjaro ARM must not be left to the generic linux resolver")
+	assert.False(t, isUnidentifiedPlatform(pf, leaf))
+}
+
 func TestBusyboxLinuxDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-busybox.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/testdata/detect-manjaro-arm.toml
+++ b/providers/os/detector/testdata/detect-manjaro-arm.toml
@@ -1,0 +1,28 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "aarch64"
+
+[files."/etc/arch-release"]
+content = ""
+
+[files."/etc/lsb-release"]
+content = """
+DISTRIB_ID=Manjaro-ARM
+DISTRIB_RELEASE=24.03
+DISTRIB_CODENAME=
+DISTRIB_DESCRIPTION="Manjaro ARM Linux"
+"""
+
+[files."/etc/os-release"]
+content = """
+NAME="Manjaro ARM"
+ID="manjaro-arm"
+ID_LIKE="manjaro arch"
+PRETTY_NAME="Manjaro ARM"
+ANSI_COLOR="1;32"
+HOME_URL="https://www.manjaro.org/"
+SUPPORT_URL="https://forum.manjaro.org/c/arm/"
+LOGO=manjarolinux
+"""


### PR DESCRIPTION
The **arm64** variant of `manjarolinux/base` is a different distribution from the amd64 one:

```
amd64:  NAME="Manjaro Linux"   ID=manjaro
arm64:  NAME="Manjaro ARM"     ID="manjaro-arm"   ID_LIKE="manjaro arch"
```

The `manjaro` resolver only matched `"manjaro"`. The arch family still matched — Manjaro ARM ships `/etc/arch-release` (a 0-byte file) — but no child claimed the platform, so resolution fell through to the generic linux resolver. An image claimed by that resolver is reported as `scratch`, and the asset also lost its arch family membership:

| | platform | family |
|---|---|---|
| before | `scratch` | `[linux unix os]` |
| after | `manjaro-arm` | `[arch linux unix os]` |

The name is left as the distribution reports it rather than folded into `manjaro`, matching how the detector treats every other os-release ID (`opensuse-leap`, `rhcos`, …). Family membership is what cross-cutting policies key on, and that is now correct.

## Verification

Fixture captured from `manjarolinux/base:20260322` (arm64), including the 0-byte `/etc/arch-release` and the `lsb-release` that supplies the `24.03` version.

The test asserts both symptoms — the missing `arch` family **and** that the leaf is not `defaultLinux`, since the name alone would not have caught this. Confirmed end to end against the live image.