### PR TITLE
🐛 network: don't report an unsigned zone when the resolver strips DNSSEC

### DIFF
--- a/providers/network/resources/dns_dnssec.go
+++ b/providers/network/resources/dns_dnssec.go
@@ -232,6 +232,29 @@ func nsec3ParamFromParams(paramsM map[string]any) *dns.NSEC3PARAM {
 	return nil
 }
 
+// dnssecVerdicts maps the four fields that are read off the answer's signatures.
+//
+// All four are unknown when the resolver did not honor the DNSSEC OK bit: it
+// then returns the same unsigned-looking answer for a signed zone and an
+// unsigned one, so reporting false would assert that a zone is unsigned on the
+// strength of an answer that was never going to carry a signature. dnssecOk
+// itself, the response code and the resolver's authenticated-data flag are
+// facts about the exchange rather than about the zone, so they stay populated
+// and the reason remains readable.
+func dnssecVerdicts(validation *dnsshake.DnssecValidation, signaturesCurrentlyValid bool) (
+	signed *llx.RawData, signaturesVerified *llx.RawData,
+	chainOfTrustValidated *llx.RawData, currentlyValid *llx.RawData,
+) {
+	if !validation.DnssecOk {
+		return llx.NilData, llx.NilData, llx.NilData, llx.NilData
+	}
+
+	return llx.BoolData(len(validation.Signatures) > 0),
+		llx.BoolData(validation.SignaturesVerified),
+		llx.BoolData(validation.ChainOfTrustValidated),
+		llx.BoolData(signaturesCurrentlyValid)
+}
+
 // dnssecValidation resolves the domain with DNSSEC requested and reports what
 // the resolution actually produced.
 //
@@ -332,6 +355,9 @@ func (d *mqlDns) dnssecValidation(fqdn string) (*mqlDnsDnssecValidationResult, e
 		expiresInData = llx.TimeData(remaining)
 	}
 
+	signedData, signaturesVerifiedData, chainOfTrustValidatedData, signaturesCurrentlyValidData :=
+		dnssecVerdicts(validation, signaturesCurrentlyValid)
+
 	res, err := CreateResource(d.MqlRuntime, "dns.dnssecValidationResult", map[string]*llx.RawData{
 		"__id":                     llx.StringData("dns.dnssecValidationResult/" + fqdn),
 		"name":                     llx.StringData(validation.Name),
@@ -339,17 +365,17 @@ func (d *mqlDns) dnssecValidation(fqdn string) (*mqlDnsDnssecValidationResult, e
 		"responseCode":             llx.StringData(validation.ResponseCode),
 		"dnssecOk":                 llx.BoolData(validation.DnssecOk),
 		"authenticatedData":        llx.BoolData(validation.AuthenticatedData),
-		"signed":                   llx.BoolData(len(validation.Signatures) > 0),
+		"signed":                   signedData,
 		"signatures":               llx.ArrayData(signatures, types.Resource("dns.rrsigRecord")),
-		"signaturesVerified":       llx.BoolData(validation.SignaturesVerified),
-		"chainOfTrustValidated":    llx.BoolData(validation.ChainOfTrustValidated),
+		"signaturesVerified":       signaturesVerifiedData,
+		"chainOfTrustValidated":    chainOfTrustValidatedData,
 		"chain":                    llx.ArrayData(llx.TArr2Raw(validation.Chain), types.String),
 		"brokenAtZone":             llx.StringData(validation.BrokenAtZone),
 		"signerNames":              llx.ArrayData(signerNames, types.String),
 		"signatureAlgorithms":      llx.ArrayData(algorithms, types.Int),
 		"earliestSignatureExpiry":  earliestExpiryData,
 		"signatureExpiresIn":       expiresInData,
-		"signaturesCurrentlyValid": llx.BoolData(signaturesCurrentlyValid),
+		"signaturesCurrentlyValid": signaturesCurrentlyValidData,
 		"error":                    llx.StringData(validation.Error),
 	})
 	if err != nil {

--- a/providers/network/resources/dns_dnssec_verdicts_internal_test.go
+++ b/providers/network/resources/dns_dnssec_verdicts_internal_test.go
@@ -1,0 +1,58 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers/network/resources/dnsshake"
+)
+
+func TestDnssecVerdicts(t *testing.T) {
+	t.Run("reports the verdicts when the resolver honored DNSSEC", func(t *testing.T) {
+		signed, verified, chain, current := dnssecVerdicts(&dnsshake.DnssecValidation{
+			DnssecOk:              true,
+			Signatures:            []dnsshake.DnssecSignature{{TypeCovered: "A"}},
+			SignaturesVerified:    true,
+			ChainOfTrustValidated: true,
+		}, true)
+
+		assert.Equal(t, llx.BoolTrue, signed)
+		assert.Equal(t, llx.BoolTrue, verified)
+		assert.Equal(t, llx.BoolTrue, chain)
+		assert.Equal(t, llx.BoolTrue, current)
+	})
+
+	t.Run("reports an unsigned zone as unsigned", func(t *testing.T) {
+		// The resolver did return DNSSEC records, so an answer with no signature
+		// really is evidence that the zone is not signed.
+		signed, verified, chain, current := dnssecVerdicts(&dnsshake.DnssecValidation{
+			DnssecOk:   true,
+			Signatures: []dnsshake.DnssecSignature{},
+		}, false)
+
+		assert.Equal(t, llx.BoolFalse, signed)
+		assert.Equal(t, llx.BoolFalse, verified)
+		assert.Equal(t, llx.BoolFalse, chain)
+		assert.Equal(t, llx.BoolFalse, current)
+	})
+
+	t.Run("reports nothing about the zone when the resolver stripped DNSSEC", func(t *testing.T) {
+		// A resolver that did not honor the DNSSEC OK bit answers without
+		// signatures whether or not the zone is signed, so an unsigned-looking
+		// answer says nothing. Reporting false here is what made a signed zone
+		// read as unsigned.
+		signed, verified, chain, current := dnssecVerdicts(&dnsshake.DnssecValidation{
+			DnssecOk:   false,
+			Signatures: []dnsshake.DnssecSignature{},
+		}, false)
+
+		assert.Equal(t, llx.NilData, signed)
+		assert.Equal(t, llx.NilData, verified)
+		assert.Equal(t, llx.NilData, chain)
+		assert.Equal(t, llx.NilData, current)
+	})
+}

--- a/providers/network/resources/dnsshake/dnssec.go
+++ b/providers/network/resources/dnsshake/dnssec.go
@@ -112,6 +112,40 @@ var rootTrustAnchors = []rootAnchor{
 	{DigestType: 2, Digest: "683d2d0acb8c9b712a1948b27f741219298d0a450d612c483af444a4c0fb2b16"},
 }
 
+// resolveWithDnssec asks one resolver for the first of the record types that
+// returns records, and reports which type answered.
+//
+// Checking is left enabled, so a resolver that validates answers SERVFAIL for a
+// zone whose signatures do not verify rather than handing back data it would
+// not itself accept.
+func (d *DnsClient) resolveWithDnssec(server, name string, recordTypes []string) (*dns.Msg, string, uint16, error) {
+	var (
+		msg        *dns.Msg
+		answerType string
+		qtype      uint16
+		lastErr    error
+	)
+
+	for _, recordType := range recordTypes {
+		candidate, err := d.exchangeDnssec(server, name, stringToType[recordType], false)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if msg == nil {
+			msg, qtype, answerType = candidate, stringToType[recordType], recordType
+		}
+		if len(candidate.Answer) > 0 {
+			return candidate, recordType, stringToType[recordType], nil
+		}
+	}
+
+	if msg == nil {
+		return nil, "", 0, lastErr
+	}
+	return msg, answerType, qtype, nil
+}
+
 // ValidateDnssec resolves the client's name with DNSSEC requested and reports
 // what came back.
 //
@@ -145,25 +179,30 @@ func (d *DnsClient) ValidateDnssec(recordTypes ...string) (*DnssecValidation, er
 		res.Error = "no resolver is configured"
 		return res, nil
 	}
-	server := d.config.Servers[0]
 
-	// Checking is left enabled, so a resolver that validates answers SERVFAIL
-	// for a zone whose signatures do not verify rather than handing back data
-	// it would not itself accept.
-	var msg *dns.Msg
-	var qtype uint16
-	var lastErr error
-	for _, recordType := range recordTypes {
-		candidate, err := d.exchangeDnssec(server, res.Name, stringToType[recordType], false)
+	// Try each configured resolver until one honors the DNSSEC OK bit. A
+	// resolver that strips EDNS0 answers without signatures however the zone is
+	// signed, so taking its answer as the verdict reports a correctly signed
+	// zone as unsigned. The first response is kept either way, so a run where
+	// no resolver honors DNSSEC still reports the response code it did get.
+	var (
+		server  string
+		msg     *dns.Msg
+		qtype   uint16
+		lastErr error
+	)
+	for _, candidateServer := range d.config.Servers {
+		candidate, candidateType, candidateQtype, err := d.resolveWithDnssec(candidateServer, res.Name, recordTypes)
 		if err != nil {
 			lastErr = err
 			continue
 		}
+
 		if msg == nil {
-			msg, qtype, res.RecordType = candidate, stringToType[recordType], recordType
+			server, msg, qtype, res.RecordType = candidateServer, candidate, candidateQtype, candidateType
 		}
-		if len(candidate.Answer) > 0 {
-			msg, qtype, res.RecordType = candidate, stringToType[recordType], recordType
+		if responseHasDnssecOk(candidate) {
+			server, msg, qtype, res.RecordType = candidateServer, candidate, candidateQtype, candidateType
 			break
 		}
 	}
@@ -179,6 +218,17 @@ func (d *DnsClient) ValidateDnssec(recordTypes ...string) (*DnssecValidation, er
 	res.ResponseCode = dns.RcodeToString[msg.Rcode]
 	res.AuthenticatedData = msg.AuthenticatedData
 	res.DnssecOk = responseHasDnssecOk(msg)
+
+	// No resolver returned DNSSEC records for a query that asked for them, so
+	// the answer says nothing about the zone: a signed zone and an unsigned one
+	// look identical from here. Stop rather than concluding from an unsigned
+	// answer that the zone is unsigned, and leave the verdicts at their zero
+	// values for the caller to report as unknown.
+	if !res.DnssecOk {
+		res.Error = "the resolver did not return DNSSEC records for a query that asked for them, " +
+			"so nothing here describes how the zone is signed"
+		return res, nil
+	}
 
 	// Reasons accumulate rather than overwrite. The resolver's refusal is
 	// context, the walk's finding is the diagnosis, and reporting only the
@@ -210,9 +260,14 @@ func (d *DnsClient) ValidateDnssec(recordTypes ...string) (*DnssecValidation, er
 		return res, nil
 	}
 
-	res.SignaturesVerified = d.verifySignatures(server, rrsigs, answer.Answer)
-	if !res.SignaturesVerified {
-		reasons = append(reasons, "no signature over the answer verified against a key its signing zone publishes")
+	verified, unreadable := d.verifySignatures(server, rrsigs, answer.Answer)
+	res.SignaturesVerified = verified
+	if !verified {
+		if unreadable != "" {
+			reasons = append(reasons, unreadable)
+		} else {
+			reasons = append(reasons, "no signature over the answer verified against a key its signing zone publishes")
+		}
 	}
 
 	// The signing zone is where the chain starts. It is the RRSIG's signer,
@@ -291,7 +346,10 @@ func fingerprintSignature(signature string) string {
 // signed zone as unvalidated. Skipping is only safe because the count below
 // requires at least one signature to have actually been checked -- otherwise an
 // answer carrying nothing but irrelevant RRSIGs would verify vacuously.
-func (d *DnsClient) verifySignatures(server string, rrsigs []*dns.RRSIG, answer []dns.RR) bool {
+// The second return explains a false result: it names the resolver when the key
+// set could not be read, and is empty when the signatures were genuinely checked
+// and did not verify.
+func (d *DnsClient) verifySignatures(server string, rrsigs []*dns.RRSIG, answer []dns.RR) (bool, string) {
 	keysByZone := map[string][]*dns.DNSKEY{}
 	verified := 0
 
@@ -304,20 +362,25 @@ func (d *DnsClient) verifySignatures(server string, rrsigs []*dns.RRSIG, answer 
 		zone := sig.SignerName
 		keys, ok := keysByZone[zone]
 		if !ok {
-			keys, _ = d.dnskeys(server, zone)
+			fetched, dnssecOk, err := d.dnskeys(server, zone)
+			if err != nil || !dnssecOk {
+				return false, "the resolver did not return the DNSKEY set for " + zone +
+					", so the answer's signatures could not be checked"
+			}
+			keys = fetched
 			keysByZone[zone] = keys
 		}
 		if len(keys) == 0 {
-			return false
+			return false, ""
 		}
 
 		if !verifyWithAnyKey(sig, keys, rrset) {
-			return false
+			return false, ""
 		}
 		verified++
 	}
 
-	return verified > 0
+	return verified > 0, ""
 }
 
 // verifyWithAnyKey reports whether any of the zone's keys validates the
@@ -352,6 +415,17 @@ func (d *DnsClient) walkChain(server, zone string) (chain []string, brokenAt str
 		keyMsg, err := d.exchangeDnssec(server, zone, dns.TypeDNSKEY, true)
 		if err != nil {
 			return chain, zone, "could not read the DNSKEY set for " + zone + ": " + err.Error()
+		}
+
+		// A resolver can honor the DNSSEC OK bit for one name and strip it for
+		// the next, so the walk has to check every response rather than trusting
+		// that the one which selected this resolver settled the question. An
+		// answer with no DNSSEC records in it cannot support any finding about
+		// the zone, and reporting one accuses the zone's operator of a break
+		// that is on the path to the resolver.
+		if !responseHasDnssecOk(keyMsg) {
+			return chain, zone, "the resolver did not return DNSSEC records for the DNSKEY set of " + zone +
+				", so the chain of trust could not be followed past it"
 		}
 
 		keys := dnskeysIn(keyMsg.Answer)
@@ -511,12 +585,15 @@ func matchesRootAnchor(keys []*dns.DNSKEY) bool {
 
 // dnskeys reads a zone's DNSKEY set, returning an empty slice rather than an
 // error when it cannot be read, because every caller treats the two the same.
-func (d *DnsClient) dnskeys(server, zone string) ([]*dns.DNSKEY, error) {
+// The second return reports whether the response carried DNSSEC records at all.
+// A resolver can honor the DNSSEC OK bit for one name and strip it for the next,
+// and an empty key set from a stripped response is not evidence about the zone.
+func (d *DnsClient) dnskeys(server, zone string) ([]*dns.DNSKEY, bool, error) {
 	msg, err := d.exchangeDnssec(server, zone, dns.TypeDNSKEY, true)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return dnskeysIn(msg.Answer), nil
+	return dnskeysIn(msg.Answer), responseHasDnssecOk(msg), nil
 }
 
 // dnskeysIn picks the DNSKEY records out of a record set.

--- a/providers/network/resources/dnsshake/dnssec_internal_test.go
+++ b/providers/network/resources/dnsshake/dnssec_internal_test.go
@@ -227,11 +227,17 @@ func TestVerifySignaturesSkipsIrrelevantRrsigs(t *testing.T) {
 		// Every signature is skipped, so nothing was actually checked. This
 		// must not pass: skipping is only safe while at least one signature
 		// still has to verify.
-		assert.False(t, d.verifySignatures("", []*dns.RRSIG{nsecSig}, []dns.RR{a1}))
+		verified, unreadable := d.verifySignatures("", []*dns.RRSIG{nsecSig}, []dns.RR{a1})
+		assert.False(t, verified)
+		// Nothing was fetched, so this is a genuine "did not verify" rather
+		// than a key set the resolver would not hand over.
+		assert.Empty(t, unreadable)
 	})
 
 	t.Run("no signatures at all does not verify", func(t *testing.T) {
-		assert.False(t, d.verifySignatures("", nil, []dns.RR{a1}))
+		verified, unreadable := d.verifySignatures("", nil, []dns.RR{a1})
+		assert.False(t, verified)
+		assert.Empty(t, unreadable)
 	})
 }
 

--- a/providers/network/resources/dnsshake/dnssec_resolver_internal_test.go
+++ b/providers/network/resources/dnsshake/dnssec_resolver_internal_test.go
@@ -1,0 +1,164 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package dnsshake
+
+import (
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dnssecResolver stands up a local resolver on an ephemeral port. When
+// honorsDnssecOk is set it echoes the DNSSEC OK bit and answers with an RRSIG
+// alongside the address, the way a resolver on a path that carries EDNS0 does.
+// Otherwise it answers with neither, which is what a resolver that strips EDNS0
+// returns for a signed zone and an unsigned one alike.
+//
+// bindAddr and bindPort pin where it listens; an empty bindPort takes an
+// ephemeral one. Pinning both is what lets two resolvers that differ only in
+// behavior sit behind one dns.ClientConfig, which carries a single port for
+// every server it lists.
+func dnssecResolver(t *testing.T, name, bindAddr, bindPort string, honorsDnssecOk bool) string {
+	t.Helper()
+
+	handler := dns.HandlerFunc(func(w dns.ResponseWriter, req *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(req)
+
+		if req.Question[0].Qtype == dns.TypeA {
+			m.Answer = append(m.Answer, &dns.A{
+				Hdr: dns.RR_Header{Name: dns.Fqdn(name), Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+				A:   net.ParseIP("192.0.2.1"),
+			})
+		}
+
+		if honorsDnssecOk {
+			opt := &dns.OPT{Hdr: dns.RR_Header{Name: ".", Rrtype: dns.TypeOPT}}
+			opt.SetUDPSize(4096)
+			opt.SetDo()
+			m.Extra = append(m.Extra, opt)
+
+			if req.Question[0].Qtype == dns.TypeA {
+				m.Answer = append(m.Answer, &dns.RRSIG{
+					Hdr:         dns.RR_Header{Name: dns.Fqdn(name), Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 300},
+					TypeCovered: dns.TypeA,
+					Algorithm:   13,
+					Labels:      2,
+					OrigTtl:     300,
+					Expiration:  0xFFFFFFF0,
+					Inception:   1,
+					KeyTag:      1234,
+					SignerName:  dns.Fqdn(name),
+					Signature:   "AAAA",
+				})
+			}
+		}
+
+		_ = w.WriteMsg(m)
+	})
+
+	if bindPort == "" {
+		bindPort = "0"
+	}
+	packetConn, err := net.ListenPacket("udp", net.JoinHostPort(bindAddr, bindPort))
+	require.NoError(t, err)
+
+	_, port, err := net.SplitHostPort(packetConn.LocalAddr().String())
+	require.NoError(t, err)
+
+	server := &dns.Server{PacketConn: packetConn, Handler: handler}
+	go func() { _ = server.ActivateAndServe() }()
+	t.Cleanup(func() { _ = server.Shutdown() })
+
+	return port
+}
+
+// validateAgainst runs a validation against one local resolver.
+func validateAgainst(t *testing.T, name, port string) *DnssecValidation {
+	t.Helper()
+
+	client, err := New(name)
+	require.NoError(t, err)
+	client.config = &dns.ClientConfig{
+		Servers: []string{"127.0.0.1"},
+		Port:    port,
+		Timeout: 2,
+	}
+
+	res, err := client.ValidateDnssec("A", "SOA")
+	require.NoError(t, err)
+	return res
+}
+
+func TestValidateDnssecReportsUnknownWhenTheResolverStripsDnssec(t *testing.T) {
+	// The resolver answers without the DNSSEC OK bit and without signatures,
+	// which is indistinguishable from an unsigned zone. Concluding "the zone is
+	// not signed" from that reported correctly signed zones as unsigned.
+	port := dnssecResolver(t, "example.com", "127.0.0.1", "", false)
+
+	res := validateAgainst(t, "example.com", port)
+
+	assert.False(t, res.DnssecOk)
+	assert.Empty(t, res.Signatures)
+	assert.False(t, res.SignaturesVerified)
+	assert.False(t, res.ChainOfTrustValidated)
+	assert.Contains(t, res.Error, "did not return DNSSEC records")
+	assert.NotContains(t, res.Error, "the zone is not signed")
+
+	// The exchange itself is still described, so the reason stays readable.
+	assert.Equal(t, "NOERROR", res.ResponseCode)
+	assert.Equal(t, "A", res.RecordType)
+}
+
+func TestValidateDnssecReadsSignaturesWhenTheResolverHonorsDnssec(t *testing.T) {
+	// The same name through a resolver that does carry DNSSEC: the signature is
+	// seen, so the "not signed" conclusion is never reached.
+	port := dnssecResolver(t, "example.com", "127.0.0.1", "", true)
+
+	res := validateAgainst(t, "example.com", port)
+
+	assert.True(t, res.DnssecOk)
+	require.Len(t, res.Signatures, 1)
+	assert.Equal(t, "A", res.Signatures[0].TypeCovered)
+	assert.NotContains(t, res.Error, "did not return DNSSEC records")
+	assert.NotContains(t, res.Error, "the zone is not signed")
+}
+
+func TestValidateDnssecPrefersAResolverThatHonorsDnssec(t *testing.T) {
+	// resolv.conf commonly lists more than one resolver and they need not behave
+	// alike. Settling for Servers[0] means one EDNS0-stripping resolver decides
+	// the answer for every zone the host scans.
+	//
+	// Both resolvers listen on the same port, one on the IPv4 loopback and one on
+	// the IPv6 loopback, because dns.ClientConfig carries a single port for every
+	// server it lists.
+	if probe, err := net.ListenPacket("udp", "[::1]:0"); err != nil {
+		t.Skip("this host has no IPv6 loopback:", err)
+	} else {
+		_ = probe.Close()
+	}
+
+	port := dnssecResolver(t, "example.com", "127.0.0.1", "", false)
+	dnssecResolver(t, "example.com", "::1", port, true)
+
+	client, err := New("example.com")
+	require.NoError(t, err)
+	client.config = &dns.ClientConfig{
+		// The stripping resolver is listed first, so taking the first answer
+		// would report this zone as unsigned.
+		Servers: []string{"127.0.0.1", "::1"},
+		Port:    port,
+		Timeout: 2,
+	}
+
+	res, err := client.ValidateDnssec("A", "SOA")
+	require.NoError(t, err)
+
+	assert.True(t, res.DnssecOk, "should have moved past the resolver that strips DNSSEC")
+	assert.Len(t, res.Signatures, 1)
+	assert.NotContains(t, res.Error, "the zone is not signed")
+}

--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -900,10 +900,14 @@ private dns.rrsigRecord @defaults("typeCovered algorithm signerName") {
 // `dns(fqdn: "example.com").dnssecValidation`.
 //
 // Nothing here raises an error when validation does not succeed. An unsigned
-// zone, an unreachable resolver, and a genuinely broken chain of trust all
-// report their state in these fields with `error` explaining which one
-// happened, so a scan of a fleet that includes unsigned domains still
-// completes.
+// zone, an unreachable resolver, a resolver that does not return DNSSEC
+// records, and a genuinely broken chain of trust all report their state in
+// these fields with `error` explaining which one happened, so a scan of a
+// fleet that includes unsigned domains still completes.
+//
+// The last of those is not a statement about the zone: when `dnssecOk` is
+// false the resolver answered without signatures whatever the zone publishes,
+// so the verdict fields are null rather than false.
 dns.dnssecValidationResult @defaults("chainOfTrustValidated authenticatedData") {
   // Name that was queried
   name string
@@ -918,8 +922,11 @@ dns.dnssecValidationResult @defaults("chainOfTrustValidated authenticatedData") 
   // Whether the resolver returned DNSSEC records for a query that asked for them
   //
   // False when the path to the resolver strips EDNS0 or the resolver does not
-  // support DNSSEC, in which case none of the other fields can be trusted to
-  // say anything about the zone.
+  // support DNSSEC. Every resolver the host is configured with is tried before
+  // this reports false. When it does, the answer describes the resolver rather
+  // than the zone, so signed, signaturesVerified, signaturesCurrentlyValid and
+  // chainOfTrustValidated are all null instead of reporting a verdict, and
+  // error says which case this is.
   dnssecOk bool
   // Whether the resolver set the Authenticated Data flag on the response
   //
@@ -928,6 +935,10 @@ dns.dnssecValidationResult @defaults("chainOfTrustValidated authenticatedData") 
   // `chainOfTrustValidated` is computed here rather than taken on trust.
   authenticatedData bool
   // Whether the answer carried at least one RRSIG record
+  //
+  // Null when dnssecOk is false: a resolver that did not return DNSSEC records
+  // answers the same way for a signed zone and an unsigned one, so an unsigned
+  // answer is not evidence that the zone is unsigned.
   signed bool
   // Signatures covering the answer
   signatures []dns.rrsigRecord
@@ -935,7 +946,7 @@ dns.dnssecValidationResult @defaults("chainOfTrustValidated authenticatedData") 
   //
   // The cryptographic check of the answer itself, independent of anything the
   // resolver claims. False when no signature could be verified, including
-  // when the answer carried none.
+  // when the answer carried none. Null when dnssecOk is false.
   signaturesVerified bool
   // Whether the chain of trust validated from this answer up to the root
   //
@@ -943,7 +954,8 @@ dns.dnssecValidationResult @defaults("chainOfTrustValidated authenticatedData") 
   // set is checked against the DS record its parent publishes, up to the IANA
   // root trust anchor. False for an unsigned zone, an insecure delegation, a
   // DS that no longer matches a published key, and any zone the walk could not
-  // reach.
+  // reach. Null when dnssecOk is false, because the answer the walk would
+  // start from never carried a signature.
   chainOfTrustValidated bool
   // Zones the chain of trust walk traversed, from the signed answer up to the root
   chain []string
@@ -973,7 +985,7 @@ dns.dnssecValidationResult @defaults("chainOfTrustValidated authenticatedData") 
   //
   // False when any signature has expired or has not yet become valid, and
   // false when the answer carried no signatures at all, so it cannot pass
-  // vacuously on an unsigned zone.
+  // vacuously on an unsigned zone. Null when dnssecOk is false.
   signaturesCurrentlyValid bool
   // Why validation did not complete, empty when the chain of trust validated
   //


### PR DESCRIPTION
## What

`dnssecValidation` concluded *"the answer carried no RRSIG record, so the zone is not signed"* whenever the answer came back without signatures — including when its own `dnssecOk` flag was false. That flag's schema comment already says that in that case none of the other fields can be trusted to say anything about the zone, but nothing acted on it.

A resolver that does not honor the DNSSEC OK bit answers identically for a signed zone and an unsigned one. The verdict described the resolver and was reported as a property of the zone.

## Why it matters

`live.com` and `chatgpt.com` are both signed and return signatures through 8.8.8.8 and 1.1.1.1. Both were reported unsigned, and `chatgpt.com` drew the sharper *"the DNSKEY set for chatgpt.com. is not signed by any key it publishes"* — an accusation against the zone's operator for a break that was on the path to the resolver.

The resource also contradicted itself inside a single result:

```
dnssec.enabled            = true
dnssec.delegationSigned   = true
dnssec.dsDigestsMatchKeys = true
dnssecValidation.signed   = false     <- same zone, same run
```

Reproduced across resolvers:

```
                 172.16.1.1          8.8.8.8            1.1.1.1
live.com/A       rrsigs=0 DO=false   rrsigs=1 DO=true   rrsigs=1 AD=true
chatgpt.com/KEY  rrsigs=0 DO=false   rrsigs=1 DO=true   rrsigs=1 DO=true
```

## Changes

- **Try every configured resolver** until one honors the DNSSEC OK bit, rather than settling for `Servers[0]`. `resolv.conf` commonly lists more than one and they need not behave alike.
- **When none of them does, say so and stop.** `signed`, `signaturesVerified`, `signaturesCurrentlyValid` and `chainOfTrustValidated` become **null** rather than false, so a check cannot read "not signed" out of an answer that was never going to carry a signature. `dnssecOk`, `responseCode` and `authenticatedData` describe the exchange rather than the zone and stay populated, so the reason remains readable.
- **Apply the same check to the DNSKEY fetches** made by the chain walk and by signature verification. A resolver can honor the bit for one name and strip it for the next, and a stripped answer there is what produced the `chatgpt.com` accusation.

### One deliberate asymmetry

`chainOfTrustValidated` stays `false` rather than null when a walk cannot be followed, while `signed` goes null. `signed` was being used as evidence *against* a zone, so a definite false there is an active false claim. `chainOfTrustValidated` is asserted positively by policies (`chainOfTrustValidated == true`), so failing closed is the right direction, and the `error` field now names the resolver as the cause. Happy to flip it to null too if reviewers would rather the two behave the same.

## Schema

Doc-comment only — no fields added or removed, so `.lr.versions` is unchanged and codegen produces no diff.

## Test plan

- `dnssec_resolver_internal_test.go` stands up local resolvers that either honor or strip the DNSSEC OK bit: one asserting the verdicts come back unknown with the resolver named and *not* "the zone is not signed"; one asserting signatures are read when the resolver does carry DNSSEC; and one with a stripping resolver listed first and a honoring one second, asserting the loop moves past the first.
- `dns_dnssec_verdicts_internal_test.go` covers the three verdict states: honored and signed, honored and genuinely unsigned, and stripped (all null).
- `go test ./...` in `providers/network/` passes.
- Live: `live.com` reports the verdicts as null with the resolver named; `chatgpt.com` reports `signed=true` with the walk's failure attributed to the resolver; `office.com` validates end to end; `google.com` and `amazon.com` are still correctly reported as unsigned zones.

## Related

The load-sensitivity noted alongside this — `office.com` flipping between runs during a 25-host parallel sweep — is starvation of the resolver by the 81-type record fan-out, not addressed here. This change makes that visible as `dnssecOk=false` with an explanation instead of a silent wrong verdict.
