### PR TITLE
🐛 os: read os.path on windows

### DIFF
--- a/providers/os/resources/os.go
+++ b/providers/os/resources/os.go
@@ -134,19 +134,52 @@ func (p *mqlOs) env() (map[string]any, error) {
 }
 
 func (p *mqlOs) path(env map[string]any) ([]any, error) {
+	conn, ok := p.MqlRuntime.Connection.(shared.Connection)
+	if !ok {
+		return nil, errors.New("cannot determine platform for path lookup")
+	}
+	isWindows := conn.Asset().Platform.IsFamily("windows")
+
 	rawPath, ok := env["PATH"]
+	if !ok && isWindows {
+		// Windows environment variable names are case-insensitive and the
+		// variable comes back from Get-ChildItem Env: as "Path", so the exact
+		// "PATH" lookup missed and os.path was empty on every Windows system.
+		for k, v := range env {
+			if strings.EqualFold(k, "PATH") {
+				rawPath, ok = v, true
+				break
+			}
+		}
+	}
 	if !ok {
 		return []any{}, nil
 	}
 
-	path := rawPath.(string)
-	parts := strings.Split(path, ":")
+	path, ok := rawPath.(string)
+	if !ok {
+		return nil, fmt.Errorf("PATH is %T, expected a string", rawPath)
+	}
+
+	return splitPathList(path, isWindows), nil
+}
+
+// splitPathList splits a PATH value into its entries. Windows separates them
+// with ';'; splitting those on ':' cut every entry apart at its drive letter.
+// Empty entries are kept: on unix an empty element means the working directory,
+// which is worth being able to audit for.
+func splitPathList(path string, isWindows bool) []any {
+	separator := ":"
+	if isWindows {
+		separator = ";"
+	}
+
+	parts := strings.Split(path, separator)
 	res := make([]any, len(parts))
 	for i := range parts {
 		res[i] = parts[i]
 	}
-
-	return res, nil
+	return res
 }
 
 func MqlTime(t time.Time) *time.Time {

--- a/providers/os/resources/os_path_test.go
+++ b/providers/os/resources/os_path_test.go
@@ -1,0 +1,59 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitPathList(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		isWindows bool
+		expected  []any
+	}{
+		{
+			// splitting this on ':' cut every entry apart at its drive letter
+			name:      "windows splits on semicolon",
+			path:      `C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem`,
+			isWindows: true,
+			expected:  []any{`C:\Windows\system32`, `C:\Windows`, `C:\Windows\System32\Wbem`},
+		},
+		{
+			name:      "unix splits on colon",
+			path:      "/usr/local/bin:/usr/bin:/bin",
+			isWindows: false,
+			expected:  []any{"/usr/local/bin", "/usr/bin", "/bin"},
+		},
+		{
+			// an empty unix entry means the working directory, which is worth
+			// keeping so it can be audited for
+			name:      "unix keeps the empty working-directory entry",
+			path:      "/usr/bin::/bin",
+			isWindows: false,
+			expected:  []any{"/usr/bin", "", "/bin"},
+		},
+		{
+			name:      "windows trailing separator",
+			path:      `C:\Windows;`,
+			isWindows: true,
+			expected:  []any{`C:\Windows`, ""},
+		},
+		{
+			name:      "single entry",
+			path:      "/bin",
+			isWindows: false,
+			expected:  []any{"/bin"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, splitPathList(tt.path, tt.isWindows))
+		})
+	}
+}


### PR DESCRIPTION
`os.path` returned an **empty list** on every Windows system.

Found while sweeping the OS provider against a live Windows 11 25H2 Azure VM.

### Two bugs in one function, and the first hid the second

```go
rawPath, ok := env["PATH"]     // (1) exact-case lookup
if !ok {
    return []any{}, nil
}
path := rawPath.(string)        // unguarded assertion
parts := strings.Split(path, ":")   // (2) unix separator, always
```

**1. The lookup missed.** Windows environment variable names are case-insensitive, and `Get-ChildItem Env:` reports the variable as `Path`. Confirmed on the live host:

```
$ mql run winrm ... -c "os.env.keys" -j
keys matching /path/i: ['Path', 'PATHEXT', 'PSModulePath']
```

So the function returned `[]` before reaching anything else.

**2. The split was hard-coded to `:`.** Had the lookup succeeded, splitting a Windows PATH on a colon would have cut every entry apart at its drive letter — `C:\Windows;C:\Windows\System32` becomes `C`, `\Windows;C`, `\Windows\System32`.

The PATH is now found case-insensitively on Windows and split on `;` there. The type assertion on the env value is guarded rather than left to panic on a non-string value.

### Verified against live infrastructure

Windows 11 25H2 (build 26200) on Azure, over WinRM:

```
before:  os.path: []
after:   os.path: ["C:\\Windows\\system32",
                   "C:\\Windows",
                   "C:\\Windows\\System32\\Wbem",
                   "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\",
                   "C:\\Windows\\System32\\OpenSSH\\",
                   "C:\\Users\\mqladmin\\AppData\\Local\\Microsoft\\WindowsApps"]
```

Linux is byte-for-byte unchanged, checked against a live Container-Optimized OS instance with the same patched provider:

```
before:  ["/usr/bin","/bin","/usr/sbin","/sbin","/usr/local/bin","/usr/local/sbin"]
after:   ["/usr/bin","/bin","/usr/sbin","/sbin","/usr/local/bin","/usr/local/sbin"]
```

### Note

Empty entries are kept rather than dropped: on unix an empty element means the working directory, which is worth being able to audit for.

## Test plan

- New `TestSplitPathList` table test over the extracted `splitPathList` helper: Windows semicolon splitting with drive letters, unix colon splitting, the empty unix working-directory entry, a Windows trailing separator, and a single entry.
- Live before/after on Windows 11 and on Container-Optimized OS as above.
- `go test ./...` green in `providers/os/resources/`.
