### PR TITLE
🐛 os: trim the line ending off the windows machine id

### DIFF
--- a/providers/os/id/platformid/testdata/windows_machineid.toml
+++ b/providers/os/id/platformid/testdata/windows_machineid.toml
@@ -1,0 +1,2 @@
+[commands."powershell -c \"Get-WmiObject -Query 'SELECT UUID FROM Win32_ComputerSystemProduct' | Select-Object -ExpandProperty UUID\""]
+stdout = "03ED6348-E1A9-4DE1-AA28-0CFEDB954237\r\n"

--- a/providers/os/id/platformid/win.go
+++ b/providers/os/id/platformid/win.go
@@ -5,6 +5,7 @@ package platformid
 
 import (
 	"io"
+	"strings"
 
 	"go.mondoo.com/mql/providers/os/connection/shared"
 )
@@ -20,8 +21,14 @@ func PowershellWindowsMachineId(conn shared.Connection) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	guid := string(data)
-	return guid, nil
+	// PowerShell terminates its output with CRLF. Without trimming it the
+	// machine id carries the line ending into every comparison, and into the
+	// asset identifier built from it in id/platform.go, which then reads
+	// "//platformid.api.mondoo.app/machineid/<uuid>\r\n". The linux and darwin
+	// providers already trim. Case is deliberately left alone: WMI reports the
+	// UUID in upper case, and lowering it here would change the identifier for
+	// every Windows asset already scanned.
+	return strings.TrimSpace(string(data)), nil
 }
 
 type WinIdProvider struct {

--- a/providers/os/id/platformid/win_test.go
+++ b/providers/os/id/platformid/win_test.go
@@ -12,13 +12,19 @@ import (
 	"go.mondoo.com/mql/providers/os/connection/mock"
 )
 
-func TestGuidWindows(t *testing.T) {
-	provider, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/guid_windows.toml"))
+// PowerShell terminates its output with CRLF. Returning it untrimmed put the
+// line ending into the machine id, and from there into the asset identifier
+// built in id/platform.go.
+func TestPowershellWindowsMachineIdTrimsLineEnding(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{Name: "windows", Family: []string{"windows", "os"}},
+	}, mock.WithPath("./testdata/windows_machineid.toml"))
 	require.NoError(t, err)
 
-	lid := WinIdProvider{connection: provider}
-	id, err := lid.ID()
+	guid, err := PowershellWindowsMachineId(conn)
 	require.NoError(t, err)
 
-	assert.Equal(t, "6BAB78BE-4623-4705-924C-2B22433A4489", id)
+	assert.Equal(t, "03ED6348-E1A9-4DE1-AA28-0CFEDB954237", guid)
+	assert.NotContains(t, guid, "\r")
+	assert.NotContains(t, guid, "\n")
 }


### PR DESCRIPTION
`os.machineid` returned the PowerShell line ending along with the UUID on every Windows system scanned from another OS — and the **asset identifier** built from it carried the CRLF too.

Found while sweeping the OS provider against a live Windows 11 25H2 Azure VM.

### What happens

`PowershellWindowsMachineId` reads the command output and returns it raw:

```go
guid := string(data)
return guid, nil
```

No trim — unlike `linux.go:32` (`strings.TrimSpace(strings.ToLower(...))`) and `osx.go:45`, which both trim. PowerShell terminates output with CRLF, and `id/platform.go:201` builds the identifier as `"//platformid.api.mondoo.app/machineid/" + guid`.

### Verified against live infrastructure

Windows 11 25H2 (build 26200) on Azure, over WinRM:

```
$ mql run winrm ... -c "os.machineid" -j
{"os.machineid":"03ED6348-E1A9-4DE1-AA28-0CFEDB954237\r\n"}

$ mql run winrm ... --id-detector machine-id -c "asset.ids" -j
{"asset.ids":["//platformid.api.mondoo.app/machineid/03ED6348-E1A9-4DE1-AA28-0CFEDB954237\r\n"]}
```

That is a malformed platform identifier, not just a cosmetic field. After the fix the id is `03ED6348-E1A9-4DE1-AA28-0CFEDB954237`.

### Why it survived

Only the PowerShell path is affected — `win_guid_unix.go`, which is what runs when scanning Windows **remotely from linux or darwin**. The native Windows build (`win_guid_windows.go`) reads the UUID straight off the WMI struct and was always clean. So a local scan on Windows never shows it.

### Deliberately not changed

Case is left alone. WMI reports the UUID upper-case, and lowering it the way the linux and darwin providers do would change the identifier for every Windows asset already scanned. Trimming already changes it for anything recorded with the trailing CRLF, but that value is malformed, so correcting it is the point. Happy to also lowercase for cross-platform consistency if you'd rather take that break in one go.

## Test plan

- New `TestPowershellWindowsMachineIdTrimsLineEnding` with `testdata/windows_machineid.toml` reproducing the exact WMI command and its `\r\n`-terminated output. Asserts the trimmed UUID and the absence of `\r` and `\n`.
- Fails on `main` (`actual: "03ED6348-...-0CFEDB954237\r\n"`), passes here; verified by reverting `win.go` and re-running.
- `go test ./...` green in `providers/os/id/platformid/`.
