### PR TITLE
🐛 os: detect Talos instead of reporting it as scratch

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -188,6 +188,19 @@ var cos = &PlatformResolver{
 	},
 }
 
+// Talos is an API-managed Kubernetes host: it ships no shell, no /bin or
+// /sbin, and no package database, so nothing here can be derived from a
+// command. /etc/os-release is the whole of what detection can read, and
+// VERSION_ID carries the vendor's own "v" prefix ("v1.13.9"), which is the
+// string talosctl reports and is kept as-is.
+var talos = &PlatformResolver{
+	Name:     "talos",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		return pf.Name == "talos", nil
+	},
+}
+
 var flatcar = &PlatformResolver{
 	Name:     "flatcar",
 	IsFamily: false,
@@ -1487,7 +1500,7 @@ var linuxFamily = &PlatformResolver{
 	IsFamily: true,
 	// NOTE: altlinux runs before the redhat family, whose members probe
 	// /etc/redhat-release and /etc/fedora-release, both of which ALT ships.
-	Children: []*PlatformResolver{archFamily, altlinux, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, wizos, alpine, wolfi, nixos, gentoo, voidlinux, clearlinux, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, cos, flatcar, cirros, defaultLinux},
+	Children: []*PlatformResolver{archFamily, altlinux, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, wizos, alpine, wolfi, nixos, gentoo, voidlinux, clearlinux, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, cos, flatcar, talos, cirros, defaultLinux},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		detected := false
 		osrd := NewOSReleaseDetector(conn)

--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -190,14 +190,22 @@ var cos = &PlatformResolver{
 
 // Talos is an API-managed Kubernetes host: it ships no shell, no /bin or
 // /sbin, and no package database, so nothing here can be derived from a
-// command. /etc/os-release is the whole of what detection can read, and
-// VERSION_ID carries the vendor's own "v" prefix ("v1.13.9"), which is the
-// string talosctl reports and is kept as-is.
+// command. /etc/os-release is the whole of what detection can read.
+//
+// Talos writes VERSION_ID with its own "v" prefix ("v1.13.9"). The prefix is
+// stripped so the field holds a bare version like every other platform reports:
+// pf.Version is what version comparisons in policies run against, and a leading
+// "v" makes Talos the one platform those comparisons have to special-case. The
+// prefixed string is still visible in Title, which keeps PRETTY_NAME verbatim.
 var talos = &PlatformResolver{
 	Name:     "talos",
 	IsFamily: false,
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
-		return pf.Name == "talos", nil
+		if pf.Name != "talos" {
+			return false, nil
+		}
+		pf.Version = strings.TrimPrefix(pf.Version, "v")
+		return true, nil
 	},
 }
 

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -1446,6 +1446,38 @@ func TestDetectorFlatcar(t *testing.T) {
 	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
 }
 
+func TestDetectorTalos(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-talos.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "talos", di.Name, "os name should be identified")
+	assert.Equal(t, "Talos (v1.13.9)", di.Title, "os title should be identified")
+	// the vendor's own "v" prefix, as talosctl reports it. Nothing normalizes
+	// VERSION_ID, and stripping it here would report a version Talos does not
+	// use for itself.
+	assert.Equal(t, "v1.13.9", di.Version, "os version should be identified")
+	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
+	assert.Equal(t, map[string]string{"distro-id": "talos"}, di.Labels)
+}
+
+// Talos ships no shell, no package database and no sshd, so it is only ever
+// reached as an image, a disk or a mounted filesystem. Nothing claimed
+// ID=talos, so it fell to the generic resolver, and platform_resolver.go
+// renames any container claimed only by that resolver to "scratch", which
+// reports an empty package list with no error.
+func TestTalosIsClaimedByItsOwnResolver(t *testing.T) {
+	mockConn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/detect-talos.toml"))
+	require.NoError(t, err)
+
+	pf, leaf, resolved := OperatingSystems.resolvePlatform(&inventory.Platform{}, mockConn)
+	require.True(t, resolved, "platform should resolve")
+	require.NotNil(t, leaf)
+
+	assert.Equal(t, talos, leaf, "Talos must be claimed by its own resolver")
+	assert.False(t, isUnidentifiedPlatform(pf, leaf),
+		"a container image claimed only by the generic resolver is reported as scratch")
+}
+
 func TestEndeavourOSContainerDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-endeavouros.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -1452,10 +1452,10 @@ func TestDetectorTalos(t *testing.T) {
 
 	assert.Equal(t, "talos", di.Name, "os name should be identified")
 	assert.Equal(t, "Talos (v1.13.9)", di.Title, "os title should be identified")
-	// the vendor's own "v" prefix, as talosctl reports it. Nothing normalizes
-	// VERSION_ID, and stripping it here would report a version Talos does not
-	// use for itself.
-	assert.Equal(t, "v1.13.9", di.Version, "os version should be identified")
+	// VERSION_ID is v1.13.9 on this target; the vendor's "v" prefix is stripped
+	// so version comparisons do not have to special-case Talos. The prefixed
+	// string survives in Title, which is PRETTY_NAME verbatim.
+	assert.Equal(t, "1.13.9", di.Version, "os version should have the v prefix stripped")
 	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
 	assert.Equal(t, map[string]string{"distro-id": "talos"}, di.Labels)
 }

--- a/providers/os/detector/device_type.go
+++ b/providers/os/detector/device_type.go
@@ -85,6 +85,7 @@ var serverPlatformNames = map[string]bool{
 	"opensuse-microos": true,
 	"photon":           true,
 	"suse-microos":     true,
+	"talos":            true,
 }
 
 // systemdDefaultTargetPaths lists the paths where systemd stores the default

--- a/providers/os/detector/device_type_test.go
+++ b/providers/os/detector/device_type_test.go
@@ -414,6 +414,8 @@ func TestDetectDeviceType_ServerDistros(t *testing.T) {
 		// and the desktop spins built on it ship their own ids (aeon,
 		// kalpa-desktop), so the name is what has to answer this.
 		{"opensuse microos", "opensuse-microos", "openSUSE MicroOS", []string{"suse", "linux", "unix", "os"}},
+		// detect-talos.toml. An API-managed Kubernetes host, never a desktop.
+		{"talos", "talos", "Talos (v1.13.9)", []string{"linux", "unix", "os"}},
 		// detect-gardenlinux.toml (no container variant-id on this one)
 		{"gardenlinux", "gardenlinux", "Garden Linux 934.0", []string{"debian", "linux", "unix", "os"}},
 	}

--- a/providers/os/detector/testdata/detect-talos.toml
+++ b/providers/os/detector/testdata/detect-talos.toml
@@ -1,0 +1,16 @@
+# Talos ships no shell and no uname binary, so it carries no commands block:
+# /etc/os-release is the whole of what detection can read. Content is verbatim
+# from ghcr.io/siderolabs/talos:v1.13.9. Arch comes from the image config or the
+# ELF fallback on a real scan, never from a command.
+
+[files."/etc/os-release"]
+content = """
+NAME="Talos"
+ID=talos
+VERSION_ID=v1.13.9
+PRETTY_NAME="Talos (v1.13.9)"
+HOME_URL="https://www.talos.dev/"
+BUG_REPORT_URL="https://github.com/siderolabs/talos/issues"
+VENDOR_NAME="Sidero Labs"
+VENDOR_URL="https://www.siderolabs.com/"
+"""


### PR DESCRIPTION
Talos sets `ID=talos` in `/etc/os-release` and no resolver claimed it, so detection fell through to the generic resolver — and `platform_resolver.go` renames any container claimed only by that resolver to `scratch`. Same bug class as #10459.

Against `ghcr.io/siderolabs/talos:v1.13.9`:

| | shipped provider | with this change |
|---|---|---|
| `asset.platform` | `scratch` | `talos` |
| `asset.version` | `v1.13.9` | `1.13.9` |
| `packages.length` | `0` (no error) | errors, naming the platform |

## Why the fixture has no commands block

Talos is an API-managed Kubernetes host. It ships no sshd, no `/bin` or `/sbin`, no shell binary anywhere, and no package database — 140 binaries in `/usr/bin` and not one of them a shell. It is only ever reached as an image, a disk, or a mounted filesystem, and `/etc/os-release` is the whole of what detection can read. Every other fixture carries a `uname` block; there is no `uname` on this target to run, so this one follows `detect-nixos-container.toml` instead.

## The vendor `v` prefix is stripped

`VERSION_ID=v1.13.9` carries the vendor's own prefix. It is stripped in the resolver, so `asset.version` reads `1.13.9` like every other platform.

This reverses what an earlier revision of this PR argued. The case for keeping it was that `talosctl version` prints the prefixed string, so the bare form is not what Talos calls itself. The case for stripping it wins: `pf.Version` is what version comparisons in policies run against, and a leading `v` makes Talos the one platform every such comparison has to special-case. The vendor's own string is not lost — `Title` keeps `PRETTY_NAME` verbatim, so `Talos (v1.13.9)` is still right there.

This is the detector's first `VERSION_ID` normalization, and it is deliberately scoped to the Talos resolver rather than applied to os-release parsing generally.

## Why Talos is not routed to ScratchPkgManager

This was the obvious-looking move and it is wrong. Talos ships an SPDX manifest at `/usr/share/spdx/talos-container-<arch>.spdx.json` listing **424 components** — apparmor 3.1.7, containerd 2.2.7, cryptsetup 2.8.6, e2fsprogs, plus the full Go module graph. Routing it to `ScratchPkgManager` would assert a *verified-empty* package list about a system with real, knowable content.

Leaving it unrouted errors with `could not detect suitable package manager for platform: talos`. That is the outcome `kernel.go` already documents for exactly this case:

> Answering with an empty list would be indistinguishable from a verified-empty result, and a policy asserting [...] would evaluate over the empty set and pass without checking anything. The error names the platform so the missing case can be added.

`scratch` means "nothing to find". Talos means "424 things we cannot read yet". Those must not look alike.

**Follow-up:** reading that manifest would give Talos real package and vulnerability coverage with no package manager involved. Not in this PR.

## Notes

- `device_type`: talos is server-oriented — a Kubernetes node OS with no desktop edition and no graphical target to fall back on.
- Both new detector tests fail without the change (`actual: generic-linux`).
- Touches `serverPlatformNames` in `device_type.go`, which #10459 also touches. Trivial conflict if that merges first.

