### PR TITLE
🐛 terraform: stop file discovery and tfvars loading from silently dropping data

### DIFF
--- a/providers/terraform/connection/discovery_test.go
+++ b/providers/terraform/connection/discovery_test.go
@@ -1,0 +1,207 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+)
+
+// hclAsset builds the single-connection asset every HCL connection expects.
+func hclAsset(path string) *inventory.Asset {
+	return &inventory.Asset{
+		Connections: []*inventory.Config{
+			{
+				Options: map[string]string{"path": path},
+				Type:    "hcl",
+			},
+		},
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+// A scan root whose own path contains ".terraform" as a substring must still be
+// scanned. The skip is meant for the vendored `.terraform/` module cache, but a
+// substring match over the full walk path also swallows directories like
+// `.terraform-configs/`, silently reporting an empty configuration.
+func TestScanRootContainingDotTerraformSubstring(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".terraform-configs")
+	writeFile(t, filepath.Join(root, "main.tf"), `resource "aws_s3_bucket" "b" {}`)
+
+	conn, err := NewHclConnection(0, hclAsset(root))
+	require.NoError(t, err)
+	assert.Len(t, conn.Parser().Files(), 1, "a directory merely containing '.terraform' in its name must still be scanned")
+}
+
+// A file named `foo.terraform.tf` is a normal configuration file, not part of
+// the vendored module cache.
+func TestFileWithDotTerraformInNameIsParsed(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "main.terraform.tf"), `resource "aws_s3_bucket" "b" {}`)
+
+	conn, err := NewHclConnection(0, hclAsset(root))
+	require.NoError(t, err)
+	assert.Len(t, conn.Parser().Files(), 1)
+}
+
+// The vendored module cache must still be skipped — the fix must not widen the
+// scan to `.terraform/`.
+func TestVendoredDotTerraformIsStillSkipped(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "main.tf"), `resource "aws_s3_bucket" "b" {}`)
+	writeFile(t, filepath.Join(root, ".terraform", "modules", "vpc", "main.tf"), `resource "aws_s3_bucket" "vendored" {}`)
+
+	conn, err := NewHclConnection(0, hclAsset(root))
+	require.NoError(t, err)
+	assert.Len(t, conn.Parser().Files(), 1, "files under .terraform/ must not be parsed")
+}
+
+// A single unparseable .tf file must not silently truncate the walk. Before the
+// fix the walk aborted at the broken file and its error was discarded, so every
+// file ordered after it vanished from a scan that reported success.
+func TestBrokenFileDoesNotTruncateScan(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "a_first.tf"), `resource "aws_s3_bucket" "a" {}`)
+	writeFile(t, filepath.Join(root, "m_broken.tf"), `resource "aws_s3_bucket" {{{`)
+	writeFile(t, filepath.Join(root, "z_last.tf"), `resource "aws_s3_bucket" "z" {}`)
+
+	conn, err := NewHclConnection(0, hclAsset(root))
+	require.NoError(t, err)
+
+	var names []string
+	for name := range conn.Parser().Files() {
+		names = append(names, filepath.Base(name))
+	}
+	assert.Contains(t, names, "a_first.tf")
+	assert.Contains(t, names, "z_last.tf", "files ordered after a broken file must still be parsed")
+}
+
+// hclparse.Parser.ParseJSONFile stores its result in the parser's file map even
+// when that result is nil (an unreadable file yields (nil, diags)). A nil entry
+// then panics every consumer that ranges over Files() and touches file.Body.
+func TestUnreadableJSONFileDoesNotPoisonParser(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "a.tf"), `variable "acl" { default = "private" }`)
+	// A dangling symlink is reported by WalkDir as a non-directory entry, so it
+	// reaches ParseHclFile and fails to open.
+	require.NoError(t, os.Symlink(filepath.Join(root, "does-not-exist"), filepath.Join(root, "b.tf.json")))
+
+	conn, err := NewHclConnection(0, hclAsset(root))
+	require.NoError(t, err)
+
+	for name, f := range conn.Parser().Files() {
+		require.NotNil(t, f, "parser holds a nil *hcl.File for %s; every Files() consumer will nil-deref", name)
+	}
+
+	// The panic surfaces here in production: buildVariableEvalContext ranges
+	// over Files() and asserts file.Body.
+	require.NotPanics(t, func() { conn.VariableEvalContext() })
+}
+
+// Terraform parses *.tfvars.json as JSON. Parsing it with the native HCL
+// syntax parser yields zero attributes, so the override never applies and every
+// var.* reference silently falls back to the variable block's default.
+func TestReadTfVarsFromJSONFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "terraform.tfvars.json")
+	writeFile(t, path, `{"image_id":"ami-json","acl":"public-read"}`)
+
+	vars := map[string]*hcl.Attribute{}
+	require.NoError(t, ReadTfVarsFromFile(path, vars))
+	require.Len(t, vars, 2, "*.tfvars.json must be parsed as JSON")
+	assert.Contains(t, vars, "image_id")
+	assert.Contains(t, vars, "acl")
+}
+
+// The security-relevant consequence of the above: a JSON tfvars override of a
+// variable default must win, exactly as it does for a native .tfvars file.
+func TestJSONTfVarsOverridesVariableDefault(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "main.tf"), `variable "acl" { default = "private" }`)
+	writeFile(t, filepath.Join(root, "terraform.tfvars.json"), `{"acl":"public-read"}`)
+
+	conn, err := NewHclConnection(0, hclAsset(root))
+	require.NoError(t, err)
+
+	ctx := conn.VariableEvalContext()
+	require.NotNil(t, ctx)
+	v, ok := ctx.Variables["var"]
+	require.True(t, ok, "no var scope built")
+	assert.Equal(t, "public-read", v.GetAttr("acl").AsString(),
+		"a terraform.tfvars.json override must beat the variable default")
+}
+
+// os.Stat fails with more than ENOENT. A path whose ancestor is a regular file
+// returns ENOTDIR with a nil FileInfo, which the ENOENT-only guard let through
+// into a nil dereference.
+func TestNonExistErrorFromStatIsNotAPanic(t *testing.T) {
+	root := t.TempDir()
+	file := filepath.Join(root, "main.tf")
+	writeFile(t, file, `resource "aws_s3_bucket" "b" {}`)
+
+	// ENOTDIR: `main.tf` is a file, so `main.tf/sub` cannot be stat'd.
+	require.NotPanics(t, func() {
+		_, err := NewHclConnection(0, hclAsset(filepath.Join(file, "sub")))
+		assert.Error(t, err)
+	})
+}
+
+// `modules/<name>/examples/<case>/` is the canonical layout of a first-party
+// Terraform module repository. Only examples vendored under `.terraform/` are
+// meant to be skipped.
+func TestFirstPartyModuleExamplesAreScanned(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "main.tf"), `resource "aws_s3_bucket" "root" {}`)
+	writeFile(t, filepath.Join(root, "modules", "vpc", "examples", "complete", "main.tf"),
+		`resource "aws_s3_bucket" "ex" { acl = "public-read" }`)
+
+	conn, err := NewHclConnection(0, hclAsset(root))
+	require.NoError(t, err)
+	assert.Len(t, conn.Parser().Files(), 2, "a repository's own modules/*/examples/* is first-party code")
+}
+
+// Examples inside the vendored module cache stay skipped.
+func TestVendoredModuleExamplesAreSkipped(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "main.tf"), `resource "aws_s3_bucket" "root" {}`)
+	writeFile(t, filepath.Join(root, ".terraform", "modules", "vpc", "examples", "complete", "main.tf"),
+		`resource "aws_s3_bucket" "ex" {}`)
+
+	conn, err := NewHclConnection(0, hclAsset(root))
+	require.NoError(t, err)
+	assert.Len(t, conn.Parser().Files(), 1)
+}
+
+// A monorepo with one module cache per stack must not report only the last
+// manifest the walk happened to reach.
+func TestMultipleModuleManifestsAreMerged(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "main.tf"), `resource "aws_s3_bucket" "b" {}`)
+	writeFile(t, filepath.Join(root, "stacks", "a", ".terraform", "modules", "modules.json"),
+		`{"Modules":[{"Key":"a-vpc","Source":"./mods/vpc","Dir":"mods/vpc"}]}`)
+	writeFile(t, filepath.Join(root, "stacks", "b", ".terraform", "modules", "modules.json"),
+		`{"Modules":[{"Key":"b-vpc","Source":"./mods/vpc","Dir":"mods/vpc"}]}`)
+
+	conn, err := NewHclConnection(0, hclAsset(root))
+	require.NoError(t, err)
+
+	manifest := conn.ModulesManifest()
+	require.NotNil(t, manifest)
+	var keys []string
+	for _, r := range manifest.Records {
+		keys = append(keys, r.Key)
+	}
+	assert.ElementsMatch(t, []string{"a-vpc", "b-vpc"}, keys,
+		"every stack's module manifest must be reported, not just the last one walked")
+}

--- a/providers/terraform/connection/hcl_manifest.go
+++ b/providers/terraform/connection/hcl_manifest.go
@@ -5,11 +5,11 @@ package connection
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -38,13 +38,89 @@ func ParseTerraformModuleManifest(manifestPath string) (*ModuleManifest, error) 
 	return &manifest, nil
 }
 
-// e.g. mondoo-operator/.github/terraform/aws/.terraform/modules/vpc/examples/secondary-cidr-blocks/main.tf/1/1
-var MODULE_EXAMPLES = regexp.MustCompile(`^.*/modules/.+/examples/.+`)
+// dotTerraformDir is the vendored module cache Terraform writes next to a
+// configuration. Its contents are copies of upstream modules, not the code
+// under review.
+const dotTerraformDir = ".terraform"
+
+// hasPathSegment reports whether rel — a slash-separated path relative to the
+// scan root — contains segment as a whole path element.
+//
+// Matching a whole segment rather than a substring matters: a substring test
+// for ".terraform" also swallows a scan root named `.terraform-configs/`, a
+// repository directory called `.terraform-modules/`, and a configuration file
+// named `main.terraform.tf`. Those are the user's own code, and skipping them
+// reported an empty configuration with no error — every policy over it then
+// passed vacuously.
+func hasPathSegment(rel, segment string) bool {
+	for _, part := range strings.Split(rel, "/") {
+		if part == segment {
+			return true
+		}
+	}
+	return false
+}
+
+// MODULE_EXAMPLES matches the `examples/` trees shipped inside modules that
+// Terraform vendored into `.terraform/modules/`. Those are upstream sample
+// configurations, not deployed code.
+//
+// The pattern is anchored on the `.terraform/` cache deliberately. Without that
+// anchor it also matched `modules/<name>/examples/<case>/`, which is the
+// canonical layout of a first-party Terraform module repository — so a
+// repository's own examples, including any misconfiguration in them, were
+// silently dropped from the scan.
+var MODULE_EXAMPLES = regexp.MustCompile(`(^|/)\.terraform/modules/.+/examples/.+`)
 
 func NewHclConnection(id uint32, asset *inventory.Asset) (*Connection, error) {
+	if len(asset.Connections) == 0 {
+		return nil, errors.New("no connection options for asset")
+	}
 	cc := asset.Connections[0]
 	path := cc.Options["path"]
 	return newHclConnection(id, path, asset)
+}
+
+// tfvarsCandidate is a variable-definitions file found during the walk,
+// together with the precedence rank it is applied at.
+type tfvarsCandidate struct {
+	path string
+	rank int
+}
+
+// Terraform's variable-definition precedence, lowest first. Files later in this
+// order override earlier ones.
+//
+//	rankExplicit  — `prod.tfvars` and friends. Terraform only loads these when
+//	                named with `-var-file`, never automatically. We keep loading
+//	                them so a scan of a directory that only carries such files
+//	                still sees values, but they must not outrank the files
+//	                Terraform does auto-load.
+//	rankDefault   — `terraform.tfvars`
+//	rankDefaultJSON — `terraform.tfvars.json`
+//	rankAuto      — `*.auto.tfvars` / `*.auto.tfvars.json`, applied in lexical order
+const (
+	rankExplicit = iota
+	rankDefault
+	rankDefaultJSON
+	rankAuto
+)
+
+func tfvarsRank(name string) int {
+	switch {
+	case name == "terraform.tfvars":
+		return rankDefault
+	case name == "terraform.tfvars.json":
+		return rankDefaultJSON
+	case strings.HasSuffix(name, ".auto.tfvars"), strings.HasSuffix(name, ".auto.tfvars.json"):
+		return rankAuto
+	default:
+		return rankExplicit
+	}
+}
+
+func isTfVarsFile(name string) bool {
+	return strings.HasSuffix(name, ".tfvars") || strings.HasSuffix(name, ".tfvars.json")
 }
 
 func newHclConnection(id uint32, path string, asset *inventory.Asset) (*Connection, error) {
@@ -63,61 +139,127 @@ func newHclConnection(id uint32, path string, asset *inventory.Asset) (*Connecti
 	// hcl files
 	loader := NewHCLFileLoader()
 	tfVars := make(map[string]*hcl.Attribute)
-	var modulesManifest *ModuleManifest
+	var manifestRecords []Record
+	seenModuleKeys := map[string]struct{}{}
 
 	assetType = configurationfiles
 	// FIXME: cannot handle relative paths
 	stat, err := os.Stat(path)
-	if os.IsNotExist(err) {
-		return nil, errors.New("path is not a valid file or directory")
+	if err != nil {
+		// os.Stat fails with more than ENOENT: a path whose ancestor is a
+		// regular file yields ENOTDIR, an unreadable parent yields EACCES, and
+		// a symlink cycle yields ELOOP. All of them return a nil FileInfo, so
+		// handling only os.IsNotExist dereferenced nil and panicked the
+		// provider on a mistyped scan path.
+		return nil, errors.Wrapf(err, "path %q is not a valid file or directory", path)
 	}
 
 	if stat.IsDir() {
-		filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
+		var tfvarsFiles []tfvarsCandidate
+
+		walkErr := filepath.WalkDir(path, func(entryPath string, d fs.DirEntry, err error) error {
 			if err != nil {
-				return err
-			}
-
-			// skip terraform module examples
-			foundExamples := MODULE_EXAMPLES.FindString(path)
-			if foundExamples != "" {
-				log.Debug().Str("path", path).Msg("ignoring terraform module example")
-				return nil
-			}
-
-			// if user asked to ignore .terraform, we skip all files in .terraform
-			if strings.Contains(path, ".terraform") && !includeDotTerraform {
-				return nil
-			}
-
-			if !d.IsDir() {
-				if strings.HasSuffix(path, ".terraform/modules/modules.json") {
-					modulesManifest, err = ParseTerraformModuleManifest(path)
-					if errors.Is(err, os.ErrNotExist) {
-						log.Debug().Str("path", path).Msg("no terraform module manifest found")
-					} else {
-						return errors.Wrap(err, fmt.Sprintf("could not parse terraform module manifest %s", path))
-					}
+				// A subdirectory we cannot read must not abort discovery of
+				// everything else in the tree.
+				log.Warn().Err(err).Str("path", entryPath).Msg("skipping unreadable path during terraform discovery")
+				if d != nil && d.IsDir() {
+					return fs.SkipDir
 				}
+				return nil
+			}
 
-				// we do not want to parse hcl files from terraform modules .terraform files
-				if strings.Contains(path, ".terraform") {
+			rel, relErr := filepath.Rel(path, entryPath)
+			if relErr != nil {
+				rel = entryPath
+			}
+			rel = filepath.ToSlash(rel)
+
+			// Skip the vendored module cache. `modules.json` inside it is read
+			// first, below, because it is the manifest describing what was
+			// vendored.
+			if hasPathSegment(rel, dotTerraformDir) {
+				if d.IsDir() {
+					// The manifest lives at .terraform/modules/modules.json, so
+					// the cache still has to be walked unless the user opted
+					// out; only its *.tf files are skipped.
+					if !includeDotTerraform {
+						return fs.SkipDir
+					}
 					return nil
 				}
 
-				log.Debug().Str("path", path).Msg("parsing hcl file")
-				err = loader.ParseHclFile(path)
-				if err != nil {
-					return errors.Wrap(err, "could not parse hcl file")
+				if includeDotTerraform && strings.HasSuffix(rel, ".terraform/modules/modules.json") {
+					manifest, mErr := ParseTerraformModuleManifest(entryPath)
+					switch {
+					case errors.Is(mErr, os.ErrNotExist):
+						log.Debug().Str("path", entryPath).Msg("no terraform module manifest found")
+					case mErr != nil:
+						log.Warn().Err(mErr).Str("path", entryPath).Msg("could not parse terraform module manifest")
+					default:
+						// A monorepo has one module cache per stack. Merging
+						// their records keeps every stack's modules visible;
+						// overwriting reported only the last one walked.
+						for _, record := range manifest.Records {
+							if _, seen := seenModuleKeys[record.Key]; seen {
+								continue
+							}
+							seenModuleKeys[record.Key] = struct{}{}
+							manifestRecords = append(manifestRecords, record)
+						}
+					}
 				}
 
-				err = ReadTfVarsFromFile(path, tfVars)
-				if err != nil {
-					return errors.Wrap(err, "could not parse tfvars file")
-				}
+				// Never parse configuration out of the vendored cache.
+				return nil
+			}
+
+			// Skip example configurations vendored inside cached modules.
+			if MODULE_EXAMPLES.MatchString(rel) {
+				log.Debug().Str("path", entryPath).Msg("ignoring terraform module example")
+				return nil
+			}
+
+			if d.IsDir() {
+				return nil
+			}
+
+			if isTfVarsFile(entryPath) {
+				// Collected rather than applied here: applying in walk order
+				// let `terraform.tfvars` override an `*.auto.tfvars` that
+				// Terraform itself ranks higher, silently inverting the
+				// effective value of a variable.
+				tfvarsFiles = append(tfvarsFiles, tfvarsCandidate{
+					path: entryPath,
+					rank: tfvarsRank(filepath.Base(entryPath)),
+				})
+				return nil
+			}
+
+			log.Debug().Str("path", entryPath).Msg("parsing hcl file")
+			if err := loader.ParseHclFile(entryPath); err != nil {
+				// A single unparseable file must not truncate the scan. The
+				// walk used to abort here and the abort was then discarded, so
+				// every file ordered after the broken one silently vanished
+				// from a scan that reported success.
+				log.Warn().Err(err).Str("path", entryPath).Msg("could not parse hcl file; skipping")
 			}
 			return nil
 		})
+		if walkErr != nil {
+			return nil, errors.Wrap(walkErr, "could not walk terraform configuration")
+		}
+
+		sort.SliceStable(tfvarsFiles, func(i, j int) bool {
+			if tfvarsFiles[i].rank != tfvarsFiles[j].rank {
+				return tfvarsFiles[i].rank < tfvarsFiles[j].rank
+			}
+			return tfvarsFiles[i].path < tfvarsFiles[j].path
+		})
+		for _, candidate := range tfvarsFiles {
+			if err := ReadTfVarsFromFile(candidate.path, tfVars); err != nil {
+				log.Warn().Err(err).Str("path", candidate.path).Msg("could not parse tfvars file; skipping")
+			}
+		}
 	} else {
 		err = loader.ParseHclFile(path)
 		if err != nil {
@@ -128,6 +270,11 @@ func newHclConnection(id uint32, path string, asset *inventory.Asset) (*Connecti
 		if err != nil {
 			return nil, errors.Wrap(err, "could not parse tfvars file")
 		}
+	}
+
+	var modulesManifest *ModuleManifest
+	if len(manifestRecords) > 0 {
+		modulesManifest = &ModuleManifest{Records: manifestRecords}
 	}
 
 	return &Connection{
@@ -148,6 +295,9 @@ func NewHclGitConnection(id uint32, asset *inventory.Asset) (*Connection, error)
 	}
 	conn, err := newHclConnection(id, path, asset)
 	if err != nil {
+		// The clone succeeded but the connection did not; without this the
+		// whole checkout stays behind in the temp dir on every failed scan.
+		closer()
 		return nil, err
 	}
 	conn.closer = closer

--- a/providers/terraform/connection/hcl_manifest.go
+++ b/providers/terraform/connection/hcl_manifest.go
@@ -41,7 +41,12 @@ func ParseTerraformModuleManifest(manifestPath string) (*ModuleManifest, error) 
 // dotTerraformDir is the vendored module cache Terraform writes next to a
 // configuration. Its contents are copies of upstream modules, not the code
 // under review.
-const dotTerraformDir = ".terraform"
+const (
+	dotTerraformDir = ".terraform"
+	// modulesDir is the only directory under .terraform the walk descends into,
+	// because it holds the vendored module manifest.
+	modulesDir = "modules"
+)
 
 // hasPathSegment reports whether rel — a slash-separated path relative to the
 // scan root — contains segment as a whole path element.
@@ -59,6 +64,19 @@ func hasPathSegment(rel, segment string) bool {
 		}
 	}
 	return false
+}
+
+// dotTerraformSubdir returns rel's path relative to the .terraform directory it
+// sits under, and whether it sits under one at all. An empty subdir means rel is
+// the .terraform directory itself.
+func dotTerraformSubdir(rel string) (string, bool) {
+	parts := strings.Split(rel, "/")
+	for i, part := range parts {
+		if part == dotTerraformDir {
+			return strings.Join(parts[i+1:], "/"), true
+		}
+	}
+	return "", false
 }
 
 // MODULE_EXAMPLES matches the `examples/` trees shipped inside modules that
@@ -185,6 +203,14 @@ func newHclConnection(id uint32, path string, asset *inventory.Asset) (*Connecti
 					if !includeDotTerraform {
 						return fs.SkipDir
 					}
+					// That manifest is the only thing under the cache worth
+					// reading, so descend just far enough to reach it. Walking
+					// the rest means walking .terraform/providers, which holds
+					// the vendored provider binaries and is routinely hundreds
+					// of megabytes.
+					if sub, _ := dotTerraformSubdir(rel); sub != "" && sub != modulesDir {
+						return fs.SkipDir
+					}
 					return nil
 				}
 
@@ -241,7 +267,15 @@ func newHclConnection(id uint32, path string, asset *inventory.Asset) (*Connecti
 				// walk used to abort here and the abort was then discarded, so
 				// every file ordered after the broken one silently vanished
 				// from a scan that reported success.
-				log.Warn().Err(err).Str("path", entryPath).Msg("could not parse hcl file; skipping")
+				// An unreadable file (a dangling symlink, a permission
+				// problem) is not a syntax problem, and saying "could not
+				// parse" about one sends the reader looking at the wrong thing.
+				var pathErr *os.PathError
+				if errors.As(err, &pathErr) {
+					log.Warn().Err(err).Str("path", entryPath).Msg("could not read hcl file; skipping")
+				} else {
+					log.Warn().Err(err).Str("path", entryPath).Msg("could not parse hcl file; skipping")
+				}
 			}
 			return nil
 		})

--- a/providers/terraform/connection/hcl_manifest_test.go
+++ b/providers/terraform/connection/hcl_manifest_test.go
@@ -67,3 +67,46 @@ func TestModuleManifestIssue676(t *testing.T) {
 		require.Nil(t, moduleManifest)
 	})
 }
+
+// TestDotTerraformSubdir pins which directories under a vendored .terraform
+// cache the walk descends into. Only the module manifest is read from there, so
+// everything except .terraform itself and .terraform/modules can be skipped
+// whole — notably .terraform/providers, which holds the vendored provider
+// binaries and is routinely hundreds of megabytes.
+func TestDotTerraformSubdir(t *testing.T) {
+	tests := []struct {
+		name        string
+		rel         string
+		wantSub     string
+		wantUnder   bool
+		wantDescend bool
+	}{
+		{name: "outside the cache", rel: "modules/vpc", wantSub: "", wantUnder: false, wantDescend: false},
+		{name: "the cache itself", rel: ".terraform", wantSub: "", wantUnder: true, wantDescend: true},
+		{name: "the modules dir", rel: ".terraform/modules", wantSub: "modules", wantUnder: true, wantDescend: true},
+		{name: "a vendored module", rel: ".terraform/modules/vpc", wantSub: "modules/vpc", wantUnder: true, wantDescend: false},
+		{name: "the provider cache", rel: ".terraform/providers", wantSub: "providers", wantUnder: true, wantDescend: false},
+		{
+			name:    "deep inside the provider cache",
+			rel:     ".terraform/providers/registry.terraform.io/hashicorp/aws/5.0.0/linux_amd64",
+			wantSub: "providers/registry.terraform.io/hashicorp/aws/5.0.0/linux_amd64", wantUnder: true, wantDescend: false,
+		},
+		// A monorepo has one cache per stack, so the match must be on the path
+		// segment rather than on depth.
+		{name: "nested cache in a monorepo", rel: "stacks/prod/.terraform", wantSub: "", wantUnder: true, wantDescend: true},
+		{name: "nested cache modules dir", rel: "stacks/prod/.terraform/modules", wantSub: "modules", wantUnder: true, wantDescend: true},
+		{name: "nested cache providers", rel: "stacks/prod/.terraform/providers", wantSub: "providers", wantUnder: true, wantDescend: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sub, under := dotTerraformSubdir(tt.rel)
+			assert.Equal(t, tt.wantUnder, under, "under .terraform")
+			assert.Equal(t, tt.wantSub, sub, "subdir")
+
+			// This mirrors the walk's descend decision.
+			descend := under && (sub == "" || sub == modulesDir)
+			assert.Equal(t, tt.wantDescend, descend, "descend")
+		})
+	}
+}

--- a/providers/terraform/connection/hcl_parser.go
+++ b/providers/terraform/connection/hcl_parser.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/json"
+	"github.com/rs/zerolog/log"
 )
 
 func NewHCLFileLoader() *hclFileLoader {
@@ -24,19 +26,33 @@ type hclFileLoader struct {
 	hclParser *hclparse.Parser
 }
 
-// ParseHclFile parses a single terraform file
+// ParseHclFile parses a single terraform file.
+//
+// The source bytes are read here rather than handed to the parser's
+// *File variants on purpose. hclparse.Parser.ParseJSONFile records its result
+// in the parser's file map before checking it, and json.ParseFile returns a
+// nil *hcl.File when the file cannot be opened — so an unreadable `.tf.json`
+// (a dangling symlink in a checkout is enough) left a nil entry in
+// Parser().Files(). Every consumer of that map dereferences file.Body, so the
+// nil surfaced later as a provider panic that took down the whole scan.
+// ParseHCL/ParseJSON always store a real *hcl.File.
 func (h *hclFileLoader) ParseHclFile(filepath string) error {
-	var parseFunc func(filename string) (*hcl.File, hcl.Diagnostics)
+	var parseFunc func(src []byte, filename string) (*hcl.File, hcl.Diagnostics)
 	switch {
 	case strings.HasSuffix(filepath, ".tf"):
-		parseFunc = h.hclParser.ParseHCLFile
+		parseFunc = h.hclParser.ParseHCL
 	case strings.HasSuffix(filepath, ".tf.json"):
-		parseFunc = h.hclParser.ParseJSONFile
+		parseFunc = h.hclParser.ParseJSON
 	default:
 		return nil
 	}
 
-	_, diag := parseFunc(filepath)
+	src, err := os.ReadFile(filepath)
+	if err != nil {
+		return err
+	}
+
+	_, diag := parseFunc(src, filepath)
 	if diag != nil && diag.HasErrors() {
 		return diag
 	}
@@ -47,28 +63,52 @@ func (h *hclFileLoader) GetParser() *hclparse.Parser {
 	return h.hclParser
 }
 
+// ReadTfVarsFromFile loads variable definitions from a `.tfvars` or
+// `.tfvars.json` file into terraformVars.
+//
+// The two formats need different parsers. Terraform reads `*.tfvars.json` as
+// JSON; running it through the native HCL syntax parser produces only syntax
+// errors, so every value in the file was silently dropped and each `var.*`
+// reference fell back to the variable block's default. A security-relevant
+// override declared in `terraform.tfvars.json` was therefore invisible to a
+// scan — a false negative with no error to notice.
 func ReadTfVarsFromFile(filename string, terraformVars map[string]*hcl.Attribute) error {
-	switch {
-	case strings.HasSuffix(filename, ".tfvars"):
-		fallthrough
-	case strings.HasSuffix(filename, ".tfvars.json"):
+	var variableFile *hcl.File
+	var diags hcl.Diagnostics
 
+	switch {
+	case strings.HasSuffix(filename, ".tfvars.json"):
 		src, err := os.ReadFile(filename)
 		if err != nil {
 			return err
 		}
-
-		// we ignore the diagnostics information here
-		variableFile, _ := hclsyntax.ParseConfig(src, filename, hcl.Pos{Line: 1, Column: 1})
-
-		// NOTE: we ignore the diagnostics info
-		attrs, _ := variableFile.Body.JustAttributes()
-		for k := range attrs {
-			v := attrs[k]
-			terraformVars[k] = v
+		variableFile, diags = json.Parse(src, filename)
+	case strings.HasSuffix(filename, ".tfvars"):
+		src, err := os.ReadFile(filename)
+		if err != nil {
+			return err
 		}
-		return nil
+		variableFile, diags = hclsyntax.ParseConfig(src, filename, hcl.Pos{Line: 1, Column: 1})
 	default:
 		return nil
 	}
+
+	// Parse diagnostics are not fatal — a partially readable tfvars file still
+	// contributes the attributes it did parse — but they must not vanish
+	// silently, or a typo'd file looks identical to an absent one.
+	if diags.HasErrors() {
+		log.Warn().Str("path", filename).Str("diagnostics", diags.Error()).Msg("could not fully parse tfvars file")
+	}
+	if variableFile == nil {
+		return nil
+	}
+
+	attrs, attrDiags := variableFile.Body.JustAttributes()
+	if attrDiags.HasErrors() {
+		log.Debug().Str("path", filename).Str("diagnostics", attrDiags.Error()).Msg("tfvars file has non-attribute content")
+	}
+	for k := range attrs {
+		terraformVars[k] = attrs[k]
+	}
+	return nil
 }

--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -138,7 +140,19 @@ func (t *mqlTerraform) ensureCache() error {
 	if ok && conn != nil {
 		if parser := conn.Parser(); parser != nil {
 			files := parser.Files()
+			// Sort the paths before building the block list. parser.Files() is a
+			// Go map, so ranging it directly randomizes block order per process
+			// — and several accessors take a last-writer-wins value while
+			// iterating (terraform.settings.backend most visibly). A policy
+			// asserting backend["type"] == "s3" against a configuration with two
+			// `terraform {}` blocks therefore passed or failed by coin flip.
+			paths := make([]string, 0, len(files))
 			for k := range files {
+				paths = append(paths, k)
+			}
+			sort.Strings(paths)
+
+			for _, k := range paths {
 				f := files[k]
 				bs, err := listHclBlocks(t.MqlRuntime, f.Body, f)
 				if err != nil {
@@ -182,29 +196,46 @@ func (t *mqlTerraform) ensureCache() error {
 		}
 
 		// labels must be pre-initialized
-		name := block.terraformID()
-		t.blocksByName[name] = block
+		key := block.blockKey()
+		if key == "" {
+			// Label-less blocks (terraform {}, locals {}, moved {}) have no
+			// identity of their own. Mapping them all to one empty key made
+			// every one of them report every other one's edges as related.
+			continue
+		}
+		t.blocksByName[key] = block
 	}
 
 	// We need blocks by name before we can jump into
 	// related blocks, because we need to access them
 	// via their name
+	edges := map[string]map[*mqlTerraformBlock]struct{}{}
+	addEdge := func(key string, to *mqlTerraformBlock) {
+		set, ok := edges[key]
+		if !ok {
+			set = map[*mqlTerraformBlock]struct{}{}
+			edges[key] = set
+		}
+		if _, dup := set[to]; dup {
+			return
+		}
+		set[to] = struct{}{}
+		t.relatedBlocks[key] = append(t.relatedBlocks[key], to)
+	}
+
 	for i := range blocks {
 		block := blocks[i].(*mqlTerraformBlock)
-		name := block.terraformID()
-
-		rel, err := listRelatedBlocks(t, block.block.Data.Body)
-		if err != nil {
-			return err
+		key := block.blockKey()
+		if key == "" {
+			continue
 		}
 
-		// connect from this block to all related blocks...
-		t.relatedBlocks[name] = append(t.relatedBlocks[name], rel...)
-		// ... and also connect the inverse (related to this block)
-		for i := range rel {
-			relBlock := rel[i]
-			relName := relBlock.terraformID()
-			t.relatedBlocks[relName] = append(t.relatedBlocks[relName], block)
+		rel := listRelatedBlocks(t, block)
+		for j := range rel {
+			// connect from this block to all related blocks...
+			addEdge(key, rel[j])
+			// ... and also connect the inverse (related to this block)
+			addEdge(rel[j].blockKey(), block)
 		}
 	}
 
@@ -212,29 +243,127 @@ func (t *mqlTerraform) ensureCache() error {
 	return nil
 }
 
-func listRelatedBlocks(t *mqlTerraform, rawBody any) ([]*mqlTerraformBlock, error) {
-	var res []*mqlTerraformBlock
-	switch body := rawBody.(type) {
-	case *hclsyntax.Body:
-		for _, v := range body.Attributes {
-			refs := getReferences(v.Expr, &hcl.EvalContext{
-				Functions: hclFunctions(),
-			})
-			// we need the resource name and its ID at least
-			if len(refs) < 2 {
-				continue
-			}
-
-			refName := strings.Join(refs[0:2], "\x00")
-			if t.blocksByName[refName] == nil { // do not add nil blocks
-				continue
-			}
-			res = append(res, t.blocksByName[refName])
-		}
-	case hcl.Body:
-		return nil, errors.New("cannot yet list related blocks for regular hcl Body")
+// listRelatedBlocks collects the blocks a block's body references.
+//
+// It walks nested blocks as well as top-level attributes (an `ingress { ... }`
+// rule naming a security group is the canonical reference shape and was
+// previously invisible), and it uses hcl.Expression.Variables(), which returns
+// every traversal in an expression tree — so references buried in templates,
+// function calls, lists and conditionals are found too.
+func listRelatedBlocks(t *mqlTerraform, block *mqlTerraformBlock) []*mqlTerraformBlock {
+	if block.block.State != plugin.StateIsSet || block.block.Data == nil {
+		return nil
 	}
-	return res, nil
+	body, ok := block.block.Data.Body.(*hclsyntax.Body)
+	if !ok {
+		// JSON-syntax (.tf.json) bodies carry no typed expression tree, so they
+		// contribute no related edges. This has to degrade rather than fail:
+		// ensureCache is the single entry point behind blocks(), providers(),
+		// datasources(), variables(), outputs(), terraform.resources and
+		// terraform.settings, so one unsupported body used to break every
+		// terraform.* accessor on the asset — including for the native .tf
+		// files beside it.
+		return nil
+	}
+
+	dir := block.blockDir()
+	var res []*mqlTerraformBlock
+	seen := map[*mqlTerraformBlock]struct{}{}
+
+	var walk func(b *hclsyntax.Body)
+	walk = func(b *hclsyntax.Body) {
+		for _, attr := range b.Attributes {
+			for _, traversal := range attr.Expr.Variables() {
+				key := referenceKey(dir, traversalNames(traversal))
+				if key == "" {
+					continue
+				}
+				ref := t.blocksByName[key]
+				if ref == nil || ref == block {
+					continue
+				}
+				if _, dup := seen[ref]; dup {
+					continue
+				}
+				seen[ref] = struct{}{}
+				res = append(res, ref)
+			}
+		}
+		for _, nested := range b.Blocks {
+			walk(nested.Body)
+		}
+	}
+	walk(body)
+
+	return res
+}
+
+// traversalNames renders the leading name path of a traversal
+// (`data.aws_subnet.ec2[x].zone` -> data, aws_subnet, ec2). An index step ends
+// the path, since anything past it addresses into a value rather than naming a
+// block.
+func traversalNames(traversal hcl.Traversal) []string {
+	res := make([]string, 0, len(traversal))
+	for _, step := range traversal {
+		switch v := step.(type) {
+		case hcl.TraverseRoot:
+			res = append(res, v.Name)
+		case hcl.TraverseAttr:
+			res = append(res, v.Name)
+		default:
+			return res
+		}
+	}
+	return res
+}
+
+// blockGraphKey builds the identity a block is tracked under in the block
+// graph: the directory that declares it, its block type, and its labels.
+//
+// The directory matters because it is Terraform's module boundary. The
+// connection walks the whole tree, so a root `main.tf` and a
+// `modules/vpc/main.tf` that both declare `resource "aws_s3_bucket" "this"`
+// used to share one key — and both buckets then reported the same related
+// list containing both modules' policies, so "every bucket has a policy" could
+// pass for a bucket that has none.
+func blockGraphKey(dir, blockType string, labels ...string) string {
+	return dir + "\x00" + blockType + "\x00" + strings.Join(labels, "\x00")
+}
+
+// referenceKey turns a reference traversal into the graph key of the block it
+// points at, or "" when it does not name a block we track.
+func referenceKey(dir string, names []string) string {
+	if len(names) == 0 {
+		return ""
+	}
+	switch names[0] {
+	case "data":
+		// data.<type>.<name>
+		if len(names) < 3 {
+			return ""
+		}
+		return blockGraphKey(dir, "data", names[1], names[2])
+	case "module":
+		if len(names) < 2 {
+			return ""
+		}
+		return blockGraphKey(dir, "module", names[1])
+	case "var":
+		if len(names) < 2 {
+			return ""
+		}
+		return blockGraphKey(dir, "variable", names[1])
+	case "local", "count", "each", "self", "path", "terraform":
+		// locals live in a label-less `locals` block that has no identity of
+		// its own; the rest are not blocks at all.
+		return ""
+	default:
+		// <type>.<name> for a managed resource
+		if len(names) < 2 {
+			return ""
+		}
+		return blockGraphKey(dir, "resource", names[0], names[1])
+	}
 }
 
 func (t *mqlTerraform) providers() ([]any, error) {
@@ -320,12 +449,23 @@ func newMqlHclBlock(runtime *plugin.Runtime, block *hcl.Block, file *hcl.File) (
 		return nil, err
 	}
 	r := res.(*mqlTerraformBlock)
-	r.block = plugin.TValue[*hcl.Block]{State: plugin.StateIsSet, Data: block}
-	r.cachedFile = plugin.TValue[*hcl.File]{State: plugin.StateIsSet, Data: file}
-	return r, err
+	// CreateResource returns the ALREADY CACHED instance when the __id matches,
+	// so this stamping runs on a shared struct: two goroutines reaching the same
+	// block through terraform.blocks and terraform.file(path).blocks used to
+	// write these fields concurrently. Stamp exactly once, which also publishes
+	// the writes to every later reader of the cached instance.
+	r.stampOnce.Do(func() {
+		r.block = plugin.TValue[*hcl.Block]{State: plugin.StateIsSet, Data: block}
+		r.cachedFile = plugin.TValue[*hcl.File]{State: plugin.StateIsSet, Data: file}
+	})
+	return r, nil
 }
 
 type mqlTerraformBlockInternal struct {
+	// stampOnce guards the one-time population of the fields below, which
+	// happens after CreateResource and therefore possibly on a shared,
+	// already-cached instance.
+	stampOnce  sync.Once
 	block      plugin.TValue[*hcl.Block]
 	cachedFile plugin.TValue[*hcl.File]
 }
@@ -424,7 +564,7 @@ func (g *mqlTerraformBlock) context() (*mqlTerraformContext, error) {
 	return cobj.(*mqlTerraformContext), nil
 }
 
-func (g *mqlTerraformBlock) terraformID() string {
+func (g *mqlTerraformBlock) blockLabels() []string {
 	labels := g.Labels.Data
 	var namearr []string
 	for i := range labels {
@@ -432,7 +572,26 @@ func (g *mqlTerraformBlock) terraformID() string {
 			namearr = append(namearr, s)
 		}
 	}
-	return strings.Join(namearr, "\x00")
+	return namearr
+}
+
+// blockDir returns the directory of the file declaring this block, which is
+// the Terraform module the block belongs to.
+func (g *mqlTerraformBlock) blockDir() string {
+	if g.block.State != plugin.StateIsSet || g.block.Data == nil {
+		return ""
+	}
+	return filepath.Dir(g.block.Data.DefRange.Filename)
+}
+
+// blockKey is this block's identity in the terraform singleton's block graph.
+// It returns "" for label-less blocks, which have no identity to key on.
+func (g *mqlTerraformBlock) blockKey() string {
+	labels := g.blockLabels()
+	if len(labels) == 0 {
+		return ""
+	}
+	return blockGraphKey(g.blockDir(), g.Type.Data, labels...)
 }
 
 func (t *mqlTerraformBlock) nameLabel() (string, error) {
@@ -502,12 +661,17 @@ func initTerraformResources(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	// terraform.resources("...") selector instances (mondoohq/mql#8966).
 	id := "terraform.resources"
 	if matchResource != nil || matchName != nil {
+		// Qualify each component by the argument key it came from.
+		// RawData.String() renders a string identically whichever key it came
+		// from, so hashing the bare values made terraform.resources(resource: X)
+		// and terraform.resources(name: X) share a cache key and the second
+		// query silently return the first one's list.
 		s := checksums.New
 		if matchResource != nil {
-			s = s.Add(resourceArg.String())
+			s = s.Add("resource").Add(resourceArg.String())
 		}
 		if matchName != nil {
-			s = s.Add(nameArg.String())
+			s = s.Add("name").Add(nameArg.String())
 		}
 		id = s.String()
 	}
@@ -807,24 +971,41 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		// TODO: are we sure we want to do this?
 		return strings.Join(res, ".")
 	case *hclsyntax.FunctionCallExpr:
-		results := []any{}
-		subVal, err := t.Value(ctx)
-		if err == nil && subVal.Type() == cty.String {
-			if t.Name == "jsonencode" {
-				// Decode into `any` so both a JSON object (`jsonencode({...})`)
-				// and a JSON array (`jsonencode([...])`) resolve. Unmarshalling
-				// into a map[string]any silently failed for a top-level array,
-				// leaving the argument empty so a check iterating the encoded
-				// list saw nothing and passed vacuously. appendCtyResult keeps
-				// the object case list-wrapped while flattening a decoded list
-				// into the result so it stays iterable.
-				var res any
-				if err := json.Unmarshal([]byte(subVal.AsString()), &res); err == nil {
-					appendCtyResult(&results, res)
+		// AsString panics on a null AND on an unknown value, and an unknown one
+		// reaches here whenever the function resolves but an argument does not
+		// (`jsonencode(<unknown>)` returns cty.UnknownVal with no diagnostic at
+		// all). Guard on known/non-null before touching the value.
+		if subVal, diags := t.Value(ctx); !diags.HasErrors() && subVal.IsKnown() && !subVal.IsNull() {
+			if subVal.Type() == cty.String {
+				results := []any{}
+				if t.Name == "jsonencode" {
+					// Decode into `any` so both a JSON object (`jsonencode({...})`)
+					// and a JSON array (`jsonencode([...])`) resolve. Unmarshalling
+					// into a map[string]any silently failed for a top-level array,
+					// leaving the argument empty so a check iterating the encoded
+					// list saw nothing and passed vacuously. appendCtyResult keeps
+					// the object case list-wrapped while flattening a decoded list
+					// into the result so it stays iterable.
+					var res any
+					if err := json.Unmarshal([]byte(subVal.AsString()), &res); err == nil {
+						appendCtyResult(&results, res)
+					}
+					return results
 				}
-			} else {
 				results = append(results, subVal.AsString())
+				return results
 			}
+			return ctyValueToGo(subVal)
+		}
+		// The function table registers only a small set of pure functions, so
+		// `format`, `merge`, `join`, `lookup`, `try`, `coalesce`, ... all fail
+		// with "Call to unknown function". Surface what the arguments reference,
+		// the way ConditionalExpr does, rather than returning an empty list: a
+		// tag-governance check reading arguments["tags"] on a
+		// `merge(var.common_tags, {...})` value otherwise saw nothing at all.
+		results := []any{}
+		for _, arg := range t.Args {
+			appendCtyResult(&results, getCtyValue(arg, ctx))
 		}
 		return results
 	case *hclsyntax.ConditionalExpr:
@@ -846,6 +1027,9 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		appendCtyResult(&results, getCtyValue(t.FalseResult, ctx))
 		return results
 	case *hclsyntax.ForExpr:
+		if val, diags := t.Value(ctx); !diags.HasErrors() && val.IsKnown() && !val.IsNull() {
+			return ctyValueToGo(val)
+		}
 		results := []any{}
 		appendCtyResult(&results, getCtyValue(t.CollExpr, ctx))
 		if t.KeyExpr != nil {
@@ -857,11 +1041,21 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		}
 		return results
 	case *hclsyntax.IndexExpr:
+		if val, diags := t.Value(ctx); !diags.HasErrors() && val.IsKnown() && !val.IsNull() {
+			return ctyValueToGo(val)
+		}
 		results := []any{}
 		appendCtyResult(&results, getCtyValue(t.Collection, ctx))
 		appendCtyResult(&results, getCtyValue(t.Key, ctx))
 		return results
 	case *hclsyntax.BinaryOpExpr:
+		// Evaluate the operation so the RESULT is surfaced, not the operands.
+		// `8080 + 1` read as [8080, 1] and `8080 > 80` as [8080, 80], which
+		// defeats every scalar comparison a policy writes against them.
+		// ConditionalExpr and UnaryOpExpr already did this; these arms did not.
+		if val, diags := t.Value(ctx); !diags.HasErrors() && val.IsKnown() && !val.IsNull() {
+			return ctyValueToGo(val)
+		}
 		results := []any{}
 		appendCtyResult(&results, getCtyValue(t.LHS, ctx))
 		appendCtyResult(&results, getCtyValue(t.RHS, ctx))
@@ -877,6 +1071,9 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		}
 		return getCtyValue(t.Val, ctx)
 	case *hclsyntax.SplatExpr:
+		if val, diags := t.Value(ctx); !diags.HasErrors() && val.IsKnown() && !val.IsNull() {
+			return ctyValueToGo(val)
+		}
 		results := []any{}
 		appendCtyResult(&results, getCtyValue(t.Source, ctx))
 		appendCtyResult(&results, getCtyValue(t.Each, ctx))
@@ -943,7 +1140,7 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		// single string. Attempt that first; otherwise fall back to surfacing the
 		// individual parts/references below (the historical behavior when off).
 		if ctx != nil && len(ctx.Variables) > 0 {
-			if subVal, diags := t.Value(ctx); !diags.HasErrors() && subVal.Type() == cty.String {
+			if subVal, diags := t.Value(ctx); !diags.HasErrors() && subVal.IsKnown() && !subVal.IsNull() && subVal.Type() == cty.String {
 				return subVal.AsString()
 			}
 		}
@@ -990,28 +1187,6 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		return v
 	default:
 		log.Warn().Msgf("unknown type %T", t)
-		return nil
-	}
-}
-
-func getReferences(expr hcl.Expression, ctx *hcl.EvalContext) []string {
-	switch t := expr.(type) {
-	case *hclsyntax.ScopeTraversalExpr:
-		traversal := t.Variables()
-		res := []string{}
-		for i := range traversal {
-			tr := traversal[i]
-			for j := range tr {
-				switch v := tr[j].(type) {
-				case hcl.TraverseRoot:
-					res = append(res, v.Name)
-				case hcl.TraverseAttr:
-					res = append(res, v.Name)
-				}
-			}
-		}
-		return res
-	default:
 		return nil
 	}
 }
@@ -1160,7 +1335,7 @@ func (g *mqlTerraformBlock) related() ([]any, error) {
 
 	terraform.lock.Lock()
 	defer terraform.lock.Unlock()
-	related := terraform.relatedBlocks[g.terraformID()]
+	related := terraform.relatedBlocks[g.blockKey()]
 	res := make([]any, len(related))
 	for i := range related {
 		res[i] = related[i]
@@ -1327,8 +1502,16 @@ func initTerraformSettings(runtime *plugin.Runtime, args map[string]*llx.RawData
 						// Shorthand syntax: aws = "~> 3.74"
 						version = v
 					}
+					// Qualify the cache key by the file that declares the
+					// constraint. This init deliberately collects the
+					// required_providers of EVERY `terraform {}` block in the
+					// tree, so keying on the provider name alone made a root
+					// `aws = "~> 3.0"` and a modules/vpc `aws = "~> 5.0"` hash
+					// to one entry — the list then held the first one twice and
+					// the module's constraint was invisible to a pin check.
 					r, err := CreateResource(runtime, "terraform.settings.requiredProvider",
 						map[string]*llx.RawData{
+							"__id":    llx.StringData("terraform.settings.requiredProvider/" + hb.DefRange.Filename + "/" + name),
 							"name":    llx.StringData(name),
 							"source":  llx.StringData(source),
 							"version": llx.StringData(version),

--- a/providers/terraform/resources/hcl_expr_test.go
+++ b/providers/terraform/resources/hcl_expr_test.go
@@ -1,0 +1,185 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// TestGetCtyValue_UnknownFunctionSurfacesReferences is a regression test for
+// arguments() returning an EMPTY list for any expression built with a function
+// the evaluator does not register.
+//
+// The function table carries only jsondecode/jsonencode, so `format`, `merge`,
+// `join`, `lookup`, `try`, `coalesce`, ... all fail evaluation with "Call to
+// unknown function". The FunctionCallExpr arm returned its empty results slice
+// on that failure with no reference fallback (unlike ScopeTraversalExpr and
+// ConditionalExpr, which do surface references), so `arguments["tags"]` came
+// back as `[]` and a tag-governance check saw nothing to complain about.
+func TestGetCtyValue_UnknownFunctionSurfacesReferences(t *testing.T) {
+	t.Run("format", func(t *testing.T) {
+		attrs := parseAttrs(t, `bucket = format("%s-logs", local.env)`)
+		got, err := hclResolvedAttributesToDict(attrs, nil)
+		require.NoError(t, err)
+		assert.True(t, containsString(got["bucket"], "local.env"),
+			"an unresolvable function call must still surface its argument references, got: %#v", got["bucket"])
+	})
+
+	t.Run("merge", func(t *testing.T) {
+		attrs := parseAttrs(t, `tags = merge(var.common_tags, { Name = "x" })`)
+		got, err := hclResolvedAttributesToDict(attrs, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, got["tags"], "merge() must not resolve to an empty value")
+		assert.True(t, containsString(got["tags"], "var.common_tags"),
+			"merge() must surface var.common_tags, got: %#v", got["tags"])
+		assert.True(t, containsString(got["tags"], "x"),
+			"merge() must surface the inline tag value, got: %#v", got["tags"])
+	})
+
+	t.Run("nested", func(t *testing.T) {
+		attrs := parseAttrs(t, `name = join("-", [var.prefix, lookup(local.names, "primary")])`)
+		got, err := hclResolvedAttributesToDict(attrs, nil)
+		require.NoError(t, err)
+		assert.True(t, containsString(got["name"], "var.prefix"),
+			"nested function calls must surface references, got: %#v", got["name"])
+		assert.True(t, containsString(got["name"], "local.names"),
+			"nested function calls must surface references, got: %#v", got["name"])
+	})
+}
+
+// TestGetCtyValue_JsonencodeStillResolves guards the registered-function path
+// against the reference fallback added above: a call that DOES evaluate must
+// keep returning its value, not its argument references.
+func TestGetCtyValue_JsonencodeStillResolves(t *testing.T) {
+	attrs := parseAttrs(t, `policy = jsonencode({ Version = "2012-10-17" })`)
+	got, err := hclResolvedAttributesToDict(attrs, nil)
+	require.NoError(t, err)
+	list, ok := got["policy"].([]any)
+	require.True(t, ok, "expected a list-wrapped map, got: %#v", got["policy"])
+	require.Len(t, list, 1)
+	assert.Equal(t, "2012-10-17", list[0].(map[string]any)["Version"])
+}
+
+// TestGetCtyValue_OperatorsEvaluateToTheirResult is a regression test for
+// BinaryOpExpr, ForExpr, IndexExpr and SplatExpr returning their OPERANDS
+// rather than the computed result.
+//
+// ConditionalExpr and UnaryOpExpr already try t.Value(ctx) first and only fall
+// back to reference-surfacing; these four never did. So `8080 + 1` read as
+// [8080, 1] instead of 8081 and `8080 > 80` read as [8080, 80] instead of true,
+// which defeats every scalar comparison a policy writes against them.
+func TestGetCtyValue_OperatorsEvaluateToTheirResult(t *testing.T) {
+	t.Run("binary arithmetic", func(t *testing.T) {
+		attrs := parseAttrs(t, `sum = 8080 + 1`)
+		got, err := hclResolvedAttributesToDict(attrs, nil)
+		require.NoError(t, err)
+		assert.Equal(t, float64(8081), got["sum"])
+	})
+
+	t.Run("binary comparison", func(t *testing.T) {
+		attrs := parseAttrs(t, `cmp = 8080 > 80`)
+		got, err := hclResolvedAttributesToDict(attrs, nil)
+		require.NoError(t, err)
+		assert.Equal(t, true, got["cmp"])
+	})
+
+	t.Run("binary over resolved locals", func(t *testing.T) {
+		attrs := parseAttrs(t, `open = local.port == 22`)
+		ctx := resolvingCtx(nil, map[string]cty.Value{"port": cty.NumberIntVal(22)})
+		got, err := hclResolvedAttributesToDict(attrs, ctx)
+		require.NoError(t, err)
+		assert.Equal(t, true, got["open"])
+	})
+
+	t.Run("for expression", func(t *testing.T) {
+		attrs := parseAttrs(t, `forx = [for p in local.list : p + 1]`)
+		ctx := resolvingCtx(nil, map[string]cty.Value{
+			"list": cty.TupleVal([]cty.Value{cty.NumberIntVal(10), cty.NumberIntVal(20)}),
+		})
+		got, err := hclResolvedAttributesToDict(attrs, ctx)
+		require.NoError(t, err)
+		assert.Equal(t, []any{float64(11), float64(21)}, got["forx"])
+	})
+
+	t.Run("index expression", func(t *testing.T) {
+		attrs := parseAttrs(t, `dyn = local.m[local.k]`)
+		ctx := resolvingCtx(nil, map[string]cty.Value{
+			"m": cty.ObjectVal(map[string]cty.Value{"a": cty.NumberIntVal(1), "b": cty.NumberIntVal(2)}),
+			"k": cty.StringVal("a"),
+		})
+		got, err := hclResolvedAttributesToDict(attrs, ctx)
+		require.NoError(t, err)
+		assert.Equal(t, float64(1), got["dyn"])
+	})
+
+	t.Run("splat expression", func(t *testing.T) {
+		attrs := parseAttrs(t, `ids = local.items[*].id`)
+		ctx := resolvingCtx(nil, map[string]cty.Value{
+			"items": cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("one")}),
+				cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("two")}),
+			}),
+		})
+		got, err := hclResolvedAttributesToDict(attrs, ctx)
+		require.NoError(t, err)
+		assert.Equal(t, []any{"one", "two"}, got["ids"])
+	})
+}
+
+// TestGetCtyValue_OperatorsKeepReferenceFallback guards the other half: when an
+// operand cannot be evaluated the arms must keep surfacing references rather
+// than collapsing to nil.
+func TestGetCtyValue_OperatorsKeepReferenceFallback(t *testing.T) {
+	cases := map[string]struct{ src, ref string }{
+		"binary": {`match = var.availability_zone == "account_based"`, "var.availability_zone"},
+		"index":  {`subnet_id = local.subnet_id_by_az_suffix[local.az_suffix]`, "local.subnet_id_by_az_suffix"},
+		"splat":  {`instance_ids = data.aws_instances.all[*].id`, "data.aws_instances.all"},
+		"for":    {`sg_ids = [for sg in data.aws_security_group.ec2 : sg.id]`, "data.aws_security_group.ec2"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			attrs := parseAttrs(t, tc.src)
+			got, err := hclResolvedAttributesToDict(attrs, nil)
+			require.NoError(t, err)
+			for _, v := range got {
+				assert.True(t, containsString(v, tc.ref),
+					"unresolvable %s expression must still surface %s, got: %#v", name, tc.ref, v)
+			}
+		})
+	}
+}
+
+// TestGetCtyValue_UnknownStringDoesNotPanic hardens the three AsString() call
+// sites against unknown cty values. cty.Value.AsString panics on a null AND on
+// an unknown value, and an unknown one reaches these paths whenever a function
+// can be resolved but one of its arguments cannot.
+func TestGetCtyValue_UnknownStringDoesNotPanic(t *testing.T) {
+	// `jsonencode(var.x)` with an unknown var evaluates to an UNKNOWN string
+	// with no diagnostic at all — the exact shape that panics on AsString().
+	attrs := parseAttrs(t, `policy = jsonencode(var.unknown_input)`)
+	ctx := resolvingCtx(map[string]cty.Value{"unknown_input": cty.UnknownVal(cty.String)}, nil)
+
+	require.NotPanics(t, func() {
+		got, err := hclResolvedAttributesToDict(attrs, ctx)
+		require.NoError(t, err)
+		_ = got["policy"]
+	})
+}
+
+// TestGetCtyValue_UnknownTemplateDoesNotPanic covers the TemplateExpr
+// AsString() call site with the same unknown-value shape.
+func TestGetCtyValue_UnknownTemplateDoesNotPanic(t *testing.T) {
+	attrs := parseAttrs(t, `name = "app-${var.env}-bucket"`)
+	ctx := resolvingCtx(map[string]cty.Value{"env": cty.UnknownVal(cty.String)}, nil)
+
+	require.NotPanics(t, func() {
+		got, err := hclResolvedAttributesToDict(attrs, ctx)
+		require.NoError(t, err)
+		assert.NotNil(t, got["name"], "an unknown interpolation must still surface something")
+	})
+}

--- a/providers/terraform/resources/hcl_ids_test.go
+++ b/providers/terraform/resources/hcl_ids_test.go
@@ -1,0 +1,247 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+)
+
+// TestTerraformResources_SelectorArgsAreKeyQualified is a regression test for
+// terraform.resources(resource: X) and terraform.resources(name: X) computing
+// the same __id.
+//
+// The checksum was built from the argument VALUE only, and RawData.String()
+// renders a string identically whichever key it came from, so the two selector
+// forms aliased in the resource cache and the second query silently returned
+// the first one's list. Shared literals like "main", "default" and "this" make
+// that collision an everyday occurrence.
+func TestTerraformResources_SelectorArgsAreKeyQualified(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf": `
+resource "web" "app" {}
+resource "aws_instance" "web" {}
+`,
+	})
+	rt := newRuntimeForDir(t, dir)
+
+	byResource, _, err := initTerraformResources(rt, map[string]*llx.RawData{
+		"resource": llx.StringData("web"),
+	})
+	require.NoError(t, err)
+	byName, _, err := initTerraformResources(rt, map[string]*llx.RawData{
+		"name": llx.StringData("web"),
+	})
+	require.NoError(t, err)
+
+	assert.NotEqual(t, byResource["__id"].Value.(string), byName["__id"].Value.(string),
+		`terraform.resources(resource: "web") and (name: "web") must not share a cache key`)
+
+	// And the lists themselves must differ, which is what the collision hid.
+	resList := byResource["list"].Value.([]any)
+	nameList := byName["list"].Value.([]any)
+	require.Len(t, resList, 1)
+	require.Len(t, nameList, 1)
+	assert.Equal(t, "web", resList[0].(*mqlTerraformBlock).Labels.Data[0])
+	assert.Equal(t, "aws_instance", nameList[0].(*mqlTerraformBlock).Labels.Data[0])
+
+	// A combined selector must be distinct from either single-key form.
+	both, _, err := initTerraformResources(rt, map[string]*llx.RawData{
+		"resource": llx.StringData("web"),
+		"name":     llx.StringData("web"),
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, byResource["__id"].Value.(string), both["__id"].Value.(string))
+	assert.NotEqual(t, byName["__id"].Value.(string), both["__id"].Value.(string))
+}
+
+// blockInDir returns the single block from the cache whose declaring file lives
+// in <root>/<sub> and whose labels match.
+func blockInDir(t *testing.T, blocks []any, root, sub string, labels ...string) *mqlTerraformBlock {
+	t.Helper()
+	want := filepath.Join(root, filepath.FromSlash(sub))
+	var found *mqlTerraformBlock
+	for i := range blocks {
+		b := blocks[i].(*mqlTerraformBlock)
+		if b.block.Data == nil {
+			continue
+		}
+		if filepath.Dir(b.block.Data.DefRange.Filename) != want {
+			continue
+		}
+		if len(b.Labels.Data) != len(labels) {
+			continue
+		}
+		match := true
+		for j := range labels {
+			if b.Labels.Data[j] != labels[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			require.Nil(t, found, "more than one block matched %v in %s", labels, sub)
+			found = b
+		}
+	}
+	require.NotNil(t, found, "no block %v found in %s", labels, sub)
+	return found
+}
+
+// TestTerraformBlock_RelatedDoesNotCrossModules is a regression test for
+// terraformID() colliding across files.
+//
+// The connection walks the whole directory tree, so a root `main.tf` and a
+// `modules/vpc/main.tf` that both declare `resource "aws_s3_bucket" "this"`
+// shared one blocksByName key. Both buckets then reported the same related
+// list containing BOTH policies, so a check like "every bucket has a policy
+// denying insecure transport" passed for the module bucket on the strength of
+// the root bucket's policy.
+func TestTerraformBlock_RelatedDoesNotCrossModules(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf": `
+resource "aws_s3_bucket" "this" {}
+
+resource "aws_s3_bucket_policy" "root" {
+  bucket = aws_s3_bucket.this.id
+  policy = "root-policy"
+}
+`,
+		"modules/vpc/main.tf": `
+resource "aws_s3_bucket" "this" {}
+
+resource "aws_s3_bucket_policy" "module" {
+  bucket = aws_s3_bucket.this.id
+  policy = "module-policy"
+}
+`,
+	})
+	rt := newRuntimeForDir(t, dir)
+	tf := newTerraformSingleton(t, rt)
+
+	blocks, err := tf.blocks()
+	require.NoError(t, err)
+
+	rootBucket := blockInDir(t, blocks, dir, ".", "aws_s3_bucket", "this")
+	moduleBucket := blockInDir(t, blocks, dir, "modules/vpc", "aws_s3_bucket", "this")
+	require.NotSame(t, rootBucket, moduleBucket, "the two buckets must be distinct block instances")
+
+	rootRelated, err := rootBucket.related()
+	require.NoError(t, err)
+	require.Len(t, rootRelated, 1, "the root bucket must only relate to the policy in its own directory")
+	assert.Equal(t, "root", rootRelated[0].(*mqlTerraformBlock).Labels.Data[1])
+
+	moduleRelated, err := moduleBucket.related()
+	require.NoError(t, err)
+	require.Len(t, moduleRelated, 1, "the module bucket must only relate to the policy in its own directory")
+	assert.Equal(t, "module", moduleRelated[0].(*mqlTerraformBlock).Labels.Data[1])
+}
+
+// TestTerraformBlock_LabellessBlocksAreNotConflated is a regression test for
+// every label-less block (`terraform {}`, `locals {}`, `moved {}`) mapping to
+// the same empty terraformID key, which made related() report unrelated blocks.
+func TestTerraformBlock_LabellessBlocksAreNotConflated(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf": `
+terraform {}
+
+locals {
+  env = "prod"
+}
+
+moved {
+  from = aws_s3_bucket.old
+  to   = aws_s3_bucket.new
+}
+
+resource "aws_s3_bucket" "new" {}
+`,
+	})
+	rt := newRuntimeForDir(t, dir)
+	tf := newTerraformSingleton(t, rt)
+
+	blocks, err := tf.blocks()
+	require.NoError(t, err)
+	require.Len(t, blocks, 4)
+
+	for i := range blocks {
+		b := blocks[i].(*mqlTerraformBlock)
+		if b.Type.Data != "terraform" && b.Type.Data != "locals" {
+			continue
+		}
+		related, err := b.related()
+		require.NoError(t, err)
+		assert.Emptyf(t, related,
+			"label-less %q block must not inherit the `moved` block's edges through a shared empty id",
+			b.Type.Data)
+	}
+}
+
+// TestTerraformSettings_BackendIsDeterministic is a regression test for
+// terraform.settings.backend flapping between runs.
+//
+// ensureCache built its block list by ranging over parser.Files(), a Go map
+// whose iteration order is randomized per process, and initTerraformSettings
+// took a last-writer-wins backend while iterating those blocks. With two
+// `terraform {}` blocks carrying a backend, a policy asserting
+// backend["type"] == "s3" passed or failed depending on the run.
+func TestTerraformSettings_BackendIsDeterministic(t *testing.T) {
+	files := map[string]string{
+		"a_backend.tf": "terraform {\n  backend \"s3\" {\n    bucket = \"tf-state\"\n  }\n}\n",
+		"z_backend.tf": "terraform {\n  backend \"local\" {\n    path = \"terraform.tfstate\"\n  }\n}\n",
+	}
+
+	var first string
+	for i := 0; i < 40; i++ {
+		rt := newRuntimeForDir(t, writeTfDir(t, files))
+		args, _, err := initTerraformSettings(rt, map[string]*llx.RawData{})
+		require.NoError(t, err)
+		backend, ok := args["backend"].Value.(map[string]any)
+		require.True(t, ok, "backend must be a dict, got %#v", args["backend"].Value)
+		typ, _ := backend["type"].(string)
+		require.NotEmpty(t, typ)
+		if i == 0 {
+			first = typ
+			continue
+		}
+		require.Equalf(t, first, typ,
+			"terraform.settings.backend must be deterministic across runs (iteration %d)", i)
+	}
+}
+
+// TestTerraformSettings_RequiredProvidersDoNotCollideAcrossFiles is a
+// regression test for terraform.settings.requiredProvider ids keyed on the
+// provider name alone.
+//
+// initTerraformSettings deliberately collects the required_providers of EVERY
+// `terraform {}` block in the tree. When the root pins `aws = "~> 3.0"` and
+// modules/vpc pins `aws = "~> 5.0"`, both entries hashed to the same cache key,
+// so the list contained the first entry twice and the module's constraint was
+// invisible to a supply-chain pin check.
+func TestTerraformSettings_RequiredProvidersDoNotCollideAcrossFiles(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf":             "terraform {\n  required_providers {\n    aws = \"~> 3.0\"\n  }\n}\n",
+		"modules/vpc/main.tf": "terraform {\n  required_providers {\n    aws = \"~> 5.0\"\n  }\n}\n",
+	})
+	rt := newRuntimeForDir(t, dir)
+
+	args, _, err := initTerraformSettings(rt, map[string]*llx.RawData{})
+	require.NoError(t, err)
+
+	list := args["requiredProviders"].Value.([]any)
+	require.Len(t, list, 2)
+
+	versions := map[string]bool{}
+	for i := range list {
+		rp := list[i].(*mqlTerraformSettingsRequiredProvider)
+		assert.Equal(t, "aws", rp.Name.Data, "the user-facing name must stay the bare provider name")
+		versions[rp.Version.Data] = true
+	}
+	assert.Equal(t, map[string]bool{"~> 3.0": true, "~> 5.0": true}, versions,
+		"both version constraints must be visible, not the first one twice")
+}

--- a/providers/terraform/resources/hcl_json_test.go
+++ b/providers/terraform/resources/hcl_json_test.go
@@ -1,0 +1,106 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// writeTfDir writes the given relative paths into a fresh temp dir and returns
+// it. Nested paths (e.g. "modules/vpc/main.tf") create their parent dirs.
+func writeTfDir(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range files {
+		full := filepath.Join(dir, filepath.FromSlash(name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o600))
+	}
+	return dir
+}
+
+// newTerraformSingleton returns the terraform singleton for a runtime.
+func newTerraformSingleton(t *testing.T, rt *plugin.Runtime) *mqlTerraform {
+	t.Helper()
+	tfraw, err := CreateResource(rt, "terraform", map[string]*llx.RawData{})
+	require.NoError(t, err)
+	return tfraw.(*mqlTerraform)
+}
+
+// TestTerraformAccessors_JSONFileDoesNotPoisonEveryAccessor is a regression
+// test for a single `.tf.json` file breaking every terraform.* accessor.
+//
+// hclparse.ParseJSON produces a plain hcl.Body (not *hclsyntax.Body), and
+// listRelatedBlocks returned a hard error for that case. That error propagated
+// out of ensureCache, which is the single entry point behind blocks(),
+// providers(), datasources(), variables(), outputs(), terraform.resources and
+// terraform.settings. So one JSON file — the default CDKTF output layout, and a
+// format the schema advertises support for — made all of them fail, including
+// for the native .tf files sitting beside it.
+func TestTerraformAccessors_JSONFileDoesNotPoisonEveryAccessor(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf": `
+variable "env" { default = "prod" }
+output "bucket" { value = aws_s3_bucket.native.id }
+provider "aws" { region = "us-east-1" }
+data "aws_ami" "ubuntu" { most_recent = true }
+resource "aws_s3_bucket" "native" {}
+`,
+		"cdk.tf.json": `{"resource":{"aws_security_group":{"sg":{"name":"allow-ssh"}}}}`,
+	})
+	rt := newRuntimeForDir(t, dir)
+	tf := newTerraformSingleton(t, rt)
+
+	blocks, err := tf.blocks()
+	require.NoError(t, err, "a .tf.json file must not break terraform.blocks")
+	require.NotEmpty(t, blocks)
+
+	providers, err := tf.providers()
+	require.NoError(t, err, "a .tf.json file must not break terraform.providers")
+	assert.Len(t, providers, 1)
+
+	datasources, err := tf.datasources()
+	require.NoError(t, err, "a .tf.json file must not break terraform.datasources")
+	assert.Len(t, datasources, 1)
+
+	variables, err := tf.variables()
+	require.NoError(t, err, "a .tf.json file must not break terraform.variables")
+	assert.Len(t, variables, 1)
+
+	outputs, err := tf.outputs()
+	require.NoError(t, err, "a .tf.json file must not break terraform.outputs")
+	assert.Len(t, outputs, 1)
+
+	args, _, err := initTerraformResources(rt, map[string]*llx.RawData{})
+	require.NoError(t, err, "a .tf.json file must not break terraform.resources")
+	list := args["list"].Value.([]any)
+	require.NotEmpty(t, list, "the native .tf resource must still be listed")
+
+	// The related() graph must resolve too, rather than erroring out.
+	native := list[0].(*mqlTerraformBlock)
+	_, err = native.related()
+	require.NoError(t, err, "a .tf.json file must not break terraform.block.related")
+}
+
+// TestTerraformSettings_JSONFileDoesNotPoisonInit covers the settings init,
+// which shares the same ensureCache entry point.
+func TestTerraformSettings_JSONFileDoesNotPoisonInit(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf":     "terraform {\n  required_providers {\n    aws = \"~> 3.0\"\n  }\n}\n",
+		"cdk.tf.json": `{"resource":{"aws_security_group":{"sg":{"name":"allow-ssh"}}}}`,
+	})
+	rt := newRuntimeForDir(t, dir)
+
+	args, _, err := initTerraformSettings(rt, map[string]*llx.RawData{})
+	require.NoError(t, err, "a .tf.json file must not break terraform.settings")
+	require.NotNil(t, args)
+	require.Len(t, args["requiredProviders"].Value.([]any), 1)
+}

--- a/providers/terraform/resources/hcl_race_test.go
+++ b/providers/terraform/resources/hcl_race_test.go
@@ -139,3 +139,61 @@ func TestTerraformResources_UnfilteredStableID(t *testing.T) {
 	require.NotEqual(t, selID, sel2["__id"].Value.(string),
 		"distinct terraform.resources(\"type\") selectors must have distinct __ids")
 }
+
+// TestNewMqlHclBlock_ConcurrentStamping is a regression test for a data race in
+// newMqlHclBlock. It wrote r.block and r.cachedFile unconditionally after
+// CreateResource — but CreateResource returns the ALREADY CACHED instance when
+// the __id matches. Two goroutines reaching the same block through
+// terraform.blocks and terraform.file(path).blocks therefore wrote the same
+// struct fields at the same time.
+//
+// Run with -race; the fix must also leave the internals correctly populated.
+func TestNewMqlHclBlock_ConcurrentStamping(t *testing.T) {
+	const iterations = 50
+
+	for i := 0; i < iterations; i++ {
+		rt := newHclRaceRuntime(t)
+
+		tfraw, err := CreateResource(rt, "terraform", map[string]*llx.RawData{})
+		require.NoError(t, err)
+		tf := tfraw.(*mqlTerraform)
+
+		filesRaw, err := tf.files()
+		require.NoError(t, err)
+		require.NotEmpty(t, filesRaw)
+
+		var wg sync.WaitGroup
+		// One goroutine walks every block through the terraform singleton...
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tf.GetBlocks()
+		}()
+		// ... while others re-list the same blocks per file, which hits the
+		// same cached terraform.block instances.
+		for f := range filesRaw {
+			file := filesRaw[f].(*mqlTerraformFile)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				blocks, err := file.blocks()
+				if err != nil {
+					return
+				}
+				for b := range blocks {
+					// Read the internals the other goroutines are stamping.
+					_ = blocks[b].(*mqlTerraformBlock).block.Data
+				}
+			}()
+		}
+		wg.Wait()
+
+		blocks, err := tf.blocks()
+		require.NoError(t, err)
+		for b := range blocks {
+			block := blocks[b].(*mqlTerraformBlock)
+			require.NotNil(t, block.block.Data, "block internals must still be populated")
+			require.NotNil(t, block.cachedFile.Data, "file internals must still be populated")
+		}
+	}
+}

--- a/providers/terraform/resources/hcl_related_test.go
+++ b/providers/terraform/resources/hcl_related_test.go
@@ -1,0 +1,165 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// relatedLabels returns the label tuples of a block's related() list, so tests
+// can assert on the graph without caring about ordering.
+func relatedLabels(t *testing.T, b *mqlTerraformBlock) map[string]bool {
+	t.Helper()
+	related, err := b.related()
+	require.NoError(t, err)
+	out := map[string]bool{}
+	for i := range related {
+		rb := related[i].(*mqlTerraformBlock)
+		key := rb.Type.Data
+		for _, l := range rb.Labels.Data {
+			key += "." + l.(string)
+		}
+		out[key] = true
+	}
+	return out
+}
+
+// TestRelated_ResolvesPrefixedReferences is a regression test for related()
+// only ever resolving managed-resource references.
+//
+// The lookup joined refs[0:2], which forms a valid key only for
+// `<type>.<name>`. A `data.aws_ami.ubuntu.id` reference produced the key
+// `data\x00aws_ami` while the data block's own id is `aws_ami\x00ubuntu`, so
+// data sources, modules and variables never appeared in the graph at all.
+func TestRelated_ResolvesPrefixedReferences(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf": `
+variable "instance_type" { default = "t3.micro" }
+
+data "aws_ami" "ubuntu" { most_recent = true }
+
+module "vpc" { source = "./modules/vpc" }
+
+resource "aws_instance" "web" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = var.instance_type
+  subnet_id     = module.vpc.subnet_id
+}
+`,
+	})
+	rt := newRuntimeForDir(t, dir)
+	tf := newTerraformSingleton(t, rt)
+
+	blocks, err := tf.blocks()
+	require.NoError(t, err)
+	web := blockInDir(t, blocks, dir, ".", "aws_instance", "web")
+
+	got := relatedLabels(t, web)
+	assert.True(t, got["data.aws_ami.ubuntu"], "data.* reference must resolve, got: %v", got)
+	assert.True(t, got["variable.instance_type"], "var.* reference must resolve, got: %v", got)
+	assert.True(t, got["module.vpc"], "module.* reference must resolve, got: %v", got)
+
+	// The inverse edges must be there too.
+	ami := blockInDir(t, blocks, dir, ".", "aws_ami", "ubuntu")
+	assert.True(t, relatedLabels(t, ami)["resource.aws_instance.web"],
+		"the data source must relate back to the resource that uses it")
+}
+
+// TestRelated_ResolvesReferencesInsideNestedBlocks is a regression test for
+// related() walking only body.Attributes. A reference written inside a nested
+// block — the standard shape for a security-group rule — was never seen.
+func TestRelated_ResolvesReferencesInsideNestedBlocks(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf": `
+resource "aws_security_group" "bastion" {
+  name = "bastion"
+}
+
+resource "aws_security_group" "app" {
+  name = "app"
+
+  ingress {
+    from_port       = 22
+    to_port         = 22
+    security_groups = [aws_security_group.bastion.id]
+  }
+}
+`,
+	})
+	rt := newRuntimeForDir(t, dir)
+	tf := newTerraformSingleton(t, rt)
+
+	blocks, err := tf.blocks()
+	require.NoError(t, err)
+	app := blockInDir(t, blocks, dir, ".", "aws_security_group", "app")
+
+	assert.True(t, relatedLabels(t, app)["resource.aws_security_group.bastion"],
+		"a reference inside a nested block must be part of the related graph")
+}
+
+// TestRelated_ResolvesReferencesInsideExpressions is a regression test for
+// getReferences() handling only bare ScopeTraversalExpr. References buried in a
+// template, a list, a conditional or a function call were invisible.
+func TestRelated_ResolvesReferencesInsideExpressions(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf": `
+resource "aws_s3_bucket" "logs" {
+  bucket = "logs"
+}
+
+resource "aws_s3_bucket" "data" {
+  bucket = "data"
+}
+
+resource "aws_s3_bucket_policy" "p" {
+  bucket    = "x-${aws_s3_bucket.logs.id}"
+  targets   = [aws_s3_bucket.data.arn]
+  encoded   = jsonencode({ b = aws_s3_bucket.logs.arn })
+}
+`,
+	})
+	rt := newRuntimeForDir(t, dir)
+	tf := newTerraformSingleton(t, rt)
+
+	blocks, err := tf.blocks()
+	require.NoError(t, err)
+	policy := blockInDir(t, blocks, dir, ".", "aws_s3_bucket_policy", "p")
+
+	got := relatedLabels(t, policy)
+	assert.True(t, got["resource.aws_s3_bucket.logs"],
+		"a reference inside a template/function must resolve, got: %v", got)
+	assert.True(t, got["resource.aws_s3_bucket.data"],
+		"a reference inside a list must resolve, got: %v", got)
+}
+
+// TestRelated_DeduplicatesRepeatedReferences keeps the graph free of duplicate
+// edges now that every traversal in an expression tree is walked: a block
+// referenced twice must appear once.
+func TestRelated_DeduplicatesRepeatedReferences(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf": `
+resource "aws_s3_bucket" "b" {
+  bucket = "b"
+}
+
+resource "aws_s3_bucket_policy" "p" {
+  bucket = aws_s3_bucket.b.id
+  policy = aws_s3_bucket.b.arn
+}
+`,
+	})
+	rt := newRuntimeForDir(t, dir)
+	tf := newTerraformSingleton(t, rt)
+
+	blocks, err := tf.blocks()
+	require.NoError(t, err)
+	policy := blockInDir(t, blocks, dir, ".", "aws_s3_bucket_policy", "p")
+
+	related, err := policy.related()
+	require.NoError(t, err)
+	assert.Len(t, related, 1, "a block referenced twice must produce one related edge")
+}

--- a/providers/terraform/resources/terraform.lr.go
+++ b/providers/terraform/resources/terraform.lr.go
@@ -2403,7 +2403,7 @@ func (c *mqlTerraformPlanResourceChange) GetActionReason() *plugin.TValue[string
 type mqlTerraformPlanProposedChange struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlTerraformPlanProposedChangeInternal it will be used here
+	mqlTerraformPlanProposedChangeInternal
 	Address         plugin.TValue[string]
 	Actions         plugin.TValue[[]any]
 	Before          plugin.TValue[any]

--- a/providers/terraform/resources/tfplan.go
+++ b/providers/terraform/resources/tfplan.go
@@ -5,7 +5,9 @@ package resources
 
 import (
 	"encoding/json"
+	"sync"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
@@ -31,10 +33,18 @@ func initTerraformPlan(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	// TODO: This only creates compatibility with v8. Please revisit this section
 	// after https://github.com/mondoohq/mql/issues/1943 is clarified.
 	if plan == nil {
+		// Every static field has to be filled in, not just some. MQL's
+		// three-valued logic makes `terraform.plan { !errored && applyable }`
+		// evaluate to TRUE over two nulls, so leaving applyable/errored unset
+		// let a "the plan is clean" assertion pass on an asset with no plan at
+		// all.
 		return map[string]*llx.RawData{
 			"formatVersion":    llx.StringData(""),
 			"terraformVersion": llx.StringData(""),
 			"resourceChanges":  llx.ArrayData([]any{}, types.Resource("terraform.plan.resourceChange")),
+			"applyable":        llx.BoolData(false),
+			"errored":          llx.BoolData(false),
+			"variables":        llx.ArrayData([]any{}, types.Resource("terraform.plan.variable")),
 		}, nil, nil
 	}
 
@@ -44,7 +54,7 @@ func initTerraformPlan(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	args["errored"] = llx.BoolData(plan.Errored)
 	args["variables"] = llx.ArrayData(
 		variablesToArrayInterface(runtime, plan.Variables),
-		types.Resource("terraform.plan.variables"),
+		types.Resource("terraform.plan.variable"),
 	)
 
 	return args, nil, nil
@@ -119,6 +129,7 @@ func (t *mqlTerraformPlan) resourceChanges() ([]any, error) {
 		}
 
 		lumiChange, err := CreateResource(t.MqlRuntime, "terraform.plan.proposedChange", map[string]*llx.RawData{
+			"__id":            llx.StringData(proposedChangeID(rc.Address, rc.Deposed)),
 			"address":         llx.StringData(rc.Address),
 			"actions":         llx.ArrayData(convert.SliceAnyToInterface[string](rc.Change.Actions), types.String),
 			"before":          llx.MapData(before, types.Any),
@@ -131,6 +142,8 @@ func (t *mqlTerraformPlan) resourceChanges() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		pc := lumiChange.(*mqlTerraformPlanProposedChange)
+		pc.stampOnce.Do(func() { pc.deposed = rc.Deposed })
 
 		r, err := CreateResource(t.MqlRuntime, "terraform.plan.resourceChange", map[string]*llx.RawData{
 			"address":         llx.StringData(rc.Address),
@@ -153,14 +166,34 @@ func (t *mqlTerraformPlan) resourceChanges() ([]any, error) {
 	return list, nil
 }
 
+// Terraform emits a separate resource_changes entry for a deposed object with
+// the SAME address, distinguished only by the `deposed` key. Without it in the
+// id both entries hash to one cache key, so the deposed change is invisible
+// while resourceChanges.length still counts two.
 func (t *mqlTerraformPlanResourceChange) id() (string, error) {
-	id := t.Address
-	return "terraform.plan.resourceChange/address/" + id.Data, nil
+	id := "terraform.plan.resourceChange/address/" + t.Address.Data
+	if t.Deposed.Data != "" {
+		id += "/deposed/" + t.Deposed.Data
+	}
+	return id, nil
 }
 
 func (t *mqlTerraformPlanProposedChange) id() (string, error) {
-	id := t.Address
-	return "terraform.plan.proposedChange/address/" + id.Data, nil
+	id := "terraform.plan.proposedChange/address/" + t.Address.Data
+	if t.deposed != "" {
+		id += "/deposed/" + t.deposed
+	}
+	return id, nil
+}
+
+// mqlTerraformPlanProposedChangeInternal carries the deposed key of the
+// resource change this proposal belongs to. The proposal is not addressable on
+// its own, so it needs the same disambiguation its parent does.
+type mqlTerraformPlanProposedChangeInternal struct {
+	// stampOnce guards the write below: CreateResource returns the cached
+	// instance when the __id matches, so this runs on a possibly-shared struct.
+	stampOnce sync.Once
+	deposed   string
 }
 
 func (t *mqlTerraformPlanConfiguration) id() (string, error) {
@@ -250,16 +283,25 @@ func (t *mqlTerraformPlanConfiguration) resources() ([]any, error) {
 func variablesToArrayInterface(runtime *plugin.Runtime, variables connection.Variables) []any {
 	var list []any
 	for k, v := range variables {
+		// Variable.Value is a json.RawMessage with omitempty, so a variable
+		// serialized as {} arrives as nil and json.Unmarshal(nil, ...) fails.
+		// Skipping it dropped the variable from the list entirely, so an audit
+		// asserting "every declared variable has a value" could not see the one
+		// that does not. Emit it with a null value instead.
 		var value any
-		err := json.Unmarshal(v.Value, &value)
-		if err != nil {
-			continue
+		if len(v.Value) > 0 {
+			if err := json.Unmarshal(v.Value, &value); err != nil {
+				log.Warn().Str("variable", k).Err(err).Msg("cannot decode terraform plan variable value")
+				value = nil
+			}
 		}
+
 		variable, err := CreateResource(runtime, "terraform.plan.variable", map[string]*llx.RawData{
 			"name":  llx.StringData(k),
-			"value": llx.AnyData(value),
+			"value": llx.DictData(value),
 		})
 		if err != nil {
+			log.Error().Str("variable", k).Err(err).Msg("cannot create terraform plan variable")
 			continue
 		}
 
@@ -267,4 +309,15 @@ func variablesToArrayInterface(runtime *plugin.Runtime, variables connection.Var
 	}
 
 	return list
+}
+
+// proposedChangeID mirrors mqlTerraformPlanProposedChange.id(). The creator
+// passes it explicitly because the deposed key lives on the parent resource
+// change, not on the proposal's own fields.
+func proposedChangeID(address, deposed string) string {
+	id := "terraform.plan.proposedChange/address/" + address
+	if deposed != "" {
+		id += "/deposed/" + deposed
+	}
+	return id
 }

--- a/providers/terraform/resources/tfplan.go
+++ b/providers/terraform/resources/tfplan.go
@@ -192,6 +192,11 @@ func (t *mqlTerraformPlanProposedChange) id() (string, error) {
 type mqlTerraformPlanProposedChangeInternal struct {
 	// stampOnce guards the write below: CreateResource returns the cached
 	// instance when the __id matches, so this runs on a possibly-shared struct.
+	// Sharing is only safe because proposedChangeID encodes the deposed key, so
+	// two entries that collide on the cache key necessarily carry the same
+	// value. stampOnce is therefore a data-race guard, not a tiebreaker: drop
+	// the deposed key from the id and the first writer would win over a
+	// genuinely different one.
 	stampOnce sync.Once
 	deposed   string
 }

--- a/providers/terraform/resources/tfplan_test.go
+++ b/providers/terraform/resources/tfplan_test.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers/terraform/connection"
+	"go.mondoo.com/mql/utils/syncx"
 )
 
 // TestTerraformPlanResourceChanges_NilPlan verifies that resourceChanges() does
@@ -25,4 +27,119 @@ func TestTerraformPlanResourceChanges_NilPlan(t *testing.T) {
 	res, err := p.resourceChanges()
 	require.NoError(t, err)
 	assert.Empty(t, res)
+}
+
+// TestTerraformPlan_NilPlanSetsStaticFields is a regression test for
+// terraform.plan.applyable / .errored / .variables resolving UNSET on an asset
+// with no plan.
+//
+// The nil-plan branch of the init filled in only formatVersion,
+// terraformVersion and resourceChanges. MQL three-valued logic then made
+// `terraform.plan { !errored && applyable }` evaluate to TRUE over two nulls,
+// so a "the plan is clean" assertion passed on an asset that carries no plan
+// at all.
+func TestTerraformPlan_NilPlanSetsStaticFields(t *testing.T) {
+	runtime := &plugin.Runtime{
+		Connection: &connection.Connection{},
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+
+	args, _, err := initTerraformPlan(runtime, map[string]*llx.RawData{})
+	require.NoError(t, err)
+	require.NotNil(t, args)
+
+	require.Contains(t, args, "applyable", "applyable must be set, not left unset")
+	assert.Equal(t, false, args["applyable"].Value)
+	require.Contains(t, args, "errored", "errored must be set, not left unset")
+	assert.Equal(t, false, args["errored"].Value)
+	require.Contains(t, args, "variables", "variables must be set, not left unset")
+	assert.Empty(t, args["variables"].Value)
+}
+
+// TestTerraformPlanResourceChange_DeposedDisambiguatesID is a regression test
+// for the resourceChange / proposedChange ids dropping the `deposed` key.
+//
+// Terraform emits a separate resource_changes entry for a deposed object with
+// the SAME address, distinguished only by `deposed`. Both hashed to one cache
+// key, so the deposed change was invisible while resourceChanges.length still
+// counted two.
+func TestTerraformPlanResourceChange_DeposedDisambiguatesID(t *testing.T) {
+	rt := newRuntimeForPlanJSON(t, `{
+  "format_version": "1.2",
+  "terraform_version": "1.6.0",
+  "resource_changes": [
+    {
+      "address": "aws_instance.web", "mode": "managed", "type": "aws_instance", "name": "web",
+      "change": { "actions": ["update"] }
+    },
+    {
+      "address": "aws_instance.web", "mode": "managed", "type": "aws_instance", "name": "web",
+      "deposed": "abc12345",
+      "change": { "actions": ["delete"] }
+    }
+  ]
+}`)
+
+	obj, err := NewResource(rt, "terraform.plan", map[string]*llx.RawData{})
+	require.NoError(t, err)
+	list, err := obj.(*mqlTerraformPlan).resourceChanges()
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+
+	changeIDs := map[string]bool{}
+	proposedIDs := map[string]bool{}
+	for i := range list {
+		rc := list[i].(*mqlTerraformPlanResourceChange)
+		id, err := rc.id()
+		require.NoError(t, err)
+		changeIDs[id] = true
+
+		pid, err := rc.Change.Data.id()
+		require.NoError(t, err)
+		proposedIDs[pid] = true
+	}
+	assert.Len(t, changeIDs, 2, "a deposed change must not share a cache key with the current change")
+	assert.Len(t, proposedIDs, 2, "the proposed change carries the same collision")
+
+	// And the two entries must really be distinct objects with distinct actions.
+	actions := map[string]bool{}
+	for i := range list {
+		rc := list[i].(*mqlTerraformPlanResourceChange)
+		actions[rc.Change.Data.Actions.Data[0].(string)] = true
+	}
+	assert.Equal(t, map[string]bool{"update": true, "delete": true}, actions)
+}
+
+// TestTerraformPlanVariables_ValuelessVariableIsKept is a regression test for
+// plan variables with no value being dropped entirely.
+//
+// Variable.Value is a json.RawMessage with omitempty, so a variable serialized
+// as {} decodes to nil and json.Unmarshal(nil, ...) fails — and the loop
+// `continue`d, deleting the variable from the list. An audit asserting "every
+// declared variable has a value" therefore could not see the one that does not.
+func TestTerraformPlanVariables_ValuelessVariableIsKept(t *testing.T) {
+	rt := newRuntimeForPlanJSON(t, `{
+  "format_version": "1.2",
+  "terraform_version": "1.6.0",
+  "variables": {
+    "region": { "value": "us-east-1" },
+    "db_password": {}
+  }
+}`)
+
+	args, _, err := initTerraformPlan(rt, map[string]*llx.RawData{})
+	require.NoError(t, err)
+
+	list := args["variables"].Value.([]any)
+	require.Len(t, list, 2, "a variable with no value must still be listed")
+
+	byName := map[string]*mqlTerraformPlanVariable{}
+	for i := range list {
+		v := list[i].(*mqlTerraformPlanVariable)
+		byName[v.Name.Data] = v
+	}
+	require.Contains(t, byName, "db_password")
+	assert.Equal(t, "us-east-1", byName["region"].Value.Data)
+	assert.Nil(t, byName["db_password"].Value.Data,
+		"the valueless variable must read as null, not be missing")
 }

--- a/providers/terraform/resources/tfstate.go
+++ b/providers/terraform/resources/tfstate.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
@@ -35,11 +36,21 @@ func initTerraformState(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	return args, nil, nil
 }
 
+// errNoState is returned by the terraform.state accessors on an asset that
+// carries no state (an HCL or plan asset). conn.State() returns (nil, nil)
+// there, and every accessor below used to check only state.Values — so a
+// terraform.state.* query against such an asset dereferenced a nil state and
+// took the provider down.
+var errNoState = errors.New("cannot find state: this asset does not carry terraform state")
+
 func (t *mqlTerraformState) outputs() ([]any, error) {
 	conn := t.MqlRuntime.Connection.(*connection.Connection)
 	state, err := conn.State()
 	if err != nil {
 		return nil, err
+	}
+	if state == nil {
+		return nil, errNoState
 	}
 
 	if state.Values == nil {
@@ -72,6 +83,10 @@ func (t *mqlTerraformState) rootModule() (*mqlTerraformStateModule, error) {
 		return nil, err
 	}
 
+	if state == nil {
+		return nil, errNoState
+	}
+
 	// A state with `values` present but no `root_module` (e.g. outputs-only or
 	// a trimmed state) decodes to a non-nil Values with a nil RootModule;
 	// guard both so we don't dereference nil.
@@ -92,6 +107,10 @@ func (t *mqlTerraformState) modules() ([]any, error) {
 	state, err := conn.State()
 	if err != nil {
 		return nil, err
+	}
+
+	if state == nil {
+		return nil, errNoState
 	}
 
 	if state.Values == nil || state.Values.RootModule == nil {
@@ -123,6 +142,10 @@ func (t *mqlTerraformState) resources() ([]any, error) {
 	providerState, err := conn.State()
 	if err != nil {
 		return nil, err
+	}
+
+	if providerState == nil {
+		return nil, errNoState
 	}
 
 	if providerState.Values == nil || providerState.Values.RootModule == nil {
@@ -162,14 +185,29 @@ func initTerraformStateOutput(runtime *plugin.Runtime, args map[string]*llx.RawD
 	// check if identifier is there
 	nameRaw := args["identifier"]
 	if nameRaw != nil {
-		name := nameRaw.Value.(string)
-		obj, err := CreateResource(runtime, "terraform.state", nil)
+		// RawData.Value is nil for a null argument, and a bare `.(string)`
+		// assertion on that panics — which crashes the whole scan, since query
+		// blocks run in goroutines.
+		name, ok := nameRaw.Value.(string)
+		if !ok {
+			return nil, nil, errors.New("terraform.state.output requires a string identifier")
+		}
+		// NewResource, not CreateResource: only NewResource runs
+		// initTerraformState, whose "cannot find state" guard is what keeps this
+		// from walking a nil state on an HCL or plan asset. CreateResource also
+		// registered an uninitialized instance under terraform.state's constant
+		// id, so a later correct lookup returned that husk and
+		// terraform.state.formatVersion read as unset.
+		obj, err := NewResource(runtime, "terraform.state", map[string]*llx.RawData{})
 		if err != nil {
 			return nil, nil, err
 		}
 		tfstate := obj.(*mqlTerraformState)
 
 		outputs := tfstate.GetOutputs()
+		if outputs.Error != nil {
+			return nil, nil, outputs.Error
+		}
 		for i := range outputs.Data {
 			o := outputs.Data[i].(*mqlTerraformStateOutput)
 			id := o.Identifier.Data
@@ -177,6 +215,11 @@ func initTerraformStateOutput(runtime *plugin.Runtime, args map[string]*llx.RawD
 				return nil, o, nil
 			}
 		}
+
+		// Falling through here would have the runtime build an output with no
+		// value and no type, whose id collides with nothing useful; report the
+		// miss instead.
+		return nil, nil, fmt.Errorf("terraform.state.output with identifier %q not found", name)
 	}
 
 	return args, nil, nil
@@ -214,9 +257,12 @@ func (t mqlTerraformStateOutput) compute_type() (any, error) {
 func (t *mqlTerraformStateModule) id() (string, error) {
 	address := t.Address
 
-	name := "terraform.module"
+	// A state root module omits its address, so it needs an id of its own. The
+	// previous bare "terraform.module" was also whatever a blank, lookup-miss
+	// module computed, so the two shared a cache key.
+	name := "terraform.state.module/root"
 	if address.Data != "" {
-		name += "/address/" + address.Data
+		name = "terraform.state.module/address/" + address.Data
 	}
 
 	return name, nil
@@ -235,14 +281,23 @@ func initTerraformStateModule(runtime *plugin.Runtime, args map[string]*llx.RawD
 
 	idRaw := args["identifier"]
 	if idRaw != nil {
-		identifier := idRaw.Value.(string)
-		obj, err := CreateResource(runtime, "terraform.state", nil)
+		identifier, ok := idRaw.Value.(string)
+		if !ok {
+			return nil, nil, errors.New("terraform.state.module requires a string identifier")
+		}
+		// See initTerraformStateOutput: NewResource runs initTerraformState,
+		// which both guards the nil state and keeps the terraform.state
+		// singleton from being cached uninitialized.
+		obj, err := NewResource(runtime, "terraform.state", map[string]*llx.RawData{})
 		if err != nil {
 			return nil, nil, err
 		}
 		tfstate := obj.(*mqlTerraformState)
 
 		modules := tfstate.GetModules()
+		if modules.Error != nil {
+			return nil, nil, modules.Error
+		}
 		for i := range modules.Data {
 			o := modules.Data[i].(*mqlTerraformStateModule)
 			id := o.Address.Data
@@ -250,7 +305,11 @@ func initTerraformStateModule(runtime *plugin.Runtime, args map[string]*llx.RawD
 				return nil, o, nil
 			}
 		}
-		delete(args, "identifier")
+
+		// Dropping the identifier and falling through built a module with no
+		// address, whose id was the ROOT module's id — so a typo'd address
+		// silently resolved to the root module's contents.
+		return nil, nil, fmt.Errorf("terraform.state.module with address %q not found", identifier)
 	}
 
 	return args, nil, nil
@@ -334,6 +393,14 @@ func (t *mqlTerraformStateResource) id() (string, error) {
 	name := "terraform.state.resource"
 	if address.Data != "" {
 		name += "/address/" + address.Data
+	}
+
+	// Terraform records a deposed object as a separate entry carrying the SAME
+	// address, distinguished only by deposed_key. Without it both entries hash
+	// to one cache key and the deposed object is invisible while the list still
+	// reports two.
+	if t.DeposedKey.Data != "" {
+		name += "/deposed/" + t.DeposedKey.Data
 	}
 
 	return name, nil

--- a/providers/terraform/resources/tfstate.go
+++ b/providers/terraform/resources/tfstate.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync/atomic"
 
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
@@ -69,7 +70,7 @@ func (t *mqlTerraformState) outputs() ([]any, error) {
 			return nil, err
 		}
 		so := r.(*mqlTerraformStateOutput)
-		so.output = output
+		so.output.Store(output)
 		list = append(list, r)
 	}
 
@@ -174,7 +175,17 @@ func (t *mqlTerraformState) resources() ([]any, error) {
 }
 
 type mqlTerraformStateOutputInternal struct {
-	output *connection.Output
+	// output is stamped after CreateResource, which hands back the ALREADY
+	// CACHED instance when the __id matches. plugin.GetOrCompute is
+	// unsynchronized, so two goroutines resolving terraform.state.outputs both
+	// miss its IsSet check, both run the accessor and both reach this write
+	// while value() and compute_type() read it.
+	//
+	// An atomic rather than a sync.Once around the write: the runtime caches
+	// the instance BEFORE the stamp runs, so a reader that picks it up from
+	// that cache has no happens-before edge to the stamp and a write-side
+	// guard alone would leave it racing.
+	output atomic.Pointer[connection.Output]
 }
 
 func initTerraformStateOutput(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -231,24 +242,26 @@ func (t *mqlTerraformStateOutput) id() (string, error) {
 }
 
 func (t *mqlTerraformStateOutput) value() (any, error) {
-	if t.output == nil {
+	output := t.output.Load()
+	if output == nil {
 		return nil, nil
 	}
 
 	var value any
-	if err := json.Unmarshal(t.output.Value, &value); err != nil {
+	if err := json.Unmarshal(output.Value, &value); err != nil {
 		return nil, err
 	}
 	return value, nil
 }
 
-func (t mqlTerraformStateOutput) compute_type() (any, error) {
-	if t.output == nil {
+func (t *mqlTerraformStateOutput) compute_type() (any, error) {
+	output := t.output.Load()
+	if output == nil {
 		return nil, nil
 	}
 
 	var typ any
-	if err := json.Unmarshal([]byte(t.output.Type), &typ); err != nil {
+	if err := json.Unmarshal([]byte(output.Type), &typ); err != nil {
 		return nil, err
 	}
 	return typ, nil
@@ -316,17 +329,28 @@ func initTerraformStateModule(runtime *plugin.Runtime, args map[string]*llx.RawD
 }
 
 type mqlTerraformStateModuleInternal struct {
-	module *connection.Module
+	// module is stamped after CreateResource, which hands back the ALREADY
+	// CACHED instance when the __id matches. The same module is reachable
+	// three ways -- terraform.state.modules walks the whole tree,
+	// terraform.state.rootModule takes the root and rootModule.childModules
+	// takes each child -- and each is a separate field resolution that runs in
+	// its own goroutine, so both this write and the reads below cross
+	// goroutines.
+	//
+	// An atomic rather than a sync.Once around the write, for the reason given
+	// on mqlTerraformStateOutputInternal.output.
+	module atomic.Pointer[connection.Module]
 }
 
 func (t *mqlTerraformStateModule) resources() ([]any, error) {
-	if t.module == nil {
+	module := t.module.Load()
+	if module == nil {
 		return nil, nil
 	}
 
 	var list []any
-	for i := range t.module.Resources {
-		resource := t.module.Resources[i]
+	for i := range module.Resources {
+		resource := module.Resources[i]
 		r, err := newMqlResource(t.MqlRuntime, resource)
 		if err != nil {
 			return nil, err
@@ -346,7 +370,7 @@ func newMqlModule(runtime *plugin.Runtime, module *connection.Module) (*mqlTerra
 	}
 
 	tmr := r.(*mqlTerraformStateModule)
-	tmr.module = module
+	tmr.module.Store(module)
 
 	return tmr, nil
 }
@@ -371,13 +395,14 @@ func newMqlResource(runtime *plugin.Runtime, resource *connection.Resource) (plu
 }
 
 func (t *mqlTerraformStateModule) childModules() ([]any, error) {
-	if t.module == nil {
+	module := t.module.Load()
+	if module == nil {
 		return nil, nil
 	}
 
 	var list []any
-	for i := range t.module.ChildModules {
-		r, err := newMqlModule(t.MqlRuntime, t.module.ChildModules[i])
+	for i := range module.ChildModules {
+		r, err := newMqlModule(t.MqlRuntime, module.ChildModules[i])
 		if err != nil {
 			return nil, err
 		}

--- a/providers/terraform/resources/tfstate_race_test.go
+++ b/providers/terraform/resources/tfstate_race_test.go
@@ -1,0 +1,161 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+)
+
+// TestNewMqlModule_ConcurrentStamping is a regression test for a data race in
+// newMqlModule, the sibling of the one fixed in newMqlHclBlock.
+//
+// newMqlModule wrote tmr.module unconditionally after CreateResource, but
+// CreateResource returns the ALREADY CACHED instance when the __id matches. The
+// same *connection.Module is reachable three ways -- terraform.state.modules
+// walks the whole tree, terraform.state.rootModule takes the root, and
+// rootModule.childModules takes each child -- and each of those is a separate
+// field resolution that can run in its own goroutine. So two goroutines wrote
+// the same struct field while a third read it in resources() / childModules().
+//
+// The goroutines call the accessor bodies (modules, rootModule, childModules)
+// rather than the generated Get* wrappers on purpose: plugin.GetOrCompute is
+// itself unsynchronized, and routing through it would report that separate,
+// SDK-wide TValue race instead of this one.
+//
+// Run with -race to surface a regression; the assertions afterwards catch the
+// user-visible symptom, a module whose internals never got populated and whose
+// resources therefore come back empty.
+func TestNewMqlModule_ConcurrentStamping(t *testing.T) {
+	const iterations = 50
+
+	for i := 0; i < iterations; i++ {
+		rt := newRuntimeForStateJSON(t, stateWithModules)
+
+		stateRaw, err := CreateResource(rt, "terraform.state", map[string]*llx.RawData{})
+		require.NoError(t, err)
+		state := stateRaw.(*mqlTerraformState)
+
+		var wg sync.WaitGroup
+
+		// Writer 1: the flattened walk stamps every module in the tree.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = state.modules()
+		}()
+
+		// Writer 2: the root module, then its children -- the same structs the
+		// flattened walk is stamping.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			root, err := state.rootModule()
+			if err != nil || root == nil {
+				return
+			}
+			children, err := root.childModules()
+			if err != nil {
+				return
+			}
+			for c := range children {
+				// Read the internals the other goroutines are stamping.
+				_ = children[c].(*mqlTerraformStateModule).module.Load()
+			}
+		}()
+
+		// Writer 3: a second flattened walk, which hands back the same cached
+		// instances and re-stamps them. This is what the terraform.state.module
+		// address lookup does internally.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			modules, err := state.modules()
+			if err != nil {
+				return
+			}
+			for m := range modules {
+				_, _ = modules[m].(*mqlTerraformStateModule).resources()
+			}
+		}()
+
+		// Reader: picks the instance straight out of the runtime cache, the way
+		// the runtime does when it resolves a field on an already-created
+		// resource. This one never calls newMqlModule, so it has no
+		// happens-before edge to the stamp -- CreateResource caches the
+		// instance BEFORE the caller stamps it. A write-side-only guard leaves
+		// this read racing.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			key := "terraform.state.module\x00terraform.state.module/address/module.vpc"
+			for a := 0; a < 200; a++ {
+				cached, ok := rt.Resources.Get(key)
+				if !ok {
+					continue
+				}
+				_, _ = cached.(*mqlTerraformStateModule).resources()
+				_, _ = cached.(*mqlTerraformStateModule).childModules()
+				return
+			}
+		}()
+
+		wg.Wait()
+
+		modules, err := state.modules()
+		require.NoError(t, err)
+		require.Len(t, modules, 2, "root module plus module.vpc")
+		for m := range modules {
+			module := modules[m].(*mqlTerraformStateModule)
+			require.NotNil(t, module.module.Load(), "module internals must still be populated")
+		}
+	}
+}
+
+// TestNewMqlStateOutput_ConcurrentStamping covers the same shape in outputs().
+//
+// plugin.GetOrCompute is unsynchronized -- it checks IsSet, computes, then
+// assigns -- so two goroutines resolving terraform.state.outputs both miss the
+// check and both run the accessor body. The second CreateResource returns the
+// cached terraform.state.output, and both goroutines then wrote so.output while
+// value() and type read it.
+func TestNewMqlStateOutput_ConcurrentStamping(t *testing.T) {
+	const iterations = 50
+
+	for i := 0; i < iterations; i++ {
+		rt := newRuntimeForStateJSON(t, stateWithModules)
+
+		stateRaw, err := CreateResource(rt, "terraform.state", map[string]*llx.RawData{})
+		require.NoError(t, err)
+		state := stateRaw.(*mqlTerraformState)
+
+		var wg sync.WaitGroup
+		for g := 0; g < 4; g++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				outputs, err := state.outputs()
+				if err != nil {
+					return
+				}
+				for o := range outputs {
+					// Reads the internal the other goroutines are stamping.
+					_, _ = outputs[o].(*mqlTerraformStateOutput).value()
+				}
+			}()
+		}
+		wg.Wait()
+
+		outputs, err := state.outputs()
+		require.NoError(t, err)
+		require.Len(t, outputs, 1)
+		for o := range outputs {
+			output := outputs[o].(*mqlTerraformStateOutput)
+			require.NotNil(t, output.output.Load(), "output internals must still be populated")
+		}
+	}
+}

--- a/providers/terraform/resources/tfstate_test.go
+++ b/providers/terraform/resources/tfstate_test.go
@@ -1,0 +1,298 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/terraform/connection"
+	"go.mondoo.com/mql/utils/syncx"
+)
+
+// newRuntimeForStateJSON builds a runtime over a real state connection reading
+// the supplied JSON, mirroring newRuntimeForDir for HCL assets.
+func newRuntimeForStateJSON(t *testing.T, stateJSON string) *plugin.Runtime {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "terraform.tfstate")
+	require.NoError(t, os.WriteFile(path, []byte(stateJSON), 0o600))
+
+	asset := &inventory.Asset{
+		Connections: []*inventory.Config{
+			{Type: "state", Options: map[string]string{"path": path}},
+		},
+	}
+	conn, err := connection.NewStateConnection(1, asset)
+	require.NoError(t, err)
+	return &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+}
+
+// newRuntimeForPlanJSON builds a runtime over a real plan connection reading
+// the supplied JSON.
+func newRuntimeForPlanJSON(t *testing.T, planJSON string) *plugin.Runtime {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "plan.json")
+	require.NoError(t, os.WriteFile(path, []byte(planJSON), 0o600))
+
+	asset := &inventory.Asset{
+		Connections: []*inventory.Config{
+			{Type: "plan", Options: map[string]string{"path": path}},
+		},
+	}
+	conn, err := connection.NewPlanConnection(1, asset)
+	require.NoError(t, err)
+	return &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+}
+
+const stateWithModules = `{
+  "format_version": "1.0",
+  "terraform_version": "1.6.0",
+  "values": {
+    "outputs": {
+      "endpoint": { "sensitive": false, "value": "https://example.com", "type": "string" }
+    },
+    "root_module": {
+      "resources": [
+        { "address": "aws_s3_bucket.root", "mode": "managed", "type": "aws_s3_bucket", "name": "root" }
+      ],
+      "child_modules": [
+        {
+          "address": "module.vpc",
+          "resources": [
+            { "address": "aws_subnet.a", "mode": "managed", "type": "aws_subnet", "name": "a" }
+          ]
+        }
+      ]
+    }
+  }
+}`
+
+// TestTerraformStateOutput_InitOnNonStateAssetDoesNotPanic is a regression test
+// for a nil-pointer crash on terraform.state.output(...) against an HCL asset.
+//
+// The init used CreateResource("terraform.state", nil), which does NOT run
+// initTerraformState, so the "cannot find state" guard was bypassed. conn.State()
+// returns (nil, nil) for HCL and plan assets, and outputs() then dereferenced
+// the nil state.
+func TestTerraformStateOutput_InitOnNonStateAssetDoesNotPanic(t *testing.T) {
+	rt := newRuntimeForDir(t, writeTfDir(t, map[string]string{
+		"main.tf": "resource \"aws_s3_bucket\" \"b\" {}\n",
+	}))
+
+	require.NotPanics(t, func() {
+		_, _, err := initTerraformStateOutput(rt, map[string]*llx.RawData{
+			"identifier": llx.StringData("x"),
+		})
+		assert.Error(t, err, "there is no state on an HCL asset, so the lookup must report that")
+	})
+}
+
+// TestTerraformStateModule_InitOnNonStateAssetDoesNotPanic covers the sibling
+// init, which had the same shape.
+func TestTerraformStateModule_InitOnNonStateAssetDoesNotPanic(t *testing.T) {
+	rt := newRuntimeForDir(t, writeTfDir(t, map[string]string{
+		"main.tf": "resource \"aws_s3_bucket\" \"b\" {}\n",
+	}))
+
+	require.NotPanics(t, func() {
+		_, _, err := initTerraformStateModule(rt, map[string]*llx.RawData{
+			"identifier": llx.StringData("module.vpc"),
+		})
+		assert.Error(t, err, "there is no state on an HCL asset, so the lookup must report that")
+	})
+}
+
+// TestTerraformStateAccessors_NilStateDoNotPanic covers the belt-and-braces
+// guards: every terraform.state collection accessor assumed a non-nil state and
+// only checked state.Values.
+func TestTerraformStateAccessors_NilStateDoNotPanic(t *testing.T) {
+	runtime := &plugin.Runtime{
+		Connection: &connection.Connection{},
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+	newState := func() *mqlTerraformState {
+		s := &mqlTerraformState{}
+		s.MqlRuntime = runtime
+		return s
+	}
+
+	require.NotPanics(t, func() {
+		_, err := newState().outputs()
+		assert.Error(t, err)
+	})
+	require.NotPanics(t, func() {
+		_, err := newState().rootModule()
+		assert.Error(t, err)
+	})
+	require.NotPanics(t, func() {
+		_, err := newState().modules()
+		assert.Error(t, err)
+	})
+	require.NotPanics(t, func() {
+		_, err := newState().resources()
+		assert.Error(t, err)
+	})
+}
+
+// TestTerraformState_OutputLookupDoesNotPoisonTheSingleton is a regression test
+// for the uninitialized terraform.state instance being cached.
+//
+// terraform.state's id() is a constant, so the CreateResource in the output
+// init registered an instance whose formatVersion/terraformVersion were never
+// populated under the shared "terraform.state" cache key. A later, correct
+// NewResource then returned that husk, and formatVersion read as unset —
+// surfacing client-side as "llx: encountered a primitive with no type
+// information". Whether a scan saw it depended purely on query order.
+func TestTerraformState_OutputLookupDoesNotPoisonTheSingleton(t *testing.T) {
+	rt := newRuntimeForStateJSON(t, stateWithModules)
+
+	// Ask for an output FIRST — this is the order that poisoned the cache.
+	_, res, err := initTerraformStateOutput(rt, map[string]*llx.RawData{
+		"identifier": llx.StringData("endpoint"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	// Now resolve the state itself; it must be fully initialized.
+	obj, err := NewResource(rt, "terraform.state", map[string]*llx.RawData{})
+	require.NoError(t, err)
+	state := obj.(*mqlTerraformState)
+	assert.Equal(t, "1.0", state.FormatVersion.Data,
+		"terraform.state.formatVersion must be populated regardless of query order")
+	assert.Equal(t, "1.6.0", state.TerraformVersion.Data)
+}
+
+// TestTerraformState_ModuleLookupDoesNotPoisonTheSingleton is the same
+// regression through terraform.state.module(...).
+func TestTerraformState_ModuleLookupDoesNotPoisonTheSingleton(t *testing.T) {
+	rt := newRuntimeForStateJSON(t, stateWithModules)
+
+	_, res, err := initTerraformStateModule(rt, map[string]*llx.RawData{
+		"identifier": llx.StringData("module.vpc"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	obj, err := NewResource(rt, "terraform.state", map[string]*llx.RawData{})
+	require.NoError(t, err)
+	state := obj.(*mqlTerraformState)
+	assert.Equal(t, "1.0", state.FormatVersion.Data,
+		"terraform.state.formatVersion must be populated regardless of query order")
+}
+
+// TestTerraformStateModule_MissReportsNotFound is a regression test for the
+// lookup-miss husk.
+//
+// On a miss the init deleted "identifier" and returned (args, nil, nil), so the
+// runtime built a module with no address. id() then returned the bare
+// "terraform.module" — exactly the id of the ROOT module, whose address is
+// omitted in state — so the husk and the root module shared a cache key and a
+// typo'd address silently resolved to the root module's contents.
+func TestTerraformStateModule_MissReportsNotFound(t *testing.T) {
+	rt := newRuntimeForStateJSON(t, stateWithModules)
+
+	_, res, err := initTerraformStateModule(rt, map[string]*llx.RawData{
+		"identifier": llx.StringData("module.nope"),
+	})
+	require.Error(t, err, "a module address that does not exist must be reported, not faked")
+	assert.Nil(t, res)
+	assert.Contains(t, err.Error(), "module.nope")
+}
+
+// TestTerraformStateOutput_MissReportsNotFound covers the sibling fall-through.
+func TestTerraformStateOutput_MissReportsNotFound(t *testing.T) {
+	rt := newRuntimeForStateJSON(t, stateWithModules)
+
+	_, res, err := initTerraformStateOutput(rt, map[string]*llx.RawData{
+		"identifier": llx.StringData("nope"),
+	})
+	require.Error(t, err, "an output that does not exist must be reported, not faked")
+	assert.Nil(t, res)
+	assert.Contains(t, err.Error(), "nope")
+}
+
+// TestTerraformStateModule_RootModuleIDIsDistinct pins the root module's id
+// away from the generic husk id it used to share.
+func TestTerraformStateModule_RootModuleIDIsDistinct(t *testing.T) {
+	rt := newRuntimeForStateJSON(t, stateWithModules)
+
+	obj, err := NewResource(rt, "terraform.state", map[string]*llx.RawData{})
+	require.NoError(t, err)
+	root, err := obj.(*mqlTerraformState).rootModule()
+	require.NoError(t, err)
+	require.NotNil(t, root)
+
+	id, err := root.id()
+	require.NoError(t, err)
+	assert.NotEqual(t, "terraform.module", id,
+		"the root module must not use the id a blank module would compute")
+	assert.Contains(t, id, "root")
+}
+
+// TestTerraformStateInits_NullArgumentDoNotPanic is a regression test for the
+// bare `.(string)` assertions on init arguments. The schema enforces the type,
+// but RawData.Value is still nil for a null argument, and
+// `interface{}(nil).(string)` panics — taking the whole scan down, since query
+// blocks run in goroutines.
+func TestTerraformStateInits_NullArgumentDoNotPanic(t *testing.T) {
+	rt := newRuntimeForStateJSON(t, stateWithModules)
+
+	require.NotPanics(t, func() {
+		_, _, _ = initTerraformStateOutput(rt, map[string]*llx.RawData{
+			"identifier": {Value: nil},
+		})
+	})
+	require.NotPanics(t, func() {
+		_, _, _ = initTerraformStateModule(rt, map[string]*llx.RawData{
+			"identifier": {Value: nil},
+		})
+	})
+}
+
+// TestTerraformStateResource_DeposedKeyDisambiguatesID is a regression test for
+// terraform.state.resource ids that ignore deposedKey.
+//
+// Terraform records a deposed object as a separate entry with the SAME address,
+// distinguished only by deposed_key. Both entries hashed to one cache key, so
+// the deposed object was invisible while the list still reported two.
+func TestTerraformStateResource_DeposedKeyDisambiguatesID(t *testing.T) {
+	rt := newRuntimeForStateJSON(t, `{
+  "format_version": "1.0",
+  "terraform_version": "1.6.0",
+  "values": {
+    "root_module": {
+      "resources": [
+        { "address": "aws_instance.web", "mode": "managed", "type": "aws_instance", "name": "web" },
+        { "address": "aws_instance.web", "mode": "managed", "type": "aws_instance", "name": "web", "deposed_key": "abc12345" }
+      ]
+    }
+  }
+}`)
+
+	obj, err := NewResource(rt, "terraform.state", map[string]*llx.RawData{})
+	require.NoError(t, err)
+	list, err := obj.(*mqlTerraformState).resources()
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+
+	ids := map[string]bool{}
+	for i := range list {
+		id, err := list[i].(*mqlTerraformStateResource).id()
+		require.NoError(t, err)
+		ids[id] = true
+	}
+	assert.Len(t, ids, 2, "a deposed object must not share a cache key with the current object")
+}


### PR DESCRIPTION
Seven defects in the terraform HCL connection, found by a static audit of file
discovery and variable loading. Every one produces wrong or missing data with
no error, which is the failure mode that matters most in a scanner: an empty
result reads as "nothing to flag" and the policy over it passes vacuously.

Each fix ships with a regression test that fails on `main`.

## Silent data loss

**A scan root whose path contains `.terraform` produced an empty, successful scan.**
The vendored-module skip tested `strings.Contains(path, ".terraform")` against
the full walk path, so it also fired on every ancestor directory. A repository
checked out at `.terraform-configs/`, a directory named `.terraform-modules/`,
or a file called `main.terraform.tf` was skipped in its entirety — no files
parsed, no error returned. Matching is now on a whole path segment taken
relative to the scan root. Files under a real `.terraform/` cache are still
skipped.

**A repository's own `modules/<name>/examples/` was dropped.**
`MODULE_EXAMPLES` was `^.*/modules/.+/examples/.+`, which matches the canonical
layout of every first-party Terraform module repository, not just the examples
vendored inside `.terraform/modules/` that the comment above it describes. The
pattern is now anchored on the `.terraform/` cache.

**One unparseable `.tf` file truncated the rest of the scan.**
`filepath.WalkDir`'s return value was discarded while the callback returned an
error on a parse failure. The walk aborted at the broken file, the abort was
thrown away, and every file ordered after it silently vanished from a scan that
reported success. Per-file parse failures now warn and continue; a genuine walk
failure is returned. HCL diagnostics reach the log instead of being dropped.

**`*.tfvars.json` contributed nothing.**
Both `.tfvars` and `.tfvars.json` were parsed with `hclsyntax.ParseConfig`, the
native-syntax parser. Terraform reads JSON variable files as JSON, so feeding
one to the native lexer yields only syntax errors — which were explicitly
discarded — and `JustAttributes()` returned an empty map. The override then
never applied, and every `var.*` reference resolved to the variable block's
`default` instead of the real value:

```
variable "acl" { default = "private" }        # main.tf
{"acl": "public-read"}                        # terraform.tfvars.json
```

audited as `private`. JSON variable files now go through
`github.com/hashicorp/hcl/v2/json`.

**Only the last module manifest survived.**
`modulesManifest` was a single pointer overwritten on each match, so a monorepo
with one `.terraform/modules/modules.json` per stack reported one stack's
modules. Records are merged across manifests and deduplicated by key.

## Panics

**`os.Stat` errors other than ENOENT dereferenced nil.**
Only `os.IsNotExist` was handled, but `os.Stat` returns a nil `FileInfo` for
every failure. A path whose ancestor is a regular file (ENOTDIR — a mistyped
scan path is enough), an unreadable parent (EACCES), or a symlink cycle (ELOOP)
reached `stat.IsDir()` and panicked the provider.

**An unreadable `.tf.json` poisoned the parser map with a nil file.**
`hclparse.Parser.ParseJSONFile` records its result before checking it, and
`json.ParseFile` returns a nil `*hcl.File` when the file cannot be opened. A
dangling symlink named `*.tf.json` in a checkout was enough to leave a nil entry
in `Parser().Files()`, and every consumer of that map dereferences `file.Body`.
Combined with the discarded walk error above, the nil survived to query time and
crashed the scan. Sources are now read in `ParseHclFile` and handed to
`ParseHCL`/`ParseJSON`, which always store a real file.

## Wrong values

**Variable files were applied in directory-walk order.**
`override.auto.tfvars` sorts before `terraform.tfvars`, so `terraform.tfvars`
won — the opposite of Terraform, where `*.auto.tfvars` ranks higher. A variable's
effective value could be reported as the inverse of what Terraform would apply.
Files are now applied in Terraform's documented precedence. Files that Terraform
only loads via `-var-file` continue to be read, at the lowest precedence, so
nothing previously visible is lost.

## Resource leak

`NewHclGitConnection` left the entire checkout in the temp directory whenever the
connection failed after a successful clone.

## Tests

New `providers/terraform/connection/discovery_test.go`, 11 cases:

- `TestScanRootContainingDotTerraformSubstring`
- `TestFileWithDotTerraformInNameIsParsed`
- `TestVendoredDotTerraformIsStillSkipped` (negative control)
- `TestBrokenFileDoesNotTruncateScan`
- `TestUnreadableJSONFileDoesNotPoisonParser`
- `TestReadTfVarsFromJSONFile`
- `TestJSONTfVarsOverridesVariableDefault`
- `TestNonExistErrorFromStatIsNotAPanic`
- `TestFirstPartyModuleExamplesAreScanned`
- `TestVendoredModuleExamplesAreSkipped` (negative control)
- `TestMultipleModuleManifestsAreMerged`

Nine of the eleven fail on `main`; the two negative controls pass before and
after, confirming the fixes do not widen the scan into the vendored cache.

`go test ./...` is green across `connection`, `provider`, and `resources`,
including the existing tests that assert exact parsed-file counts.
