### PR TITLE
🐛 os: detect Bottlerocket without /etc/bottlerocket-release

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -726,43 +726,58 @@ var amazonlinux = &PlatformResolver{
 	},
 }
 
+// Bottlerocket carries /etc/bottlerocket-release on older versions, but newer
+// ones dropped it, and on a raw root-partition scan (an EBS volume snapshot)
+// /etc is an overlay whose upper layer lives on the data partition, so neither
+// that file nor /etc/os-release is present. The canonical /usr/lib/os-release
+// always is, and the linux family detection already reads it, so the release
+// file is only an enrichment source here and the claim falls back to the name
+// os-release yielded. Gating the claim on opening the file left those systems
+// to the generic linux fallback, and a container or container image claimed by
+// that fallback is reported as "scratch".
 var bottlerocket = &PlatformResolver{
 	Name:     "bottlerocket",
 	IsFamily: false,
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
-		f, err := conn.FileSystem().Open("/etc/bottlerocket-release")
-		if err != nil {
-			return false, nil
-		}
-		defer f.Close()
-
-		c, err := io.ReadAll(f)
-		if err != nil || len(c) == 0 {
-			log.Debug().Err(err)
-			return false, nil
-		}
-
-		osr, err := ParseOsRelease(strings.TrimSpace(string(c)))
-		if err == nil {
-			if len(osr["ID"]) > 0 {
-				pf.Name = osr["ID"]
-			}
-			if len(osr["PRETTY_NAME"]) > 0 {
-				pf.Title = osr["PRETTY_NAME"]
-			}
-			if len(osr["VERSION_ID"]) > 0 {
-				pf.Version = osr["VERSION_ID"]
-			}
-			if len(osr["BUILD_ID"]) > 0 {
-				pf.Build = osr["BUILD_ID"]
-			}
-		}
-
-		if pf.Name == "bottlerocket" {
-			return true, nil
-		}
-		return false, nil
+		enrichFromBottlerocketRelease(pf, conn)
+		return pf.Name == "bottlerocket", nil
 	},
+}
+
+// enrichFromBottlerocketRelease overlays /etc/bottlerocket-release onto pf when
+// that file is present. Every field it sets is best-effort: a missing or
+// unreadable file leaves pf as the os-release detection left it.
+func enrichFromBottlerocketRelease(pf *inventory.Platform, conn shared.Connection) {
+	f, err := conn.FileSystem().Open("/etc/bottlerocket-release")
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	c, err := io.ReadAll(f)
+	if err != nil || len(c) == 0 {
+		log.Debug().Err(err).Msg("platform> cannot read /etc/bottlerocket-release")
+		return
+	}
+
+	osr, err := ParseOsRelease(strings.TrimSpace(string(c)))
+	if err != nil {
+		log.Debug().Err(err).Msg("platform> cannot parse /etc/bottlerocket-release")
+		return
+	}
+
+	if len(osr["ID"]) > 0 {
+		pf.Name = osr["ID"]
+	}
+	if len(osr["PRETTY_NAME"]) > 0 {
+		pf.Title = osr["PRETTY_NAME"]
+	}
+	if len(osr["VERSION_ID"]) > 0 {
+		pf.Version = osr["VERSION_ID"]
+	}
+	if len(osr["BUILD_ID"]) > 0 {
+		pf.Build = osr["BUILD_ID"]
+	}
 }
 
 var windriver = &PlatformResolver{

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -657,6 +657,35 @@ func TestBottlerocketEBSDetector(t *testing.T) {
 	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
 }
 
+// Newer Bottlerocket ships no /etc/bottlerocket-release, and a root-partition
+// scan sees no /etc/os-release either. Detection gated the claim on opening the
+// release file, so the generic resolver took those systems and a container
+// image was reported as "scratch". Name, title and version still looked right,
+// because the family detection had already read /usr/lib/os-release.
+func TestBottlerocketEBSIsClaimedByItsOwnResolver(t *testing.T) {
+	mockConn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/detect-bottlerocket-ebs.toml"))
+	require.NoError(t, err)
+
+	pf, leaf, resolved := OperatingSystems.resolvePlatform(&inventory.Platform{}, mockConn)
+	require.True(t, resolved, "platform should resolve")
+	require.NotNil(t, leaf)
+
+	assert.Equal(t, bottlerocket, leaf, "bottlerocket must claim its own root partition")
+	assert.False(t, isUnidentifiedPlatform(pf, leaf),
+		"a container image claimed only by the generic resolver is reported as scratch")
+}
+
+// The release file still wins where it exists: it carries BUILD_ID, which
+// /usr/lib/os-release on that variant does not.
+func TestBottlerocketReleaseFileStillEnriches(t *testing.T) {
+	mockConn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/detect-bottlerocket.toml"))
+	require.NoError(t, err)
+
+	_, leaf, resolved := OperatingSystems.resolvePlatform(&inventory.Platform{}, mockConn)
+	require.True(t, resolved, "platform should resolve")
+	assert.Equal(t, bottlerocket, leaf)
+}
+
 func TestScientificLinuxDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-scientific.toml")
 	assert.Nil(t, err, "was able to create the provider")


### PR DESCRIPTION
Newer Bottlerocket, and any raw root-partition scan, was claimed by the generic linux fallback.

Detection gated its claim on opening `/etc/bottlerocket-release` and returned early when that failed, **never reaching the `pf.Name == "bottlerocket"` check below it**:

```go
f, err := conn.FileSystem().Open("/etc/bottlerocket-release")
if err != nil {
    return false, nil        // <- early return
}
...
if pf.Name == "bottlerocket" { // <- unreachable when the file is absent
```

Newer Bottlerocket no longer ships that file, and on an EBS volume snapshot `/etc` is an overlay whose upper layer lives on the data partition, so neither it nor `/etc/os-release` is present on the root partition. The canonical `/usr/lib/os-release` always is, and the linux family detection already reads it.

The file is now an enrichment source rather than a gate, and the claim falls back to the name os-release yielded.

```
before:  leaf=generic-linux
after:   leaf=bottlerocket
```

**The release file still wins where it exists.** On the `aws-k8s` variant `/etc/os-release` reports `ID=amzn` (Amazon Linux 2) and only `/etc/bottlerocket-release` names the platform correctly, so the override is load-bearing and is preserved.

### Why the existing test didn't catch it

`TestBottlerocketEBSDetector` asserts name, title, version, arch and family — all of which were already correct, because the *family* detection populated them from `/usr/lib/os-release`. Both `bottlerocket` and `generic-linux` are direct children of `linuxFamily`, so even `Family` is identical. Only the leaf differs, and the leaf is what `isUnidentifiedPlatform` reads — so the visible symptom was a container or container image reported as `scratch`.

Same shape as #10446 (COS), #10444 (Void Linux) and #10443 (Manjaro ARM).

## Test plan

- `TestBottlerocketEBSIsClaimedByItsOwnResolver` — asserts the leaf is the `bottlerocket` resolver and `isUnidentifiedPlatform` is false. Fails on `main` (`actual: generic-linux`), passes here; verified by reverting `detector_all.go` and re-running.
- `TestBottlerocketReleaseFileStillEnriches` — guards the `ID=amzn` override path so the enrichment can't silently regress.
- Existing `TestBottlerocketDetector` and `TestBottlerocketEBSDetector` pass unchanged.
- `go test ./...` green in `providers/os/detector/`.
