### PR TITLE
⭐ Runtime.EnsureResourcesRecording: mount and register in one call

### DIFF
--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -919,13 +919,12 @@ func (r *Runtime) EnsureResourcesRecording(asset *inventory.Asset) error {
 			}
 		}
 	}
-	if conf == nil {
+	if conf != nil {
 		// A nil connection config cannot be registered (EnsureAsset derefs
-		// it); the recording stays mounted and connect-time registration
-		// covers the asset once a real connection exists.
-		return nil
+		// it); in that case the recording stays mounted and connect-time
+		// registration covers the asset once a real connection exists.
+		r.recording.EnsureAsset(asset, providerID, connectionID, conf)
 	}
-	r.recording.EnsureAsset(asset, providerID, connectionID, conf)
 	return nil
 }
 

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -913,11 +913,17 @@ func (r *Runtime) EnsureResourcesRecording(asset *inventory.Asset) error {
 	conf := asset.Connections[0]
 	if connectionID > 0 {
 		for _, c := range asset.Connections {
-			if c.Id == connectionID {
+			if c != nil && c.Id == connectionID {
 				conf = c
 				break
 			}
 		}
+	}
+	if conf == nil {
+		// A nil connection config cannot be registered (EnsureAsset derefs
+		// it); the recording stays mounted and connect-time registration
+		// covers the asset once a real connection exists.
+		return nil
 	}
 	r.recording.EnsureAsset(asset, providerID, connectionID, conf)
 	return nil

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -869,6 +869,43 @@ func (r *Runtime) EnableResourcesRecording() error {
 	return r.SetRecording(recording)
 }
 
+// EnsureResourcesRecording makes this runtime record resource data for
+// asset, regardless of when it is called relative to the runtime's
+// connection. It mounts an in-memory recording if none is mounted (the same
+// Null-only swap as EnableResourcesRecording, so a recording the caller
+// mounted — e.g. via --record — is never clobbered) and registers asset
+// with the mounted recording.
+//
+// The registration is what makes late enabling work, and it encodes three
+// invariants of the recording machinery that callers should not have to
+// know: assets are normally registered at CONNECT time (a recording mounted
+// afterwards knows no connections), AddData silently drops rows for
+// connections the recording does not know, and readers look assets up by
+// the identity on the registered asset — so asset should be the one
+// carrying the identity readers will use (e.g. the platform-assigned MRN),
+// with the connection config whose Id writes are keyed under. An asset with
+// no connections mounts the recording and skips registration: the runtime
+// has not connected yet, and connect-time registration will cover it.
+func (r *Runtime) EnsureResourcesRecording(asset *inventory.Asset) error {
+	if err := r.EnableResourcesRecording(); err != nil {
+		return err
+	}
+	if asset == nil || len(asset.Connections) == 0 {
+		return nil
+	}
+
+	providerID := ""
+	var connectionID uint32
+	if r.Provider != nil && r.Provider.Instance != nil {
+		providerID = r.Provider.Instance.ID
+	}
+	if r.Provider != nil && r.Provider.Connection != nil {
+		connectionID = r.Provider.Connection.Id
+	}
+	r.recording.EnsureAsset(asset, providerID, connectionID, asset.Connections[0])
+	return nil
+}
+
 func (r *Runtime) SetRecording(recording llx.Recording) error {
 	r.recording = recording
 	if r.Provider == nil || r.Provider.Instance == nil {

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -902,7 +902,24 @@ func (r *Runtime) EnsureResourcesRecording(asset *inventory.Asset) error {
 	if r.Provider != nil && r.Provider.Connection != nil {
 		connectionID = r.Provider.Connection.Id
 	}
-	r.recording.EnsureAsset(asset, providerID, connectionID, asset.Connections[0])
+
+	// Register under the config of the runtime's ACTIVE connection when the
+	// asset carries several: the recording indexes writes by conf.Id, and
+	// AddData silently drops rows for connection ids it does not know — so
+	// registering a non-active connection's config would reproduce exactly
+	// the silent-drop failure this method exists to prevent. Fall back to
+	// the first connection when none matches (or the runtime has not
+	// connected yet, where connect-time registration covers the rest).
+	conf := asset.Connections[0]
+	if connectionID > 0 {
+		for _, c := range asset.Connections {
+			if c.Id == connectionID {
+				conf = c
+				break
+			}
+		}
+	}
+	r.recording.EnsureAsset(asset, providerID, connectionID, conf)
 	return nil
 }
 


### PR DESCRIPTION
API half of the resources-recording fix (consumer: mondoohq/cnspec#3576).

`EnableResourcesRecording` only mounts an in-memory recording. A caller enabling it after the runtime connected — the only option when the feature arrives server-driven mid-scan — then needs three internals of the recording machinery to make it actually record:

1. assets register with the recording at **connect time**, so a recording mounted later knows no connections;
2. `recording.AddData` **silently drops** rows for unknown connections;
3. readers (`GetAssetData`) look up by the identity on the *registered* asset — the platform-assigned MRN, which the connection-time asset doesn't carry yet.

cnspec#3576 currently encodes all three from outside. `EnsureResourcesRecording(asset)` folds mount + registration into the type that owns those internals: Null-only mount (a `--record` recording is never clobbered), then `EnsureAsset` with the caller's identity-bearing asset and the runtime's own provider/connection metadata. An asset with no connections mounts and skips registration — the runtime hasn't connected yet, and connect-time registration covers it.

No behavior change for existing callers; `EnableResourcesRecording` stays as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)