### PR TITLE
🐛 os: detect Void Linux instead of reporting it as scratch

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -931,6 +931,20 @@ var altlinux = &PlatformResolver{
 	},
 }
 
+// Void Linux ships only /etc/os-release, carrying ID=void and no version of any
+// kind because it is a rolling release. Without a resolver of its own the
+// generic linux fallback claimed it, and a container image claimed by that
+// fallback is reported as "scratch" — discarding the identity the image states
+// outright. Note the os provider has no xbps support, so packages are not
+// available on this platform; detection only.
+var voidlinux = &PlatformResolver{
+	Name:     "void",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		return pf.Name == "void", nil
+	},
+}
+
 var mageia = &PlatformResolver{
 	Name:     "mageia",
 	IsFamily: false,
@@ -1426,7 +1440,7 @@ var linuxFamily = &PlatformResolver{
 	IsFamily: true,
 	// NOTE: altlinux runs before the redhat family, whose members probe
 	// /etc/redhat-release and /etc/fedora-release, both of which ALT ships.
-	Children: []*PlatformResolver{archFamily, altlinux, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, wizos, alpine, wolfi, nixos, gentoo, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, flatcar, cirros, defaultLinux},
+	Children: []*PlatformResolver{archFamily, altlinux, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, wizos, alpine, wolfi, nixos, gentoo, voidlinux, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, flatcar, cirros, defaultLinux},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		detected := false
 		osrd := NewOSReleaseDetector(conn)

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -878,6 +878,32 @@ func TestManjaroArmIsClaimedByItsOwnResolver(t *testing.T) {
 	assert.False(t, isUnidentifiedPlatform(pf, leaf))
 }
 
+// Void Linux ships only /etc/os-release, with ID=void and no version of any
+// kind (it is a rolling release). Nothing claimed it, so the generic resolver
+// did, and container images were reported as "scratch" even though the image
+// says exactly what it is.
+func TestVoidLinuxDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-void.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "void", di.Name, "os name should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
+}
+
+func TestVoidLinuxIsClaimedByItsOwnResolver(t *testing.T) {
+	mockConn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/detect-void.toml"))
+	require.NoError(t, err)
+
+	pf, leaf, resolved := OperatingSystems.resolvePlatform(&inventory.Platform{}, mockConn)
+	require.True(t, resolved, "platform should resolve")
+	require.NotNil(t, leaf)
+
+	assert.NotEqual(t, defaultLinux, leaf, "Void must not be left to the generic linux resolver")
+	assert.False(t, isUnidentifiedPlatform(pf, leaf),
+		"a container image claimed only by the generic resolver is reported as scratch")
+}
+
 func TestBusyboxLinuxDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-busybox.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/testdata/detect-void.toml
+++ b/providers/os/detector/testdata/detect-void.toml
@@ -1,0 +1,13 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[files."/etc/os-release"]
+content = """
+NAME="void"
+ID="void"
+DISTRIB_ID="void"
+PRETTY_NAME="void"
+"""


### PR DESCRIPTION
`voidlinux/voidlinux` container images were reported as platform **`scratch`**.

Void ships only `/etc/os-release`:

```
NAME="void"
ID="void"
DISTRIB_ID="void"
PRETTY_NAME="void"
```

No version of any kind — it is a rolling release. With no resolver of its own, the generic linux fallback claimed it, and an image claimed by that fallback is reported as `scratch`.

| | platform | family |
|---|---|---|
| before | `scratch` | `[linux unix os]` |
| after | `void` | `[linux unix os]` |

## Why this one is worth naming

`scratch` is the right answer for an image that genuinely cannot be identified — `tatsushid/tinycore`, for instance, ships no os-release at all and is correctly reported as `scratch`. Void is the opposite case: the image states exactly what it is and we were throwing that away.

## Scope

Detection only. The os provider has no `xbps` support, so `packages` are not available on this platform. Reporting the platform is still strictly better than reporting nothing — it is what makes a Void asset addressable by a policy filter at all.

Found while scanning 87 distro container images against the detector.