### PR TITLE
🛑 os: detect darwin systems as macOS, drop the legacy darwin platform

### DIFF
--- a/providers/os/detector/catalog_test.go
+++ b/providers/os/detector/catalog_test.go
@@ -40,4 +40,8 @@ func TestCatalogPlatforms(t *testing.T) {
 	}
 	require.NotNil(t, ubuntu, "ubuntu should be a catalogued platform")
 	assert.Equal(t, []string{"debian", "linux", "unix", "os"}, ubuntu.fam)
+
+	// darwin is a kernel and a family, never a platform of its own
+	assert.True(t, byName["macos"], "macos should be a catalogued platform")
+	assert.False(t, byName["darwin"], "darwin should not be a catalogued platform")
 }

--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -35,9 +35,11 @@ var macOS = &PlatformResolver{
 			pf.Title = "macOS"
 		}
 
-		// the property list carries the build version, which sw_vers does not
-		// report, so prefer it whenever it is readable
-		// check xml /System/Library/CoreServices/SystemVersion.plist
+		// sw_vers, which the darwin family reads, carries the same product name,
+		// version and build. It is a command though, so it is unavailable on a
+		// scan with no command capability (a mounted disk image, for example),
+		// where the property list is the only source left. Read it whenever it
+		// is readable and let it override.
 		f, err := conn.FileSystem().Open("/System/Library/CoreServices/SystemVersion.plist")
 		if err != nil {
 			log.Debug().Err(err).Msg("platform> could not read the macOS system version property list")

--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -25,38 +25,48 @@ var macOS = &PlatformResolver{
 	Name:     "macos",
 	IsFamily: false,
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
-		// when we reach here, we know it is darwin
+		// When we reach here, we know it is darwin, and macOS is the only
+		// operating system built on it that mql can connect to. Darwin is the
+		// kernel, not a product, so the system is reported as macOS even when
+		// neither sw_vers nor the system version property list can be read.
+		pf.Name = "macos"
+		if pf.Title == "" || strings.EqualFold(pf.Title, "darwin") {
+			// uname reports the kernel name, which is not the product name
+			pf.Title = "macOS"
+		}
+
+		// the property list carries the build version, which sw_vers does not
+		// report, so prefer it whenever it is readable
 		// check xml /System/Library/CoreServices/SystemVersion.plist
 		f, err := conn.FileSystem().Open("/System/Library/CoreServices/SystemVersion.plist")
 		if err != nil {
-			return false, nil
+			log.Debug().Err(err).Msg("platform> could not read the macOS system version property list")
+			return true, nil
 		}
 		defer f.Close()
 
 		c, err := io.ReadAll(f)
 		if err != nil || len(c) == 0 {
-			return false, nil
+			log.Debug().Err(err).Msg("platform> macOS system version property list is empty")
+			return true, nil
 		}
 
 		sv, err := ParseMacOSSystemVersion(string(c))
-		if err != nil || len(c) == 0 {
-			return false, nil
+		if err != nil {
+			log.Debug().Err(err).Msg("platform> could not parse the macOS system version property list")
+			return true, nil
 		}
 
-		pf.Name = "macos"
-		pf.Title = sv["ProductName"]
-		pf.Version = sv["ProductVersion"]
-		pf.Build = sv["ProductBuildVersion"]
+		if len(sv["ProductName"]) > 0 {
+			pf.Title = sv["ProductName"]
+		}
+		if len(sv["ProductVersion"]) > 0 {
+			pf.Version = sv["ProductVersion"]
+		}
+		if len(sv["ProductBuildVersion"]) > 0 {
+			pf.Build = sv["ProductBuildVersion"]
+		}
 
-		return true, nil
-	},
-}
-
-// is part of the darwin platform and fallback for non-known darwin systems
-var otherDarwin = &PlatformResolver{
-	Name:     "darwin",
-	IsFamily: false,
-	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		return true, nil
 	},
 }
@@ -1233,14 +1243,6 @@ var windows = &PlatformResolver{
 	},
 }
 
-var slugRe = regexp.MustCompile("[^a-z0-9]+")
-
-func slugifyDarwin(s string) string {
-	s = strings.ToLower(s)
-	s = slugRe.ReplaceAllString(s, "_")
-	return strings.Trim(s, "_")
-}
-
 var (
 	// characters that are dropped outright, so "FRITZ!OS" slugs to "fritzos"
 	// instead of gaining a separator where the punctuation used to be
@@ -1264,7 +1266,7 @@ func slugifyPlatformName(s string) string {
 var darwinFamily = &PlatformResolver{
 	Name:     inventory.FAMILY_DARWIN,
 	IsFamily: true,
-	Children: []*PlatformResolver{macOS, otherDarwin},
+	Children: []*PlatformResolver{macOS},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		if !strings.Contains(strings.ToLower(pf.Name), "darwin") {
 			return false, nil
@@ -1274,22 +1276,20 @@ var darwinFamily = &PlatformResolver{
 		// read information from /usr/bin/sw_vers
 		osrd := NewOSReleaseDetector(conn)
 		dsv, err := osrd.darwin_swversion()
-		// ignore dsv config if we got an error
-		if err == nil {
-			if len(dsv["ProductName"]) > 0 {
-				// name needs to be slugged
-				pf.Name = slugifyDarwin(dsv["ProductName"])
-				if pf.Name == "mac_os_x" {
-					pf.Name = "macos"
-				}
-				pf.Title = dsv["ProductName"]
-			}
-			if len(dsv["ProductVersion"]) > 0 {
-				pf.Version = dsv["ProductVersion"]
-			}
-		} else {
-			// TODO: we know its darwin, but without swversion support
-			log.Error().Err(err)
+		if err != nil {
+			// we know it is darwin, the macos resolver reports what it can
+			log.Debug().Err(err).Msg("platform> could not read sw_vers")
+			return true, nil
+		}
+
+		if len(dsv["ProductName"]) > 0 {
+			pf.Title = dsv["ProductName"]
+		}
+		if len(dsv["ProductVersion"]) > 0 {
+			pf.Version = dsv["ProductVersion"]
+		}
+		if len(dsv["BuildVersion"]) > 0 {
+			pf.Build = dsv["BuildVersion"]
 		}
 
 		return true, nil

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -1054,7 +1054,35 @@ func TestMacOSsDetector(t *testing.T) {
 	assert.Equal(t, "macos", di.Name, "os name should be identified")
 	assert.Equal(t, "Mac OS X", di.Title, "os title should be identified")
 	assert.Equal(t, "10.14.5", di.Version, "os version should be identified")
+	assert.Equal(t, "18F132", di.Build, "os build should be identified")
 	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"darwin", "bsd", "unix", "os"}, di.Family)
+}
+
+// A darwin system whose system version property list is unreadable is still
+// macOS: the details come from sw_vers instead of the property list.
+func TestMacOSWithoutSystemVersionPlistDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-macos-no-plist.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "macos", di.Name, "os name should be identified")
+	assert.Equal(t, "macOS", di.Title, "os title should be identified")
+	assert.Equal(t, "15.5", di.Version, "os version should be identified")
+	assert.Equal(t, "24F74", di.Build, "os build should be identified")
+	assert.Equal(t, "arm64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"darwin", "bsd", "unix", "os"}, di.Family)
+}
+
+// A darwin system that reports neither sw_vers nor a system version property
+// list is reported as macOS without a version, never as the kernel name.
+func TestMacOSWithoutSwVersDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-darwin-bare.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "macos", di.Name, "os name should be identified")
+	assert.Equal(t, "macOS", di.Title, "os title should be identified")
+	assert.Empty(t, di.Version, "os version is unknown")
+	assert.Equal(t, "arm64", di.Arch, "os arch should be identified")
 	assert.Equal(t, []string{"darwin", "bsd", "unix", "os"}, di.Family)
 }
 

--- a/providers/os/detector/testdata/detect-darwin-bare.toml
+++ b/providers/os/detector/testdata/detect-darwin-bare.toml
@@ -1,0 +1,8 @@
+[commands."uname -s"]
+stdout = "Darwin"
+
+[commands."uname -m"]
+stdout = "arm64"
+
+[commands."uname -r"]
+stdout = "24.5.0"

--- a/providers/os/detector/testdata/detect-macos-no-plist.toml
+++ b/providers/os/detector/testdata/detect-macos-no-plist.toml
@@ -1,0 +1,15 @@
+[commands."uname -s"]
+stdout = "Darwin"
+
+[commands."uname -m"]
+stdout = "arm64"
+
+[commands."uname -r"]
+stdout = "24.5.0"
+
+[commands."/usr/bin/sw_vers"]
+stdout = """
+ProductName:	macOS
+ProductVersion:	15.5
+BuildVersion:	24F74
+"""


### PR DESCRIPTION
## What

Removes the legacy `darwin` fallback platform from OS detection. Darwin is a kernel, not an operating system, and every system mql can connect to that runs it is macOS.

The detector tree carried an unconditional fallback leaf named `darwin` under the darwin family:

```go
// is part of the darwin platform and fallback for non-known darwin systems
var otherDarwin = &PlatformResolver{
	Name:     "darwin",
	IsFamily: false,
	Detect: func(...) (bool, error) { return true, nil },
}
```

Because `macos` only claimed a system when `/System/Library/CoreServices/SystemVersion.plist` was readable and parseable, any Mac that failed that read fell through to this leaf and was reported under the platform name `darwin`. The same leaf also put `darwin` into the provider's advertised platform catalog (`osTree` is derived from the detector tree), so it showed up as a platform of its own alongside `macos`.

## How

`macos` now claims every system the darwin family matches, and reports whatever detail is available:

- the system version property list when it can be read (product name, version, build)
- otherwise the product name, version and build that `sw_vers` already returned
- `macOS` as the title when neither is available, since `uname` only reports the kernel name (`Darwin`)

The `darwin` fallback leaf is gone, along with `slugifyDarwin`, which only existed to derive a platform name for it. The family resolver now also keeps the `BuildVersion` from `sw_vers`, so a Mac without a readable property list still reports a build.

The empty `log.Error().Err(err)` in the family resolver (an event that was never sent, so the `sw_vers` failure was silent) is now a real debug log.

## Breaking change

- Assets previously reported as platform `darwin` are now reported as `macos`.
- `darwin` is no longer part of the OS platform catalog. It remains a platform *family* (`["darwin", "bsd", "unix", "os"]`), which is unchanged.

## Test plan

- New mock fixtures and tests in `providers/os/detector`:
  - `TestMacOSWithoutSystemVersionPlistDetector` — `uname` + `sw_vers`, no property list → `macos` / `macOS` / `15.5` / build `24F74`
  - `TestMacOSWithoutSwVersDetector` — `uname` only → `macos` / `macOS`, no version, never the kernel name
  - `TestMacOSsDetector` additionally pins the build version
  - `TestCatalogPlatforms` asserts `macos` is catalogued and `darwin` is not
- `go test ./detector/...` passes; the two failures in the full `providers/os` suite (`connection/device/linux` build failure, `TestLocalConnectionIdDetectors`) reproduce unchanged on `main`.
- Live check on macOS 26.5.2 with the rebuilt provider:

```
asset: {
  build: "25F84"
  version: "26.5.2"
  title: "macOS, Virtual machine"
  platform: "macos"
  family: [ "darwin", "bsd", "unix", "os" ]
}
```

- Confirmed the regenerated `providers/os/dist/os.json` no longer carries a `darwin` platform entry.
