### PR TITLE
🐛 network: report a cookie's name when its value is empty

### DIFF
--- a/providers/network/resources/http.go
+++ b/providers/network/resources/http.go
@@ -464,19 +464,36 @@ func (x *mqlHttpHeaderContentType) id() (string, error) {
 // this cookie's attribute map.
 func parseSetCookieDirectives(raw any) (name *llx.RawData, value *llx.RawData, params *llx.RawData) {
 	name, value, params = llx.NilData, llx.NilData, llx.NilData
-	parseHeaderFields([]any{raw}, func(key string, val string) {
-		// RFC 6265 section 5.2: attribute names are case-insensitive,
-		// while cookie names and values keep their casing
-		if name.Value == nil && val != "" {
-			name = llx.StringData(key)
-			value = llx.StringData(val)
-			return
+
+	header, ok := raw.(string)
+	if !ok {
+		return name, value, params
+	}
+
+	for i, field := range strings.Split(header, ";") {
+		key, val, hasValue := strings.Cut(strings.TrimSpace(field), "=")
+
+		// RFC 6265 section 5.2: the first field is the cookie's name and value,
+		// and every field after it is an attribute. Position is what decides
+		// this, not whether a value is present - a cookie cleared by setting it
+		// to the empty string is still that cookie, and reading it as an
+		// attribute shifts every following attribute onto the wrong key.
+		if i == 0 {
+			// No "=" at all is not a name-value pair, so the header sets no
+			// cookie; a browser discards the whole thing.
+			if hasValue {
+				name, value = llx.StringData(key), llx.StringData(val)
+			}
+			continue
 		}
+
+		// Attribute names are case-insensitive; their values keep their casing.
 		if params.Value == nil {
 			params = llx.MapData(map[string]any{}, types.String)
 		}
 		params.Value.(map[string]any)[strings.ToLower(key)] = val
-	})
+	}
+
 	return name, value, params
 }
 

--- a/providers/network/resources/http_internal_test.go
+++ b/providers/network/resources/http_internal_test.go
@@ -193,6 +193,45 @@ func TestParseSetCookieDirectives(t *testing.T) {
 		_, _, params := parseSetCookieDirectives("sid=1; Domain=Example.COM; SameSite=Strict")
 		assert.Equal(t, map[string]any{"domain": "Example.COM", "samesite": "Strict"}, params.Value)
 	})
+
+	t.Run("names a cookie that is set to an empty value", func(t *testing.T) {
+		// Clearing a cookie by setting it to the empty string is ordinary, and
+		// the header still names the cookie being cleared. Reading the empty
+		// value as "not the name-value pair" promoted the first attribute into
+		// the cookie and shifted every attribute after it onto the wrong key.
+		name, value, params := parseSetCookieDirectives(
+			"ct0=; Max-Age=-1; Path=/; Domain=.example.com; Secure; SameSite=Lax")
+		assert.Equal(t, llx.StringData("ct0"), name)
+		assert.Equal(t, llx.StringData(""), value)
+		assert.Equal(t, map[string]any{
+			"max-age":  "-1",
+			"path":     "/",
+			"domain":   ".example.com",
+			"secure":   "",
+			"samesite": "Lax",
+		}, params.Value)
+	})
+
+	t.Run("names a cookie whose only field is an empty value", func(t *testing.T) {
+		name, value, params := parseSetCookieDirectives("sid=")
+		assert.Equal(t, llx.StringData("sid"), name)
+		assert.Equal(t, llx.StringData(""), value)
+		assert.Equal(t, llx.NilData, params)
+	})
+
+	t.Run("keeps a value that contains its own equals signs", func(t *testing.T) {
+		name, value, _ := parseSetCookieDirectives("token=a=b=c; Path=/")
+		assert.Equal(t, llx.StringData("token"), name)
+		assert.Equal(t, llx.StringData("a=b=c"), value)
+	})
+
+	t.Run("sets no cookie when the first field is not a name-value pair", func(t *testing.T) {
+		// RFC 6265 section 5.2 step 2: a cookie-string with no "=" in its
+		// name-value pair is ignored entirely.
+		name, value, _ := parseSetCookieDirectives("justaflag; Path=/")
+		assert.Equal(t, llx.NilData, name)
+		assert.Equal(t, llx.NilData, value)
+	})
 }
 
 func TestHttpHeaderSetCookie(t *testing.T) {


### PR DESCRIPTION
## What

`parseSetCookieDirectives` picked the first `key=value` pair with a **non-empty** value as the cookie's name and value. A cookie set to the empty string — the ordinary way to clear one — therefore never claimed the name-value slot, so its real name fell through into the attribute map and the first attribute was promoted to be the cookie. Every attribute after it shifted along with it.

RFC 6265 §5.2 makes this positional: the first field is the name-value pair, everything after it is an attribute, whatever the value happens to be. This parses it that way, and ignores a first field with no `=` at all, which a browser discards as setting no cookie.

## Why it matters

The output is wrong in both directions — the name and value are somebody else's, and the flags land on a cookie that was never sent. On `x.com`:

```
Set-Cookie: ct0=; Max-Age=-1; Path=/; Domain=.x.com; Secure; SameSite=Lax
```

was reported as

```
name   = "Max-Age"
value  = "-1"
params = {ct0:"", domain:".x.com", path:"/", secure:"", samesite:"Lax"}
```

Cookie-hardening policies are the main consumer of `setCookies`, and four of the twenty-five most-visited sites set a cookie this way: `ct0` (x.com), `ULC` (bing.com), `ClientId` (live.com), `__Secure-YEC` (youtube.com).

`setCookie` (deprecated, singular) shares the parser and is fixed by the same change.

## Test plan

- Four new cases in `TestParseSetCookieDirectives`: a cookie cleared to an empty value with a full attribute list, a header whose only field is `sid=`, a value containing its own `=` signs, and a first field that is not a name-value pair at all.
- `go test ./resources/` passes; existing cookie tests unchanged.
- Live check: all four affected sites now report the cookie's own name and its full attribute set — `ct0` regains `secure` and `samesite`, `__Secure-YEC` regains `httponly`, `secure` and `samesite`.
