### PR TITLE
🐛 k8s: honor the --context flag when selecting the cluster

### DIFF
--- a/providers/k8s/connection/api/connection.go
+++ b/providers/k8s/connection/api/connection.go
@@ -58,7 +58,15 @@ func NewConnection(id uint32, asset *inventory.Asset, discoveryCache *resources.
 		}
 	}
 
-	config, err := buildConfigFromFlags("", kubeconfigPath, "")
+	// The requested context selects which cluster in the kubeconfig to talk to.
+	// Without it every scan targets whatever current-context happens to be, while
+	// still being reported under the requested name.
+	contextName := ""
+	if len(asset.Connections) > 0 {
+		contextName = asset.Connections[0].Options[shared.OPTION_CONTEXT]
+	}
+
+	config, err := buildConfigFromFlags("", kubeconfigPath, contextName)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +109,11 @@ func NewConnection(id uint32, asset *inventory.Asset, discoveryCache *resources.
 	}
 
 	currentClusterName := ""
-	if ctx, ok := kubeConfig.Contexts[kubeConfig.CurrentContext]; ok {
+	selectedContext := kubeConfig.CurrentContext
+	if contextName != "" {
+		selectedContext = contextName
+	}
+	if ctx, ok := kubeConfig.Contexts[selectedContext]; ok {
 		currentClusterName = ctx.Cluster
 	} else {
 		// right now we use the name of the first node to identify the cluster
@@ -131,7 +143,10 @@ func NewConnection(id uint32, asset *inventory.Asset, discoveryCache *resources.
 // buildConfigFromFlags we rebuild clientcmd.BuildConfigFromFlags to make sure we do not log warnings for every
 // scan.
 func buildConfigFromFlags(masterUrl, kubeconfigPath string, context string) (*rest.Config, error) {
-	if kubeconfigPath == "" && masterUrl == "" {
+	// An in-cluster config has no contexts to choose from, so falling back to it
+	// would quietly ignore the requested one. Let the kubeconfig loader run and
+	// report that the context is missing instead.
+	if kubeconfigPath == "" && masterUrl == "" && context == "" {
 		kubeconfig, err := rest.InClusterConfig()
 		if err == nil {
 			return kubeconfig, nil

--- a/providers/k8s/connection/api/connection_context_test.go
+++ b/providers/k8s/connection/api/connection_context_test.go
@@ -1,0 +1,83 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const twoClusterKubeconfig = `apiVersion: v1
+kind: Config
+current-context: dev
+clusters:
+- name: dev-cluster
+  cluster:
+    server: https://dev.example.com:6443
+- name: prod-cluster
+  cluster:
+    server: https://prod.example.com:6443
+contexts:
+- name: dev
+  context:
+    cluster: dev-cluster
+    user: dev-user
+- name: prod
+  context:
+    cluster: prod-cluster
+    user: prod-user
+users:
+- name: dev-user
+  user: {}
+- name: prod-user
+  user: {}
+`
+
+func writeKubeconfig(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config")
+	require.NoError(t, os.WriteFile(path, []byte(twoClusterKubeconfig), 0o600))
+	return path
+}
+
+// TestBuildConfigFromFlagsContext pins that the requested context selects the
+// cluster. Passing an empty context used to be the only thing the connection
+// ever did, so --context prod silently scanned whatever current-context was
+// while still labelling the asset "prod".
+func TestBuildConfigFromFlagsContext(t *testing.T) {
+	path := writeKubeconfig(t)
+
+	tests := []struct {
+		name       string
+		context    string
+		wantServer string
+	}{
+		{name: "no context falls back to current-context", context: "", wantServer: "https://dev.example.com:6443"},
+		{name: "explicit context selects its cluster", context: "prod", wantServer: "https://prod.example.com:6443"},
+		{name: "explicit current-context is still honored", context: "dev", wantServer: "https://dev.example.com:6443"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := buildConfigFromFlags("", path, tt.context)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantServer, cfg.Host)
+		})
+	}
+}
+
+// TestBuildConfigFromFlagsUnknownContext pins that a context that is not in the
+// kubeconfig is an error. It used to be accepted, and the scan silently ran
+// against current-context under the requested name.
+func TestBuildConfigFromFlagsUnknownContext(t *testing.T) {
+	path := writeKubeconfig(t)
+
+	_, err := buildConfigFromFlags("", path, "does-not-exist")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does-not-exist")
+}


### PR DESCRIPTION
## What

`ParseCLI` stored `--context` in the connection options (`provider.go:69-71`), but the only code that read it back was `Name()`, which uses it for the asset's **display name**. The client config was built as:

```go
config, err := buildConfigFromFlags("", kubeconfigPath, "")   // context hardcoded empty
```

so client-go always connected to whatever `current-context` happened to be.

## Why it matters

The scan targets the wrong cluster and reports it under the right name:

```
mql run k8s --context prod ...
```

connects to `current-context` and labels every asset `prod`. Worse, a context that does not exist in the kubeconfig at all was accepted silently. Against a live cluster whose current-context was `minikube`:

```
$ kubectl config current-context
minikube
$ mql run k8s --context this-context-does-not-exist -c 'k8s.namespaces.length'
→ use cluster name from --context cluster-name=this-context-does-not-exist
...
exit code: 0
```

A user auditing "prod" can get a clean report that was actually produced against staging, with nothing in the output to indicate it.

## The fix

`buildConfigFromFlags` already plumbed its `context` argument into `ConfigOverrides.CurrentContext` — it was only ever called with `""`. The fix passes the requested context. Two follow-ons come with it:

- The in-cluster shortcut is skipped when a context was requested. An in-cluster config has no contexts, so falling back to it would quietly ignore the request; letting the kubeconfig loader run reports the missing context instead.
- The cluster name is resolved from the requested context rather than `current-context`, so `Name()` describes the cluster actually scanned.

## Verification

Live against minikube, after the fix:

```
$ mql run k8s --context this-context-does-not-exist -c 'k8s.namespaces.length'
x unable to create runtime for asset error="... context \"this-context-does-not-exist\" does not exist"

$ mql run k8s --context mql-alias -c 'k8s.namespaces.length'     # real second context
[{"k8s.namespaces.length":6}, ...]
```

## Tests

`connection_context_test.go` builds a two-cluster kubeconfig and pins that the requested context selects its cluster's server, that an empty context still falls back to `current-context`, and that an unknown context is an error rather than a silent fallback.

`go test ./...` in `providers/k8s/` passes (8/8 packages).