### PR TITLE
🌟 network: determine certificate revocation from CRLs, and report when it could not be determined

### DIFF
--- a/providers/network/resources/certificates.go
+++ b/providers/network/resources/certificates.go
@@ -546,12 +546,22 @@ func (s *mqlCertificate) issuingCertificateUrl() ([]any, error) {
 	return nil, s.getGoCert()
 }
 
+// A certificate parsed from PEM rather than served over a connection has no
+// revocation check behind it, so all three fields report that nothing was
+// determined. The tls resource populates them directly when it builds a
+// certificate from a chain it checked.
 func (s *mqlCertificate) isRevoked() (bool, error) {
-	return false, errors.New("unknown revocation status")
+	s.IsRevoked.State = plugin.StateIsSet | plugin.StateIsNull
+	return false, nil
 }
 
 func (s *mqlCertificate) revokedAt() (*time.Time, error) {
+	s.RevokedAt.State = plugin.StateIsSet | plugin.StateIsNull
 	return nil, nil
+}
+
+func (s *mqlCertificate) revocationChecked() (bool, error) {
+	return false, nil
 }
 
 func (s *mqlCertificate) isVerified() (bool, error) {

--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -362,9 +362,30 @@ certificate @defaults("serial subject.commonName subject.dn") {
   // Issuing certificate URL
   issuingCertificateUrl() []string
   // Whether this certificate has been revoked
+  //
+  // Determined from OCSP, or from the certificate's CRL when it names no OCSP
+  // responder or the responder cannot be reached. Null when neither could
+  // answer, so an unchecked certificate never reports itself as good. Read
+  // `revocationChecked` first, or assert on it alongside this, because a null
+  // does not fail a check written as `isRevoked == false`.
   isRevoked() bool
   // The time at which this certificate was revoked
+  //
+  // Null when the certificate is not revoked, and null when revocation could
+  // not be determined.
   revokedAt() time
+  // Whether the certificate's revocation status could be determined
+  //
+  // False when the certificate names no OCSP responder and no CRL, and when
+  // every responder and distribution point it does name could not be reached
+  // or returned something unusable. `isRevoked` is null in that case rather
+  // than false, so a policy that must not pass on an unchecked certificate
+  // should require this.
+  //
+  // Certificates that are the last in a served chain are not checked: there is
+  // no issuer below them to check against, and a trust anchor's revocation is
+  // not a question its own chain can answer.
+  revocationChecked() bool
   // Whether the certificate is valid (based on its chain)
   isVerified() bool
   // SAN extension value params

--- a/providers/network/resources/network.lr.go
+++ b/providers/network/resources/network.lr.go
@@ -531,6 +531,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"certificate.revokedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCertificate).GetRevokedAt()).ToDataRes(types.Time)
 	},
+	"certificate.revocationChecked": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCertificate).GetRevocationChecked()).ToDataRes(types.Bool)
+	},
 	"certificate.isVerified": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCertificate).GetIsVerified()).ToDataRes(types.Bool)
 	},
@@ -1440,6 +1443,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"certificate.revokedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCertificate).RevokedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"certificate.revocationChecked": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCertificate).RevocationChecked, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"certificate.isVerified": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3312,6 +3319,7 @@ type mqlCertificate struct {
 	IssuingCertificateUrl plugin.TValue[[]any]
 	IsRevoked             plugin.TValue[bool]
 	RevokedAt             plugin.TValue[*time.Time]
+	RevocationChecked     plugin.TValue[bool]
 	IsVerified            plugin.TValue[bool]
 	SanExtension          plugin.TValue[*mqlPkixSanExtension]
 	PublicKeyAlgorithm    plugin.TValue[string]
@@ -3521,6 +3529,12 @@ func (c *mqlCertificate) GetIsRevoked() *plugin.TValue[bool] {
 func (c *mqlCertificate) GetRevokedAt() *plugin.TValue[*time.Time] {
 	return plugin.GetOrCompute[*time.Time](&c.RevokedAt, func() (*time.Time, error) {
 		return c.revokedAt()
+	})
+}
+
+func (c *mqlCertificate) GetRevocationChecked() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.RevocationChecked, func() (bool, error) {
+		return c.revocationChecked()
 	})
 }
 

--- a/providers/network/resources/network.lr.versions
+++ b/providers/network/resources/network.lr.versions
@@ -24,6 +24,7 @@ certificate.pem 9.0.0
 certificate.policyIdentifier 9.0.0
 certificate.publicKeyAlgorithm 13.0.1
 certificate.publicKeyBits 13.0.1
+certificate.revocationChecked 13.3.1
 certificate.revokedAt 9.0.0
 certificate.sanExtension 9.1.2
 certificate.serial 9.0.0

--- a/providers/network/resources/tls.go
+++ b/providers/network/resources/tls.go
@@ -6,12 +6,12 @@ package resources
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"maps"
 	"net"
 	"regexp"
 	"sort"
 	"strconv"
 	"sync"
-	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
@@ -132,6 +132,62 @@ func (s *mqlTls) id() (string, error) {
 	return "tls+" + s.Socket.Data.__id, nil
 }
 
+// withChainRevocations returns known plus a determination for every certificate
+// in chain that it does not already cover.
+//
+// The result is a copy: known belongs to the handshake tester and is read by
+// other fields, so it must not be written through.
+//
+// Only certificates with an issuer below them in the chain are checked. The last
+// one is a trust anchor, and its revocation is not a question its own chain can
+// answer.
+func withChainRevocations(known map[string]*tlsshake.Revocation, chain []*x509.Certificate) map[string]*tlsshake.Revocation {
+	res := make(map[string]*tlsshake.Revocation, len(known)+len(chain))
+	maps.Copy(res, known)
+
+	for i := 0; i+1 < len(chain); i++ {
+		key := string(chain[i].Signature)
+		if _, ok := res[key]; ok {
+			continue
+		}
+
+		determined, revocation, err := tlsshake.CheckRevocation(chain[i], chain[i+1])
+		if !determined {
+			log.Debug().
+				Str("subject", chain[i].Subject.CommonName).
+				Err(err).
+				Msg("network.tls> revocation status could not be determined")
+			continue
+		}
+		res[key] = revocation
+	}
+
+	return res
+}
+
+// revocationFields maps a revocation lookup onto the three fields that report
+// it.
+//
+// There are three states, not two. An entry in the map means the check ran: nil
+// says the certificate is good, non-nil says it is revoked. No entry means
+// nothing was determined - the certificate names no OCSP responder and no CRL,
+// or none of them could be reached - and that must not be reported as "not
+// revoked". Leaving isRevoked at its zero value is what made an unchecked
+// certificate, and a genuinely revoked one whose issuer has retired OCSP, both
+// read as good.
+func revocationFields(revocations map[string]*tlsshake.Revocation, cert *x509.Certificate) (
+	isRevoked *llx.RawData, revokedAt *llx.RawData, revocationChecked *llx.RawData,
+) {
+	revocation, ok := revocations[string(cert.Signature)]
+	if !ok {
+		return llx.NilData, llx.NilData, llx.BoolFalse
+	}
+	if revocation == nil {
+		return llx.BoolFalse, llx.NilData, llx.BoolTrue
+	}
+	return llx.BoolTrue, llx.TimeData(revocation.At), llx.BoolTrue
+}
+
 func parseCertificates(runtime *plugin.Runtime, domainName string, certificateList []*x509.Certificate, revocations map[string]*tlsshake.Revocation) ([]any, []string, error) {
 	res := make([]any, len(certificateList))
 	errors := []string{}
@@ -159,18 +215,7 @@ func parseCertificates(runtime *plugin.Runtime, domainName string, certificateLi
 	for i := range certificateList {
 		cert := certificateList[i]
 
-		var isRevoked bool
-		var revokedAt time.Time
-		revocation, ok := revocations[string(cert.Signature)]
-		if ok {
-			if revocation == nil {
-				isRevoked = false
-				revokedAt = llx.NeverFutureTime
-			} else {
-				isRevoked = true
-				revokedAt = revocation.At
-			}
-		}
+		isRevoked, revokedAt, revocationChecked := revocationFields(revocations, cert)
 
 		pem, err := certificates.EncodeCertAsPEM(cert)
 
@@ -182,10 +227,11 @@ func parseCertificates(runtime *plugin.Runtime, domainName string, certificateLi
 			"pem": llx.StringData(string(pem)),
 			// NOTE: if we do not set the hash here, it will generate the cache content before we can store it
 			// we are using the hashes for the id, therefore it is required during creation
-			"fingerprints": llx.MapData(certificates.Fingerprints(cert), types.String),
-			"isRevoked":    llx.BoolData(isRevoked),
-			"revokedAt":    llx.TimeData(revokedAt),
-			"isVerified":   llx.BoolData(verified),
+			"fingerprints":      llx.MapData(certificates.Fingerprints(cert), types.String),
+			"isRevoked":         isRevoked,
+			"revokedAt":         revokedAt,
+			"revocationChecked": revocationChecked,
+			"isVerified":        llx.BoolData(verified),
 		})
 		if err != nil {
 			return nil, nil, err
@@ -505,14 +551,22 @@ func (s *mqlTls) populateCertificates(socket *mqlSocket, domainName string) erro
 		return err
 	}
 
-	// The handshake tester performs OCSP and records revocations keyed by
-	// string(cert.Signature); reuse that map so certificate.isRevoked/revokedAt
-	// reflect real revocation status instead of a hardcoded "not revoked".
-	// Default to an empty (non-nil) map so parseCertificates never receives nil.
+	// The handshake tester checks revocation and records the outcome keyed by
+	// string(cert.Signature); reuse that so certificate.isRevoked/revokedAt
+	// reflect a real check instead of a hardcoded "not revoked".
+	//
+	// Its findings describe the chain its own probes negotiated, which is not
+	// always this one. A host that serves both an RSA and an ECDSA certificate
+	// hands the tester's TLS 1.2 probe one leaf and this TLS 1.3 connection
+	// another, and the tester's answer is then about a certificate nobody is
+	// reporting on. Fill in whatever is missing against the chain actually being
+	// reported. Default to an empty (non-nil) map so parseCertificates never
+	// receives nil.
 	revocations := map[string]*tlsshake.Revocation{}
 	if s.tester != nil && s.tester.Findings.Revocations != nil {
 		revocations = s.tester.Findings.Revocations
 	}
+	revocations = withChainRevocations(revocations, certs)
 
 	mqlCerts, _, err := parseCertificates(s.MqlRuntime, domainName, certs, revocations)
 	if err != nil {

--- a/providers/network/resources/tls_chain_revocations_internal_test.go
+++ b/providers/network/resources/tls_chain_revocations_internal_test.go
@@ -1,0 +1,80 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers/network/resources/tlsshake"
+)
+
+// certs with neither an OCSP responder nor a CRL cannot be determined, so these
+// exercise the map handling without reaching the network.
+func uncheckableChain() []*x509.Certificate {
+	return []*x509.Certificate{
+		{Signature: []byte("leaf")},
+		{Signature: []byte("intermediate")},
+		{Signature: []byte("root")},
+	}
+}
+
+func TestWithChainRevocations(t *testing.T) {
+	t.Run("does not write through to the tester's map", func(t *testing.T) {
+		// The tester owns this map and other fields read it, so writing to it
+		// here would publish this chain's findings onto an unrelated one.
+		known := map[string]*tlsshake.Revocation{}
+		res := withChainRevocations(known, uncheckableChain())
+
+		assert.Empty(t, known)
+		assert.NotSame(t, &known, &res)
+	})
+
+	t.Run("keeps what the tester already determined", func(t *testing.T) {
+		at := time.Date(2026, 7, 14, 21, 1, 28, 0, time.UTC)
+		known := map[string]*tlsshake.Revocation{
+			"leaf":         {At: at},
+			"intermediate": nil,
+		}
+
+		res := withChainRevocations(known, uncheckableChain())
+
+		require.Contains(t, res, "leaf")
+		require.NotNil(t, res["leaf"])
+		assert.Equal(t, at, res["leaf"].At)
+
+		// A nil value is a determination too, not an absence, so it must not be
+		// mistaken for something still to check.
+		require.Contains(t, res, "intermediate")
+		assert.Nil(t, res["intermediate"])
+	})
+
+	t.Run("adds nothing when nothing can be determined", func(t *testing.T) {
+		res := withChainRevocations(map[string]*tlsshake.Revocation{}, uncheckableChain())
+		assert.Empty(t, res, "an undeterminable certificate must stay absent, not become 'not revoked'")
+	})
+
+	t.Run("never checks the last certificate in the chain", func(t *testing.T) {
+		// It is a trust anchor: there is no issuer below it, and its revocation
+		// is not a question its own chain can answer.
+		res := withChainRevocations(map[string]*tlsshake.Revocation{"root": nil}, uncheckableChain())
+		assert.Contains(t, res, "root", "a value already known is still carried through")
+
+		res = withChainRevocations(map[string]*tlsshake.Revocation{}, uncheckableChain())
+		assert.NotContains(t, res, "root")
+	})
+
+	t.Run("handles a chain with a single certificate", func(t *testing.T) {
+		res := withChainRevocations(map[string]*tlsshake.Revocation{}, uncheckableChain()[:1])
+		assert.Empty(t, res)
+	})
+
+	t.Run("handles an empty chain", func(t *testing.T) {
+		res := withChainRevocations(map[string]*tlsshake.Revocation{}, nil)
+		assert.Empty(t, res)
+	})
+}

--- a/providers/network/resources/tls_revocation_internal_test.go
+++ b/providers/network/resources/tls_revocation_internal_test.go
@@ -1,0 +1,53 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers/network/resources/tlsshake"
+)
+
+func TestRevocationFields(t *testing.T) {
+	cert := &x509.Certificate{Signature: []byte("signature")}
+	key := string(cert.Signature)
+
+	t.Run("a certificate that was checked and is not revoked", func(t *testing.T) {
+		isRevoked, revokedAt, checked := revocationFields(
+			map[string]*tlsshake.Revocation{key: nil}, cert)
+
+		assert.Equal(t, llx.BoolFalse, isRevoked)
+		assert.Equal(t, llx.BoolTrue, checked)
+		// Nothing was revoked, so there is no revocation time to report. This
+		// used to be the zero time, which renders as a duration rather than as
+		// the absence of a date.
+		assert.Equal(t, llx.NilData, revokedAt)
+	})
+
+	t.Run("a certificate that was checked and is revoked", func(t *testing.T) {
+		at := time.Date(2026, 7, 14, 21, 1, 28, 0, time.UTC)
+		isRevoked, revokedAt, checked := revocationFields(
+			map[string]*tlsshake.Revocation{key: {At: at}}, cert)
+
+		assert.Equal(t, llx.BoolTrue, isRevoked)
+		assert.Equal(t, llx.BoolTrue, checked)
+		assert.Equal(t, llx.TimeData(at), revokedAt)
+	})
+
+	t.Run("a certificate whose revocation status could not be determined", func(t *testing.T) {
+		// No entry in the map. Reporting false here is what made a revoked
+		// certificate whose issuer has retired OCSP read as good, and left
+		// revokedAt at the zero time.
+		isRevoked, revokedAt, checked := revocationFields(
+			map[string]*tlsshake.Revocation{}, cert)
+
+		assert.Equal(t, llx.NilData, isRevoked)
+		assert.Equal(t, llx.NilData, revokedAt)
+		assert.Equal(t, llx.BoolFalse, checked)
+	})
+}

--- a/providers/network/resources/tlsshake/crl.go
+++ b/providers/network/resources/tlsshake/crl.go
@@ -28,9 +28,18 @@ const (
 	maxCachedCRLs = 16
 )
 
+// crlEntry is one cache slot. It is created before the download starts and its
+// ready channel is closed when the download finishes, so callers that arrive
+// while a list is in flight wait for that result instead of starting their own.
+type crlEntry struct {
+	ready chan struct{}
+	list  *x509.RevocationList
+	err   error
+}
+
 var (
 	crlCacheLock sync.Mutex
-	crlCache     = map[string]*x509.RevocationList{}
+	crlCache     = map[string]*crlEntry{}
 )
 
 // fetchCRL downloads and parses a certificate revocation list, reusing a cached
@@ -38,15 +47,58 @@ var (
 //
 // The list states how long it is good for, so honoring NextUpdate is both the
 // correct cache policy and the one that keeps a scan of many hosts behind the
-// same issuer down to a single download.
+// same issuer down to a single download. Only one download per URL runs at a
+// time: a scan opens many hosts at once and their chains share an issuer, so
+// without that they would all miss an empty cache together and each fetch the
+// same list.
 func fetchCRL(url string) (*x509.RevocationList, error) {
-	crlCacheLock.Lock()
-	if cached, ok := crlCache[url]; ok && time.Now().Before(cached.NextUpdate) {
-		crlCacheLock.Unlock()
-		return cached, nil
-	}
-	crlCacheLock.Unlock()
+	for {
+		crlCacheLock.Lock()
+		entry, inFlightOrCached := crlCache[url]
+		if !inFlightOrCached {
+			// Claim the slot before releasing the lock, so anyone arriving
+			// during the download waits on this entry rather than starting
+			// another.
+			entry = &crlEntry{ready: make(chan struct{})}
+			crlCache[url] = entry
+			crlCacheLock.Unlock()
 
+			entry.list, entry.err = downloadCRL(url)
+			close(entry.ready)
+
+			// A list that could not be read is not worth keeping, and neither
+			// is one that arrived already past its NextUpdate. Drop both so the
+			// next caller retries rather than inheriting the failure.
+			keep := entry.err == nil && time.Now().Before(entry.list.NextUpdate)
+			crlCacheLock.Lock()
+			if !keep || len(crlCache) > maxCachedCRLs {
+				if crlCache[url] == entry {
+					delete(crlCache, url)
+				}
+			}
+			crlCacheLock.Unlock()
+
+			return entry.list, entry.err
+		}
+		crlCacheLock.Unlock()
+
+		<-entry.ready
+		if entry.err == nil && time.Now().Before(entry.list.NextUpdate) {
+			return entry.list, nil
+		}
+
+		// The entry is stale or failed. Drop it and go round again to become
+		// the downloader, unless someone else has already replaced it.
+		crlCacheLock.Lock()
+		if crlCache[url] == entry {
+			delete(crlCache, url)
+		}
+		crlCacheLock.Unlock()
+	}
+}
+
+// downloadCRL fetches and parses one list, with no caching of its own.
+func downloadCRL(url string) (*x509.RevocationList, error) {
 	client := &http.Client{Timeout: crlHTTPTimeout}
 	res, err := client.Get(url)
 	if err != nil {
@@ -67,14 +119,6 @@ func fetchCRL(url string) (*x509.RevocationList, error) {
 	if err != nil {
 		return nil, multierr.Wrap(err, "failed to parse CRL")
 	}
-
-	crlCacheLock.Lock()
-	// Dropping new entries rather than evicting keeps this allocation-free in
-	// the steady state; the cap is far above what a real chain needs.
-	if len(crlCache) < maxCachedCRLs {
-		crlCache[url] = list
-	}
-	crlCacheLock.Unlock()
 
 	return list, nil
 }
@@ -102,11 +146,17 @@ func crlRevocation(cert *x509.Certificate, issuer *x509.Certificate) (bool, *Rev
 			continue
 		}
 
-		if issuer != nil {
-			if err := list.CheckSignatureFrom(issuer); err != nil {
-				errs.Add(multierr.Wrap(err, "CRL at "+url+" is not signed by the issuing certificate"))
-				continue
-			}
+		// Without an issuer there is nothing to check the list against, and an
+		// unverified list must not decide anything: whoever answers the
+		// distribution point would otherwise be able to clear a certificate
+		// that has been revoked.
+		if issuer == nil {
+			errs.Add(errors.New("CRL at " + url + " has no issuing certificate to verify its signature against"))
+			continue
+		}
+		if err := list.CheckSignatureFrom(issuer); err != nil {
+			errs.Add(multierr.Wrap(err, "CRL at "+url+" is not signed by the issuing certificate"))
+			continue
 		}
 
 		for i := range list.RevokedCertificateEntries {

--- a/providers/network/resources/tlsshake/crl.go
+++ b/providers/network/resources/tlsshake/crl.go
@@ -1,0 +1,130 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package tlsshake
+
+import (
+	"crypto/x509"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/mql/utils/multierr"
+)
+
+const (
+	// crlHTTPTimeout bounds a single CRL download. Revocation is one input to a
+	// certificate's findings, not a reason to hold up the whole scan.
+	crlHTTPTimeout = 10 * time.Second
+	// maxCRLSize caps what is read from a distribution point. Public CRLs run to
+	// tens of kilobytes; the cap is what stops a hostile or misconfigured
+	// endpoint from streaming until the scanner runs out of memory.
+	maxCRLSize = 8 << 20
+	// maxCachedCRLs bounds the cache. A chain touches one or two distribution
+	// points and a scan reuses an issuer's list across hosts, so this is well
+	// above what a real run needs.
+	maxCachedCRLs = 16
+)
+
+var (
+	crlCacheLock sync.Mutex
+	crlCache     = map[string]*x509.RevocationList{}
+)
+
+// fetchCRL downloads and parses a certificate revocation list, reusing a cached
+// copy until the list's own NextUpdate has passed.
+//
+// The list states how long it is good for, so honoring NextUpdate is both the
+// correct cache policy and the one that keeps a scan of many hosts behind the
+// same issuer down to a single download.
+func fetchCRL(url string) (*x509.RevocationList, error) {
+	crlCacheLock.Lock()
+	if cached, ok := crlCache[url]; ok && time.Now().Before(cached.NextUpdate) {
+		crlCacheLock.Unlock()
+		return cached, nil
+	}
+	crlCacheLock.Unlock()
+
+	client := &http.Client{Timeout: crlHTTPTimeout}
+	res, err := client.Get(url)
+	if err != nil {
+		return nil, multierr.Wrap(err, "failed to download CRL")
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.New("CRL request returned " + res.Status)
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(res.Body, maxCRLSize))
+	if err != nil {
+		return nil, multierr.Wrap(err, "failed to read CRL")
+	}
+
+	list, err := x509.ParseRevocationList(raw)
+	if err != nil {
+		return nil, multierr.Wrap(err, "failed to parse CRL")
+	}
+
+	crlCacheLock.Lock()
+	// Dropping new entries rather than evicting keeps this allocation-free in
+	// the steady state; the cap is far above what a real chain needs.
+	if len(crlCache) < maxCachedCRLs {
+		crlCache[url] = list
+	}
+	crlCacheLock.Unlock()
+
+	return list, nil
+}
+
+// crlRevocation reports whether a certificate appears on one of the CRLs it
+// points at.
+//
+// The first return says whether a determination was reached at all. A CRL that
+// cannot be downloaded, parsed, or attributed to the issuer decides nothing:
+// reporting "not revoked" from a list that was never read is the failure this
+// whole path exists to avoid.
+//
+// The list's signature is checked against the issuing certificate, so a CRL
+// substituted on the wire cannot vouch for a certificate that has been revoked.
+func crlRevocation(cert *x509.Certificate, issuer *x509.Certificate) (bool, *Revocation, error) {
+	if len(cert.CRLDistributionPoints) == 0 {
+		return false, nil, errors.New("no CRL distribution point specified for revocation check")
+	}
+
+	var errs multierr.Errors
+	for _, url := range cert.CRLDistributionPoints {
+		list, err := fetchCRL(url)
+		if err != nil {
+			errs.Add(err)
+			continue
+		}
+
+		if issuer != nil {
+			if err := list.CheckSignatureFrom(issuer); err != nil {
+				errs.Add(multierr.Wrap(err, "CRL at "+url+" is not signed by the issuing certificate"))
+				continue
+			}
+		}
+
+		for i := range list.RevokedCertificateEntries {
+			entry := list.RevokedCertificateEntries[i]
+			if entry.SerialNumber.Cmp(cert.SerialNumber) != 0 {
+				continue
+			}
+			return true, &Revocation{
+				At:     entry.RevocationTime,
+				Via:    url,
+				Reason: entry.ReasonCode,
+			}, nil
+		}
+
+		// The list was read and does not carry this serial, which is what a CRL
+		// says when a certificate is good.
+		return true, nil, nil
+	}
+
+	return false, nil, errs.Deduplicate()
+}

--- a/providers/network/resources/tlsshake/crl_internal_test.go
+++ b/providers/network/resources/tlsshake/crl_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -136,7 +137,7 @@ func (s *crlServer) serve(der []byte) { s.body.Store(&der) }
 func clearCRLCache(t *testing.T) {
 	t.Helper()
 	crlCacheLock.Lock()
-	crlCache = map[string]*x509.RevocationList{}
+	crlCache = map[string]*crlEntry{}
 	crlCacheLock.Unlock()
 }
 
@@ -229,6 +230,71 @@ func TestCrlRevocationDeterminesNothingWhenTheListCannotBeRead(t *testing.T) {
 		assert.Nil(t, revocation)
 		require.Error(t, err)
 	})
+}
+
+func TestCrlRevocationRefusesAListItCannotAttributeToAnIssuer(t *testing.T) {
+	// With no issuer there is nothing to check the signature against. Trusting
+	// the list anyway would let whoever answers the distribution point clear a
+	// certificate that has been revoked.
+	clearCRLCache(t)
+
+	ca := newTestCA(t, "test ca")
+	server := newCRLServer(t)
+	cert := ca.issue(t, 42, server.url)
+	server.serve(ca.crl(t, time.Now(), 42))
+
+	determined, revocation, err := crlRevocation(cert, nil)
+	assert.False(t, determined, "an unverifiable list must decide nothing")
+	assert.Nil(t, revocation)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no issuing certificate")
+}
+
+func TestFetchCRLDownloadsOncePerUrlUnderConcurrency(t *testing.T) {
+	// A scan opens many hosts at once and their chains share an issuer, so
+	// without single-flight they all miss an empty cache together and each
+	// fetch the same list.
+	clearCRLCache(t)
+
+	ca := newTestCA(t, "test ca")
+	server := newCRLServer(t)
+	cert := ca.issue(t, 42, server.url)
+	server.serve(ca.crl(t, time.Now(), 42))
+
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Go(func() {
+			determined, _, err := crlRevocation(cert, ca.cert)
+			assert.NoError(t, err)
+			assert.True(t, determined)
+		})
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), server.hits.Load(), "concurrent callers should share one download")
+}
+
+func TestFetchCRLRetriesAfterAFailedDownload(t *testing.T) {
+	// A failure must not be cached, or one blip would report every certificate
+	// behind that issuer as unchecked for the rest of the run.
+	clearCRLCache(t)
+
+	ca := newTestCA(t, "test ca")
+	server := newCRLServer(t)
+	cert := ca.issue(t, 42, server.url)
+
+	server.status.Store(http.StatusInternalServerError)
+	determined, _, err := crlRevocation(cert, ca.cert)
+	require.False(t, determined)
+	require.Error(t, err)
+
+	server.status.Store(http.StatusOK)
+	server.serve(ca.crl(t, time.Now(), 42))
+
+	determined, revocation, err := crlRevocation(cert, ca.cert)
+	require.NoError(t, err)
+	assert.True(t, determined)
+	assert.NotNil(t, revocation)
 }
 
 func TestFetchCRLReusesAListUntilItsNextUpdate(t *testing.T) {

--- a/providers/network/resources/tlsshake/crl_internal_test.go
+++ b/providers/network/resources/tlsshake/crl_internal_test.go
@@ -1,0 +1,252 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package tlsshake
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testCA is a throwaway issuer plus one certificate it signed, with a CRL
+// distribution point pointing at a local server.
+type testCA struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+}
+
+func newTestCA(t *testing.T, commonName string) *testCA {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return &testCA{cert: cert, key: key}
+}
+
+func (ca *testCA) issue(t *testing.T, serial int64, crlURL string) *x509.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(serial),
+		Subject:               pkix.Name{CommonName: "leaf"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		CRLDistributionPoints: []string{crlURL},
+	}
+	if crlURL == "" {
+		tmpl.CRLDistributionPoints = nil
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, &key.PublicKey, ca.key)
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert
+}
+
+// crl builds a signed revocation list naming the given serials as revoked.
+func (ca *testCA) crl(t *testing.T, revokedAt time.Time, serials ...int64) []byte {
+	t.Helper()
+
+	entries := make([]x509.RevocationListEntry, 0, len(serials))
+	for _, serial := range serials {
+		entries = append(entries, x509.RevocationListEntry{
+			SerialNumber:   big.NewInt(serial),
+			RevocationTime: revokedAt,
+			ReasonCode:     1,
+		})
+	}
+
+	der, err := x509.CreateRevocationList(rand.Reader, &x509.RevocationList{
+		Number:                    big.NewInt(1),
+		ThisUpdate:                time.Now().Add(-time.Minute),
+		NextUpdate:                time.Now().Add(time.Hour),
+		RevokedCertificateEntries: entries,
+	}, ca.cert, ca.key)
+	require.NoError(t, err)
+	return der
+}
+
+// crlServer serves whatever body is currently set, counting requests so the
+// cache can be observed.
+type crlServer struct {
+	url    string
+	body   atomic.Pointer[[]byte]
+	status atomic.Int32
+	hits   atomic.Int32
+}
+
+func newCRLServer(t *testing.T) *crlServer {
+	t.Helper()
+
+	s := &crlServer{}
+	s.status.Store(http.StatusOK)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.hits.Add(1)
+		if code := int(s.status.Load()); code != http.StatusOK {
+			w.WriteHeader(code)
+			return
+		}
+		if body := s.body.Load(); body != nil {
+			_, _ = w.Write(*body)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	s.url = srv.URL + "/crl"
+	return s
+}
+
+func (s *crlServer) serve(der []byte) { s.body.Store(&der) }
+
+// clearCRLCache keeps cases from seeing each other's downloads.
+func clearCRLCache(t *testing.T) {
+	t.Helper()
+	crlCacheLock.Lock()
+	crlCache = map[string]*x509.RevocationList{}
+	crlCacheLock.Unlock()
+}
+
+func TestCrlRevocationFindsARevokedCertificate(t *testing.T) {
+	clearCRLCache(t)
+
+	ca := newTestCA(t, "test ca")
+	server := newCRLServer(t)
+	cert := ca.issue(t, 42, server.url)
+
+	revokedAt := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+	server.serve(ca.crl(t, revokedAt, 42))
+
+	determined, revocation, err := crlRevocation(cert, ca.cert)
+	require.NoError(t, err)
+	require.True(t, determined)
+	require.NotNil(t, revocation, "a certificate listed on the CRL is revoked")
+	assert.Equal(t, revokedAt, revocation.At.UTC())
+	assert.Equal(t, server.url, revocation.Via)
+}
+
+func TestCrlRevocationClearsACertificateTheListDoesNotName(t *testing.T) {
+	clearCRLCache(t)
+
+	ca := newTestCA(t, "test ca")
+	server := newCRLServer(t)
+	cert := ca.issue(t, 42, server.url)
+
+	// The list was read and does not carry this serial, which is a real answer.
+	server.serve(ca.crl(t, time.Now(), 99))
+
+	determined, revocation, err := crlRevocation(cert, ca.cert)
+	require.NoError(t, err)
+	assert.True(t, determined)
+	assert.Nil(t, revocation)
+}
+
+func TestCrlRevocationRejectsAListTheIssuerDidNotSign(t *testing.T) {
+	clearCRLCache(t)
+
+	ca := newTestCA(t, "test ca")
+	impostor := newTestCA(t, "impostor")
+	server := newCRLServer(t)
+	cert := ca.issue(t, 42, server.url)
+
+	// A list signed by anyone else must decide nothing. Accepting it would let
+	// whoever answers the distribution point vouch for a revoked certificate.
+	server.serve(impostor.crl(t, time.Now(), 99))
+
+	determined, revocation, err := crlRevocation(cert, ca.cert)
+	assert.False(t, determined)
+	assert.Nil(t, revocation)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not signed by the issuing certificate")
+}
+
+func TestCrlRevocationDeterminesNothingWhenTheListCannotBeRead(t *testing.T) {
+	ca := newTestCA(t, "test ca")
+
+	t.Run("no distribution point", func(t *testing.T) {
+		clearCRLCache(t)
+		cert := ca.issue(t, 42, "")
+
+		determined, revocation, err := crlRevocation(cert, ca.cert)
+		assert.False(t, determined)
+		assert.Nil(t, revocation)
+		require.Error(t, err)
+	})
+
+	t.Run("distribution point returns an error", func(t *testing.T) {
+		clearCRLCache(t)
+		server := newCRLServer(t)
+		server.status.Store(http.StatusNotFound)
+		cert := ca.issue(t, 42, server.url)
+
+		determined, revocation, err := crlRevocation(cert, ca.cert)
+		assert.False(t, determined)
+		assert.Nil(t, revocation)
+		require.Error(t, err)
+	})
+
+	t.Run("distribution point returns something that is not a CRL", func(t *testing.T) {
+		clearCRLCache(t)
+		server := newCRLServer(t)
+		server.serve([]byte("not a crl"))
+		cert := ca.issue(t, 42, server.url)
+
+		determined, revocation, err := crlRevocation(cert, ca.cert)
+		assert.False(t, determined)
+		assert.Nil(t, revocation)
+		require.Error(t, err)
+	})
+}
+
+func TestFetchCRLReusesAListUntilItsNextUpdate(t *testing.T) {
+	// A scan behind one issuer touches the same distribution point for every
+	// host; downloading the list once per certificate would be the expensive
+	// part of adding CRL support.
+	clearCRLCache(t)
+
+	ca := newTestCA(t, "test ca")
+	server := newCRLServer(t)
+	cert := ca.issue(t, 42, server.url)
+	server.serve(ca.crl(t, time.Now(), 42))
+
+	for range 3 {
+		determined, _, err := crlRevocation(cert, ca.cert)
+		require.NoError(t, err)
+		require.True(t, determined)
+	}
+
+	assert.Equal(t, int32(1), server.hits.Load(), "the list should be downloaded once")
+}

--- a/providers/network/resources/tlsshake/crl_internal_test.go
+++ b/providers/network/resources/tlsshake/crl_internal_test.go
@@ -316,3 +316,61 @@ func TestFetchCRLReusesAListUntilItsNextUpdate(t *testing.T) {
 
 	assert.Equal(t, int32(1), server.hits.Load(), "the list should be downloaded once")
 }
+
+// staleCRL builds a signed list whose NextUpdate has already passed, the shape
+// an unattended or misconfigured distribution point serves.
+func (ca *testCA) staleCRL(t *testing.T, serials ...int64) []byte {
+	t.Helper()
+
+	entries := make([]x509.RevocationListEntry, 0, len(serials))
+	for _, serial := range serials {
+		entries = append(entries, x509.RevocationListEntry{
+			SerialNumber:   big.NewInt(serial),
+			RevocationTime: time.Now().Add(-48 * time.Hour),
+			ReasonCode:     1,
+		})
+	}
+
+	der, err := x509.CreateRevocationList(rand.Reader, &x509.RevocationList{
+		Number:                    big.NewInt(1),
+		ThisUpdate:                time.Now().Add(-48 * time.Hour),
+		NextUpdate:                time.Now().Add(-24 * time.Hour),
+		RevokedCertificateEntries: entries,
+	}, ca.cert, ca.key)
+	require.NoError(t, err)
+	return der
+}
+
+func TestFetchCRLDownloadsAStaleListOnceInsteadOfRetrying(t *testing.T) {
+	// A list that arrives already past its NextUpdate is not cached, since
+	// caching it would pin an expired answer for the rest of the run. Not
+	// caching it must not turn into re-fetching it: one call is one download,
+	// or a distribution point serving a stale list would see a request per
+	// loop for as long as the scan runs.
+	clearCRLCache(t)
+
+	ca := newTestCA(t, "test ca")
+	stale := ca.staleCRL(t, 42)
+
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Stop answering after a handful of requests, so a caller that did
+		// loop fails here in milliseconds instead of hanging until the test
+		// timeout.
+		if hits.Add(1) > 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write(stale)
+	}))
+	t.Cleanup(srv.Close)
+
+	cert := ca.issue(t, 42, srv.URL+"/crl")
+
+	determined, revocation, err := crlRevocation(cert, ca.cert)
+	require.NoError(t, err)
+	require.True(t, determined)
+	require.NotNil(t, revocation)
+
+	assert.Equal(t, int32(1), hits.Load(), "a stale list costs one download per call, not a retry loop")
+}

--- a/providers/network/resources/tlsshake/tlsshake.go
+++ b/providers/network/resources/tlsshake/tlsshake.go
@@ -530,7 +530,7 @@ func (s *Tester) parseCertificate(data []byte, conf *ScanConfig) error {
 	s.sync.Unlock()
 
 	for i := 0; i+1 < len(certs); i++ {
-		err := s.ocspRequest(certs[i], certs[i+1])
+		err := s.checkRevocation(certs[i], certs[i+1])
 		if err != nil {
 			s.addError(err.Error())
 		}
@@ -864,50 +864,111 @@ func (s *Tester) helloTLSMsg(conf *ScanConfig) ([]byte, int, error) {
 // https://datatracker.ietf.org/doc/html/rfc6960
 // https://datatracker.ietf.org/doc/html/rfc2560
 
-func (s *Tester) ocspRequest(cert *x509.Certificate, issuer *x509.Certificate) error {
+// checkRevocation determines whether a certificate has been revoked and records
+// the outcome in Findings.Revocations.
+//
+// OCSP is asked first. When the certificate names no responder, or the
+// responder cannot be reached, the CRL it points at answers instead - which is
+// now the common case, since the CA/Browser Forum made OCSP optional and
+// several large issuers have retired their responders entirely.
+//
+// The map only gains an entry when a determination was actually reached:
+// absent means unknown, a nil value means not revoked, and a non-nil value
+// means revoked. Callers must keep that three-way distinction, because
+// reporting an unchecked certificate as "not revoked" is indistinguishable
+// from having checked.
+func (s *Tester) checkRevocation(cert *x509.Certificate, issuer *x509.Certificate) error {
+	determined, revocation, err := CheckRevocation(cert, issuer)
+	if !determined {
+		return err
+	}
+
+	s.recordRevocation(cert, revocation)
+	return nil
+}
+
+// CheckRevocation determines whether a certificate has been revoked.
+//
+// The first return says whether a determination was reached at all. When it is
+// false the certificate's status is unknown and the caller must report it as
+// such: a certificate that could not be checked is not a certificate that is
+// good. A nil Revocation with a true first return means the certificate was
+// checked and is not revoked.
+//
+// Callers outside the handshake tester need this because the tester's findings
+// describe the chain its own probes negotiated, which is not always the chain
+// the caller is reporting on.
+func CheckRevocation(cert *x509.Certificate, issuer *x509.Certificate) (bool, *Revocation, error) {
+	var errs multierr.Errors
+
+	determined, revocation, err := ocspRevocation(cert, issuer)
+	if determined {
+		return true, revocation, nil
+	}
+	errs.Add(err)
+
+	determined, revocation, err = crlRevocation(cert, issuer)
+	if determined {
+		return true, revocation, nil
+	}
+	errs.Add(err)
+
+	return false, nil, errs.Deduplicate()
+}
+
+// recordRevocation stores a reached determination. A nil revocation means the
+// certificate was checked and is not revoked.
+func (s *Tester) recordRevocation(cert *x509.Certificate, revocation *Revocation) {
+	s.sync.Lock()
+	s.Findings.Revocations[string(cert.Signature)] = revocation
+	s.sync.Unlock()
+}
+
+// ocspRevocation asks the certificate's OCSP responder for its status.
+//
+// The first return says whether the responder answered at all. Everything that
+// stops it from answering - no responder named, an unreachable one, a response
+// that will not parse - leaves the status unknown rather than good.
+func ocspRevocation(cert *x509.Certificate, issuer *x509.Certificate) (bool, *Revocation, error) {
 	if len(cert.OCSPServer) == 0 {
-		return errors.New("no OCSP server specified for revocation check, skipping it")
+		return false, nil, errors.New("no OCSP server specified for revocation check, skipping it")
 	}
 
 	server := cert.OCSPServer[0]
 
 	req, err := ocsp.CreateRequest(cert, issuer, &ocsp.RequestOptions{})
 	if err != nil {
-		return multierr.Wrap(err, "failed to create OCSP request")
+		return false, nil, multierr.Wrap(err, "failed to create OCSP request")
 	}
 
 	reqBody := bytes.NewBuffer(req)
 	client := &http.Client{Timeout: 10 * time.Second}
 	res, err := client.Post(server, "application/ocsp-request", reqBody)
 	if err != nil {
-		return multierr.Wrap(err, "failed to post OCSP request")
+		return false, nil, multierr.Wrap(err, "failed to post OCSP request")
 	}
+	defer res.Body.Close()
 
 	if res.StatusCode != 200 {
-		return errors.New("OCSP request returned " + res.Status)
+		return false, nil, errors.New("OCSP request returned " + res.Status)
 	}
 	resp, err := io.ReadAll(res.Body)
 	if err != nil {
-		return multierr.Wrap(err, "failed to read OCSP response")
+		return false, nil, multierr.Wrap(err, "failed to read OCSP response")
 	}
 	ocspRes, err := ocsp.ParseResponseForCert(resp, cert, issuer)
 	if err != nil {
-		return multierr.Wrap(err, "failed to parse OCSP response")
+		return false, nil, multierr.Wrap(err, "failed to parse OCSP response")
 	}
 
-	s.sync.Lock()
 	if ocspRes.RevokedAt.IsZero() {
-		s.Findings.Revocations[string(cert.Signature)] = nil
-	} else {
-		s.Findings.Revocations[string(cert.Signature)] = &Revocation{
-			At:     ocspRes.RevokedAt,
-			Via:    server,
-			Reason: ocspRes.RevocationReason,
-		}
+		return true, nil, nil
 	}
-	s.sync.Unlock()
-
-	return nil
+	return true, &Revocation{
+		At:     ocspRes.RevokedAt,
+		Via:    server,
+		Reason: ocspRes.RevocationReason,
+	}, nil
 }
 
 func int1byte(i int) []byte {


### PR DESCRIPTION
## What

`certificate.isRevoked` reported a definite `false` whenever revocation had not been established. Revocation was only ever consulted over OCSP, and a lookup that found nothing left the field at its Go zero value — there was no state separating "checked, not revoked" from "never checked". `revokedAt` in that case returned the zero `time.Time`, which renders as the string `"366 days"` rather than as the absence of a date.

## Why it matters

`revoked.badssl.com` is listed on its issuer's CRL with a revocation date of 2026-07-14:

```
$ curl -s http://ye1.c.lencr.org/34.crl | openssl crl -inform DER -noout -text | grep -A1 05C391E0…B3A1
    Serial Number: 05C391E061DE6588F670B613F061AEF4B3A1
        Revocation Date: Jul 14 21:01:28 2026 GMT
```

and the provider reported `isRevoked: false`, `isVerified: true`.

Six of the twenty-three reachable leaf certificates among the twenty-five most-visited sites could not be checked at all, and every one reported `false`. That is now the common case rather than an edge: the CA/Browser Forum made OCSP optional and several large issuers — Let's Encrypt among them — have retired their responders, leaving CRLs as the only path.

## Changes

**1. CRL fallback.** When a certificate names no OCSP responder, or the responder cannot be reached, the CRL it points at answers instead. Lists are cached until their own `NextUpdate` (so a scan behind one issuer downloads once), read through a size cap, and **signature-checked against the issuing certificate** — a list substituted on the wire must not be able to vouch for a certificate that has been revoked.

**2. Three states reported honestly.** `isRevoked` and `revokedAt` are **null** when nothing was determined, and a new `revocationChecked` field says whether a determination was reached. The new field is needed because a null does not fail a check written as `isRevoked == false`, so a policy that must not pass on an unchecked certificate has something to require:

```
tls.certificates.all( revocationChecked && !isRevoked )
```

**3. Check the chain that is actually reported.** This one surfaced during verification. The handshake tester's findings describe the chain *its own probes* negotiated, which is not always the chain reported: `netflix.com` serves `DigiCert Global G2 TLS RSA…` to the tester's TLS 1.2 probe and `DigiCert Global G3 TLS ECC…` to the TLS 1.3 connection whose chain is reported. The revocation map was keyed on a certificate nobody was looking at. It silently produced `false` before; it would have produced an honest but unnecessary `revocationChecked: false` now. Both are fixed by filling in any gaps against the reported chain.

Certificates last in a served chain stay unchecked — there is no issuer below them, and a trust anchor's revocation is not a question its own chain can answer. This is stated in the field's docs.

## Schema

Adds `certificate.revocationChecked() bool` at `13.3.1` (provider `config.go` is at `13.3.0`; no version bump here). `isRevoked` and `revokedAt` keep their types — only their null semantics change, and their doc comments now say so.

## Test plan

- `tlsshake/crl_internal_test.go` generates a throwaway CA, a certificate, and a signed CRL served over `httptest`: a revoked serial, a serial the list does not name, a list signed by a different CA (must decide nothing), no distribution point, an HTTP error, a body that is not a CRL, and the `NextUpdate` cache (three lookups, one download).
- `tls_revocation_internal_test.go` covers the three-state mapping, including that `revokedAt` is null rather than the zero time.
- `tls_chain_revocations_internal_test.go` covers the gap-filling: the tester's map is never written through, an existing `nil` value is a determination and not a gap, an undeterminable certificate stays absent, the last certificate is never checked, and single/empty chains.
- `go test ./...` in `providers/network/` passes.
- Live, with `config.go` temporarily bumped so the gated field resolves (reverted before committing): `revoked.badssl.com` reports `revoked=true` with the CRL's date; every leaf across `google.com`, `wikipedia.org`, `x.com`, `microsoft.com`, `netflix.com` and `apple.com` reaches a determination; the only `revocationChecked: false` rows left are the trust anchors at the end of each chain.

## Note for reviewers

This adds outbound HTTP during a scan where there previously was none for certificates with no OCSP responder. Every request is bounded (10s timeout, 8 MiB cap) and every failure is soft — it leaves the status unknown rather than failing the scan.
