### PR TITLE
🐛 network: actually connect without SNI for nonSniCertificates

### DIFF
--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -232,6 +232,15 @@ tls @defaults("socket domainName") {
   // Certificates provided in this TLS/SSL connection
   certificates(socket, domainName) []certificate
   // Certificates provided without server name indication (SNI)
+  //
+  // The full chain the endpoint serves to a client that sends no SNI, which is
+  // what an attacker reaches by connecting to the address directly. On a host
+  // with several virtual hosts behind one address this is the default one, and
+  // it is often a certificate for an unrelated name, so comparing it against
+  // `certificates` shows what the address discloses on its own.
+  //
+  // Null when the endpoint requires SNI and would not complete a handshake
+  // without it, which is different from serving no certificate.
   nonSniCertificates(socket, domainName) []certificate
   // Whether the served leaf certificate covers the connection hostname
   //

--- a/providers/network/resources/tls.go
+++ b/providers/network/resources/tls.go
@@ -392,7 +392,7 @@ func dialTLSWithoutSNI(dialer *net.Dialer, proto, addr string) (*tls.Conn, error
 	// not verify is the finding rather than a reason to refuse the connection.
 	// Verifying at the transport would make the resource fail on exactly the
 	// endpoints it exists to describe.
-	conn := tls.Client(raw, &tls.Config{InsecureSkipVerify: true}) // #nosec G402
+	conn := tls.Client(raw, &tls.Config{InsecureSkipVerify: true})
 	if err := conn.Handshake(); err != nil {
 		conn.Close()
 		return nil, err

--- a/providers/network/resources/tls.go
+++ b/providers/network/resources/tls.go
@@ -367,8 +367,54 @@ func (s *mqlTls) extensions(params any) ([]any, error) {
 	return res, nil
 }
 
+// dialTLSWithoutSNI opens a TLS connection that sends no server_name extension.
+//
+// tls.DialWithDialer cannot do this: it clones the config and fills ServerName
+// in from the dial address whenever it is empty, so a config with no ServerName
+// still sends SNI for the host being dialed. Dialing the socket separately and
+// handing it to tls.Client is what actually leaves the extension off, which is
+// the whole point of the probe.
+func dialTLSWithoutSNI(dialer *net.Dialer, proto, addr string) (*tls.Conn, error) {
+	raw, err := dialer.Dial(proto, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := raw.SetDeadline(time.Now().Add(DefaultDialerTimeout)); err != nil {
+		raw.Close()
+		return nil, err
+	}
+
+	conn := tls.Client(raw, &tls.Config{InsecureSkipVerify: true})
+	if err := conn.Handshake(); err != nil {
+		raw.Close()
+		return nil, err
+	}
+
+	// The deadline covered the handshake; leaving it in place would expire the
+	// connection while the caller is still reading from it.
+	if err := raw.SetDeadline(time.Time{}); err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+// gatherTlsCertificates returns the chain the endpoint serves for domainName,
+// and the chain it serves to a client that sends no SNI at all.
+//
+// The second chain is reported in full rather than as the certificates that
+// differ from the first. A host that serves the same certificate either way
+// genuinely does serve it without SNI, and reporting nothing there says the
+// opposite. The interesting case - a default virtual host answering with an
+// unrelated certificate - reads the same way in both shapes.
+//
+// Only a failure of the first connection is an error. A server that requires
+// SNI closes the second one, and that is an answer about the endpoint rather
+// than a failure of the scan: the non-SNI chain comes back nil and the caller
+// reports it as unknown.
 func gatherTlsCertificates(proto, host, port, domainName string) ([]*x509.Certificate, []*x509.Certificate, error) {
-	isSNIcert := map[string]struct{}{}
 	dialer := &net.Dialer{Timeout: DefaultDialerTimeout}
 	addr := net.JoinHostPort(host, port)
 	log.Trace().
@@ -376,6 +422,7 @@ func gatherTlsCertificates(proto, host, port, domainName string) ([]*x509.Certif
 		Str("domain_name", domainName).
 		Dur("timeout", DefaultDialerTimeout).
 		Msg("network.tls> gathering tls certificates")
+
 	conn, err := tls.DialWithDialer(dialer, proto, addr, &tls.Config{
 		InsecureSkipVerify: true,
 		ServerName:         domainName,
@@ -385,28 +432,19 @@ func gatherTlsCertificates(proto, host, port, domainName string) ([]*x509.Certif
 	}
 	defer conn.Close()
 
-	// Get the ConnectionState where we can find x509.Certificate(s)
 	sniCerts := conn.ConnectionState().PeerCertificates
-	for _, sniCerts := range sniCerts {
-		isSNIcert[sniCerts.SerialNumber.String()] = struct{}{}
-	}
 
-	nonSniCerts := []*x509.Certificate{}
-	nonSniConn, err := tls.DialWithDialer(dialer, proto, addr, &tls.Config{
-		InsecureSkipVerify: true,
-	})
+	nonSniConn, err := dialTLSWithoutSNI(dialer, proto, addr)
 	if err != nil {
-		return nil, nil, err
+		log.Debug().
+			Str("address", addr).
+			Err(err).
+			Msg("network.tls> endpoint served no certificate without SNI")
+		return sniCerts, nil, nil
 	}
 	defer nonSniConn.Close()
-	potentialNonSniCerts := nonSniConn.ConnectionState()
-	for _, nonSniCert := range potentialNonSniCerts.PeerCertificates {
-		if _, ok := isSNIcert[nonSniCert.SerialNumber.String()]; !ok {
-			nonSniCerts = append(nonSniCerts, nonSniCert)
-		}
-	}
 
-	return sniCerts, nonSniCerts, nil
+	return sniCerts, nonSniConn.ConnectionState().PeerCertificates, nil
 }
 
 // we should only detect once if the socket is running on TLS or not, if we have already detected it and, it
@@ -521,6 +559,19 @@ func (s *mqlTls) populateCertificates(socket *mqlSocket, domainName string) erro
 		s.Certificates = plugin.TValue[[]any]{Data: mqlCerts, State: plugin.StateIsSet}
 	}
 
+	// A server that requires SNI closes the connection that omits it, so there
+	// is no chain to report. That is unknown rather than empty: an empty list
+	// would read as "this endpoint serves nothing without SNI", which is a
+	// different statement from "it would not talk to us at all".
+	if nonSniCerts == nil {
+		s.NonSniCertificates.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil
+	}
+
+	// The non-SNI chain is matched against the same domain name so that
+	// isVerified keeps its meaning: the question there is whether the
+	// certificate served without SNI would satisfy a client asking for this
+	// host, which is exactly what makes a default virtual host interesting.
 	mqlNonSniCerts, _, err := parseCertificates(s.MqlRuntime, domainName, nonSniCerts, revocations)
 	if err != nil {
 		s.NonSniCertificates = plugin.TValue[[]any]{Error: err, State: plugin.StateIsSet}

--- a/providers/network/resources/tls.go
+++ b/providers/network/resources/tls.go
@@ -385,9 +385,16 @@ func dialTLSWithoutSNI(dialer *net.Dialer, proto, addr string) (*tls.Conn, error
 		return nil, err
 	}
 
-	conn := tls.Client(raw, &tls.Config{InsecureSkipVerify: true})
+	// Certificate verification is deliberately off, and here it is not even
+	// well defined: with no server name there is nothing to verify the
+	// certificate against. This resource reports validity rather than requiring
+	// it, through isVerified and certificateMatchesDomain, so a chain that does
+	// not verify is the finding rather than a reason to refuse the connection.
+	// Verifying at the transport would make the resource fail on exactly the
+	// endpoints it exists to describe.
+	conn := tls.Client(raw, &tls.Config{InsecureSkipVerify: true}) // #nosec G402
 	if err := conn.Handshake(); err != nil {
-		raw.Close()
+		conn.Close()
 		return nil, err
 	}
 

--- a/providers/network/resources/tls_sni_internal_test.go
+++ b/providers/network/resources/tls_sni_internal_test.go
@@ -1,0 +1,178 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sniRecorder is a TLS endpoint that records the server name each handshake
+// asked for and answers with a certificate named after it, so a probe's SNI can
+// be read back off the certificate it receives.
+type sniRecorder struct {
+	addr        string
+	lastSNI     atomic.Pointer[string]
+	requireSNI  atomic.Bool
+	defaultName string
+}
+
+func newSNIRecorder(t *testing.T, defaultName string) *sniRecorder {
+	t.Helper()
+
+	rec := &sniRecorder{defaultName: defaultName}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	rec.addr = listener.Addr().String()
+
+	config := &tls.Config{
+		GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			// Record what the handshake actually asked for, in its own
+			// variable: storing a pointer to one that is then reassigned would
+			// report the substituted default instead of the empty name.
+			observed := hello.ServerName
+			rec.lastSNI.Store(&observed)
+
+			name := hello.ServerName
+			if name == "" {
+				if rec.requireSNI.Load() {
+					return nil, assertRequiresSNI
+				}
+				name = rec.defaultName
+			}
+			return selfSignedFor(name)
+		},
+	}
+
+	go func() {
+		for {
+			raw, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				conn := tls.Server(raw, config)
+				_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+				_ = conn.Handshake()
+				_ = conn.Close()
+			}()
+		}
+	}()
+	t.Cleanup(func() { _ = listener.Close() })
+
+	return rec
+}
+
+var assertRequiresSNI = &sniRequiredError{}
+
+type sniRequiredError struct{}
+
+func (*sniRequiredError) Error() string { return "this endpoint requires SNI" }
+
+func selfSignedFor(commonName string) (*tls.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: commonName},
+		DNSNames:              []string{commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}, nil
+}
+
+func splitAddr(t *testing.T, addr string) (string, string) {
+	t.Helper()
+	host, port, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	return host, port
+}
+
+func TestDialTLSWithoutSNISendsNoServerName(t *testing.T) {
+	// tls.DialWithDialer clones the config and fills ServerName in from the
+	// dial address whenever it is empty, so the "without SNI" probe was sending
+	// SNI for the host being dialed and the two chains always came back
+	// identical.
+	rec := newSNIRecorder(t, "default.example")
+
+	conn, err := dialTLSWithoutSNI(&net.Dialer{Timeout: 5 * time.Second}, "tcp", rec.addr)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	require.NotNil(t, rec.lastSNI.Load())
+	assert.Equal(t, "", *rec.lastSNI.Load(), "no server_name extension should be sent")
+
+	certs := conn.ConnectionState().PeerCertificates
+	require.NotEmpty(t, certs)
+	assert.Equal(t, "default.example", certs[0].Subject.CommonName)
+}
+
+func TestGatherTlsCertificatesReportsTheFullNonSniChain(t *testing.T) {
+	// The two chains differ here, which is the case that matters: a default
+	// virtual host answering an address with an unrelated certificate.
+	rec := newSNIRecorder(t, "default.example")
+	host, port := splitAddr(t, rec.addr)
+
+	sniCerts, nonSniCerts, err := gatherTlsCertificates("tcp", host, port, "asked-for.example")
+	require.NoError(t, err)
+
+	require.NotEmpty(t, sniCerts)
+	assert.Equal(t, "asked-for.example", sniCerts[0].Subject.CommonName)
+
+	require.NotEmpty(t, nonSniCerts, "the non-SNI chain must be reported, not diffed away")
+	assert.Equal(t, "default.example", nonSniCerts[0].Subject.CommonName)
+}
+
+func TestGatherTlsCertificatesReportsAnIdenticalNonSniChain(t *testing.T) {
+	// The endpoint serves the same certificate either way. It genuinely does
+	// serve that certificate without SNI, so reporting nothing here would say
+	// the opposite.
+	rec := newSNIRecorder(t, "same.example")
+	host, port := splitAddr(t, rec.addr)
+
+	sniCerts, nonSniCerts, err := gatherTlsCertificates("tcp", host, port, "same.example")
+	require.NoError(t, err)
+
+	require.NotEmpty(t, sniCerts)
+	require.NotEmpty(t, nonSniCerts)
+	assert.Equal(t, "same.example", nonSniCerts[0].Subject.CommonName)
+}
+
+func TestGatherTlsCertificatesSurvivesAnEndpointThatRequiresSNI(t *testing.T) {
+	// The non-SNI handshake fails. That must not take the SNI chain down with
+	// it: before, an error from the second connection failed both.
+	rec := newSNIRecorder(t, "default.example")
+	rec.requireSNI.Store(true)
+	host, port := splitAddr(t, rec.addr)
+
+	sniCerts, nonSniCerts, err := gatherTlsCertificates("tcp", host, port, "asked-for.example")
+	require.NoError(t, err, "a server that requires SNI is an answer, not a scan failure")
+
+	require.NotEmpty(t, sniCerts)
+	assert.Equal(t, "asked-for.example", sniCerts[0].Subject.CommonName)
+	assert.Nil(t, nonSniCerts, "unknown, rather than an empty chain")
+}


### PR DESCRIPTION
## What

`tls.nonSniCertificates` returned `[]` for every host on the internet.

The "without SNI" chain was fetched with `tls.DialWithDialer` and an empty `ServerName` — but the standard library clones the config and fills `ServerName` in from the dial address whenever it is empty:

```go
// crypto/tls
if c.ServerName == "" {
    c = c.Clone()
    c.ServerName = hostname
}
```

So the probe sent SNI after all, both chains came back identical, and the set difference the field was built from was always empty. Confirmed directly:

```go
tls.DialWithDialer(d, "tcp", "bing.com:443", &tls.Config{InsecureSkipVerify: true})
// ConnectionState().ServerName == "bing.com"   ← not empty
```

## Changes

- Dial the socket and hand it to `tls.Client`, which does *not* back-fill `ServerName`, so no `server_name` extension goes out.
- Report the non-SNI chain **in full** rather than as the certificates that differ from the SNI chain. A host that serves the same certificate either way genuinely does serve it without SNI, and reporting nothing there says the opposite. The interesting case — a default virtual host answering with an unrelated certificate — reads the same in either shape.

Two things fell out of connecting for real:

- **A server that requires SNI now closes that connection.** Its error was previously returned from `gatherTlsCertificates`, which would have taken the *SNI* chain down with it — so `certificates` would have started failing on those hosts. It is now reported as an unknown (null) non-SNI chain, and `certificates` is unaffected.
- The handshake gets its own deadline; the dialer's timeout only covers the dial.

## Verified live

Matches `openssl s_client -noservername` exactly on every host checked:

| host | SNI leaf | non-SNI leaf |
|---|---|---|
| bing.com | www.bing.com | `*.azureedge.net` |
| office.com | m365.cloud.microsoft | `*.azureedge.net` |
| temu.com | `*.temu.com` | `*.kwcdn.com` |
| apple.com | apple.com | images.apple.com |
| google.com | `*.google.com` | `invalid2.invalid` |
| live.com | outlook.live.com | outlook.live.com |
| wikipedia.org | `*.wikipedia.org` | `*.wikipedia.org` |

Google's non-SNI certificate is its `OU=No SNI provided - please fix your client., CN=invalid2.invalid` placeholder — previously invisible.

## Test plan

`tls_sni_internal_test.go` stands up a TLS endpoint that records the server name each handshake asked for and answers with a certificate named after it:

- `dialTLSWithoutSNI` sends an empty `ServerName` and receives the default certificate.
- The two chains differ → the non-SNI chain is reported, not diffed away.
- The two chains are identical → still reported, rather than empty.
- The endpoint requires SNI → `gatherTlsCertificates` returns the SNI chain with no error and a nil non-SNI chain.

`go test ./...` in `providers/network/` passes.

## Schema

Doc-comment only — no fields added or removed, so `.lr.versions` is unchanged.
