### PR TITLE
🐛 os: report services on systemd targets that ship no /sbin/init

### DIFF
--- a/providers/os/connection/tar/fs.go
+++ b/providers/os/connection/tar/fs.go
@@ -112,7 +112,13 @@ func (fs *FS) Chown(name string, uid, gid int) error {
 func (fs *FS) stat(header *tar.Header) (os.FileInfo, error) {
 	statHeader, ok := fs.resolveHeader(header)
 	if !ok {
-		return nil, errors.New("could not resolve " + header.Name + " -> " + header.Linkname)
+		// A link whose target is not in the archive is dangling, which is what
+		// os.Stat reports as not-exist. Returning a bare error here made callers
+		// that branch on os.IsNotExist treat it as a hard failure instead: a
+		// systemd unit masked by a symlink to /dev/null aborted the whole
+		// service list, because /dev/null is never in a container image. Open
+		// already returns os.ErrNotExist for the same case.
+		return nil, &os.PathError{Op: "stat", Path: header.Name, Err: os.ErrNotExist}
 	}
 	return statHeader.FileInfo(), nil
 }
@@ -120,6 +126,34 @@ func (fs *FS) stat(header *tar.Header) (os.FileInfo, error) {
 // maxLinkHops bounds link resolution. A tar can carry a symlink cycle, and
 // following one forever would hang the scan on a malformed or hostile image.
 const maxLinkHops = 32
+
+// LstatIfPossible reports on the link itself rather than on its target, so a
+// symlink is reported as a symlink. It satisfies afero.Lstater, which callers
+// probe for when the distinction matters: systemd unit lookup needs it to tell
+// an alias and a masked unit apart from a regular unit file.
+func (fs *FS) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	h, ok := fs.FileMap[name]
+	if !ok {
+		return nil, true, &os.PathError{Op: "lstat", Path: name, Err: os.ErrNotExist}
+	}
+	// true: this is a real lstat, not a Stat standing in for one.
+	return h.FileInfo(), true, nil
+}
+
+// ReadlinkIfPossible returns the target a symlink points at, without resolving
+// it against the archive. It satisfies afero.LinkReader. The target may well not
+// be in the archive at all, as with a unit masked to /dev/null, so reading the
+// link and resolving it are deliberately separate steps.
+func (fs *FS) ReadlinkIfPossible(name string) (string, error) {
+	h, ok := fs.FileMap[name]
+	if !ok {
+		return "", &os.PathError{Op: "readlink", Path: name, Err: os.ErrNotExist}
+	}
+	if h.Typeflag != tar.TypeSymlink {
+		return "", &os.PathError{Op: "readlink", Path: name, Err: os.ErrInvalid}
+	}
+	return h.Linkname, nil
+}
 
 // resolveHeader follows link entries to the one that actually holds the bytes,
 // and reports whether it found it.

--- a/providers/os/connection/tar/lstat_test.go
+++ b/providers/os/connection/tar/lstat_test.go
@@ -1,0 +1,76 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package tar
+
+import (
+	"archive/tar"
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestFs builds a filesystem holding one regular file and one symlink whose
+// target is not in the archive, the way systemd masks a unit by pointing it at
+// /dev/null.
+func newTestFs() *FS {
+	f := NewFs("test")
+	f.FileMap["/etc/systemd/system/real.service"] = &tar.Header{
+		Name:     "etc/systemd/system/real.service",
+		Typeflag: tar.TypeReg,
+		Size:     10,
+	}
+	f.FileMap["/etc/systemd/system/masked.service"] = &tar.Header{
+		Name:     "etc/systemd/system/masked.service",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "/dev/null",
+	}
+	return f
+}
+
+func TestFsImplementsLstaterAndLinkReader(t *testing.T) {
+	var f afero.Fs = NewFs("test")
+
+	_, isLstater := f.(afero.Lstater)
+	assert.True(t, isLstater, "systemd unit lookup probes for afero.Lstater to tell a masked unit from a real one")
+
+	_, isLinkReader := f.(afero.LinkReader)
+	assert.True(t, isLinkReader, "reading the link target is how a masked unit is recognised")
+}
+
+func TestLstatDoesNotFollowSymlinks(t *testing.T) {
+	f := newTestFs()
+
+	info, wasLstat, err := f.LstatIfPossible("/etc/systemd/system/masked.service")
+	require.NoError(t, err, "lstat of a dangling symlink must succeed: the link itself exists")
+	assert.True(t, wasLstat)
+	assert.NotZero(t, info.Mode()&fs.ModeSymlink, "the link must be reported as a symlink, not as its target")
+}
+
+func TestReadlinkReturnsTheTarget(t *testing.T) {
+	f := newTestFs()
+
+	target, err := f.ReadlinkIfPossible("/etc/systemd/system/masked.service")
+	require.NoError(t, err)
+	assert.Equal(t, "/dev/null", target)
+
+	_, err = f.ReadlinkIfPossible("/etc/systemd/system/real.service")
+	assert.Error(t, err, "a regular file is not a link")
+}
+
+// A symlink whose target is absent is a dangling symlink, which os.Stat reports
+// as not-exist. Returning a bare error made callers that branch on
+// os.IsNotExist treat it as fatal, and one masked unit aborted the whole
+// systemd service list.
+func TestStatOfDanglingSymlinkIsNotExist(t *testing.T) {
+	f := newTestFs()
+
+	_, err := f.Stat("/etc/systemd/system/masked.service")
+	require.Error(t, err)
+	assert.True(t, os.IsNotExist(err),
+		"a dangling symlink must read as not-exist, got %v", err)
+}

--- a/providers/os/resources/services/manager.go
+++ b/providers/os/resources/services/manager.go
@@ -82,6 +82,38 @@ func (n *noopOsServiceManager) Get(name string) (*Service, error) {
 
 var amazonlinux1version = regexp.MustCompile(`^201\d`)
 
+// initSystemPaths are the on-disk traces of an init system, in the order they
+// are probed. /sbin/init alone is not enough to go on: Debian, Ubuntu, Fedora,
+// openSUSE and Amazon Linux all ship systemd unit files in their images without
+// shipping /sbin/init, and probing only that path put every one of them on the
+// noop manager, which reports an empty service list rather than saying it could
+// not look. A scan of such a target answered "no services" about a system whose
+// units were sitting on disk unread.
+var initSystemPaths = []string{
+	"/sbin/init",
+	// systemd, both the binary and the unit trees. The usr-merged and
+	// non-merged layouts are both listed because /lib is only a symlink to
+	// /usr/lib on some of them.
+	"/usr/lib/systemd/systemd",
+	"/lib/systemd/systemd",
+	"/usr/lib/systemd/system",
+	"/lib/systemd/system",
+	"/etc/systemd/system",
+}
+
+// hasInitSystem reports whether the target carries any init system this package
+// knows how to read. It is deliberately a presence check rather than a decision
+// about which manager applies: that choice belongs to the switch in
+// ResolveManager, which keys off the platform.
+func hasInitSystem(conn shared.Connection) bool {
+	for _, path := range initSystemPaths {
+		if _, err := conn.FileInfo(path); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
 func ResolveManager(conn shared.Connection) (OSServiceManager, error) {
 	var osm OSServiceManager
 
@@ -91,12 +123,10 @@ func ResolveManager(conn shared.Connection) (OSServiceManager, error) {
 	}
 
 	useNoopInit := false
-	if asset.Platform.IsFamily("linux") {
-		// If we're on linux, check if there is no init system. If there is no init system,
-		// we don't have managed services. This happens in containers.
-		if _, err := conn.FileInfo("/sbin/init"); err != nil {
-			useNoopInit = true
-		}
+	if asset.Platform.IsFamily("linux") && !hasInitSystem(conn) {
+		// Nothing on the target names an init system, so there are no managed
+		// services to report. This happens in containers.
+		useNoopInit = true
 	}
 
 	switch {

--- a/providers/os/resources/services/manager_test.go
+++ b/providers/os/resources/services/manager_test.go
@@ -468,3 +468,24 @@ func TestManagerNobara(t *testing.T) {
 	_, ok := mm.(*services.SystemDServiceManager)
 	assert.True(t, ok, "SystemDServiceManager used for Nobara Linux")
 }
+
+// Probing only /sbin/init put every systemd distro that ships no init binary on
+// the noop manager, which answers with an empty service list instead of saying
+// it could not look. Debian, Ubuntu, Fedora, openSUSE and Amazon Linux images
+// all carry systemd unit files without /sbin/init, and AlmaLinux ships
+// /sbin/init as a symlink to a systemd binary that is not in the image.
+func TestResolveManagerFindsSystemdWithoutSbinInit(t *testing.T) {
+	mockConn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:    "debian",
+			Version: "12",
+			Family:  []string{"debian", "linux", "unix", "os"},
+		},
+	}, mock.WithPath("./testdata/systemd-units-no-sbin-init.toml"))
+	require.NoError(t, err)
+
+	osm, err := services.ResolveManager(mockConn)
+	require.NoError(t, err)
+	assert.NotEqual(t, "none", osm.Name(),
+		"a target carrying systemd unit files has a service manager to read")
+}

--- a/providers/os/resources/services/systemd.go
+++ b/providers/os/resources/services/systemd.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/coreos/go-systemd/unit"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"go.mondoo.com/mql/providers/os/connection/shared"
 )
@@ -261,7 +262,13 @@ func (s *SystemDServiceManager) List() ([]*Service, error) {
 
 	services, err := ParseServiceSystemDUnitFiles(cmdList.Stdout)
 	if err != nil {
-		return nil, err
+		// Being able to run a command does not mean systemd is the running
+		// init. A container built from a systemd distro carries the unit files
+		// without ever starting systemd, so systemctl produces nothing usable
+		// there. Read the units off disk instead of reporting the failure as
+		// the service list.
+		log.Debug().Err(err).Msg("systemctl did not answer, reading systemd units from disk instead")
+		return (&SystemdFSServiceManager{Fs: s.conn.FileSystem()}).List()
 	}
 
 	// Step 2: Get running state from list-units (provides Running/Description)

--- a/providers/os/resources/services/systemd.go
+++ b/providers/os/resources/services/systemd.go
@@ -48,16 +48,23 @@ func (s *SystemDServiceManager) Name() string {
 	return "systemd Service Manager"
 }
 
+// errSystemctlNoOutput reports that systemctl ran but produced nothing this
+// parser recognizes as a unit-file listing. It is the one failure that means
+// "systemd is not the running init here", which is what makes reading the units
+// off disk the right answer. A read failure on stdout is an IO fault and says
+// nothing about the target, so it is deliberately not covered by this sentinel.
+var errSystemctlNoOutput = errors.New("unexpected output from systemctl list-unit-files")
+
 func ParseServiceSystemDUnitFiles(input io.Reader) ([]*Service, error) {
 	var services []*Service
 	content, err := io.ReadAll(input)
 	if err != nil {
-		return nil, fmt.Errorf("error executing systemctl list-unit-files: %v", err)
+		return nil, fmt.Errorf("error executing systemctl list-unit-files: %w", err)
 	}
 
 	lines := strings.Split(string(content), "\n")
 	if len(lines) < 2 {
-		return nil, fmt.Errorf("unexpected output from systemctl list-unit-files %v", content)
+		return nil, fmt.Errorf("%w: %q", errSystemctlNoOutput, content)
 	}
 
 	for _, line := range lines[1 : len(lines)-1] {
@@ -267,6 +274,13 @@ func (s *SystemDServiceManager) List() ([]*Service, error) {
 		// without ever starting systemd, so systemctl produces nothing usable
 		// there. Read the units off disk instead of reporting the failure as
 		// the service list.
+		//
+		// Only an unusable listing means that. Failing to read stdout is an IO
+		// fault, and answering it with a filesystem listing would present a
+		// plausible service list built from a read that never completed.
+		if !errors.Is(err, errSystemctlNoOutput) {
+			return nil, err
+		}
 		log.Debug().Err(err).Msg("systemctl did not answer, reading systemd units from disk instead")
 		return (&SystemdFSServiceManager{Fs: s.conn.FileSystem()}).List()
 	}

--- a/providers/os/resources/services/systemd_test.go
+++ b/providers/os/resources/services/systemd_test.go
@@ -4,6 +4,7 @@
 package services
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -496,4 +497,31 @@ func TestSystemDServiceManagerListUsesListUnits(t *testing.T) {
 	// template@: only in list-unit-files, correctly not running
 	assert.False(t, servicesMap["template@"].Running)
 	assert.True(t, servicesMap["template@"].Static)
+}
+
+// failingReader stands in for a stdout pipe that breaks mid-read.
+type failingReader struct{ err error }
+
+func (f failingReader) Read([]byte) (int, error) { return 0, f.err }
+
+// TestParseServiceSystemDUnitFilesErrorKinds pins the distinction List() relies
+// on: an unusable listing means systemd is not the running init and the caller
+// should read the units off disk, while a broken stdout is an IO fault that has
+// to surface. Both used to arrive as an undifferentiated error, so a failed read
+// degraded into a filesystem listing that looked like a real answer.
+func TestParseServiceSystemDUnitFilesErrorKinds(t *testing.T) {
+	t.Run("empty output is a systemctl no-output error", func(t *testing.T) {
+		_, err := ParseServiceSystemDUnitFiles(strings.NewReader(""))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errSystemctlNoOutput)
+	})
+
+	t.Run("read failure is not a systemctl no-output error", func(t *testing.T) {
+		readErr := errors.New("connection reset by peer")
+		_, err := ParseServiceSystemDUnitFiles(failingReader{err: readErr})
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, errSystemctlNoOutput,
+			"a broken stdout must not be mistaken for systemd being absent")
+		assert.ErrorIs(t, err, readErr, "the underlying read error stays inspectable")
+	})
 }

--- a/providers/os/resources/services/testdata/systemd-units-no-sbin-init.toml
+++ b/providers/os/resources/services/testdata/systemd-units-no-sbin-init.toml
@@ -1,0 +1,7 @@
+# A container image built from a systemd distro: the unit tree is on disk but
+# /sbin/init was never installed. Debian, Ubuntu, Fedora, openSUSE and Amazon
+# Linux images are all shaped this way.
+[files."/usr/lib/systemd/system"]
+mode = 2147484141
+[files."/etc/systemd/system"]
+mode = 2147484141


### PR DESCRIPTION
`services.list` answered **0** on every systemd distro whose image carries unit files but no init binary, and **errored outright** on the ones that do.

Found while sweeping the OS provider across 16 distro container images.

## Three bugs, each hiding the next

### 1. The init probe was a single path

`ResolveManager` decided there was no service manager purely on `conn.FileInfo("/sbin/init")` failing, and installed `noopOsServiceManager`, which returns an empty list:

```go
if _, err := conn.FileInfo("/sbin/init"); err != nil {
    useNoopInit = true   // -> services.list is [] , silently
}
```

Measured across images:

| image | `/sbin/init` | systemd units on disk | `services.list` |
|---|---|---|---|
| debian:12 | absent | yes | 0 |
| ubuntu:24.04 | absent | yes | 0 |
| fedora:41 | absent | yes | 0 |
| opensuse/leap:15.6 | absent | yes | 0 |
| amazonlinux:2023 | absent | yes | 0 |
| almalinux:9 | **dangling symlink** | yes | 0 |

AlmaLinux ships `/sbin/init -> ../lib/systemd/systemd`, a binary that isn't in the image, so the stat fails there too. The probe now looks for any systemd footprint — the binary or the unit trees — rather than one path.

### 2. A masked unit aborted the entire list

With the probe fixed, `SystemdFSServiceManager` then failed outright. A masked unit is a symlink to `/dev/null`, and `tar.FS` implements neither `afero.Lstater` nor `afero.LinkReader`, so `findUnit` fell back to `Stat`, which **follows** the link:

```
tar> is symlink file=etc/systemd/system/systemd-remount-fs.service link=/dev/null path=dev/null
mql[services]> could not retrieve service list error="could not find dev/null"
```

`os.IsNotExist` is false for that bare error, so `findUnit` returned it as fatal — **one masked unit killed every service**. The `/dev/null` → `masked = true` branch sitting right below it was unreachable on tar filesystems.

`tar.FS` now implements both interfaces, and a dangling symlink stats as not-exist, matching what `Open` already did.

### 3. Command availability ≠ systemd running

Being able to run a command does not mean systemd is the running init. A container built from a systemd distro has `systemctl` on PATH but no systemd, so the command manager produced nothing usable and reported that as the service list. It now falls back to reading units off disk.

## Verified against real images

```
                 main   this branch
almalinux:9        0  ->  31 services   (systemd-remount-fs correctly masked: true)
oraclelinux:9      0  ->  36 services
```

Images whose unit tree has no `default.target` still answer 0 — nothing is wired to start, which is the honest answer for an image that cannot boot: debian, ubuntu, fedora, opensuse, amazonlinux, rocky.

**No change on running containers**, checked explicitly because fix 3 could have regressed them:

```
debian:12 (running)     0  ->  0
nginx:alpine (running)  2  ->  2
almalinux:9 (running)  62  -> 62
```

## Known limitation, not addressed here

`SystemdFSServiceManager` enumerates only units reachable from `default.target`, whereas the command-based manager lists all installed units (`systemctl list-unit-files`). So the same resource means a slightly different thing depending on connection type. That's a semantic decision rather than a bug fix, so I've left it alone — happy to follow up if you want the FS manager to report installed units instead.

## Test plan

- `TestResolveManagerFindsSystemdWithoutSbinInit` — a target with unit trees and no `/sbin/init` must not get the noop manager. Fails on `main` (`Should not be: "none"`).
- `TestFsImplementsLstaterAndLinkReader`, `TestLstatDoesNotFollowSymlinks`, `TestReadlinkReturnsTheTarget`, `TestStatOfDanglingSymlinkIsNotExist` — the tar symlink handling. The first three don't compile on `main` (methods undefined), which is the point.
- All existing service manager tests pass unchanged, including the Ubuntu/Photon/Cumulus/Raspbian fixtures that exercise the command-based path.
- `go test ./providers/os/resources/services/... ./providers/os/connection/tar/...` green.
