### PR TITLE
🐛 os: detect Container-Optimized OS instead of reporting it as scratch

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -169,6 +169,21 @@ var azurelinux = &PlatformResolver{
 	},
 }
 
+// Container-Optimized OS from Google ships only /etc/os-release, carrying
+// ID=cos along with VERSION_ID and BUILD_ID. Without a resolver of its own the
+// generic linux fallback claimed it: an SSH or local scan still reported the
+// name os-release states, but a container or container image claimed by that
+// fallback is reported as "scratch", and the name never reached the platform
+// catalog, so cos had no family chain to filter on. Note cos ships no package
+// manager, so packages are not available on this platform; detection only.
+var cos = &PlatformResolver{
+	Name:     "cos",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		return pf.Name == "cos", nil
+	},
+}
+
 var flatcar = &PlatformResolver{
 	Name:     "flatcar",
 	IsFamily: false,
@@ -1468,7 +1483,7 @@ var linuxFamily = &PlatformResolver{
 	IsFamily: true,
 	// NOTE: altlinux runs before the redhat family, whose members probe
 	// /etc/redhat-release and /etc/fedora-release, both of which ALT ships.
-	Children: []*PlatformResolver{archFamily, altlinux, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, wizos, alpine, wolfi, nixos, gentoo, voidlinux, clearlinux, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, flatcar, cirros, defaultLinux},
+	Children: []*PlatformResolver{archFamily, altlinux, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, wizos, alpine, wolfi, nixos, gentoo, voidlinux, clearlinux, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, cos, flatcar, cirros, defaultLinux},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		detected := false
 		osrd := NewOSReleaseDetector(conn)

--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -169,13 +169,8 @@ var azurelinux = &PlatformResolver{
 	},
 }
 
-// Container-Optimized OS from Google ships only /etc/os-release, carrying
-// ID=cos along with VERSION_ID and BUILD_ID. Without a resolver of its own the
-// generic linux fallback claimed it: an SSH or local scan still reported the
-// name os-release states, but a container or container image claimed by that
-// fallback is reported as "scratch", and the name never reached the platform
-// catalog, so cos had no family chain to filter on. Note cos ships no package
-// manager, so packages are not available on this platform; detection only.
+// Container-Optimized OS ships only /etc/os-release, with ID=cos. It has no
+// package manager, so this is detection only.
 var cos = &PlatformResolver{
 	Name:     "cos",
 	IsFamily: false,

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -1267,10 +1267,8 @@ func TestGoogleCOSDetector(t *testing.T) {
 	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
 }
 
-// Container-Optimized OS ships only /etc/os-release, with ID=cos. Nothing
-// claimed it, so the generic resolver did: an SSH scan still reported the name
-// os-release states, but a container image was reported as "scratch" and the
-// name never reached the platform catalog.
+// Asserting the name would pass either way: the generic fallback leaves
+// whatever os-release said. Container images are what break.
 func TestGoogleCOSIsClaimedByItsOwnResolver(t *testing.T) {
 	mockConn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/detect-google-cos.toml"))
 	require.NoError(t, err)
@@ -1284,7 +1282,6 @@ func TestGoogleCOSIsClaimedByItsOwnResolver(t *testing.T) {
 		"a container image claimed only by the generic resolver is reported as scratch")
 }
 
-// cos must reach the platform catalog, which is built from the detector tree.
 func TestGoogleCOSIsInPlatformCatalog(t *testing.T) {
 	assert.Equal(t, []string{"os", "unix", "linux"}, osTree["cos"],
 		"cos must carry a family chain for policy filters to match on")

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -1267,6 +1267,29 @@ func TestGoogleCOSDetector(t *testing.T) {
 	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
 }
 
+// Container-Optimized OS ships only /etc/os-release, with ID=cos. Nothing
+// claimed it, so the generic resolver did: an SSH scan still reported the name
+// os-release states, but a container image was reported as "scratch" and the
+// name never reached the platform catalog.
+func TestGoogleCOSIsClaimedByItsOwnResolver(t *testing.T) {
+	mockConn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/detect-google-cos.toml"))
+	require.NoError(t, err)
+
+	pf, leaf, resolved := OperatingSystems.resolvePlatform(&inventory.Platform{}, mockConn)
+	require.True(t, resolved, "platform should resolve")
+	require.NotNil(t, leaf)
+
+	assert.NotEqual(t, defaultLinux, leaf, "cos must not be left to the generic linux resolver")
+	assert.False(t, isUnidentifiedPlatform(pf, leaf),
+		"a container image claimed only by the generic resolver is reported as scratch")
+}
+
+// cos must reach the platform catalog, which is built from the detector tree.
+func TestGoogleCOSIsInPlatformCatalog(t *testing.T) {
+	assert.Equal(t, []string{"os", "unix", "linux"}, osTree["cos"],
+		"cos must carry a family chain for policy filters to match on")
+}
+
 func TestElementaryOSDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-elementary.toml")
 	assert.Nil(t, err, "was able to create the provider")


### PR DESCRIPTION
Google Container-Optimized OS was left to the generic linux fallback.

COS ships only `/etc/os-release`, carrying `ID=cos` alongside `VERSION_ID` and `BUILD_ID`. With no resolver of its own the generic fallback claimed it. An SSH or local scan still reported `cos`, because that name comes straight from os-release, which is why the existing `TestGoogleCOSDetector` passed and hid this.

Two things did break:

- **A container or container image claimed by that fallback is reported as `scratch`.** `isUnidentifiedPlatform` keys off *which resolver matched* (`leaf == defaultLinux`), not the platform name, so the identity the image states outright is discarded.
- **The name never reached `osTree`**, so `CatalogPlatforms()` never advertised `cos` and `detector.Family("cos")` returned empty, leaving no family chain for a policy filter to match on.

```
before:  leaf=generic-linux  osTree["cos"]=[]
after:   leaf=cos            osTree["cos"]=[os unix linux]
```

Same shape as #10444 (Void Linux) and #10443 (Manjaro ARM).

Detection only: COS ships no package manager, so `packages` is not available on this platform. Reporting the platform is what makes a COS node addressable by a policy filter at all.

## Test plan

- `TestGoogleCOSIsClaimedByItsOwnResolver` — asserts the leaf is not `defaultLinux` and `isUnidentifiedPlatform` is false, so the container-image path no longer collapses to `scratch`.
- `TestGoogleCOSIsInPlatformCatalog` — asserts `osTree["cos"]` carries `[os unix linux]`.
- Both fail on `main` and pass with this change; verified by reverting `detector_all.go` and re-running.
- Existing `TestGoogleCOSDetector` still passes unchanged (name, title, version, build, family).
- `go test ./...` in `providers/os/` shows no new failures. Two pre-existing failures on `main` are unrelated and unchanged: `connection/device/linux` build failure (`undefined: snapshot.MockVolumeMounter`) and `TestLocalConnectionIdDetectors` (environment-dependent id-detector count).
