### PR TITLE
🐛 k8s: stop namespace scoping from emptying cluster-scoped collections

### DIFF
--- a/providers/k8s/connection/shared/resources/filter.go
+++ b/providers/k8s/connection/shared/resources/filter.go
@@ -10,6 +10,15 @@ import (
 )
 
 func FilterResource(resType *ApiResource, resourceObjects []runtime.Object, name string, namespace string) ([]runtime.Object, error) {
+	// A namespace only selects among namespaced kinds. Cluster-scoped objects
+	// (Nodes, ClusterRoles, PersistentVolumes, ...) carry an empty
+	// metadata.namespace, so matching them against a requested namespace would
+	// discard every one of them and report the kind as empty rather than
+	// out of scope.
+	if !resType.Resource.Namespaced {
+		namespace = ""
+	}
+
 	// filter root resources
 	roots := filterResource(resourceObjects, resType.Resource.Kind, name, namespace)
 	return roots, nil

--- a/providers/k8s/connection/shared/resources/filter_test.go
+++ b/providers/k8s/connection/shared/resources/filter_test.go
@@ -1,0 +1,127 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func testObject(kind, namespace, name string) runtime.Object {
+	u := &unstructured.Unstructured{Object: map[string]any{}}
+	u.SetGroupVersionKind(schema.GroupVersionKind{Kind: kind, Version: "v1"})
+	u.SetName(name)
+	if namespace != "" {
+		u.SetNamespace(namespace)
+	}
+	return u
+}
+
+func apiResource(kind string, namespaced bool) *ApiResource {
+	return &ApiResource{
+		Resource: metav1.APIResource{Kind: kind, Name: kind + "s", Namespaced: namespaced},
+	}
+}
+
+func names(objs []runtime.Object) []string {
+	out := make([]string, 0, len(objs))
+	for _, o := range objs {
+		out = append(out, o.(*unstructured.Unstructured).GetName())
+	}
+	return out
+}
+
+// TestFilterResourceClusterScoped pins that a namespace filter never applies to
+// cluster-scoped kinds. Those objects have an empty metadata.namespace, so
+// comparing it to a requested namespace used to drop all of them and report the
+// kind as empty — a scan scoped to a namespace saw zero Nodes, zero
+// ClusterRoles and zero PersistentVolumes rather than the real ones.
+func TestFilterResourceClusterScoped(t *testing.T) {
+	objs := []runtime.Object{
+		testObject("Node", "", "node-a"),
+		testObject("Node", "", "node-b"),
+	}
+
+	res, err := FilterResource(apiResource("Node", false), objs, "", "prod")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"node-a", "node-b"}, names(res),
+		"cluster-scoped objects must survive a namespace filter")
+}
+
+// TestFilterResourceNamespaced pins that namespaced kinds still honor the
+// namespace filter, so the cluster-scoped carve-out does not widen the scope of
+// a namespaced scan.
+func TestFilterResourceNamespaced(t *testing.T) {
+	objs := []runtime.Object{
+		testObject("Pod", "prod", "web"),
+		testObject("Pod", "staging", "web"),
+		testObject("Pod", "prod", "db"),
+	}
+
+	res, err := FilterResource(apiResource("Pod", true), objs, "", "prod")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"web", "db"}, names(res))
+}
+
+func TestFilterResourceByName(t *testing.T) {
+	tests := []struct {
+		name       string
+		kind       string
+		namespaced bool
+		objs       []runtime.Object
+		wantName   string
+		namespace  string
+		expected   []string
+	}{
+		{
+			name:       "name filter on a namespaced kind",
+			kind:       "Pod",
+			namespaced: true,
+			objs: []runtime.Object{
+				testObject("Pod", "prod", "web"),
+				testObject("Pod", "prod", "db"),
+			},
+			wantName:  "web",
+			namespace: "prod",
+			expected:  []string{"web"},
+		},
+		{
+			name:       "name filter on a cluster-scoped kind ignores the namespace",
+			kind:       "ClusterRole",
+			namespaced: false,
+			objs: []runtime.Object{
+				testObject("ClusterRole", "", "admin"),
+				testObject("ClusterRole", "", "viewer"),
+			},
+			wantName:  "admin",
+			namespace: "prod",
+			expected:  []string{"admin"},
+		},
+		{
+			name:       "other kinds are never returned",
+			kind:       "Pod",
+			namespaced: true,
+			objs: []runtime.Object{
+				testObject("Pod", "prod", "web"),
+				testObject("Service", "prod", "web"),
+			},
+			namespace: "prod",
+			expected:  []string{"web"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := FilterResource(apiResource(tt.kind, tt.namespaced), tt.objs, tt.wantName, tt.namespace)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, names(res))
+		})
+	}
+}


### PR DESCRIPTION
## What

A namespace filter was applied to every kind, including cluster-scoped ones. Nodes, ClusterRoles, ClusterRoleBindings, PersistentVolumes, StorageClasses, PriorityClasses, RuntimeClasses and the webhook configurations all carry an empty `metadata.namespace`, so comparing that against the requested namespace discarded every object and reported the kind as empty.

## Why it matters

This is on the **default scan path**, not just behind an explicit flag. Staged discovery gives each namespace asset a connection with `OPTION_NAMESPACE` set (`discovery.go:291`), so on a plain `mql shell k8s` against a live cluster, 27 of 29 discovered assets reported `k8s.clusterroles.length == 0` while the cluster actually had 71:

```
$ mql run k8s -c 'k8s.clusterroles.length' -j     # before
per-asset values: Counter({'0': 27, '71': 2})
$ kubectl get clusterroles --no-headers | wc -l
71
```

A policy asserting on cluster-scoped RBAC ("no ClusterRole grants `*` on `*`") evaluates against an empty set and **passes vacuously** rather than failing. That is the wrong direction for a security check to be wrong.

With an explicit `--namespaces` it is equally visible:

```
$ mql run k8s --namespaces mql-test -c '{nodes: k8s.nodes.length, clusterroles: k8s.clusterroles.length, pvs: k8s.persistentVolumes.length}'
{"clusterroles":0,"nodes":0,"pvs":0}      # actual cluster: 71, 1, 1
```

## The fix

The objects were already fetched correctly — `GetKindResources` uses the non-namespaced client interface for cluster-scoped kinds, so they are all present in the result. Only `filterResource` afterwards threw them away. The fix skips the namespace comparison for kinds the API server reports as `Namespaced: false`.

Namespaced kinds are unaffected and stay scoped, so this does not widen the scope of a namespaced scan.

Both callers benefit: the live-cluster connection (`api/connection.go:291`) and the manifest parser (`manifest_parser.go:192`).

## Verification

Live against a minikube cluster (k8s v1.34.0), after the fix:

```
$ mql run k8s --namespaces mql-test -c '{nodes: ..., clusterroles: ..., pvs: ..., pods: ...}'
{"clusterroles":71,"nodes":1,"pods":7,"pvs":1}
```

Cluster-scoped kinds are restored while `pods` stays correctly scoped to the 7 in `mql-test`.

## Tests

Added `filter_test.go` covering the cluster-scoped carve-out, that namespaced kinds still filter, and name-filter behaviour for both scopes. Verified the new test has teeth — reverting the one-line guard fails it:

```
Error:  Not equal:
        expected: []string{"node-a", "node-b"}
        actual  : []string{}
Messages: cluster-scoped objects must survive a namespace filter
```

`go test ./...` in `providers/k8s/` passes (8/8 packages).

## Note

While verifying this I found a **second, independent** bug that this PR does not address: per-asset results for the same query flap nondeterministically within one scan (`k8s.clusterroles` returns 0 on some assets and 71 on others, varying run to run). That traces to an unsynchronized `TValue` write in `plugin.GetOrCompute` (`providers-sdk/v1/plugin/runtime.go:284`), confirmed with `-race`. It is SDK-wide rather than k8s-specific and needs a maintainer call on where the synchronization belongs, so I have reported it separately rather than folding a core concurrency change in here.