### PR TITLE
🐛 os: fail when the apparmor profile list cannot be read

### DIFF
--- a/providers/os/resources/apparmor.go
+++ b/providers/os/resources/apparmor.go
@@ -133,8 +133,9 @@ func (a *mqlApparmor) fetchStatusFromKernel() (*apparmorStatus, error) {
 		return nil, err
 	}
 
+	profiles, profilesErr := readApparmorProfilesFromFS(conn.FileSystem())
 	status := &apparmorStatus{
-		Profiles:  readApparmorProfilesFromFS(conn.FileSystem()),
+		Profiles:  profiles,
 		Processes: readApparmorProcessesFromFS(conn.FileSystem(), procs),
 	}
 
@@ -145,14 +146,25 @@ func (a *mqlApparmor) fetchStatusFromKernel() (*apparmorStatus, error) {
 	if !profilesAvailable && len(status.Processes) == 0 {
 		return nil, errors.New("AppArmor kernel interfaces unavailable")
 	}
+	// The list exists but we could not read it. securityfs enforces
+	// CAP_MAC_ADMIN regardless of the mode bits, so an unprivileged scan gets
+	// EACCES on a world-readable path. Reporting zero profiles there states as
+	// fact something that was never read, and an audit for unconfined or
+	// complain-mode profiles would pass on it.
+	if profilesAvailable && profilesErr != nil {
+		return nil, fmt.Errorf("apparmor profiles at %s could not be read: %w", apparmorProfilesPath, profilesErr)
+	}
 
 	return status, nil
 }
 
-func readApparmorProfilesFromFS(fs afero.Fs) map[string]string {
+// readApparmorProfilesFromFS reads the kernel's loaded-profile list. The error
+// is returned rather than swallowed: on a host where the path exists but cannot
+// be opened, an empty map is not the same answer as "no profiles are loaded".
+func readApparmorProfilesFromFS(fs afero.Fs) (map[string]string, error) {
 	f, err := fs.Open(apparmorProfilesPath)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	defer f.Close()
 
@@ -164,7 +176,7 @@ func readApparmorProfilesFromFS(fs afero.Fs) map[string]string {
 			profiles[name] = mode
 		}
 	}
-	return profiles
+	return profiles, nil
 }
 
 func readApparmorProcessesFromFS(fs afero.Fs, procs []*processmgr.OSProcess) map[string][]apparmorProcInfo {

--- a/providers/os/resources/apparmor_test.go
+++ b/providers/os/resources/apparmor_test.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -92,7 +93,8 @@ func TestReadApparmorProfilesFromFS(t *testing.T) {
 		"/usr/sbin/dnsmasq (complain)\n"), 0o444)
 	require.NoError(t, err)
 
-	profiles := readApparmorProfilesFromFS(fs)
+	profiles, err := readApparmorProfilesFromFS(fs)
+	require.NoError(t, err)
 	require.Len(t, profiles, 3)
 	assert.Equal(t, "enforce", profiles["/usr/sbin/chronyd"])
 	assert.Equal(t, "unconfined", profiles["MongoDB Compass"])
@@ -150,4 +152,40 @@ func TestApparmorProcessExecutable(t *testing.T) {
 	}))
 
 	assert.Equal(t, "3", apparmorProcessExecutable(&processmgr.OSProcess{Pid: 3}))
+}
+
+// securityfs enforces CAP_MAC_ADMIN regardless of the mode bits, so an
+// unprivileged scan gets EACCES on a world-readable profiles list. Container-
+// Optimized OS is such a host: the file is mode 444 and stat-able, aa-status
+// and apparmor_status are not installed at all, and the read fails. Swallowing
+// that error reported zero profiles on a host running an enforcing one.
+func TestFetchStatusFromKernelUnreadableProfiles(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/sys/kernel/security/apparmor", 0o755))
+	require.NoError(t, afero.WriteFile(fs, apparmorProfilesPath, []byte("docker-default (enforce)\n"), 0o444))
+
+	// the list is present and stat-able, but every open of it fails
+	blocked := &openDeniedFs{Fs: fs, path: apparmorProfilesPath}
+
+	exists, err := afero.Exists(blocked, apparmorProfilesPath)
+	require.NoError(t, err)
+	require.True(t, exists, "the profiles list must still stat")
+
+	profiles, err := readApparmorProfilesFromFS(blocked)
+	require.Error(t, err, "an unreadable profiles list must not read as an empty one")
+	assert.Nil(t, profiles)
+}
+
+// openDeniedFs stats normally but refuses to open one path, the way securityfs
+// behaves for a caller without CAP_MAC_ADMIN.
+type openDeniedFs struct {
+	afero.Fs
+	path string
+}
+
+func (f *openDeniedFs) Open(name string) (afero.File, error) {
+	if name == f.path {
+		return nil, os.ErrPermission
+	}
+	return f.Fs.Open(name)
 }


### PR DESCRIPTION
`apparmor.profiles` reported **zero** profiles on Container-Optimized OS, on a host running an enforcing one.

Found while sweeping the OS provider against a live `cos-stable-121` instance.

### What happens

COS installs neither `apparmor_status` nor `aa-status`, so `fetchStatusFromJSON` fails and detection falls back to the kernel interfaces. There:

```go
func readApparmorProfilesFromFS(fs afero.Fs) map[string]string {
	f, err := fs.Open(apparmorProfilesPath)
	if err != nil {
		return nil        // <- error discarded
	}
```

and the guard that follows only fires when the path is *absent*:

```go
if !profilesAvailable && len(status.Processes) == 0 {
	return nil, errors.New("AppArmor kernel interfaces unavailable")
}
```

The path is not absent. securityfs enforces `CAP_MAC_ADMIN` regardless of the mode bits, so on the live host:

```
$ ls -la /sys/kernel/security/apparmor/profiles
-r--r--r-- 1 root root 0 ...          <- mode 444, stat succeeds

$ cat /sys/kernel/security/apparmor/profiles
cat: ...: Permission denied           <- every unprivileged open fails

$ sudo cat /sys/kernel/security/apparmor/profiles
docker-default (enforce)              <- ground truth: one enforcing profile
```

`afero.Exists` returns true, the guard does not fire, and an empty profile map is reported as fact.

**This is the denylist failure mode.** An audit for unconfined or complain-mode profiles passes on a host whose profile list was never read — it sees zero profiles and concludes there is nothing to flag.

### The fix

The read error propagates, and a profile list that exists but cannot be opened is reported as a failure rather than as an empty one. A host with no AppArmor at all is unchanged: there the open fails because the path is absent, `profilesAvailable` is false, and the existing "kernel interfaces unavailable" path still applies.

### Verified against live infrastructure

Same `cos-stable-121` host, shipped provider vs. patched:

```
before:  apparmor.profiles.length: 0

after:   could not retrieve apparmor status via json or kernel interfaces:
           apparmor_status --json: bash: line 1: apparmor_status: command not found;
           aa-status --json: bash: line 1: aa-status: command not found;
           fallback failed: apparmor profiles at /sys/kernel/security/apparmor/profiles
           could not be read: permission denied
         apparmor.profiles.length: no data available
```

Same class as #10452 (`kernel.modules` reporting 0 when lsmod is missing), found in the same sweep.

## Test plan

- New `TestFetchStatusFromKernelUnreadableProfiles` with an afero wrapper that stats normally but refuses to open the profiles path, the way securityfs behaves without `CAP_MAC_ADMIN`. Asserts the path still stats, and that reading it returns an error rather than an empty map.
- `TestReadApparmorProfilesFromFS` updated for the new signature; still asserts the three parsed profiles.
- All existing apparmor tests pass unchanged.
- `go test ./...` green in `providers/os/`.
