### PR TITLE
🐛 os: keep the os-release name instead of reporting scratch

### DIFF
--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -989,6 +989,45 @@ func TestClearLinuxIsClaimedByItsOwnResolver(t *testing.T) {
 		"a container image claimed only by the generic resolver is reported as scratch")
 }
 
+// A distribution with no resolver of its own is still claimed by the generic
+// linux resolver, which leaves the name os-release supplied. Container images
+// in that state were reported as "scratch", discarding an identity the image
+// states outright. Reserve "scratch" for images that genuinely say nothing.
+func TestOsReleaseNameSurvivesTheGenericResolver(t *testing.T) {
+	for _, tc := range []struct {
+		fixture string
+		name    string
+		version string
+	}{
+		{"detect-slackware.toml", "slackware", "15.0"},
+		{"detect-deepin.toml", "deepin", "25"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mockConn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/"+tc.fixture))
+			require.NoError(t, err)
+
+			pf, leaf, resolved := OperatingSystems.resolvePlatform(&inventory.Platform{}, mockConn)
+			require.True(t, resolved)
+			assert.Equal(t, tc.name, pf.Name)
+			assert.Equal(t, tc.version, pf.Version)
+			assert.False(t, isUnidentifiedPlatform(pf, leaf),
+				"os-release named this distribution, so a container image must not report scratch")
+		})
+	}
+}
+
+// An image that names nothing is still unidentified, and "scratch" stays the
+// honest answer for it.
+func TestImageWithNoOsReleaseStaysUnidentified(t *testing.T) {
+	mockConn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/detect-generic-linux.toml"))
+	require.NoError(t, err)
+
+	pf, leaf, resolved := OperatingSystems.resolvePlatform(&inventory.Platform{}, mockConn)
+	require.True(t, resolved)
+	assert.True(t, isUnidentifiedPlatform(pf, leaf),
+		"nothing named this system, so it stays scratch")
+}
+
 func TestBusyboxLinuxDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-busybox.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/platform_resolver.go
+++ b/providers/os/detector/platform_resolver.go
@@ -37,15 +37,30 @@ type PlatformResolver struct {
 }
 
 // isUnidentifiedPlatform reports whether detection could not pin down which
-// system this actually is: either nothing named it at all, or the generic
-// fallback resolver was the one that claimed it. Container images in that state
-// are reported as "scratch" instead of by a derived or generic name.
+// system this actually is. Container images in that state are reported as
+// "scratch" instead of by a derived or generic name.
 //
-// This deliberately keys off the resolver that matched rather than the platform
-// name, because a resolver does not always emit the name it is registered under
-// (the "oracle" resolver emits "oraclelinux", for example).
+// This keys off the resolver that matched rather than the platform name,
+// because a resolver does not always emit the name it is registered under (the
+// "oracle" resolver emits "oraclelinux", for example).
+//
+// The generic resolver claiming a system is not on its own enough to call it
+// unidentified. It leaves whatever name os-release supplied, and a
+// distribution that states ID= has told us exactly what it is even though the
+// provider has no resolver for it. Reporting "scratch" there discards an
+// identity the image gives outright, which is how Slackware, Deepin and Anolis
+// OS images were coming back. An image that names nothing still has no
+// distro-id recorded, so it stays unidentified.
 func isUnidentifiedPlatform(pf *inventory.Platform, leaf *PlatformResolver) bool {
-	return pf.Name == "" || leaf == defaultLinux
+	if pf.Name == "" {
+		return true
+	}
+	if leaf != defaultLinux {
+		return false
+	}
+
+	_, namedByOsRelease := pf.Metadata[LabelDistroID]
+	return !namedByOsRelease
 }
 
 func (r *PlatformResolver) Resolve(conn shared.Connection) (*inventory.Platform, bool) {

--- a/providers/os/detector/testdata/detect-deepin.toml
+++ b/providers/os/detector/testdata/detect-deepin.toml
@@ -1,0 +1,16 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[files."/etc/os-release"]
+content = """
+PRETTY_NAME="Deepin 25"
+NAME="Deepin"
+VERSION_CODENAME=crimson
+ID=deepin
+HOME_URL="https://www.deepin.org/"
+BUG_REPORT_URL="https://bbs.deepin.org"
+VERSION_ID="25"
+"""

--- a/providers/os/detector/testdata/detect-slackware.toml
+++ b/providers/os/detector/testdata/detect-slackware.toml
@@ -1,0 +1,19 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[files."/etc/slackware-version"]
+content = "Slackware 15.0"
+
+[files."/etc/os-release"]
+content = """
+NAME=Slackware
+VERSION="15.0"
+ID=slackware
+VERSION_ID=15.0
+PRETTY_NAME="Slackware 15.0 x86_64"
+ANSI_COLOR="0;34"
+CPE_NAME="cpe:/o:slackware:slackware_linux:15.0"
+"""


### PR DESCRIPTION
A distribution with no resolver of its own is claimed by the generic linux resolver, which leaves the name os-release supplied. Container images in that state were reported as `scratch` — discarding an identity the image states outright.

## Evidence

Found by scanning **108 distro container images**. Three more distros state `ID=` and a version, all parsed correctly, and all reported `scratch`:

| image | os-release | reported |
|---|---|---|
| `vbatts/slackware` | `ID=slackware`, `15.0` | `scratch` |
| `linuxdeepin/deepin` | `ID=deepin`, `25` | `scratch` |
| `openanolis/anolisos` | `ID=anolis`, `8.8` | `scratch` |

## The change

`isUnidentifiedPlatform` treated "the generic resolver claimed it" as equivalent to "we don't know what this is". Those aren't the same thing. A system that states `ID=` has told us what it is, whether or not this provider has a resolver for it.

An image that names nothing records no `distro-id`, so it stays unidentified and `scratch` keeps its meaning for the case it was written for — covered by a test against the existing `detect-generic-linux` fixture.

## Relationship to the recent per-distro fixes

This is the general form of four fixes already merged — ALT (#10440), Manjaro ARM (#10443), Void (#10444) and Clear Linux (#10445). Those resolvers stay: they pin their platforms with tests, and Manjaro ARM in particular carries `arch` family membership that this change cannot infer. What changes is that the *next* distribution without one gets named rather than erased, instead of arriving as a bug report.

## Verification

Validated end to end on an x86_64 daemon, with a control image to confirm the locally built provider was under test:

```
vbatts/slackware      -> slackware 15.0
linuxdeepin/deepin    -> deepin 25
openanolis/anolisos   -> anolis 8.8
tatsushid/tinycore    -> tinycore 11.0   (also previously scratch)
```

Full detector suite passes.