### PR TITLE
🐛 network: parse the url query and fragment

### DIFF
--- a/providers/network/resources/url.go
+++ b/providers/network/resources/url.go
@@ -11,6 +11,7 @@ import (
 
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/types"
 )
 
 func initUrl(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -61,8 +62,32 @@ func initUrl(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]
 			args["rawQuery"] = llx.StringData(u.RawQuery)
 		}
 
-		if u.RawFragment != "" || args["rawFragment"] == nil {
-			args["rawFragment"] = llx.StringData(u.RawFragment)
+		// query was never populated here at all, so every read of it reached the
+		// runtime unset and surfaced as a provider bug rather than as a value.
+		//
+		// A query string may repeat a key; the field is a map, so it cannot hold
+		// both. The first occurrence wins, which is what url.Values.Get returns
+		// and what most servers read.
+		query := map[string]any{}
+		for key, values := range u.Query() {
+			if len(values) != 0 {
+				query[key] = values[0]
+			}
+		}
+		if len(query) != 0 || args["query"] == nil {
+			args["query"] = llx.MapData(query, types.String)
+		}
+
+		// RawFragment is only filled in when the fragment carries escaping that
+		// differs from the canonical encoding, so an ordinary "#section" left it
+		// empty and the fragment was reported as absent. Fall back to the decoded
+		// form, which is what the URL carried.
+		rawFragment := u.RawFragment
+		if rawFragment == "" {
+			rawFragment = u.Fragment
+		}
+		if rawFragment != "" || args["rawFragment"] == nil {
+			args["rawFragment"] = llx.StringData(rawFragment)
 		}
 	}
 	return args, nil, nil
@@ -87,12 +112,23 @@ func (x *mqlUrl) string() (string, error) {
 		host += ":" + strconv.Itoa(int(x.Port.Data))
 	}
 
+	// URL.String renders the fragment from Fragment, escaping it, and uses
+	// RawFragment only when it is a valid encoding of that same value. Setting
+	// RawFragment alone therefore dropped the fragment from the round trip
+	// entirely. Supply both: the decoded form for the value, and the raw form so
+	// a fragment that was escaped unusually comes back out as it went in.
+	fragment, err := url.PathUnescape(x.RawFragment.Data)
+	if err != nil {
+		fragment = x.RawFragment.Data
+	}
+
 	u := url.URL{
 		Scheme:      x.Scheme.Data,
 		User:        user,
 		Host:        host,
 		Path:        x.Path.Data,
 		RawQuery:    x.RawQuery.Data,
+		Fragment:    fragment,
 		RawFragment: x.RawFragment.Data,
 	}
 	return u.String(), nil

--- a/providers/network/resources/url_internal_test.go
+++ b/providers/network/resources/url_internal_test.go
@@ -1,0 +1,125 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+func parseRawURL(t *testing.T, raw string) map[string]*llx.RawData {
+	t.Helper()
+
+	args, res, err := initUrl(nil, map[string]*llx.RawData{"raw": llx.StringData(raw)})
+	require.NoError(t, err)
+	require.Nil(t, res)
+	return args
+}
+
+func TestInitUrlParsesTheQuery(t *testing.T) {
+	// query was never populated, so every read of it reached the runtime unset
+	// and the scan reported a provider bug instead of a value.
+	t.Run("splits the query into its parameters", func(t *testing.T) {
+		args := parseRawURL(t, "https://example.com/a?x=1&y=two")
+
+		require.Contains(t, args, "query")
+		assert.Equal(t, map[string]any{"x": "1", "y": "two"}, args["query"].Value)
+	})
+
+	t.Run("is empty rather than absent when there is no query", func(t *testing.T) {
+		args := parseRawURL(t, "https://example.com/a")
+
+		require.Contains(t, args, "query")
+		assert.Equal(t, map[string]any{}, args["query"].Value)
+	})
+
+	t.Run("keeps the first of a repeated parameter", func(t *testing.T) {
+		// The field is a map and cannot hold both. First is what
+		// url.Values.Get returns and what most servers read.
+		args := parseRawURL(t, "https://example.com/a?x=1&x=2")
+		assert.Equal(t, map[string]any{"x": "1"}, args["query"].Value)
+	})
+
+	t.Run("decodes percent-encoded parameters", func(t *testing.T) {
+		args := parseRawURL(t, "https://example.com/a?path=%2Fetc%2Fpasswd")
+		assert.Equal(t, map[string]any{"path": "/etc/passwd"}, args["query"].Value)
+	})
+
+	t.Run("keeps rawQuery as sent", func(t *testing.T) {
+		args := parseRawURL(t, "https://example.com/a?x=1&y=two")
+		assert.Equal(t, "x=1&y=two", args["rawQuery"].Value)
+	})
+}
+
+func TestInitUrlParsesTheFragment(t *testing.T) {
+	t.Run("reports an ordinary fragment", func(t *testing.T) {
+		// Go fills RawFragment only when the escaping is non-canonical, so this
+		// used to come back empty.
+		args := parseRawURL(t, "https://example.com/a#section")
+		assert.Equal(t, "section", args["rawFragment"].Value)
+	})
+
+	t.Run("keeps unusual escaping as sent", func(t *testing.T) {
+		args := parseRawURL(t, "https://example.com/a#frag%2Fx")
+		assert.Equal(t, "frag%2Fx", args["rawFragment"].Value)
+	})
+
+	t.Run("is empty when there is no fragment", func(t *testing.T) {
+		args := parseRawURL(t, "https://example.com/a")
+		assert.Equal(t, "", args["rawFragment"].Value)
+	})
+}
+
+func urlFromArgs(args map[string]*llx.RawData) *mqlUrl {
+	str := func(key string) plugin.TValue[string] {
+		if v, ok := args[key]; ok {
+			s, _ := v.Value.(string)
+			return plugin.TValue[string]{Data: s, State: plugin.StateIsSet}
+		}
+		return plugin.TValue[string]{State: plugin.StateIsSet}
+	}
+	num := func(key string) plugin.TValue[int64] {
+		if v, ok := args[key]; ok {
+			n, _ := v.Value.(int64)
+			return plugin.TValue[int64]{Data: n, State: plugin.StateIsSet}
+		}
+		return plugin.TValue[int64]{State: plugin.StateIsSet}
+	}
+
+	return &mqlUrl{
+		Scheme:      str("scheme"),
+		User:        str("user"),
+		Password:    str("password"),
+		Host:        str("host"),
+		Port:        num("port"),
+		Path:        str("path"),
+		RawQuery:    str("rawQuery"),
+		RawFragment: str("rawFragment"),
+	}
+}
+
+func TestUrlStringRoundTrip(t *testing.T) {
+	// The fragment was rendered from RawFragment alone, which URL.String only
+	// honors when it agrees with Fragment - so it was dropped from the
+	// reassembled URL in every case, escaped or not.
+	for _, raw := range []string{
+		"https://example.com/a#section",
+		"https://example.com/a#frag%2Fx",
+		"https://example.com/a?x=1&y=two#section",
+		"https://user:pass@example.com:8443/a/b?x=1#f",
+		"https://example.com/a",
+		"http://example.com",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			args := parseRawURL(t, raw)
+			got, err := urlFromArgs(args).string()
+			require.NoError(t, err)
+			assert.Equal(t, raw, got)
+		})
+	}
+}


### PR DESCRIPTION
## What

Three fields on the `url` resource reported nothing.

**`query` was never populated.** `initUrl` fills in scheme, user, password, host, port, path, `rawQuery` and `rawFragment` — but not `query`, and there is no computed accessor for it either. Every read crossed the plugin boundary unset:

```
$ mql run host … -c 'url("https://u:p@example.com:8443/a/b?x=1&y=2#frag").query'
x provider returned no data and no error for a field; the field was never set
  on the resource (provider bug)  field=query resource=url
x llx: encountered a primitive with no type information, coercing to null
  query: null
```

This hit 25 of 25 hosts in a sweep — it is not conditional on anything.

**`rawFragment` was empty for ordinary fragments.** It reads Go's `u.RawFragment`, which the standard library only fills in when a fragment carries escaping that differs from the canonical encoding. `#section` leaves it empty, so the fragment was reported as absent.

**`string` dropped the fragment entirely** — escaped or not. `URL.String` renders the fragment from `Fragment` and consults `RawFragment` only when the two agree, so setting `RawFragment` alone rendered nothing.

## Changes

- `query` is parsed from the URL. A query may repeat a key and the field is a `map`, so the first occurrence wins — what `url.Values.Get` returns and what most servers read. Noted in the code.
- `rawFragment` falls back to the decoded fragment when `RawFragment` is empty, so it reports the fragment either way and still preserves unusual escaping as sent.
- `string` supplies both `Fragment` and `RawFragment`, so the reassembled URL round-trips.

Before / after on the same input:

```
url("https://u:p@example.com:8443/a/b?x=1&y=two#frag")
  query        null  ->  {x: "1", y: "two"}
  rawFragment  ""    ->  "frag"
  string       "https://u:p@example.com:8443/a/b?x=1&y=two"
            -> "https://u:p@example.com:8443/a/b?x=1&y=two#frag"
```

## Test plan

`url_internal_test.go`:

- **query** — splits parameters, is an empty map rather than absent when there is no query, keeps the first of a repeated key, decodes percent-encoding, and leaves `rawQuery` as sent.
- **fragment** — an ordinary `#section`, one with unusual escaping (`#frag%2Fx`) kept as sent, and none at all.
- **round trip** — six URLs reassembled through `string()` and compared against the input, covering fragment, query, both, userinfo with a port, and neither.

`go test ./...` in `providers/network/` passes. Verified live: the provider-bug warning is gone and all three fields report correctly.

## Note on scope

`rawFragment` and `string` were filed as a lower-severity finding than `query`, but all three live in the same function and the fragment ones are two lines. Shipping the `query` fix while leaving the fragment broken in the same resource seemed worse than fixing both.

## Schema

No `.lr` change — these fields are already declared; they were simply never filled in.
