### PR TITLE
🐛 os: detect openSUSE MicroOS instead of reporting it as scratch

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -844,11 +844,17 @@ var sles = &PlatformResolver{
 	},
 }
 
+// suseMicroOs claims both transactional SUSE systems: SUSE Linux Enterprise
+// Micro, which sets ID=suse-microos, and openSUSE MicroOS, which sets
+// ID=opensuse-microos. They share a read-only root, transactional-update and
+// zypper, so every consumer in the provider treats them alike, and the
+// services manager already dispatches on both names.
 var suseMicroOs = &PlatformResolver{
 	Name:     "suse-microos",
 	IsFamily: false,
+	Emits:    []string{"suse-microos", "opensuse-microos"},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
-		if pf.Name == "suse-microos" {
+		if pf.Name == "suse-microos" || pf.Name == "opensuse-microos" {
 			return true, nil
 		}
 		return false, nil

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -599,6 +599,38 @@ func TestSuse5MicroDetector(t *testing.T) {
 	assert.Equal(t, []string{"suse", "linux", "unix", "os"}, di.Family)
 }
 
+// openSUSE MicroOS sets ID=opensuse-microos, which no resolver claimed: the
+// suse family's only micro leaf matched SLE Micro's ID=suse-microos. Detection
+// fell through to the generic resolver, so the platform carried no suse family
+// and a container image or running container was renamed to "scratch", which
+// routes to ScratchPkgManager and reports an empty package list with no error.
+func TestOpenSuseMicroOsIsClaimedByTheMicroOsResolver(t *testing.T) {
+	mockConn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/detect-opensuse-microos.toml"))
+	require.NoError(t, err)
+
+	pf, leaf, resolved := OperatingSystems.resolvePlatform(&inventory.Platform{}, mockConn)
+	require.True(t, resolved, "platform should resolve")
+	require.NotNil(t, leaf)
+
+	assert.Equal(t, suseMicroOs, leaf, "openSUSE MicroOS must be claimed by the micro resolver")
+	assert.False(t, isUnidentifiedPlatform(pf, leaf),
+		"a container image claimed only by the generic resolver is reported as scratch")
+}
+
+func TestOpenSuseMicroOsDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-opensuse-microos.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "opensuse-microos", di.Name, "os name should be identified")
+	assert.Equal(t, "openSUSE MicroOS", di.Title, "os title should be identified")
+	assert.Equal(t, "20260822", di.Version, "os version should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	// the suse family is what routes it to zypper/rpm packages, the suse
+	// kernel filter and the suse update manager
+	assert.Equal(t, []string{"suse", "linux", "unix", "os"}, di.Family)
+	assert.Equal(t, map[string]string{"distro-id": "opensuse-microos"}, di.Labels)
+}
+
 func TestAmazon1LinuxDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-amazonlinux-2017.09.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/device_type.go
+++ b/providers/os/detector/device_type.go
@@ -77,13 +77,14 @@ var desktopPlatformNames = map[string]bool{
 // are containers or servers. Desktop Alpine users will be detected via the
 // systemd target or session directory fallbacks.
 var serverPlatformNames = map[string]bool{
-	"alpine":       true,
-	"bottlerocket": true,
-	"cos":          true,
-	"flatcar":      true,
-	"gardenlinux":  true,
-	"photon":       true,
-	"suse-microos": true,
+	"alpine":           true,
+	"bottlerocket":     true,
+	"cos":              true,
+	"flatcar":          true,
+	"gardenlinux":      true,
+	"opensuse-microos": true,
+	"photon":           true,
+	"suse-microos":     true,
 }
 
 // systemdDefaultTargetPaths lists the paths where systemd stores the default

--- a/providers/os/detector/device_type_test.go
+++ b/providers/os/detector/device_type_test.go
@@ -410,6 +410,10 @@ func TestDetectDeviceType_ServerDistros(t *testing.T) {
 		{"photon os", "photon", "VMware Photon OS/Linux", []string{"linux", "unix", "os"}},
 		// detect-suse-micro-5.toml
 		{"suse microos", "suse-microos", "SUSE Linux Enterprise Micro 5.1", []string{"suse", "linux", "unix", "os"}},
+		// detect-opensuse-microos.toml. The title carries no "server" keyword
+		// and the desktop spins built on it ship their own ids (aeon,
+		// kalpa-desktop), so the name is what has to answer this.
+		{"opensuse microos", "opensuse-microos", "openSUSE MicroOS", []string{"suse", "linux", "unix", "os"}},
 		// detect-gardenlinux.toml (no container variant-id on this one)
 		{"gardenlinux", "gardenlinux", "Garden Linux 934.0", []string{"debian", "linux", "unix", "os"}},
 	}

--- a/providers/os/detector/testdata/detect-opensuse-microos.toml
+++ b/providers/os/detector/testdata/detect-opensuse-microos.toml
@@ -1,0 +1,26 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "6.16.3-1-default"
+
+[files."/etc/os-release"]
+content = """
+NAME="openSUSE MicroOS"
+# VERSION="20260822"
+ID="opensuse-microos"
+ID_LIKE="suse opensuse opensuse-tumbleweed microos sl-micro"
+VERSION_ID="20260822"
+PRETTY_NAME="openSUSE MicroOS"
+SYSEXT_LEVEL="glibc-2.43"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:microos:20260822"
+BUG_REPORT_URL="https://bugzilla.opensuse.org"
+SUPPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://www.opensuse.org/"
+DOCUMENTATION_URL="https://en.opensuse.org/Portal:MicroOS"
+LOGO="distributor-logo-MicroOS"
+"""

--- a/providers/os/resources/purl/purl.go
+++ b/providers/os/resources/purl/purl.go
@@ -92,6 +92,8 @@ func NewPackageURL(pf *inventory.Platform, t Type, name, version string, modifie
 			purlNamespace = "opensuse"
 		case "opensuse-tumbleweed":
 			purlNamespace = "opensuse"
+		case "opensuse-microos":
+			purlNamespace = "opensuse"
 		case "sles":
 			purlNamespace = "suse"
 		}

--- a/providers/os/resources/purl/purl_test.go
+++ b/providers/os/resources/purl/purl_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/package-url/packageurl-go"
 	"github.com/stretchr/testify/assert"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/detector"
 	"go.mondoo.com/mql/providers/os/resources/purl"
 )
 
@@ -297,6 +298,21 @@ func TestPackageURLString(t *testing.T) {
 		}
 		p := purl.NewPackageURL(platform, purl.TypeRPM, "testpkg", "1.0.0")
 		expected := "pkg:rpm/suse/testpkg@1.0.0?arch=x86_64"
+		assert.Equal(t, expected, p.String())
+	})
+
+	// matches what openSUSE's own build service emits for MicroOS packages:
+	// the namespace collapses to opensuse and the product stays in the distro
+	// qualifier.
+	t.Run("openSUSE MicroOS package", func(t *testing.T) {
+		platform := &inventory.Platform{
+			Name:    "opensuse-microos",
+			Arch:    "x86_64",
+			Version: "20260822",
+			Labels:  map[string]string{detector.LabelDistroID: "opensuse-microos"},
+		}
+		p := purl.NewPackageURL(platform, purl.TypeRPM, "testpkg", "1.0.0")
+		expected := "pkg:rpm/opensuse/testpkg@1.0.0?arch=x86_64&distro=opensuse-microos-20260822"
 		assert.Equal(t, expected, p.String())
 	})
 }

--- a/providers/os/resources/updates/updates.go
+++ b/providers/os/resources/updates/updates.go
@@ -33,7 +33,7 @@ func ResolveSystemUpdateManager(conn shared.Connection) (OperatingSystemUpdateMa
 
 	// TODO: use OS family and select package manager
 	switch pf.Name {
-	case "opensuse", "sles", "opensuse-leap", "opensuse-tumbleweed": // suse family
+	case "opensuse", "sles", "opensuse-leap", "opensuse-tumbleweed", "opensuse-microos": // suse family
 		um = &SuseUpdateManager{conn: conn}
 	case "windows":
 		um = &WindowsUpdateManager{conn: conn}


### PR DESCRIPTION
openSUSE MicroOS sets `ID=opensuse-microos` in `/etc/os-release`. No resolver claimed that name — the suse family's only micro leaf matched SLE Micro's `ID=suse-microos`. Detection fell through to the generic resolver, so the platform carried no `suse` family.

For a container that is not just a missing family, it is a rename. `platform_resolver.go` reports any asset claimed only by the generic resolver as `scratch`, and `scratch` routes to `ScratchPkgManager`, which returns an empty package list **and no error**. An openSUSE MicroOS container scanned as zero packages and a clean vulnerability report.

## Before / after

Measured against a container built from the real `MicroOS-release` package (genuine `/etc/os-release`, real rpm database), scanned on Docker Engine as both an image and a running container:

| | shipped provider | with this change |
|---|---|---|
| `asset.platform` | `scratch` | `opensuse-microos` |
| `asset.family` | `linux, unix, os` | `suse, linux, unix, os` |
| `packages.length` | `0` (no error) | `73` |
| `os.updates` | "could not detect suitable update manager" | resolves |

```
pkg:rpm/opensuse/MicroOS-release@20260806-3396.1?arch=aarch64&distro=opensuse-microos-20260806
```

## What changed

`suseMicroOs` now claims both transactional SUSE systems and declares them via `Emits`, so both names reach `osTree` and the provider catalog. The `suse` family is what routes the platform to zypper/rpm packages, to the suse kernel filter (whose `kernel-<flavor>-base` case was written for MicroOS but never reached it) and to the suse update manager. `services/manager.go` already dispatched on `opensuse-microos` since #6152; nothing else did.

- **device_type** — `opensuse-microos` is server-oriented, like `suse-microos`. The desktop spins built on it ship their own ids (`aeon`, `kalpa-desktop`), so the name is unambiguous and does not shadow a desktop.
- **updates** — route it to the suse update manager.
- **purl** — namespace collapses to `opensuse`, matching what openSUSE's own build service emits for MicroOS packages in the SBOMs it ships alongside the MicroOS images. The product stays in the `distro` qualifier.

## Why the existing guard-rail test missed it

`TestEveryEmittedPlatformNameIsInTheTree` was added to enforce exactly this invariant, but it skips leaves claimed by `defaultLinux` by design — that resolver can emit any ID an unknown system carries, so it cannot be enumerated. openSUSE MicroOS landed in precisely that blind spot. The new fixture is what proves the distro is claimed by a real resolver; both new detector tests fail on `main` (`actual: generic-linux`, and family missing `suse`).

The fixture content is the verbatim `/etc/os-release` from `MicroOS-release-20260822-4266.1`, not a reconstruction.
