### PR TITLE
🐛 cloudformation: resolve YAML aliases and stop one bad member erasing a whole section

### DIFF
--- a/providers/cloudformation/resources/cloudformation.go
+++ b/providers/cloudformation/resources/cloudformation.go
@@ -11,13 +11,47 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
 	"go.mondoo.com/ranger-rpc/codes"
 	"go.mondoo.com/ranger-rpc/status"
 	"gopkg.in/yaml.v3"
 )
 
+// maxAliasDepth bounds alias resolution. YAML requires an anchor to be defined
+// before it is referenced, so a cycle cannot occur in a well-formed document,
+// but a hand-crafted tree must not be able to spin a scan forever.
+const maxAliasDepth = 100
+
+// resolveAlias follows a YAML alias to the node it points at. The parser
+// records the anchor target on the alias node itself, so this resolves
+// references that live elsewhere in the document.
+func resolveAlias(n *yaml.Node) *yaml.Node {
+	for i := 0; n != nil && n.Kind == yaml.AliasNode && i < maxAliasDepth; i++ {
+		n = n.Alias
+	}
+	return n
+}
+
+// isMergeKey reports whether a mapping key is the YAML merge key `<<`, whose
+// value contributes another mapping's keys to this one.
+func isMergeKey(n *yaml.Node) bool {
+	return n != nil && (n.Tag == "!!merge" || n.Value == "<<")
+}
+
+// scalarValue returns the text of a scalar node, resolving an alias first and
+// yielding "" for anything that is not a scalar (a mapping, a sequence, or a
+// missing node). Callers read CloudFormation attributes such as Type and
+// DeletionPolicy through it, so `Type: *sharedType` reports the anchored value
+// instead of an empty string.
+func scalarValue(n *yaml.Node) string {
+	n = resolveAlias(n)
+	if n == nil || n.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return n.Value
+}
+
 func gatherMapValue(n *yaml.Node, key string) (*yaml.Node, *yaml.Node, error) {
+	n = resolveAlias(n)
 	if n == nil {
 		return nil, nil, status.Error(codes.InvalidArgument, "node is nil for key "+key)
 	}
@@ -33,6 +67,7 @@ func gatherMapValue(n *yaml.Node, key string) (*yaml.Node, *yaml.Node, error) {
 	}
 
 	// search for key
+	var merges []*yaml.Node
 	for i := 0; i < len(n.Content); i += 2 {
 		keyNode := n.Content[i]
 		valueNode := n.Content[i+1]
@@ -40,24 +75,60 @@ func gatherMapValue(n *yaml.Node, key string) (*yaml.Node, *yaml.Node, error) {
 		if keyNode.Value == key {
 			return keyNode, valueNode, nil
 		}
+		if isMergeKey(keyNode) {
+			merges = append(merges, valueNode)
+		}
+	}
+
+	// A merge key contributes the keys of another mapping, but only where this
+	// mapping does not define them itself, so merges are searched after the
+	// whole map. Within a merge sequence the earlier entry wins. Without this,
+	// a resource written as `<<: *base` reports no Type at all and every
+	// type-scoped policy silently skips it.
+	for _, merge := range merges {
+		source := resolveAlias(merge)
+		if source == nil {
+			continue
+		}
+		if source.Kind == yaml.SequenceNode {
+			for _, item := range source.Content {
+				if k, v, err := gatherMapValue(item, key); err == nil {
+					return k, v, nil
+				}
+			}
+			continue
+		}
+		if k, v, err := gatherMapValue(source, key); err == nil {
+			return k, v, nil
+		}
 	}
 
 	return nil, nil, status.Error(codes.NotFound, fmt.Sprintf("key %s not found", key))
 }
 
+// isAbsentKey reports whether a gatherMapValue error means "this field has no
+// value here", covering both a mapping that lacks the key (NotFound) and a
+// body that is not a mapping at all (InvalidArgument: a null resource body, a
+// scalar parameter body). Both leave the single field empty; neither is a
+// reason to drop the row, let alone every other row in the section.
+func isAbsentKey(err error) bool {
+	code := status.Code(err)
+	return code == codes.NotFound || code == codes.InvalidArgument
+}
+
 func convertYamlToDict(valueNode *yaml.Node) (map[string]any, error) {
-	data, err := yaml.Marshal(valueNode)
+	v, err := convertYamlNodeToValue(valueNode)
 	if err != nil {
 		return nil, err
 	}
-
-	dict := make(map[string](any))
-	err = yaml.Unmarshal(data, &dict)
-	if err != nil {
-		return nil, err
+	if v == nil {
+		return map[string](any){}, nil
 	}
-
-	return convert.JsonToDict(dict)
+	dict, ok := v.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("expected a mapping, got %T", v)
+	}
+	return dict, nil
 }
 
 // nodeToDict resolves the child node under `key` to a Go value suitable for
@@ -67,7 +138,7 @@ func convertYamlToDict(valueNode *yaml.Node) (map[string]any, error) {
 func nodeToDict(parent *yaml.Node, key string) (any, error) {
 	_, val, err := gatherMapValue(parent, key)
 	if err != nil {
-		if status.Code(err) == codes.NotFound {
+		if isAbsentKey(err) {
 			return nil, nil
 		}
 		return nil, err
@@ -82,13 +153,14 @@ func nodeToDict(parent *yaml.Node, key string) (any, error) {
 func nodeToInt(parent *yaml.Node, key string) (*int64, error) {
 	_, val, err := gatherMapValue(parent, key)
 	if err != nil {
-		if status.Code(err) == codes.NotFound {
+		if isAbsentKey(err) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	if val.Kind != yaml.ScalarNode {
-		return nil, fmt.Errorf("expected scalar for %s, got kind %v", key, val.Kind)
+	val = resolveAlias(val)
+	if val == nil || val.Kind != yaml.ScalarNode {
+		return nil, fmt.Errorf("expected scalar for %s", key)
 	}
 	if n, err := strconv.ParseInt(val.Value, 10, 64); err == nil {
 		return &n, nil
@@ -132,13 +204,14 @@ func optionalIntConstraint(parent *yaml.Node, key, param string) *int64 {
 func nodeToDictList(parent *yaml.Node, key string) ([]any, error) {
 	_, val, err := gatherMapValue(parent, key)
 	if err != nil {
-		if status.Code(err) == codes.NotFound {
+		if isAbsentKey(err) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	if val.Kind != yaml.SequenceNode {
-		return nil, fmt.Errorf("expected sequence for %s, got kind %v", key, val.Kind)
+	val = resolveAlias(val)
+	if val == nil || val.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("expected sequence for %s", key)
 	}
 	out := make([]any, 0, len(val.Content))
 	for _, item := range val.Content {
@@ -151,21 +224,21 @@ func nodeToDictList(parent *yaml.Node, key string) ([]any, error) {
 	return out, nil
 }
 
-// convertYamlNodeToValue handles a single YAML node — scalar, sequence, or
-// mapping — and returns the matching Go value, normalized for the llx dict
-// primitive (ints become float64, nested maps become map[string]any). The
-// round-trip through JSON mirrors what convert.JsonToDict does for maps but
-// also accepts scalars and lists at the top level.
+// convertYamlNodeToValue handles a single YAML node (scalar, sequence, or
+// mapping) and returns the matching Go value, normalized for the llx dict
+// primitive (ints become float64, nested maps become map[string]any). Decoding
+// the node rather than re-parsing its serialized form resolves anchors,
+// aliases, and merge keys, whose definitions live elsewhere in the document
+// and are therefore absent from the serialized subtree.
 func convertYamlNodeToValue(n *yaml.Node) (any, error) {
-	data, err := yaml.Marshal(n)
-	if err != nil {
-		return nil, err
+	if n == nil {
+		return nil, nil
 	}
 	var v any
-	if err := yaml.Unmarshal(data, &v); err != nil {
+	if err := n.Decode(&v); err != nil {
 		return nil, err
 	}
-	jsonBytes, err := json.Marshal(v)
+	jsonBytes, err := json.Marshal(normalizeYamlKeys(v))
 	if err != nil {
 		return nil, err
 	}
@@ -174,4 +247,70 @@ func convertYamlNodeToValue(n *yaml.Node) (any, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+// normalizeYamlKeys rewrites mapping keys that YAML allows but JSON does not.
+// A Mappings section keyed on `true`/`false`/`2`/`null` decodes to a
+// map[any]any, which json.Marshal rejects outright, and that rejection takes
+// down every other member of the section with it. Such a key becomes its
+// string spelling instead.
+func normalizeYamlKeys(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		for k, val := range t {
+			t[k] = normalizeYamlKeys(val)
+		}
+		return t
+	case map[any]any:
+		out := make(map[string]any, len(t))
+		for k, val := range t {
+			out[yamlKeyToString(k)] = normalizeYamlKeys(val)
+		}
+		return out
+	case []any:
+		for i, val := range t {
+			t[i] = normalizeYamlKeys(val)
+		}
+		return t
+	}
+	return v
+}
+
+func yamlKeyToString(k any) string {
+	switch t := k.(type) {
+	case nil:
+		return "null"
+	case string:
+		return t
+	default:
+		return fmt.Sprint(t)
+	}
+}
+
+// optionalDict reads a dict-valued field, degrading a value we cannot
+// represent to null (an absent field) rather than failing. `owner` names the
+// enclosing resource/output/parameter so the warning is actionable.
+//
+// The alternative, propagating the error, erases every sibling row: one
+// malformed Value on one output would drop the whole outputs list.
+func optionalDict(parent *yaml.Node, key, owner string) any {
+	v, err := nodeToDict(parent, key)
+	if err != nil {
+		log.Warn().Err(err).Str("owner", owner).Str("field", key).
+			Msg("cloudformation: unreadable field; reporting it as absent")
+		return nil
+	}
+	return v
+}
+
+// optionalDictList is optionalDict for a list-valued field, e.g. a parameter
+// whose AllowedValues is written as a bare scalar instead of a list.
+func optionalDictList(parent *yaml.Node, key, owner string) []any {
+	v, err := nodeToDictList(parent, key)
+	if err != nil {
+		log.Warn().Err(err).Str("owner", owner).Str("field", key).
+			Msg("cloudformation: unreadable list field; reporting it as absent")
+		return nil
+	}
+	return v
 }

--- a/providers/cloudformation/resources/cloudformation_test.go
+++ b/providers/cloudformation/resources/cloudformation_test.go
@@ -147,6 +147,9 @@ func loadTemplate(path string) (*mqlCloudformationTemplate, error) {
 			},
 		},
 	}, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
 	runtime.Connection = conn

--- a/providers/cloudformation/resources/template.go
+++ b/providers/cloudformation/resources/template.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/aws-cloudformation/rain/cft"
@@ -121,10 +122,14 @@ func (r *mqlCloudformationTemplate) extractDict(section cft.Section) (map[string
 		// A section member's value need not be a mapping — a Metadata entry
 		// like `License: Apache-2.0` is a scalar, and Metadata is free-form.
 		// convertYamlNodeToValue accepts scalars, sequences, and mappings, so
-		// one scalar member no longer fails the whole section.
+		// one scalar member no longer fails the whole section. A member we
+		// still cannot read is dropped on its own rather than taking every
+		// other member of the section with it.
 		val, err := convertYamlNodeToValue(valueNode)
 		if err != nil {
-			return nil, err
+			log.Warn().Err(err).Str("section", string(section)).Str("member", keyNode.Value).
+				Msg("cloudformation: unreadable section member; skipping it")
+			continue
 		}
 
 		result[keyNode.Value] = val
@@ -161,6 +166,17 @@ func (r *mqlCloudformationTemplate) rules() (map[string]any, error) {
 	return r.extractDict(cft.Rules)
 }
 
+// sectionMemberID builds the cache key for a member of a template section.
+// YAML preserves duplicate mapping keys, so a template can declare two
+// resources (or outputs, or parameters) under the same logical ID. Keying the
+// resource on the logical ID alone makes the second one collide with the first
+// in the runtime cache, and the query then reports the first one's data twice
+// while the second is invisible. `contentIndex` is the member's position in the
+// section's Content slice, which is stable for a given template.
+func sectionMemberID(name string, contentIndex int) string {
+	return fmt.Sprintf("%s/%d", name, contentIndex/2)
+}
+
 func (x *mqlCloudformationResource) id() (string, error) {
 	return x.Name.Data, nil
 }
@@ -192,15 +208,15 @@ func (r *mqlCloudformationTemplate) resources() ([]any, error) {
 
 		_, val, err := gatherMapValue(valueNode, "Type")
 		if err == nil {
-			resourceType = val.Value
+			resourceType = scalarValue(val)
 		}
 		_, val, err = gatherMapValue(valueNode, "Condition")
 		if err == nil {
-			resourceCondition = val.Value
+			resourceCondition = scalarValue(val)
 		}
 		_, val, err = gatherMapValue(valueNode, "Documentation")
 		if err == nil {
-			resourceDocumentation = val.Value
+			resourceDocumentation = scalarValue(val)
 		}
 
 		// Attributes/Properties are objects in valid CloudFormation. A
@@ -224,15 +240,24 @@ func (r *mqlCloudformationTemplate) resources() ([]any, error) {
 			}
 		}
 
+		// DependsOn is either one logical ID or a list of them. Only scalars
+		// name a logical ID: a mapping or nested list entry has no Value, and
+		// appending it would report a dependency on the empty logical ID "".
 		var dependsOn []any
 		_, val, err = gatherMapValue(valueNode, "DependsOn")
 		if err == nil {
-			switch val.Kind {
-			case yaml.ScalarNode:
-				dependsOn = []any{val.Value}
-			case yaml.SequenceNode:
+			val = resolveAlias(val)
+			switch {
+			case val == nil:
+			case val.Kind == yaml.SequenceNode:
 				for _, item := range val.Content {
-					dependsOn = append(dependsOn, item.Value)
+					if entry := scalarValue(item); entry != "" {
+						dependsOn = append(dependsOn, entry)
+					}
+				}
+			default:
+				if entry := scalarValue(val); entry != "" {
+					dependsOn = []any{entry}
 				}
 			}
 		}
@@ -240,27 +265,18 @@ func (r *mqlCloudformationTemplate) resources() ([]any, error) {
 		deletionPolicy := ""
 		_, val, err = gatherMapValue(valueNode, "DeletionPolicy")
 		if err == nil {
-			deletionPolicy = val.Value
+			deletionPolicy = scalarValue(val)
 		}
 
 		updateReplacePolicy := ""
 		_, val, err = gatherMapValue(valueNode, "UpdateReplacePolicy")
 		if err == nil {
-			updateReplacePolicy = val.Value
+			updateReplacePolicy = scalarValue(val)
 		}
 
-		creationPolicy, err := nodeToDict(valueNode, "CreationPolicy")
-		if err != nil {
-			return nil, err
-		}
-		updatePolicy, err := nodeToDict(valueNode, "UpdatePolicy")
-		if err != nil {
-			return nil, err
-		}
-		resourceMetadata, err := nodeToDict(valueNode, "Metadata")
-		if err != nil {
-			return nil, err
-		}
+		creationPolicy := optionalDict(valueNode, "CreationPolicy", keyNode.Value)
+		updatePolicy := optionalDict(valueNode, "UpdatePolicy", keyNode.Value)
+		resourceMetadata := optionalDict(valueNode, "Metadata", keyNode.Value)
 
 		ctx, err := r.nodeContext(keyNode, valueNode)
 		if err != nil {
@@ -268,6 +284,7 @@ func (r *mqlCloudformationTemplate) resources() ([]any, error) {
 		}
 
 		pkg, err := CreateResource(r.MqlRuntime, "cloudformation.resource", map[string]*llx.RawData{
+			"__id":                llx.StringData(sectionMemberID(keyNode.Value, i)),
 			"name":                llx.StringData(keyNode.Value),
 			"type":                llx.StringData(resourceType),
 			"condition":           llx.StringData(resourceCondition),
@@ -403,25 +420,22 @@ func (r *mqlCloudformationTemplate) outputs() ([]any, error) {
 			log.Warn().Err(cerr).Str("output", keyNode.Value).Msg("cloudformation: output body is not an object; leaving empty")
 		}
 
-		value, err := nodeToDict(valueNode, "Value")
-		if err != nil {
-			return nil, err
-		}
+		value := optionalDict(valueNode, "Value", keyNode.Value)
 
 		description := ""
 		if _, n, err := gatherMapValue(valueNode, "Description"); err == nil {
-			description = n.Value
+			description = scalarValue(n)
 		}
 
 		condition := ""
 		if _, n, err := gatherMapValue(valueNode, "Condition"); err == nil {
-			condition = n.Value
+			condition = scalarValue(n)
 		}
 
 		exportName := ""
 		if _, exportNode, err := gatherMapValue(valueNode, "Export"); err == nil {
 			if _, n, err := gatherMapValue(exportNode, "Name"); err == nil {
-				exportName = n.Value
+				exportName = scalarValue(n)
 			}
 		}
 
@@ -431,6 +445,7 @@ func (r *mqlCloudformationTemplate) outputs() ([]any, error) {
 		}
 
 		pkg, err := CreateResource(r.MqlRuntime, "cloudformation.output", map[string]*llx.RawData{
+			"__id":        llx.StringData(sectionMemberID(keyNode.Value, i)),
 			"name":        llx.StringData(keyNode.Value),
 			"properties":  llx.DictData(dict),
 			"value":       llx.DictData(value),
@@ -474,27 +489,27 @@ func (r *mqlCloudformationTemplate) parameterList() ([]any, error) {
 
 		paramType := ""
 		if _, n, err := gatherMapValue(valueNode, "Type"); err == nil {
-			paramType = n.Value
+			paramType = scalarValue(n)
 		}
 
 		description := ""
 		if _, n, err := gatherMapValue(valueNode, "Description"); err == nil {
-			description = n.Value
+			description = scalarValue(n)
 		}
 
 		allowedPattern := ""
 		if _, n, err := gatherMapValue(valueNode, "AllowedPattern"); err == nil {
-			allowedPattern = n.Value
+			allowedPattern = scalarValue(n)
 		}
 
 		constraintDescription := ""
 		if _, n, err := gatherMapValue(valueNode, "ConstraintDescription"); err == nil {
-			constraintDescription = n.Value
+			constraintDescription = scalarValue(n)
 		}
 
 		noEcho := false
 		if _, n, err := gatherMapValue(valueNode, "NoEcho"); err == nil {
-			noEcho = parseCfnBool(n.Value)
+			noEcho = parseCfnBool(scalarValue(n))
 		}
 
 		// A constraint we can't represent degrades that single field to null.
@@ -506,15 +521,8 @@ func (r *mqlCloudformationTemplate) parameterList() ([]any, error) {
 		minValue := optionalIntConstraint(valueNode, "MinValue", keyNode.Value)
 		maxValue := optionalIntConstraint(valueNode, "MaxValue", keyNode.Value)
 
-		defaultDict, err := nodeToDict(valueNode, "Default")
-		if err != nil {
-			return nil, err
-		}
-
-		allowedValues, err := nodeToDictList(valueNode, "AllowedValues")
-		if err != nil {
-			return nil, err
-		}
+		defaultDict := optionalDict(valueNode, "Default", keyNode.Value)
+		allowedValues := optionalDictList(valueNode, "AllowedValues", keyNode.Value)
 
 		ctx, err := r.nodeContext(keyNode, valueNode)
 		if err != nil {
@@ -522,7 +530,7 @@ func (r *mqlCloudformationTemplate) parameterList() ([]any, error) {
 		}
 
 		pkg, err := CreateResource(r.MqlRuntime, "cloudformation.parameter", map[string]*llx.RawData{
-			"__id":                  llx.StringData(keyNode.Value),
+			"__id":                  llx.StringData(sectionMemberID(keyNode.Value, i)),
 			"name":                  llx.StringData(keyNode.Value),
 			"type":                  llx.StringData(paramType),
 			"default":               llx.DictData(defaultDict),
@@ -568,10 +576,27 @@ func (r *mqlCloudformationTemplate) types() ([]any, error) {
 		return nil, nil
 	}
 
-	list, err := template.GetTypes()
-	if err != nil {
-		return nil, err
+	// Collect the types locally rather than through cft.GetTypes, which fails
+	// the whole call on the first resource without a literal Type (a
+	// work-in-progress entry, or one whose Type arrives through a merge key
+	// it does not resolve). One such entry must not empty the list.
+	result := make([]any, 0, len(body.Content)/2)
+	seen := make(map[string]struct{}, len(body.Content)/2)
+	for i := 0; i < len(body.Content); i += 2 {
+		_, typeNode, err := gatherMapValue(body.Content[i+1], "Type")
+		if err != nil {
+			continue
+		}
+		resourceType := scalarValue(typeNode)
+		if resourceType == "" {
+			continue
+		}
+		if _, ok := seen[resourceType]; ok {
+			continue
+		}
+		seen[resourceType] = struct{}{}
+		result = append(result, resourceType)
 	}
 
-	return convert.SliceAnyToInterface(list), nil
+	return result, nil
 }

--- a/providers/cloudformation/resources/yamlfidelity_test.go
+++ b/providers/cloudformation/resources/yamlfidelity_test.go
@@ -1,0 +1,359 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resourcesByName(t *testing.T, tpl *mqlCloudformationTemplate) map[string]*mqlCloudformationResource {
+	t.Helper()
+	res := tpl.GetResources()
+	require.NoError(t, res.Error)
+	out := map[string]*mqlCloudformationResource{}
+	for _, r := range res.Data {
+		rr := r.(*mqlCloudformationResource)
+		out[rr.Name.Data] = rr
+	}
+	return out
+}
+
+func outputsByName(t *testing.T, tpl *mqlCloudformationTemplate) map[string]*mqlCloudformationOutput {
+	t.Helper()
+	res := tpl.GetOutputs()
+	require.NoError(t, res.Error)
+	out := map[string]*mqlCloudformationOutput{}
+	for _, r := range res.Data {
+		rr := r.(*mqlCloudformationOutput)
+		out[rr.Name.Data] = rr
+	}
+	return out
+}
+
+func parametersByName(t *testing.T, tpl *mqlCloudformationTemplate) map[string]*mqlCloudformationParameter {
+	t.Helper()
+	res := tpl.GetParameterList()
+	require.NoError(t, res.Error)
+	out := map[string]*mqlCloudformationParameter{}
+	for _, r := range res.Data {
+		rr := r.(*mqlCloudformationParameter)
+		out[rr.Name.Data] = rr
+	}
+	return out
+}
+
+// BUG 1: a YAML alias in a resource's Properties must resolve to the anchored
+// mapping. Blanking it makes a policy that asserts every bucket blocks public
+// access pass vacuously on the aliased bucket.
+func TestAliasInResourceProperties(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Resources:
+  A:
+    Type: AWS::S3::Bucket
+    Properties: &p
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+  B:
+    Type: AWS::S3::Bucket
+    Properties: *p
+`)
+	byName := resourcesByName(t, tpl)
+	require.Len(t, byName, 2)
+	for _, name := range []string{"A", "B"} {
+		props := byName[name].Properties.Data
+		require.Contains(t, props, "PublicAccessBlockConfiguration", "%s must carry the anchored properties", name)
+		pab := props["PublicAccessBlockConfiguration"].(map[string]any)
+		assert.Equal(t, true, pab["BlockPublicAcls"])
+	}
+}
+
+// BUG 1: an alias inside an output Value erased every output in the template.
+func TestAliasInOutputValue(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Resources:
+  A:
+    Type: AWS::S3::Bucket
+Outputs:
+  First:
+    Value: &v
+      Fn::GetAtt: [A, Arn]
+  Second:
+    Value: *v
+`)
+	byName := outputsByName(t, tpl)
+	require.Len(t, byName, 2, "an aliased output Value must not erase the outputs list")
+	for _, name := range []string{"First", "Second"} {
+		val, ok := byName[name].Value.Data.(map[string]any)
+		require.True(t, ok, "%s Value must resolve to a mapping", name)
+		assert.Contains(t, val, "Fn::GetAtt")
+	}
+}
+
+// BUG 1: an alias inside a parameter Default erased every parameter.
+func TestAliasInParameterDefault(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Parameters:
+  A:
+    Type: String
+    Default: &d "hello"
+  B:
+    Type: String
+    Default: *d
+  Secret:
+    Type: String
+    NoEcho: true
+`)
+	byName := parametersByName(t, tpl)
+	require.Len(t, byName, 3, "an aliased Default must not erase the parameter list")
+	assert.Equal(t, "hello", byName["A"].Default.Data)
+	assert.Equal(t, "hello", byName["B"].Default.Data)
+	assert.True(t, byName["Secret"].NoEcho.Data)
+}
+
+// BUG 1: an alias inside Mappings erased the whole section.
+func TestAliasInMappings(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Mappings:
+  Base:
+    Config: &c
+      Instances: 3
+  Prod:
+    Config: *c
+`)
+	m := tpl.GetMappings()
+	require.NoError(t, m.Error)
+	require.Len(t, m.Data, 2, "an aliased mapping member must not erase the section")
+	prod := m.Data["Prod"].(map[string]any)
+	cfg := prod["Config"].(map[string]any)
+	assert.Equal(t, float64(3), cfg["Instances"])
+}
+
+// BUG 1: an alias inside Conditions erased the whole section.
+func TestAliasInConditions(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Conditions:
+  IsProd: &prod
+    Fn::Equals: [prod, prod]
+  AlsoProd: *prod
+`)
+	c := tpl.GetConditions()
+	require.NoError(t, c.Error)
+	require.Len(t, c.Data, 2, "an aliased condition must not erase the section")
+	assert.NotNil(t, c.Data["AlsoProd"])
+}
+
+// BUG 2: a merge key must contribute Type (and the other scalar attributes) to
+// the merged resource, or every type-scoped control silently skips it.
+func TestMergeKeyResolvesResourceAttributes(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Base: &base
+  Type: AWS::S3::Bucket
+  DeletionPolicy: Retain
+Resources:
+  A:
+    <<: *base
+    Properties:
+      BucketName: x
+  B:
+    Type: AWS::SQS::Queue
+`)
+	byName := resourcesByName(t, tpl)
+	require.Len(t, byName, 2)
+	assert.Equal(t, "AWS::S3::Bucket", byName["A"].Type.Data, "merge key must supply Type")
+	assert.Equal(t, "Retain", byName["A"].DeletionPolicy.Data, "merge key must supply DeletionPolicy")
+
+	types := tpl.GetTypes()
+	require.NoError(t, types.Error)
+	assert.ElementsMatch(t, []any{"AWS::S3::Bucket", "AWS::SQS::Queue"}, types.Data)
+}
+
+// BUG 2: an explicit key must win over the same key coming from a merge.
+func TestMergeKeyExplicitKeyWins(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Base: &base
+  Type: AWS::S3::Bucket
+Resources:
+  A:
+    <<: *base
+    Type: AWS::SQS::Queue
+`)
+	byName := resourcesByName(t, tpl)
+	assert.Equal(t, "AWS::SQS::Queue", byName["A"].Type.Data)
+}
+
+// BUG 3: a null resource body (routine work-in-progress) erased every resource.
+func TestNullResourceBodyKeepsSiblings(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Resources:
+  MyBucket:
+  MyQueue:
+    Type: AWS::SQS::Queue
+`)
+	byName := resourcesByName(t, tpl)
+	require.Len(t, byName, 2, "a null resource body must not erase its siblings")
+	assert.Equal(t, "AWS::SQS::Queue", byName["MyQueue"].Type.Data)
+	assert.Equal(t, "", byName["MyBucket"].Type.Data)
+}
+
+// BUG 3: a null output body erased every output.
+func TestNullOutputBodyKeepsSiblings(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Outputs:
+  Empty:
+  Real:
+    Value: hello
+`)
+	byName := outputsByName(t, tpl)
+	require.Len(t, byName, 2, "a null output body must not erase its siblings")
+	assert.Equal(t, "hello", byName["Real"].Value.Data)
+}
+
+// BUG 3: a scalar parameter body erased every parameter, including the NoEcho
+// credential parameter a policy hunts for.
+func TestScalarParameterBodyKeepsSiblings(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Parameters:
+  Foo: bar
+  Secret:
+    Type: String
+    NoEcho: true
+`)
+	byName := parametersByName(t, tpl)
+	require.Len(t, byName, 2, "a scalar parameter body must not erase its siblings")
+	assert.True(t, byName["Secret"].NoEcho.Data)
+}
+
+// BUG 3: AllowedValues written as a scalar instead of a list erased every
+// parameter.
+func TestScalarAllowedValuesKeepsParameters(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Parameters:
+  Env:
+    Type: String
+    AllowedValues: prod
+  Secret:
+    Type: String
+    NoEcho: true
+`)
+	byName := parametersByName(t, tpl)
+	require.Len(t, byName, 2, "a scalar AllowedValues must not erase the parameter list")
+	assert.True(t, byName["Secret"].NoEcho.Data)
+	assert.Empty(t, byName["Env"].AllowedValues.Data)
+}
+
+// BUG 4: YAML keeps duplicate mapping keys, so two resources can share a
+// logical ID. They must not collapse onto the first one's data.
+func TestDuplicateLogicalIdsAreDistinct(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Resources:
+  Dup:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: first
+  Dup:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: second
+`)
+	res := tpl.GetResources()
+	require.NoError(t, res.Error)
+	require.Len(t, res.Data, 2)
+
+	seen := map[string]bool{}
+	for _, r := range res.Data {
+		seen[r.(*mqlCloudformationResource).Type.Data] = true
+	}
+	assert.True(t, seen["AWS::S3::Bucket"], "the first duplicate must be reported")
+	assert.True(t, seen["AWS::SQS::Queue"], "the second duplicate must not alias to the first")
+}
+
+func TestDuplicateOutputAndParameterIdsAreDistinct(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Parameters:
+  Dup:
+    Type: String
+  Dup:
+    Type: Number
+Outputs:
+  Dup:
+    Value: first
+  Dup:
+    Value: second
+`)
+	params := tpl.GetParameterList()
+	require.NoError(t, params.Error)
+	require.Len(t, params.Data, 2)
+	paramTypes := map[string]bool{}
+	for _, p := range params.Data {
+		paramTypes[p.(*mqlCloudformationParameter).Type.Data] = true
+	}
+	assert.True(t, paramTypes["String"])
+	assert.True(t, paramTypes["Number"], "the second duplicate parameter must not alias to the first")
+
+	outs := tpl.GetOutputs()
+	require.NoError(t, outs.Error)
+	require.Len(t, outs.Data, 2)
+	outValues := map[any]bool{}
+	for _, o := range outs.Data {
+		outValues[o.(*mqlCloudformationOutput).Value.Data] = true
+	}
+	assert.True(t, outValues["first"])
+	assert.True(t, outValues["second"], "the second duplicate output must not alias to the first")
+}
+
+// BUG 5: a bool/number/null mapping key made the whole section fail to
+// serialize, taking every other mapping with it.
+func TestNonStringMappingKeys(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Mappings:
+  EnableByEnv:
+    true:
+      Instances: 3
+    false:
+      Instances: 1
+  RegionMap:
+    us-east-1:
+      HVM64: ami-1234
+`)
+	m := tpl.GetMappings()
+	require.NoError(t, m.Error)
+	require.Len(t, m.Data, 2, "a non-string mapping key must not erase the section")
+
+	byEnv := m.Data["EnableByEnv"].(map[string]any)
+	on := byEnv["true"].(map[string]any)
+	assert.Equal(t, float64(3), on["Instances"])
+	off := byEnv["false"].(map[string]any)
+	assert.Equal(t, float64(1), off["Instances"])
+}
+
+// BUG 6: one resource without a literal Type emptied the whole types() list.
+func TestTypesSkipsResourceWithoutType(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Resources:
+  Good:
+    Type: AWS::S3::Bucket
+  AlsoGood:
+    Type: AWS::SQS::Queue
+  Bad:
+    Properties:
+      Foo: bar
+`)
+	types := tpl.GetTypes()
+	require.NoError(t, types.Error, "a resource without Type must not empty the type list")
+	assert.ElementsMatch(t, []any{"AWS::S3::Bucket", "AWS::SQS::Queue"}, types.Data)
+}
+
+// BUG 7: a non-scalar DependsOn entry became a phantom "" dependency.
+func TestDependsOnSkipsNonScalarEntries(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Resources:
+  A:
+    Type: AWS::S3::Bucket
+  B:
+    Type: AWS::SQS::Queue
+    DependsOn:
+      - A
+      - Nested: thing
+`)
+	byName := resourcesByName(t, tpl)
+	assert.Equal(t, []any{"A"}, byName["B"].DependsOn.Data, "a mapping entry must not become an empty dependency")
+}
+
+// BUG 8: the test harness dropped the connection error, so an unparseable
+// template nil-dereferenced instead of reporting the parse failure.
+func TestLoadTemplateReportsParseError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "broken.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("Resources:\n\tBucket: oops\n"), 0o600))
+	_, err := loadTemplate(path)
+	require.Error(t, err, "an unparseable template must surface the parse error")
+}


### PR DESCRIPTION
Eight fidelity bugs in the CloudFormation template parser. Each one makes an IaC
policy pass on data that was never actually read, so the failure mode is a green
result rather than an error.

Every fix landed test-first: the regression test was written and confirmed
failing against `main` for the stated reason before the code changed.

## BUG 1 (critical) — YAML anchors/aliases are blanked, or erase whole sections

`convertYamlToDict` and `convertYamlNodeToValue` both did `yaml.Marshal(node)`
followed by `yaml.Unmarshal`. An alias node marshals back out as the bare text
`*anchor`, and the anchor definition lives elsewhere in the document, so the
re-parse failed with `yaml: unknown anchor 'p' referenced`.

```yaml
Resources:
  A:
    Type: AWS::S3::Bucket
    Properties: &p
      PublicAccessBlockConfiguration:
        BlockPublicAcls: true
  B:
    Type: AWS::S3::Bucket
    Properties: *p
```

Before: resource `B` reported `properties: {}` behind a `log.Warn`. A control
asserting every bucket has a `PublicAccessBlockConfiguration` passed vacuously
on `B`. When the alias sat in an output `Value`, a parameter `Default`, or a
Mappings/Conditions member, the whole list or section was erased instead of one
field.

Fix: decode the node with `yaml.Node.Decode`, which resolves anchors, aliases,
and merge keys natively, and keep the JSON normalization pass that follows.
Verified in resource Properties, output Value, parameter Default, Mappings, and
Conditions.

## BUG 2 (high) — YAML merge keys silently drop `Type`

`gatherMapValue` searched for a literal `Type` key; a merged mapping stores the
key `<<` pointing at an alias, and nothing resolved it.

```yaml
Base: &base
  Type: AWS::S3::Bucket
  DeletionPolicy: Retain
Resources:
  A:
    <<: *base
    Properties: {BucketName: x}
```

Before: `type == ""`, so `resources.where(type == "AWS::S3::Bucket")` never
matched the bucket and every type-scoped control skipped it silently.

Fix: `gatherMapValue` searches merge sources after the mapping's own keys, so a
key the mapping defines itself still wins, and within a merge sequence the
earlier entry wins. Scalar attributes are read through a new `scalarValue`
helper that also resolves an aliased value (`Type: *sharedType`).

## BUG 3 (high) — one malformed member erases the entire list

`gatherMapValue` returns `InvalidArgument` (not `NotFound`) when the container
is not a mapping, and `nodeToDict`/`nodeToDictList` only swallowed `NotFound`.
Every one of these erased an entire section:

```yaml
Resources:
  MyBucket:            # null body, routine work-in-progress
  MyQueue:
    Type: AWS::SQS::Queue
```
```yaml
Outputs:
  Empty:
  Real:
    Value: hello
```
```yaml
Parameters:
  Foo: bar             # scalar body
  Secret:
    Type: String
    NoEcho: true       # the credential parameter a policy hunts for, gone
```
```yaml
Parameters:
  Env:
    Type: String
    AllowedValues: prod   # scalar where a list belongs
```

Fix: treat `InvalidArgument` from `gatherMapValue` the same as `NotFound` inside
`nodeToDict`/`nodeToInt`/`nodeToDictList` (a non-mapping body means the field is
absent, not that the row is doomed), and degrade the individual field with a
`log.Warn` at each call site via new `optionalDict`/`optionalDictList` helpers.
This mirrors the `optionalIntConstraint` pattern already in the file, whose
comment explains the same reasoning. `extractDict` likewise skips an unreadable
member instead of dropping the section.

## BUG 4 (high) — duplicate logical IDs alias to the first entry

YAML preserves duplicate mapping keys, and the `__id` was the logical name
alone, so the second entry collided with the first in the runtime cache.

```yaml
Resources:
  Dup: {Type: AWS::S3::Bucket, Properties: {BucketName: first}}
  Dup: {Type: AWS::SQS::Queue, Properties: {QueueName: second}}
```

Before: two rows both reading `AWS::S3::Bucket`. The SQS queue was invisible and
replaced by a phantom duplicate of the bucket. Same shape for
`cloudformation.output` and `cloudformation.parameter`.

Fix: pass an explicit ordinal-qualified `"__id"` (`<name>/<index>`) at each
`CreateResource` site. `name` is unchanged and remains the queryable field.

## BUG 5 (medium) — non-string mapping keys wipe the whole section

Decoding into `any` yields `map[any]any` when a key is a bool, number, or null,
and `json.Marshal` then fails with
`json: unsupported value: jsontext: object member name must be a string`.

```yaml
Mappings:
  EnableByEnv:
    true:  {Instances: 3}
    false: {Instances: 1}
```

Before: `mappings` errored and returned nothing, taking every other mapping with
it. Fix: normalize such keys to their string spelling before the JSON pass.

## BUG 6 (medium) — `types()` fails wholesale when a resource lacks a `Type`

It delegated to rain's `template.GetTypes()`, which returns
`expected <id> to have Type` on the first offender, so one work-in-progress
entry emptied the entire list. Fix: walk the already-validated Resources
mapping locally, skipping entries with no scalar Type (and picking up types
that arrive through a merge key).

## BUG 7 (low) — `DependsOn` non-scalar entries become phantom `""` deps

A mapping item in the sequence has no `Value`, so it appended `""`. Fix: skip
non-scalar entries; resolve an aliased `DependsOn` too.

## BUG 8 — test-harness defect

`loadTemplate` never checked the error from `NewCloudformationConnection`, so a
template that fails to parse produced a nil connection and the test
nil-dereferenced inside `initCloudformationTemplate` instead of reporting the
parse error. Fixed first, because it hides every other failure.

## Tests

New file `providers/cloudformation/resources/yamlfidelity_test.go`, all confirmed
failing before the fix:

| test | bug |
|---|---|
| `TestAliasInResourceProperties` | 1 |
| `TestAliasInOutputValue` | 1 |
| `TestAliasInParameterDefault` | 1 |
| `TestAliasInMappings` | 1 |
| `TestAliasInConditions` | 1 |
| `TestMergeKeyResolvesResourceAttributes` | 2, 6 |
| `TestMergeKeyExplicitKeyWins` | 2 |
| `TestNullResourceBodyKeepsSiblings` | 3 |
| `TestNullOutputBodyKeepsSiblings` | 3 |
| `TestScalarParameterBodyKeepsSiblings` | 3 |
| `TestScalarAllowedValuesKeepsParameters` | 3 |
| `TestDuplicateLogicalIdsAreDistinct` | 4 |
| `TestDuplicateOutputAndParameterIdsAreDistinct` | 4 |
| `TestNonStringMappingKeys` | 5 |
| `TestTypesSkipsResourceWithoutType` | 6 |
| `TestDependsOnSkipsNonScalarEntries` | 7 |
| `TestLoadTemplateReportsParseError` | 8 |

No schema change, so no `.lr`/`.lr.versions`/codegen diff, and no version bump.

Checks run locally: `go test ./...` in `providers/cloudformation` (green,
including the pre-existing suite over every `testdata/` template), `go vet`,
`gofmt -l`, `golangci-lint run ./...` (0 issues), `go mod tidy` (no diff),
`typos`, and `make providers/build/cloudformation`.
