### PR TITLE
🐛 os: read the rpm database on ALT Linux

### DIFF
--- a/providers/os/resources/packages/altlinux_test.go
+++ b/providers/os/resources/packages/altlinux_test.go
@@ -1,0 +1,34 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package packages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+)
+
+// ALT Linux is rpm based but is not in the redhat family: it ships
+// /etc/redhat-release and /etc/fedora-release carrying only "ALT Container", so
+// detection gives it a resolver of its own under plain linux. Without a case of
+// its own it matched nothing here, and packages errored on a system with a
+// populated rpm database.
+func TestResolveSystemPkgManagersAltLinux(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:    "altlinux",
+			Version: "11",
+			Family:  []string{"linux", "unix", "os"},
+		},
+	}, mock.WithPath("./testdata/packages_alt.toml"))
+	require.NoError(t, err)
+
+	pms, err := ResolveSystemPkgManagers(conn)
+	require.NoError(t, err, "ALT Linux has an rpm database, so a manager must resolve")
+	require.Len(t, pms, 1)
+	assert.Equal(t, "Rpm Package Manager", pms[0].Name())
+}

--- a/providers/os/resources/packages/packages.go
+++ b/providers/os/resources/packages/packages.go
@@ -123,6 +123,13 @@ func ResolveSystemPkgManagers(conn shared.Connection) ([]OperatingSystemPkgManag
 		// This is supported in Debian and Ubuntu:
 		// https: // snapcraft.io/docs/distro-support
 		pms = append(pms, &SnapPkgManager{conn: conn, platform: asset.Platform})
+	// ALT Linux is rpm based but is not in the redhat family: it ships
+	// /etc/redhat-release and /etc/fedora-release carrying only "ALT Container"
+	// with no distro name, so detection gives it a resolver of its own under
+	// plain linux. Without a case here it matched nothing and packages reported
+	// an error on a system with a populated rpm database.
+	case asset.Platform.Name == "altlinux":
+		fallthrough
 	case asset.Platform.Name == "amazonlinux" || asset.Platform.Name == "photon" || asset.Platform.Name == "wrlinux" || asset.Platform.Name == "bottlerocket" || asset.Platform.Name == "azurelinux":
 		fallthrough
 	case asset.Platform.IsFamily("redhat") ||

--- a/providers/os/resources/packages/testdata/packages_alt.toml
+++ b/providers/os/resources/packages/testdata/packages_alt.toml
@@ -1,0 +1,2 @@
+[commands."uname -m"]
+stdout = "aarch64"


### PR DESCRIPTION
`packages` errored on ALT Linux with `could not detect suitable package manager for platform`, on a system carrying **111 rpm packages**.

Found while sweeping the OS provider across 16 distro container images.

### Why

ALT Linux is rpm based but is **not in the redhat family**. As the detector comment explains, it ships `/etc/redhat-release` and `/etc/fedora-release` carrying only `"ALT Container"` with no distro name and no version, so nothing in the redhat family can identify it — which is why it got a resolver of its own under plain linux (#10441).

That leaves its family as `[linux unix os]`, which matches no case in `ResolveSystemPkgManagers`:

```go
case asset.Platform.IsFamily("redhat") ||
     asset.Platform.IsFamily("euler") ||
     asset.Platform.Name == "mageia":
    pms = append(pms, &RpmPkgManager{...})
```

So package detection gave up rather than reading a database that was sitting right there.

### Verified against the live image

```
$ docker run --rm alt:latest rpm -qa | wc -l
111

$ mql run docker image alt:latest -c "packages.length"
before:  could not detect suitable package manager for platform
after:   packages.length: 111

$ mql run docker image alt:latest -c 'packages.list[0] { name version arch format }'
{ name: "filesystem", version: "3.1-alt1", arch: "aarch64", format: "rpm" }
```

## Test plan

- `TestResolveSystemPkgManagersAltLinux` — asserts an rpm manager resolves for platform `altlinux` with family `[linux unix os]`. Fails on `main` with the "could not detect suitable package manager" error; passes here.
- `go test ./providers/os/resources/packages/...` green.
