### PR TITLE
🐛 os: read kernel modules from /proc when lsmod is not in /sbin

### DIFF
--- a/providers/os/resources/kernel/manager.go
+++ b/providers/os/resources/kernel/manager.go
@@ -14,7 +14,10 @@ import (
 	"go.mondoo.com/mql/providers/os/connection/shared"
 )
 
-const sysctlPath = "/proc/sys/"
+const (
+	sysctlPath      = "/proc/sys/"
+	procModulesPath = "/proc/modules"
+)
 
 type KernelInfo struct {
 	Version   string            `json:"version"`
@@ -151,13 +154,31 @@ func (s *LinuxKernelManager) Parameters() (map[string]string, error) {
 }
 
 func (s *LinuxKernelManager) Modules() ([]*KernelModule, error) {
-	// TODO: use proc in future
-	cmd, err := s.conn.RunCommand("/sbin/lsmod")
+	if s.conn.Capabilities().Has(shared.Capability_RunCommand) {
+		cmd, err := s.conn.RunCommand("/sbin/lsmod")
+		// lsmod does not live in /sbin on every distro: Container-Optimized OS
+		// ships it as /bin/lsmod and has an empty /sbin, so the command exits
+		// 127 with no output. Nothing checked the exit status, so an empty
+		// parse was reported as "no modules loaded" rather than as a failure,
+		// and a policy asserting a module is absent passed without ever
+		// reading the module list.
+		if err == nil && cmd.ExitStatus == 0 {
+			log.Debug().Msg("using lsmod to read kernel modules")
+			return ParseLsmod(cmd.Stdout), nil
+		}
+	}
+
+	// /proc/modules is the kernel's own interface, so it needs no binary on
+	// PATH and works for a filesystem-only scan that cannot run commands at
+	// all. Parameters() already falls back the same way onto /proc/sys.
+	log.Debug().Msg("using /proc/modules to read kernel modules")
+	f, err := s.conn.FileSystem().Open(procModulesPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not read kernel modules")
 	}
+	defer f.Close()
 
-	return ParseLsmod(cmd.Stdout), nil
+	return ParseLinuxProcModules(f), nil
 }
 
 type OSXKernelManager struct {

--- a/providers/os/resources/kernel/manager.go
+++ b/providers/os/resources/kernel/manager.go
@@ -162,7 +162,17 @@ func (s *LinuxKernelManager) Modules() ([]*KernelModule, error) {
 		// parse was reported as "no modules loaded" rather than as a failure,
 		// and a policy asserting a module is absent passed without ever
 		// reading the module list.
-		if err == nil && cmd.ExitStatus == 0 {
+		//
+		// Each way of missing is logged separately: a command that could not be
+		// run at all and one that ran and failed are different problems on the
+		// target, and from the fallback alone they look identical.
+		switch {
+		case err != nil:
+			log.Debug().Err(err).Msg("could not run /sbin/lsmod, falling back to /proc/modules")
+		case cmd.ExitStatus != 0:
+			log.Debug().Int("exit", cmd.ExitStatus).
+				Msg("/sbin/lsmod exited non-zero, falling back to /proc/modules")
+		default:
 			log.Debug().Msg("using lsmod to read kernel modules")
 			return ParseLsmod(cmd.Stdout), nil
 		}

--- a/providers/os/resources/kernel/manager_test.go
+++ b/providers/os/resources/kernel/manager_test.go
@@ -171,3 +171,30 @@ func TestManagerAIX(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "7300-03-00-2446", info.Version)
 }
+
+// Container-Optimized OS ships lsmod as /bin/lsmod and has an empty /sbin, so
+// the hard-coded /sbin/lsmod exits 127 with no output. Nothing checked the exit
+// status, so the empty parse was reported as "no modules loaded" and a policy
+// asserting a module is absent passed without the list ever being read.
+func TestManagerCOSFallsBackToProcModules(t *testing.T) {
+	mockConn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:    "cos",
+			Version: "121",
+			Family:  []string{"linux", "unix", "os"},
+		},
+	}, mock.WithPath("./testdata/cos.toml"))
+	require.NoError(t, err)
+
+	mm, err := ResolveManager(mockConn)
+	require.NoError(t, err)
+
+	modules, err := mm.Modules()
+	require.NoError(t, err)
+	require.Len(t, modules, 13, "modules must come from /proc/modules when lsmod is absent")
+
+	assert.Equal(t, "nft_chain_nat", modules[0].Name)
+	assert.Equal(t, "12288", modules[0].Size)
+	assert.Equal(t, "3", modules[0].UsedBy)
+	assert.Equal(t, "fuse", modules[12].Name)
+}

--- a/providers/os/resources/kernel/testdata/cos.toml
+++ b/providers/os/resources/kernel/testdata/cos.toml
@@ -1,0 +1,22 @@
+# Container-Optimized OS from Google. lsmod lives in /bin, and /sbin is empty,
+# so the hard-coded /sbin/lsmod exits 127 with no output. Captured from a live
+# cos-stable-121 instance.
+[commands."/sbin/lsmod"]
+stdout = ""
+exit_status = 127
+
+[files."/proc/modules"]
+content = """nft_chain_nat 12288 3 - Live 0x0000000000000000
+xt_MASQUERADE 12288 1 - Live 0x0000000000000000
+nf_nat 53248 2 nft_chain_nat,xt_MASQUERADE, Live 0x0000000000000000
+xt_addrtype 12288 2 - Live 0x0000000000000000
+nft_compat 20480 8 - Live 0x0000000000000000
+nf_tables 352256 129 nft_chain_nat,nft_compat, Live 0x0000000000000000
+crc32c_intel 16384 4 - Live 0x0000000000000000
+aesni_intel 360448 0 - Live 0x0000000000000000
+crypto_simd 16384 1 aesni_intel, Live 0x0000000000000000
+virtio_balloon 24576 0 - Live 0x0000000000000000
+cryptd 28672 1 crypto_simd, Live 0x0000000000000000
+loadpin_trigger 8192 0 [permanent], Live 0x0000000000000000 (O)
+fuse 184320 1 - Live 0x0000000000000000
+"""


### PR DESCRIPTION
`kernel.modules` reported **zero** modules on Container-Optimized OS, on a host with thirteen loaded.

`LinuxKernelManager.Modules` ran a hard-coded `/sbin/lsmod` and passed the result straight to the parser:

```go
cmd, err := s.conn.RunCommand("/sbin/lsmod")
if err != nil {
    return nil, errors.Wrap(err, "could not read kernel modules")
}
return ParseLsmod(cmd.Stdout), nil   // <- no ExitStatus check
```

COS ships lsmod as `/bin/lsmod` and its `/sbin` is empty, so the command exits **127** with no output. `RunCommand` returns no error when the command *runs* and exits non-zero, so the empty parse was reported as "no modules loaded" rather than as a failure.

That is a silent wrong answer, not a missing one: **a policy asserting a module is absent passed on a list that was never read.**

### The fix

`Modules` now mirrors what `Parameters` already does twenty lines above in the same file — use the command when it works, otherwise fall back to the kernel's own interface. The `/proc/modules` parser it needs, `ParseLinuxProcModules`, **was already written and tested, but nothing had ever called it**:

```
$ grep -rn "ParseLinuxProcModules" --include="*.go" .
providers/os/resources/kernel/modules.go:47:func ParseLinuxProcModules(...)
providers/os/resources/kernel/modules_test.go:42:  entries := ParseLinuxProcModules(f)
```

This also resolves the `// TODO: use proc in future` left on the function, and makes the field work for a filesystem-only scan that cannot run commands at all.

### Verified against live infrastructure

A real `cos-stable-121` GCE instance, same host, shipped provider vs. patched:

```
before:  kernel.modules.length: 0
after:   kernel.modules.length: 13
```

Ground truth on that host:

```
$ which lsmod        -> /bin/lsmod
$ ls /sbin/lsmod     -> No such file or directory
$ /sbin/lsmod; echo $?  -> 127
$ lsmod | tail -n +2 | wc -l  -> 13
```

### Not affected

The `/sbin/sysctl` call immediately above has the same hard-coded shape, and `/usr/sbin/sysctl` is likewise the real path on COS — but it already guards on `ExitStatus` and falls back to walking `/proc/sys`, so `kernel.parameters` was never wrong. Only `Modules` lacked the guard.

## Test plan

- New `TestManagerCOSFallsBackToProcModules` with `testdata/cos.toml` — `/sbin/lsmod` at `exit_status = 127`, `/proc/modules` captured verbatim from the live COS instance. Asserts 13 modules with name/size/usedBy on the first and last. Fails on `main` (`"[]" should have 13 item(s), but has 0`), passes here; verified by reverting `manager.go` and re-running.
- Existing manager tests for Debian, CentOS, Amazon Linux 1, macOS, FreeBSD, OpenBSD and AIX all still pass — the lsmod path is unchanged when it works.
- `go test ./...` green in `providers/os/resources/kernel/`.
