### PR TITLE
🐛 os: detect Clear Linux OS instead of reporting it as scratch

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -937,6 +937,19 @@ var altlinux = &PlatformResolver{
 // fallback is reported as "scratch" — discarding the identity the image states
 // outright. Note the os provider has no xbps support, so packages are not
 // available on this platform; detection only.
+// Clear Linux OS ships only /etc/os-release, as a symlink to the copy in
+// /usr/lib, carrying ID=clear-linux-os. Without a resolver of its own the
+// generic linux fallback claimed it, and a container image claimed by that
+// fallback is reported as "scratch". Detection only: the os provider has no
+// swupd support, so packages are not available on this platform.
+var clearlinux = &PlatformResolver{
+	Name:     "clear-linux-os",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		return pf.Name == "clear-linux-os", nil
+	},
+}
+
 var voidlinux = &PlatformResolver{
 	Name:     "void",
 	IsFamily: false,
@@ -1440,7 +1453,7 @@ var linuxFamily = &PlatformResolver{
 	IsFamily: true,
 	// NOTE: altlinux runs before the redhat family, whose members probe
 	// /etc/redhat-release and /etc/fedora-release, both of which ALT ships.
-	Children: []*PlatformResolver{archFamily, altlinux, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, wizos, alpine, wolfi, nixos, gentoo, voidlinux, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, flatcar, cirros, defaultLinux},
+	Children: []*PlatformResolver{archFamily, altlinux, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, wizos, alpine, wolfi, nixos, gentoo, voidlinux, clearlinux, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, flatcar, cirros, defaultLinux},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		detected := false
 		osrd := NewOSReleaseDetector(conn)

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -904,6 +904,32 @@ func TestVoidLinuxIsClaimedByItsOwnResolver(t *testing.T) {
 		"a container image claimed only by the generic resolver is reported as scratch")
 }
 
+// Clear Linux OS ships only /etc/os-release (a symlink to /usr/lib/os-release),
+// carrying ID=clear-linux-os. Nothing claimed it, so the generic resolver did
+// and container images were reported as "scratch".
+func TestClearLinuxDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-clearlinux.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "clear-linux-os", di.Name, "os name should be identified")
+	assert.Equal(t, "43630", di.Version, "os version should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
+}
+
+func TestClearLinuxIsClaimedByItsOwnResolver(t *testing.T) {
+	mockConn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/detect-clearlinux.toml"))
+	require.NoError(t, err)
+
+	pf, leaf, resolved := OperatingSystems.resolvePlatform(&inventory.Platform{}, mockConn)
+	require.True(t, resolved, "platform should resolve")
+	require.NotNil(t, leaf)
+
+	assert.NotEqual(t, defaultLinux, leaf, "Clear Linux must not be left to the generic linux resolver")
+	assert.False(t, isUnidentifiedPlatform(pf, leaf),
+		"a container image claimed only by the generic resolver is reported as scratch")
+}
+
 func TestBusyboxLinuxDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-busybox.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/testdata/detect-clearlinux.toml
+++ b/providers/os/detector/testdata/detect-clearlinux.toml
@@ -1,0 +1,21 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[files."/etc/os-release"]
+content = """
+NAME="Clear Linux OS"
+VERSION=1
+ID=clear-linux-os
+ID_LIKE=clear-linux-os
+VERSION_ID=43630
+PRETTY_NAME="Clear Linux OS"
+ANSI_COLOR="1;35"
+HOME_URL="https://clearlinux.org"
+SUPPORT_URL="https://clearlinux.org"
+BUG_REPORT_URL="mailto:dev@clearlinux.discoursemail.com"
+PRIVACY_POLICY_URL="http://www.intel.com/privacy"
+BUILD_ID=43630
+"""


### PR DESCRIPTION
`clearlinux:latest` and `clearlinux:base` were reported as platform **`scratch`**.

Clear Linux ships only `/etc/os-release` (a symlink to `/usr/lib/os-release`):

```
NAME="Clear Linux OS"
ID=clear-linux-os
VERSION_ID=43630
```

The version parsed fine — it was the identity that was discarded. With no resolver of its own, the generic linux fallback claimed it, and an image claimed by that fallback is reported as `scratch`.

| | platform | version |
|---|---|---|
| before | `scratch` | `43630` |
| after | `clear-linux-os` | `43630` |

## Scope

Detection only. The os provider has no `swupd` support, so `packages` are not available on this platform — but reporting the platform is what makes a Clear Linux asset addressable by a policy filter at all.

Found while scanning 96 distro container images against the detector. This is the fourth distro hitting the same structural weakness (after ALT, Manjaro ARM and Void): a distro with no dedicated resolver becomes `scratch` as a container image even when its os-release states exactly what it is.

Verified end to end against both `clearlinux` tags on an x86_64 daemon, with a control image to confirm the locally built provider was actually the one under test.