### PR TITLE
📄 network: document initializers that compile

### DIFF
--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -20,7 +20,7 @@ socket @defaults("protocol port address") {
 
 // HTTP endpoint
 //
-// Entry point for HTTP probing. Use `http.get(rawUrl: "https://...")`
+// Entry point for HTTP probing. Use `http.get("https://...")`
 // to perform a GET against a URL and inspect the response status,
 // headers (parsed into sub-resources for HSTS, CSP, cookies, and other
 // security headers), and body.
@@ -29,11 +29,12 @@ http {}
 // HTTP GET request
 //
 // Result of an HTTP GET against a URL, for probing how a web endpoint
-// responds. Initialize with `http.get(rawUrl: "https://example.com",
-// followRedirects: true)`. The `header` sub-resource parses the
-// response's security headers (HSTS, CSP, X-Frame-Options,
-// X-XSS-Protection, X-Content-Type-Options, Referrer-Policy,
-// Content-Type, and Set-Cookie) into individually queryable values.
+// responds. Initialize with `http.get("https://example.com", true)`,
+// where the second argument decides whether redirects are followed. The
+// `header` sub-resource parses the response's security headers (HSTS,
+// CSP, X-Frame-Options, X-XSS-Protection, X-Content-Type-Options,
+// Referrer-Policy, Content-Type, and Set-Cookie) into individually
+// queryable values.
 http.get @defaults("url statusCode") {
   init(rawUrl string, followRedirects bool)
   // URL for this request
@@ -162,7 +163,7 @@ private http.header.setCookie @defaults("name value") {
 //
 // URL broken into its components, generally represented as
 // `[scheme:][//[user[:password]@]host[:port]][/]path[?query][#fragment]`.
-// Initialize with `url(raw: "https://user:pass@host:443/p?q=1#f")` and
+// Initialize with `url("https://user:pass@host:443/p?q=1#f")` and
 // inspect any of the parsed components individually: scheme, user /
 // password user-info pair, host, port, path, parsed query map, raw
 // query string, and fragment.
@@ -193,7 +194,7 @@ url @defaults("string") {
 // TLS/SSL connection inspection
 //
 // TLS posture of a network endpoint. Initialize with
-// `tls(target: "host:port")` (an optional `domainName` enables SNI
+// `tls("host:port")` (an optional `domainName` enables SNI
 // testing). Surfaces every TLS / SSL version the endpoint accepts,
 // the cipher suites and extensions advertised, the version, cipher,
 // and key-exchange group a modern client actually negotiates, and the


### PR DESCRIPTION
## What

Three resources document an initializer form that the compiler rejects. Named resource arguments have to name a **declared field**, and `rawUrl`, `raw` and `target` are init parameters with no field behind them:

```
$ mql run host google.com -c 'http.get(rawUrl: "https://example.com").statusCode'
failed to compile: resource http.get does not have a field named rawUrl

$ mql run host google.com -c 'url(raw: "https://example.com").host'
failed to compile: resource url does not have a field named raw

$ mql run host google.com -c 'tls(target: "example.com:443").negotiatedVersion'
failed to compile: resource tls does not have a field named target
```

Each of those is the exact line from that resource's doc comment — the text published as the resource documentation — so anyone following it hits a compile error on their first query.

## Change

Docs only: show the positional form, which works.

```
http.get("https://example.com", true)
url("https://user:pass@host:443/p?q=1#f")
tls("host:port")
```

`dns(fqdn:)` and `domainName(fqdn:)` are left alone — `fqdn` is a declared field on both, so the named form there compiles and reads better.

## Why not add the backing fields instead

That was the alternative: give `http.get` a `rawUrl` field, `url` a `raw` field, `tls` a `target` field, so the named form resolves. It would make the docs true without changing them, but each one duplicates a value the resource already exposes in parsed form (`url`, the individual URL components, `socket`), and adding three permanent fields to fix three comments is the wrong trade. Correcting the docs costs nothing and loses nothing.

Making the compiler accept init-parameter names generally would be the deeper fix, but that is `mqlc` behavior affecting every provider, not a network change.

## Test plan

Compiled every initializer example that now appears in `network.lr`, plus the two named forms that were already correct:

```
ok    http.get("https://example.com").statusCode
ok    http.get("https://example.com", true).statusCode
ok    url("https://user:pass@example.com:443/p?q=1#f").host
ok    tls("example.com:443").negotiatedVersion
ok    dns(fqdn: "example.com").fqdn
ok    dns(fqdn: "example.com").spf
ok    dns(fqdn: "example.com").dmarc
ok    dns(fqdn: "example.com").dnssecValidation
ok    domainName(fqdn: "x.example.com").tld
```

Also grepped the rest of the repo for the broken forms — nothing else uses them.

## Schema

Doc-comment only. No fields added or removed, so `.lr.versions` and the generated code are unchanged.
