### PR TITLE
🐛 os: follow hard links in container image tars

### DIFF
--- a/providers/os/connection/tar/fs.go
+++ b/providers/os/connection/tar/fs.go
@@ -55,13 +55,9 @@ func (fs *FS) Open(path string) (afero.File, error) {
 		return nil, os.ErrNotExist
 	}
 
-	if h.Typeflag == tar.TypeSymlink {
-		resolvedPath := fs.resolveSymlink(h)
-		log.Debug().Str("path", path).Str("resolved", Abs(resolvedPath)).Msg("file is a symlink, resolved it")
-		h, ok = fs.FileMap[Abs(resolvedPath)]
-		if !ok {
-			return nil, os.ErrNotExist
-		}
+	h, ok = fs.resolveEntry(h)
+	if !ok {
+		return nil, os.ErrNotExist
 	}
 
 	reader, err := fs.open(h)
@@ -114,23 +110,66 @@ func (fs *FS) Chown(name string, uid, gid int) error {
 }
 
 func (fs *FS) stat(header *tar.Header) (os.FileInfo, error) {
-	statHeader := header
-	if header.Typeflag == tar.TypeSymlink {
-		path := fs.resolveSymlink(header)
-		h, ok := fs.FileMap[Abs(path)]
-		if !ok {
-			return nil, errors.New("could not find " + path)
-		}
-		statHeader = h
+	statHeader, ok := fs.resolveEntry(header)
+	if !ok {
+		return nil, errors.New("could not resolve " + header.Name)
 	}
 	return statHeader.FileInfo(), nil
 }
 
+// maxLinkHops bounds link resolution so a cyclic archive cannot spin forever.
+const maxLinkHops = 10
+
+// resolveEntry follows symlinks and hard links to the entry that actually holds
+// the content. Tar records a hard link as a name plus a target path relative to
+// the archive root, carrying no data of its own, so reading one without
+// following it yields an empty file. OSTree-based images reach
+// /usr/lib/os-release exactly that way: a symlink from /etc onto a hard link
+// into the ostree object store.
+func (fs *FS) resolveEntry(header *tar.Header) (*tar.Header, bool) {
+	h := header
+	// The path we are logically at. A hard link does not move it: it points at
+	// where the bytes are stored, not at a new location in the tree. That
+	// matters when the bytes turn out to be a relative symlink, which has to be
+	// resolved against the directory we entered by. On an OSTree image
+	// /etc/redhat-release is a hard link into the object store holding a symlink
+	// to "fedora-release", and that means /etc/fedora-release.
+	logical := header.Name
+	for i := 0; i < maxLinkHops; i++ {
+		var target string
+		switch h.Typeflag {
+		case tar.TypeSymlink:
+			target = Abs(fs.resolveSymlinkFrom(logical, h.Linkname))
+			log.Debug().Str("path", logical).Str("resolved", target).Msg("file is a symlink, resolved it")
+			logical = target
+		case tar.TypeLink:
+			// a hard link target is already relative to the archive root
+			target = Abs(h.Linkname)
+			log.Debug().Str("path", logical).Str("resolved", target).Msg("file is a hard link, resolved it")
+		default:
+			return h, true
+		}
+
+		next, ok := fs.FileMap[target]
+		if !ok {
+			return nil, false
+		}
+		h = next
+	}
+
+	log.Warn().Str("path", header.Name).Msg("tar> too many link hops, giving up")
+	return nil, false
+}
+
 // resolve symlink file
 func (fs *FS) resolveSymlink(header *tar.Header) string {
-	dest := header.Name
-	link := header.Linkname
+	return fs.resolveSymlinkFrom(header.Name, header.Linkname)
+}
 
+// resolveSymlinkFrom resolves link as it would be read from dest. A relative
+// target is relative to dest's directory, so callers that arrived by a hard
+// link pass the path they came in on rather than the storage location.
+func (fs *FS) resolveSymlinkFrom(dest string, link string) string {
 	var path string
 	if filepath.IsAbs(link) {
 		var err error
@@ -158,8 +197,8 @@ func (fs *FS) open(header *tar.Header) (io.Reader, error) {
 	defer f.Close()
 
 	path := header.Name
-	if header.Typeflag == tar.TypeSymlink {
-		path = fs.resolveSymlink(header)
+	if resolved, ok := fs.resolveEntry(header); ok {
+		path = resolved.Name
 	}
 
 	// extract file from tar stream

--- a/providers/os/connection/tar/fs.go
+++ b/providers/os/connection/tar/fs.go
@@ -161,11 +161,6 @@ func (fs *FS) resolveEntry(header *tar.Header) (*tar.Header, bool) {
 	return nil, false
 }
 
-// resolve symlink file
-func (fs *FS) resolveSymlink(header *tar.Header) string {
-	return fs.resolveSymlinkFrom(header.Name, header.Linkname)
-}
-
 // resolveSymlinkFrom resolves link as it would be read from dest. A relative
 // target is relative to dest's directory, so callers that arrived by a hard
 // link pass the path they came in on rather than the storage location.
@@ -186,6 +181,8 @@ func (fs *FS) resolveSymlinkFrom(dest string, link string) string {
 	return path
 }
 
+// open reads the content of a fully resolved entry. Callers resolve symlinks
+// and hard links with resolveEntry first.
 func (fs *FS) open(header *tar.Header) (io.Reader, error) {
 	log.Debug().Str("file", header.Name).Msg("tar> load file content")
 
@@ -196,10 +193,9 @@ func (fs *FS) open(header *tar.Header) (io.Reader, error) {
 	}
 	defer f.Close()
 
+	// header is already resolved by Open, so this is the entry that holds the
+	// data rather than a link to it
 	path := header.Name
-	if resolved, ok := fs.resolveEntry(header); ok {
-		path = resolved.Name
-	}
 
 	// extract file from tar stream
 	reader, err := fsutil.ExtractFileFromTarStream(path, f)

--- a/providers/os/connection/tar/load_test.go
+++ b/providers/os/connection/tar/load_test.go
@@ -7,6 +7,9 @@ import (
 	archivetar "archive/tar"
 	"bytes"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -102,4 +105,97 @@ func BenchmarkLoad(b *testing.B) {
 	var withoutMap runtime.MemStats
 	runtime.ReadMemStats(&withoutMap)
 	b.ReportMetric(float64(held-withoutMap.HeapAlloc)/float64(entries), "retained-B/entry")
+}
+
+// OSTree-based images (Fedora CoreOS, and the rpm-ostree family generally) do
+// not store /usr/lib/os-release as a regular file. It is a hard link into the
+// ostree object store, reached through a symlink from /etc:
+//
+//	etc/os-release      -> ../usr/lib/os-release                 (symlink)
+//	usr/lib/os-release  link to sysroot/ostree/repo/objects/...   (hard link)
+//
+// A tar hard-link entry carries no content of its own, so without following it
+// the file reads as empty and the platform cannot be identified at all.
+func TestTarFollowsHardLinks(t *testing.T) {
+	const osRelease = "NAME=\"Fedora Linux\"\nID=fedora\nVERSION_ID=44\n"
+	const objectPath = "sysroot/ostree/repo/objects/a2/69745d02ee36b7709513ce323b1cf401aa2745f.file"
+
+	var buf bytes.Buffer
+	tw := archivetar.NewWriter(&buf)
+	require.NoError(t, tw.WriteHeader(&archivetar.Header{
+		Name: objectPath, Typeflag: archivetar.TypeReg, Mode: 0o644, Size: int64(len(osRelease)),
+	}))
+	_, err := tw.Write([]byte(osRelease))
+	require.NoError(t, err)
+	require.NoError(t, tw.WriteHeader(&archivetar.Header{
+		Name: "usr/lib/os-release", Typeflag: archivetar.TypeLink, Linkname: objectPath, Mode: 0o644,
+	}))
+	require.NoError(t, tw.WriteHeader(&archivetar.Header{
+		Name: "etc/os-release", Typeflag: archivetar.TypeSymlink, Linkname: "../usr/lib/os-release", Mode: 0o777,
+	}))
+	require.NoError(t, tw.Close())
+
+	tmp := filepath.Join(t.TempDir(), "image.tar")
+	require.NoError(t, os.WriteFile(tmp, buf.Bytes(), 0o644))
+
+	c := &Connection{fs: NewFs(tmp)}
+	require.NoError(t, c.Load(bytes.NewReader(buf.Bytes())))
+
+	t.Run("reads through a hard link", func(t *testing.T) {
+		f, err := c.fs.Open("/usr/lib/os-release")
+		require.NoError(t, err)
+		content, err := io.ReadAll(f)
+		require.NoError(t, err)
+		assert.Equal(t, osRelease, string(content))
+	})
+
+	t.Run("reads through a symlink onto a hard link", func(t *testing.T) {
+		f, err := c.fs.Open("/etc/os-release")
+		require.NoError(t, err)
+		content, err := io.ReadAll(f)
+		require.NoError(t, err)
+		assert.Equal(t, osRelease, string(content), "this is how Fedora CoreOS reports its platform")
+	})
+
+	t.Run("a relative symlink behind a hard link resolves from where we came in", func(t *testing.T) {
+		// etc/redhat-release is a hard link to an ostree object that is itself a
+		// symlink to "fedora-release". That target is relative to /etc, the path
+		// we entered by, not to the object store the hard link pointed into.
+		const releaseText = "Fedora release 44 (Coming Soon)\n"
+		const objSymlink = "sysroot/ostree/repo/objects/e8/1400dd73cc60112e3213386396401d5c50e2.file"
+
+		var b bytes.Buffer
+		w := archivetar.NewWriter(&b)
+		require.NoError(t, w.WriteHeader(&archivetar.Header{
+			Name: "etc/fedora-release", Typeflag: archivetar.TypeReg, Mode: 0o644, Size: int64(len(releaseText)),
+		}))
+		_, err := w.Write([]byte(releaseText))
+		require.NoError(t, err)
+		require.NoError(t, w.WriteHeader(&archivetar.Header{
+			Name: objSymlink, Typeflag: archivetar.TypeSymlink, Linkname: "fedora-release", Mode: 0o777,
+		}))
+		require.NoError(t, w.WriteHeader(&archivetar.Header{
+			Name: "etc/redhat-release", Typeflag: archivetar.TypeLink, Linkname: objSymlink, Mode: 0o644,
+		}))
+		require.NoError(t, w.Close())
+
+		tmp2 := filepath.Join(t.TempDir(), "ostree.tar")
+		require.NoError(t, os.WriteFile(tmp2, b.Bytes(), 0o644))
+		c2 := &Connection{fs: NewFs(tmp2)}
+		require.NoError(t, c2.Load(bytes.NewReader(b.Bytes())))
+
+		f, err := c2.fs.Open("/etc/redhat-release")
+		require.NoError(t, err)
+		content, err := io.ReadAll(f)
+		require.NoError(t, err)
+		assert.Equal(t, releaseText, string(content))
+	})
+
+	t.Run("stat reports the target size", func(t *testing.T) {
+		f, err := c.fs.Open("/etc/os-release")
+		require.NoError(t, err)
+		st, err := f.Stat()
+		require.NoError(t, err)
+		assert.Equal(t, int64(len(osRelease)), st.Size())
+	})
 }


### PR DESCRIPTION
OSTree-based images could not be identified **at all**. `quay.io/fedora/fedora-coreos:stable` scanned as platform `scratch`, version `unknown`, no title — none of its release files could be read.

## Why

Those images don't store `/usr/lib/os-release` as a regular file. It's a hard link into the ostree object store, reached through a symlink from `/etc`:

```
etc/os-release      -> ../usr/lib/os-release                 (symlink)
usr/lib/os-release  link to sysroot/ostree/repo/objects/...   (hard link)
```

The tar filesystem handled `tar.TypeSymlink` in four places and `tar.TypeLink` **nowhere**. A hard-link entry carries no data of its own, so the file read back empty and every release file on the image was invisible.

## Two defects, the second hidden behind the first

Symlink and hard-link resolution now share one bounded walk (bounded because an archive can describe a cycle — something the old per-call resolution couldn't express, but a loop can).

Resolution also has to track **the path we arrived by**. A hard link points at where the bytes live, not at a new location in the tree, so a relative symlink found behind one must still resolve against the directory we entered by:

```
etc/redhat-release   link to sysroot/ostree/repo/objects/e8/1400dd….file   (hard link)
        that object  -> "fedora-release"                                    (relative symlink)
```

That means `/etc/fedora-release`. Resolving it against the *object store* directory instead finds nothing. This only became visible after the first fix landed — with hard links unfollowed, the chain never got far enough to be wrong.

## Result

| | platform | version | family |
|---|---|---|---|
| before | `scratch` | `unknown` | `[linux unix os]` |
| after | `fedora` | `44` | `[redhat linux unix os]` |

## Verification

Both cases are covered by tests built from real archives (not mocks), each failing first for the right reason — `""` for the unread hard link, `file does not exist` for the mis-based symlink.

Validated end to end against the live image, with a control image to confirm the locally built provider was the one under test. Full `connection/tar` and `detector` suites pass.

Likely also affects other rpm-ostree images (Silverblue, Kinoite) and anything else built with hard-linked `/usr` content.