### PR TITLE
🐛 os: make the platform tree match the names detection emits

### DIFF
--- a/providers/os/detector/catalog_test.go
+++ b/providers/os/detector/catalog_test.go
@@ -4,10 +4,14 @@
 package detector
 
 import (
+	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
 )
 
 func TestCatalogPlatforms(t *testing.T) {
@@ -44,4 +48,38 @@ func TestCatalogPlatforms(t *testing.T) {
 	// darwin is a kernel and a family, never a platform of its own
 	assert.True(t, byName["macos"], "macos should be a catalogued platform")
 	assert.False(t, byName["darwin"], "darwin should not be a catalogued platform")
+}
+
+// Every name detection can actually emit has to be in the tree, or the platform
+// carries no family chain and plugin.PlatformInfo.Apply cannot find it in the
+// catalog, which degrades the asset to "unknown". The catalog test above only
+// compares the catalog against the tree; nothing compared the tree against what
+// resolvers really set, and a resolver does not always emit the name it is
+// registered under.
+//
+// Leaves claimed by defaultLinux are excluded: that resolver can emit any ID an
+// unknown system happens to carry, so it cannot be enumerated. A system landing
+// there is its own known problem, reported as "scratch" for container images,
+// and the fix is to give it a resolver.
+func TestEveryEmittedPlatformNameIsInTheTree(t *testing.T) {
+	fixtures, err := filepath.Glob("./testdata/*.toml")
+	require.NoError(t, err)
+	require.NotEmpty(t, fixtures)
+	sort.Strings(fixtures)
+
+	for _, fixture := range fixtures {
+		conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath(fixture))
+		if err != nil {
+			continue // not a platform-detection fixture
+		}
+
+		pf, leaf, resolved := OperatingSystems.resolvePlatform(&inventory.Platform{}, conn)
+		if !resolved || leaf == nil || leaf == defaultLinux || pf.Name == "" {
+			continue
+		}
+
+		_, ok := osTree[pf.Name]
+		assert.True(t, ok, "%s: resolver %q emits platform %q, which is not in the tree",
+			filepath.Base(fixture), leaf.Name, pf.Name)
+	}
 }

--- a/providers/os/detector/detector.go
+++ b/providers/os/detector/detector.go
@@ -115,11 +115,14 @@ func traverseFamily(r *PlatformResolver, parents []string) map[string][]string {
 	}
 
 	// return child (no family), under every name it can emit
-	res := map[string][]string{
-		r.Name: parents,
+	names := r.Emits
+	if names == nil {
+		names = []string{r.Name}
 	}
-	for _, alias := range r.Emits {
-		res[alias] = parents
+
+	res := map[string][]string{}
+	for _, name := range names {
+		res[name] = parents
 	}
 	return res
 }

--- a/providers/os/detector/detector.go
+++ b/providers/os/detector/detector.go
@@ -114,10 +114,14 @@ func traverseFamily(r *PlatformResolver, parents []string) map[string][]string {
 		return res
 	}
 
-	// return child (no family)
-	return map[string][]string{
+	// return child (no family), under every name it can emit
+	res := map[string][]string{
 		r.Name: parents,
 	}
+	for _, alias := range r.Emits {
+		res[alias] = parents
+	}
+	return res
 }
 
 func Family(platform string) []string {

--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -150,6 +150,7 @@ var arch = &PlatformResolver{
 var manjaro = &PlatformResolver{
 	Name:     "manjaro",
 	IsFamily: false,
+	Emits:    []string{"manjaro-arm"},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		// Manjaro ARM ships ID=manjaro-arm with ID_LIKE="manjaro arch". It is the
 		// same distribution built for ARM and belongs to the arch family just as
@@ -611,6 +612,7 @@ var cloudlinux = &PlatformResolver{
 var centos = &PlatformResolver{
 	Name:     "centos",
 	IsFamily: false,
+	Emits:    []string{"rockylinux", "almalinux"},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		// works for centos 5+
 		if strings.Contains(pf.Title, "CentOS") || pf.Name == "centos" {
@@ -684,6 +686,7 @@ var fedora = &PlatformResolver{
 var oracle = &PlatformResolver{
 	Name:     "oracle",
 	IsFamily: false,
+	Emits:    []string{"oraclelinux"},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		// works for oracle 7+
 		if pf.Name == "ol" {
@@ -816,6 +819,7 @@ var windriver = &PlatformResolver{
 var opensuse = &PlatformResolver{
 	Name:     "opensuse",
 	IsFamily: false,
+	Emits:    []string{"opensuse-leap", "opensuse-tumbleweed"},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		if pf.Name == "opensuse" || pf.Name == "opensuse-leap" || pf.Name == "opensuse-tumbleweed" {
 			return true, nil
@@ -1009,6 +1013,7 @@ var mageia = &PlatformResolver{
 var mxlinux = &PlatformResolver{
 	Name:     "mxlinux",
 	IsFamily: false,
+	Emits:    []string{"mx"},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		osrd := NewOSReleaseDetector(conn)
 		lsb, err := osrd.lsbconfig()

--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -150,18 +150,14 @@ var arch = &PlatformResolver{
 var manjaro = &PlatformResolver{
 	Name:     "manjaro",
 	IsFamily: false,
-	Emits:    []string{"manjaro", "manjaro-arm"},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
-		// Manjaro ARM ships ID=manjaro-arm with ID_LIKE="manjaro arch". It is the
-		// same distribution built for ARM and belongs to the arch family just as
-		// manjaro does. Without it the arch family matched on /etc/arch-release
-		// but no child claimed the platform, so the generic fallback took it and
-		// container images were reported as "scratch". The name is left as the
-		// distribution reports it rather than folded into "manjaro".
-		if pf.Name == "manjaro" || pf.Name == "manjaro-arm" {
+		// Manjaro ARM ships ID=manjaro-arm. It is the same distribution built for
+		// ARM, so it reports as manjaro rather than as a platform of its own.
+		if pf.Name == "manjaro-arm" {
+			pf.Name = "manjaro"
 			return true, nil
 		}
-		return false, nil
+		return pf.Name == "manjaro", nil
 	},
 }
 

--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -150,7 +150,7 @@ var arch = &PlatformResolver{
 var manjaro = &PlatformResolver{
 	Name:     "manjaro",
 	IsFamily: false,
-	Emits:    []string{"manjaro-arm"},
+	Emits:    []string{"manjaro", "manjaro-arm"},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		// Manjaro ARM ships ID=manjaro-arm with ID_LIKE="manjaro arch". It is the
 		// same distribution built for ARM and belongs to the arch family just as
@@ -612,7 +612,7 @@ var cloudlinux = &PlatformResolver{
 var centos = &PlatformResolver{
 	Name:     "centos",
 	IsFamily: false,
-	Emits:    []string{"rockylinux", "almalinux"},
+	Emits:    []string{"centos", "rockylinux", "almalinux"},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		// works for centos 5+
 		if strings.Contains(pf.Title, "CentOS") || pf.Name == "centos" {
@@ -819,7 +819,7 @@ var windriver = &PlatformResolver{
 var opensuse = &PlatformResolver{
 	Name:     "opensuse",
 	IsFamily: false,
-	Emits:    []string{"opensuse-leap", "opensuse-tumbleweed"},
+	Emits:    []string{"opensuse", "opensuse-leap", "opensuse-tumbleweed"},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		if pf.Name == "opensuse" || pf.Name == "opensuse-leap" || pf.Name == "opensuse-tumbleweed" {
 			return true, nil
@@ -1793,6 +1793,9 @@ var WindowsFamily = &PlatformResolver{
 var unknownOperatingSystem = &PlatformResolver{
 	Name:     "unknown-os",
 	IsFamily: false,
+	// names nothing: it is the terminal fallback and leaves the platform
+	// unnamed, so "unknown-os" is not a platform any asset can report
+	Emits: []string{},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		// if we reach here, we really do not know the system
 		log.Debug().Msg("platform> we do not know the operating system, please contact support")

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -880,14 +880,12 @@ func TestAltLinuxIsClaimedByItsOwnResolver(t *testing.T) {
 		"a container image claimed only by the generic resolver is reported as scratch")
 }
 
-// Manjaro ARM sets ID=manjaro-arm, not manjaro. The arch family matched on
-// /etc/arch-release but no child claimed it, so the generic fallback took it and
-// container images were reported as "scratch".
+// Manjaro ARM sets ID=manjaro-arm and reports as manjaro.
 func TestManjaroArmDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-manjaro-arm.toml")
 	assert.Nil(t, err, "was able to create the provider")
 
-	assert.Equal(t, "manjaro-arm", di.Name, "os name should be identified")
+	assert.Equal(t, "manjaro", di.Name, "Manjaro ARM is manjaro, not a platform of its own")
 	assert.Equal(t, "24.03", di.Version, "os version should come from lsb")
 	assert.Equal(t, []string{"arch", "linux", "unix", "os"}, di.Family,
 		"Manjaro ARM belongs to the arch family")

--- a/providers/os/detector/platform_resolver.go
+++ b/providers/os/detector/platform_resolver.go
@@ -19,12 +19,20 @@ type PlatformResolver struct {
 	Children []*PlatformResolver
 	Detect   detect
 
-	// Emits lists platform names this resolver can set beyond its own Name.
-	// A resolver does not always emit the name it is registered under: "oracle"
-	// emits "oraclelinux", and "centos" also claims Rocky and AlmaLinux. Every
-	// name detection can produce has to reach osTree, or the platform has no
-	// family chain and the provider catalog does not list it, which degrades it
-	// to "unknown" in plugin.PlatformInfo.Apply.
+	// Emits lists every platform name this resolver can set, and defaults to
+	// the resolver's own Name when it is nil. A resolver does not always emit
+	// the name it is registered under: "oracle" only ever emits "oraclelinux",
+	// and "centos" also claims Rocky and AlmaLinux.
+	//
+	// Every name detection can produce has to reach osTree, or the platform has
+	// no family chain and the provider catalog does not list it, which degrades
+	// it to "unknown" in plugin.PlatformInfo.Apply. Listing the names instead of
+	// assuming Name also keeps the reverse out: a registered name that nothing
+	// can emit would sit in the tree and the catalog as a platform that never
+	// appears on any asset.
+	//
+	// A resolver that names nothing, such as the unknown-os fallback, declares
+	// an empty, non-nil list.
 	Emits []string
 }
 

--- a/providers/os/detector/platform_resolver.go
+++ b/providers/os/detector/platform_resolver.go
@@ -18,6 +18,14 @@ type PlatformResolver struct {
 	IsFamily bool
 	Children []*PlatformResolver
 	Detect   detect
+
+	// Emits lists platform names this resolver can set beyond its own Name.
+	// A resolver does not always emit the name it is registered under: "oracle"
+	// emits "oraclelinux", and "centos" also claims Rocky and AlmaLinux. Every
+	// name detection can produce has to reach osTree, or the platform has no
+	// family chain and the provider catalog does not list it, which degrades it
+	// to "unknown" in plugin.PlatformInfo.Apply.
+	Emits []string
 }
 
 // isUnidentifiedPlatform reports whether detection could not pin down which


### PR DESCRIPTION
Oracle Linux, Rocky, AlmaLinux, openSUSE Leap, openSUSE Tumbleweed and MX Linux were all missing from the platform tree, and so from the provider catalog. Three names were in the tree that no system can ever report.

**A resolver does not always emit the name it is registered under** — `platform_resolver.go` already says so, citing `oracle` → `oraclelinux`. `osTree` was keyed by the *registered* name, so the emitted name never reached it, and the registered name sat there whether or not anything could produce it.

Consequences of a **missing** name:

- `detector.Family(name)` returns empty — no family chain to filter a policy on.
- `CatalogPlatforms()` does not list it, and a name absent from the catalog makes `plugin.PlatformInfo.Apply` log an error and set the asset to **`unknown`**.

## Emits

Resolvers now declare through `Emits` every platform name they can set, defaulting to the resolver's own `Name` when nil. Declaring the names rather than assuming `Name` closes the hole in both directions at once — a name that can be emitted reaches the tree, and a name nothing emits cannot sit in it.

| resolver | emits |
|---|---|
| `oracle` | `oraclelinux` — never `oracle` |
| `mxlinux` | `mx` — never `mxlinux` |
| `centos` | `centos`, `rockylinux`, `almalinux` |
| `opensuse` | `opensuse`, `opensuse-leap`, `opensuse-tumbleweed` |
| `unknown-os` | nothing: the terminal fallback leaves the platform unnamed |

## Manjaro ARM is manjaro

Manjaro ARM ships `ID=manjaro-arm`, and the resolver passed that through as a platform of its own. It is the same distribution built for ARM, so it now reports as `manjaro` and `manjaro-arm` is not a platform at all.

The title still reads `Manjaro ARM` and the family is still `arch`, so nothing about the asset is lost, and a policy filtering on `manjaro` now matches ARM hosts as well.

## Dead ends removed

`oracle`, `mxlinux` and `unknown-os` were names in the tree and the catalog that detection cannot produce — `oracle` always sets `oraclelinux`, `mxlinux` always sets `mx`, and `unknown-os` names nothing. Each was verified against the resolver body rather than by the absence of a fixture; those are not the same thing.

`darwin` is a fourth, left alone here because #10450 removes that resolver outright.

Net effect on the tree: **69 → 72**, six emitted names added and three phantoms dropped.

## Why nothing caught it

`catalog.go` documents the invariant — the catalog "stays in sync with the platforms detection can actually produce" — but nothing enforced it. `TestCatalogPlatforms` compares the catalog against the tree, and **both were wrong in the same direction**. Nothing compared the tree against what resolvers really set.

`TestEveryEmittedPlatformNameIsInTheTree` resolves every detection fixture and asserts the name that actually comes out is in the tree. On `main` it fails on twelve fixtures:

```
detect-almalinux-8.toml:        resolver "centos"   emits "almalinux"
detect-almalinux-9.toml:        resolver "centos"   emits "almalinux"
detect-manjaro-arm.toml:        resolver "manjaro"  emits "manjaro-arm"
detect-mx.toml:                 resolver "mxlinux"  emits "mx"
detect-opensuse-leap-15.toml:   resolver "opensuse" emits "opensuse-leap"
detect-opensuse-leap-16.toml:   resolver "opensuse" emits "opensuse-leap"
detect-opensuse-tumbleweed.toml:resolver "opensuse" emits "opensuse-tumbleweed"
detect-oracle6.toml:            resolver "oracle"   emits "oraclelinux"
detect-oracle7.toml:            resolver "oracle"   emits "oraclelinux"
detect-oracle8.toml:            resolver "oracle"   emits "oraclelinux"
detect-rocky-linux-8.toml:      resolver "centos"   emits "rockylinux"
detect-rocky-linux-9.toml:      resolver "centos"   emits "rockylinux"
```

The `manjaro-arm` line is fixed by normalizing the name rather than by registering it.

Leaves claimed by `defaultLinux` are excluded: it can emit whatever ID an unknown system carries, so those cannot be enumerated. A system landing there is a separate known problem — reported as `scratch` for container images — and the fix for each is a resolver of its own (#10443, #10444, #10446, #10447).

## Test plan

- `TestEveryEmittedPlatformNameIsInTheTree` over all detection fixtures — fails on twelve on `main`, passes here; verified by reverting `detector_all.go` + `detector.go` and re-running.
- `TestCatalogPlatforms` still passes: the catalog and tree stay the same size as each other.
- `TestManjaroArmDetector` now asserts the platform is `manjaro`; verified end to end against the live `manjarolinux/base:20260322` arm64 image, which reports `manjaro` with family `arch`.
- No tests added for the dead-end removal: the phantoms were found with a throwaway probe over the tree and confirmed by reading each resolver, and there is no behavior to assert once a name that nothing emits is gone.
- `go test ./...` green in `providers/os/detector/`.
