### PR TITLE
🐛 kustomize: read the modern labels syntax and file-referenced replacements

### DIFF
--- a/providers/kustomize/connection/connection.go
+++ b/providers/kustomize/connection/connection.go
@@ -5,6 +5,7 @@ package connection
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -241,13 +242,28 @@ func scanForKustomizations(dir string, depth int, entries *[]*KustomizationEntry
 func loadSingleKustomization(dir string) (*KustomizationEntry, error) {
 	fSys := filesys.MakeFsOnDisk()
 
+	// Count every recognized filename rather than taking the first that
+	// reads. Kustomize's own loader (target.LoadKustFile) hard-errors on more
+	// than one match, so a directory holding both kustomization.yaml and
+	// Kustomization can never be built. Picking one of them reported that
+	// file's static fields while the resources accessor failed with krusty's
+	// error, presenting the directory as half-valid.
+	var data []byte
+	matched := make([]string, 0, len(kustomizationFilenames))
 	for _, filename := range kustomizationFilenames {
 		filePath := filepath.Join(dir, filename)
-		data, err := fSys.ReadFile(filePath)
+		content, err := fSys.ReadFile(filePath)
 		if err != nil {
 			continue
 		}
+		matched = append(matched, filename)
+		data = content
+	}
 
+	switch len(matched) {
+	case 0:
+		return nil, ErrNoKustomization
+	case 1:
 		k := &types.Kustomization{}
 		if err := k.Unmarshal(data); err != nil {
 			return nil, err
@@ -264,7 +280,8 @@ func loadSingleKustomization(dir string) (*KustomizationEntry, error) {
 			Path:          dir,
 			Kustomization: k,
 		}, nil
+	default:
+		return nil, fmt.Errorf("found multiple kustomization files under %s: %s",
+			dir, strings.Join(matched, ", "))
 	}
-
-	return nil, ErrNoKustomization
 }

--- a/providers/kustomize/connection/connection_test.go
+++ b/providers/kustomize/connection/connection_test.go
@@ -174,3 +174,32 @@ func TestLoadKustomizations_SkipsHiddenAndNoiseDirs(t *testing.T) {
 	require.Len(t, entries, 1, "only the real subdir should be discovered")
 	assert.Equal(t, realDir, entries[0].Path)
 }
+
+// BUG 8: two recognized kustomization filenames in one directory. The loader
+// took whichever read first, so mql reported that file's static fields while
+// `kustomize build` (and therefore the `resources` accessor) hard-errors with
+// "Found multiple kustomization files under: ..." — a directory reported as
+// half-valid. Mirror kustomize and refuse the directory outright.
+func TestLoadSingleKustomization_MultipleFilesIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	body := "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "kustomization.yaml"), []byte(body), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Kustomization"), []byte(body), 0o600))
+
+	_, err := loadSingleKustomization(dir)
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrNoKustomization),
+		"an ambiguous directory is not the same as an empty one")
+	assert.Contains(t, err.Error(), "multiple kustomization files")
+}
+
+// A single recognized filename that is not the default still loads.
+func TestLoadSingleKustomization_AlternateFilenameStillLoads(t *testing.T) {
+	dir := t.TempDir()
+	body := "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nnamespace: alt\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "kustomization.yml"), []byte(body), 0o600))
+
+	entry, err := loadSingleKustomization(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "alt", entry.Kustomization.Namespace)
+}

--- a/providers/kustomize/go.mod
+++ b/providers/kustomize/go.mod
@@ -124,5 +124,5 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20260330154417-16be699c7b31 // indirect
 	moul.io/http2curl v1.0.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
+	sigs.k8s.io/yaml v1.6.0
 )

--- a/providers/kustomize/provider/provider_test.go
+++ b/providers/kustomize/provider/provider_test.go
@@ -476,33 +476,23 @@ func TestInitKustomizeKustomization_SelectorWorks(t *testing.T) {
 	assert.Equal(t, "staging", string(nsResp.Data.Value))
 }
 
-// A selector for a path the connection didn't load returns a bare resource
-// (matching the project's "bare resource is a valid empty state" rule);
-// computed field accessors then surface a clear error instead of panicking.
-func TestInitKustomizeKustomization_UnknownPathFieldsErrorCleanly(t *testing.T) {
+// A selector for a path the connection didn't load used to fall through to
+// `args, nil, nil`. The runtime then built the resource from the `path` arg
+// alone, leaving every other field UNSET — not null, unset — which surfaces
+// client-side as "llx: encountered a primitive with no type information,
+// coercing to null" with nothing pointing at the cause. The miss is now
+// reported where it happens, the way the sibling kustomize.image init does.
+func TestInitKustomizeKustomization_UnknownPathIsNotFound(t *testing.T) {
 	srv, resp := newTestService("../testdata/basic")
 
-	createResp, err := srv.GetData(&plugin.DataReq{
+	_, err := srv.GetData(&plugin.DataReq{
 		Connection: resp.Id,
 		Resource:   "kustomize.kustomization",
 		Args: map[string]*llx.Primitive{
 			"path": llx.StringPrimitive("/does/not/exist"),
 		},
 	})
-	require.NoError(t, err)
-	require.Empty(t, createResp.Error)
-	kID := string(createResp.Data.Value)
-	require.NotEmpty(t, kID)
-
-	// Computed accessor that depends on Internal state should error
-	// (with a friendly message), not panic.
-	resp2, err := srv.GetData(&plugin.DataReq{
-		Connection: resp.Id,
-		Resource:   "kustomize.kustomization",
-		ResourceId: kID,
-		Field:      "patches",
-	})
-	require.NoError(t, err, "transport call must not fail")
-	assert.NotEmpty(t, resp2.Error, "unknown path should surface as a field error")
-	assert.Contains(t, resp2.Error, "no kustomization loaded")
+	require.Error(t, err, "an unresolvable path must not produce a husk resource")
+	assert.Contains(t, err.Error(), "no kustomization loaded for path")
+	assert.Contains(t, err.Error(), "/does/not/exist")
 }

--- a/providers/kustomize/resources/fidelity_test.go
+++ b/providers/kustomize/resources/fidelity_test.go
@@ -1,0 +1,378 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/kustomize/connection"
+	kustomizeTypes "sigs.k8s.io/kustomize/api/types"
+)
+
+// newMultiFileTestRuntime is the multi-file sibling of newImageTestRuntime: it
+// materializes every named file (relative paths, subdirectories allowed) into
+// a temp directory and connects a real KustomizeConnection to it. Needed for
+// the declarations that span more than one file, such as a replacement
+// declared by `path:` or a patch pointing at a sibling YAML.
+func newMultiFileTestRuntime(t *testing.T, files map[string]string) (*plugin.Runtime, string) {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range files {
+		full := filepath.Join(dir, name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o750))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o600))
+	}
+
+	asset := &inventory.Asset{Connections: []*inventory.Config{{
+		Options: map[string]string{"path": dir},
+	}}}
+	conn, err := connection.NewKustomizeConnection(1, asset, &inventory.Config{})
+	require.NoError(t, err)
+	return plugin.NewRuntime(conn, nil, false, CreateResource, NewResource, GetData, SetData, nil), dir
+}
+
+// onlyKustomization returns the single kustomization the runtime's connection
+// loaded, already routed through newMqlKustomization.
+func onlyKustomization(t *testing.T, rt *plugin.Runtime) *mqlKustomizeKustomization {
+	t.Helper()
+	conn := rt.Connection.(*connection.KustomizeConnection)
+	entries := conn.Kustomizations()
+	require.Len(t, entries, 1)
+	k, err := newMqlKustomization(rt, entries[0])
+	require.NoError(t, err)
+	return k
+}
+
+// captureLogs redirects the global zerolog logger for the duration of the test
+// and returns the accumulated output.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := log.Logger
+	log.Logger = zerolog.New(buf).Level(zerolog.WarnLevel)
+	t.Cleanup(func() { log.Logger = prev })
+	return buf
+}
+
+// BUG 1: the modern `labels:` syntax (what `kustomize edit fix` writes, and
+// what the docs recommend) landed in types.Kustomization.Labels, which nothing
+// in the provider read. commonLabels reported {} for an overlay that does
+// label every rendered object, so a "must carry an owner label" policy failed
+// on compliant input and a deny-list policy passed vacuously.
+func TestCommonLabelsIncludesModernLabelsSyntax(t *testing.T) {
+	rt, _ := newMultiFileTestRuntime(t, map[string]string{
+		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- pairs:
+    app: web
+    env: prod
+  includeSelectors: true
+`,
+	})
+
+	k := onlyKustomization(t, rt)
+	require.NotNil(t, k.CommonLabels.Data)
+	assert.Equal(t, "web", k.CommonLabels.Data["app"])
+	assert.Equal(t, "prod", k.CommonLabels.Data["env"])
+}
+
+// Both syntaxes may appear together (kustomize only rejects the overlap on a
+// shared key). Neither may shadow the other.
+func TestCommonLabelsMergesLegacyAndModernSyntax(t *testing.T) {
+	rt, _ := newMultiFileTestRuntime(t, map[string]string{
+		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  legacy: "yes"
+labels:
+- pairs:
+    modern: "yes"
+`,
+	})
+
+	k := onlyKustomization(t, rt)
+	assert.Equal(t, "yes", k.CommonLabels.Data["legacy"])
+	assert.Equal(t, "yes", k.CommonLabels.Data["modern"])
+}
+
+const replacementFileKustomization = `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+replacements:
+- path: repl.yaml
+`
+
+const replacementFileBody = `source:
+  kind: ConfigMap
+  name: app-config
+  fieldPath: data.version
+targets:
+- select:
+    kind: Deployment
+    name: web
+  fieldPaths:
+  - spec.template.spec.containers.0.image
+`
+
+// BUG 2: `replacements: - path: file.yaml` produced a completely blank row.
+// types.ReplacementField carries the file reference in Path, and the provider
+// only ever read the inline Source/Targets, so a replacement that rewrites a
+// container image reported as injecting nothing, from nowhere, into nothing.
+func TestReplacementDeclaredByFileIsResolved(t *testing.T) {
+	rt, _ := newMultiFileTestRuntime(t, map[string]string{
+		"kustomization.yaml": replacementFileKustomization,
+		"repl.yaml":          replacementFileBody,
+	})
+
+	k := onlyKustomization(t, rt)
+	repls, err := k.replacements()
+	require.NoError(t, err)
+	require.Len(t, repls, 1)
+
+	r := repls[0].(*mqlKustomizeReplacement)
+	assert.Equal(t, "repl.yaml", r.Path.Data, "the file reference must stay visible")
+	assert.Equal(t, "ConfigMap", r.SourceKind.Data)
+	assert.Equal(t, "app-config", r.SourceName.Data)
+	assert.Equal(t, "data.version", r.SourcePath.Data)
+
+	targets, err := r.targets()
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	tgt := targets[0].(*mqlKustomizeReplacementTarget)
+	assert.Equal(t, "Deployment", tgt.Kind.Data)
+	assert.Equal(t, "web", tgt.Name.Data)
+	assert.Equal(t, "spec.template.spec.containers.0.image", tgt.FieldPath.Data)
+}
+
+// A replacement file may hold a list of replacements rather than a single
+// mapping (kustomize accepts both). Every entry must surface as its own row.
+func TestReplacementFileWithListYieldsEveryEntry(t *testing.T) {
+	rt, _ := newMultiFileTestRuntime(t, map[string]string{
+		"kustomization.yaml": replacementFileKustomization,
+		"repl.yaml": `- source:
+    kind: ConfigMap
+    name: first
+    fieldPath: data.a
+  targets:
+  - select:
+      kind: Deployment
+      name: web
+    fieldPaths:
+    - spec.a
+- source:
+    kind: ConfigMap
+    name: second
+    fieldPath: data.b
+  targets:
+  - select:
+      kind: Deployment
+      name: api
+    fieldPaths:
+    - spec.b
+`,
+	})
+
+	k := onlyKustomization(t, rt)
+	repls, err := k.replacements()
+	require.NoError(t, err)
+	require.Len(t, repls, 2)
+
+	names := []string{
+		repls[0].(*mqlKustomizeReplacement).SourceName.Data,
+		repls[1].(*mqlKustomizeReplacement).SourceName.Data,
+	}
+	assert.ElementsMatch(t, []string{"first", "second"}, names)
+	assert.NotEqual(t, repls[0].(*mqlKustomizeReplacement).__id, repls[1].(*mqlKustomizeReplacement).__id)
+}
+
+// The file read reuses the patch path-containment guard, so a replacement that
+// points outside the kustomization directory is refused. The row still carries
+// the path so the refusal is visible rather than looking like an empty
+// replacement.
+func TestReplacementFileEscapingKustomizationDirIsRefused(t *testing.T) {
+	rt, dir := newMultiFileTestRuntime(t, map[string]string{
+		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+replacements:
+- path: ../escape.yaml
+`,
+	})
+	outside := filepath.Join(filepath.Dir(dir), "escape.yaml")
+	require.NoError(t, os.WriteFile(outside, []byte(replacementFileBody), 0o600))
+	defer os.Remove(outside)
+
+	buf := captureLogs(t)
+	k := onlyKustomization(t, rt)
+	repls, err := k.replacements()
+	require.NoError(t, err)
+	require.Len(t, repls, 1)
+
+	r := repls[0].(*mqlKustomizeReplacement)
+	assert.Equal(t, "../escape.yaml", r.Path.Data)
+	assert.Empty(t, r.SourceKind.Data, "an escaping path must not be read")
+	assert.Contains(t, buf.String(), "escapes the kustomization directory")
+}
+
+// A replacement path that does not resolve still has to surface the path and
+// warn rather than emitting a silent blank row.
+func TestReplacementFileMissingSurfacesPathAndWarns(t *testing.T) {
+	rt, _ := newMultiFileTestRuntime(t, map[string]string{
+		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+replacements:
+- path: gone.yaml
+`,
+	})
+
+	buf := captureLogs(t)
+	k := onlyKustomization(t, rt)
+	repls, err := k.replacements()
+	require.NoError(t, err)
+	require.Len(t, repls, 1)
+
+	assert.Equal(t, "gone.yaml", repls[0].(*mqlKustomizeReplacement).Path.Data)
+	assert.Contains(t, buf.String(), "gone.yaml")
+}
+
+// BUG 3: a lookup miss fell through to `args, nil, nil`, so the runtime built
+// the resource from the partial `path` arg and left every other field UNSET,
+// which surfaces client-side as "primitive with no type information" with no
+// attribution. The sibling initKustomizeImage already returns a not-found
+// error; this one has to as well.
+func TestInitKustomizeKustomizationUnknownPathErrors(t *testing.T) {
+	rt, _ := newMultiFileTestRuntime(t, map[string]string{
+		"kustomization.yaml": "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\n",
+	})
+
+	_, res, err := initKustomizeKustomization(rt, map[string]*llx.RawData{
+		"path": llx.StringData("/nope/not/here"),
+	})
+	require.Error(t, err)
+	assert.Nil(t, res)
+	assert.Contains(t, err.Error(), "/nope/not/here")
+}
+
+// The bare-resource fast paths stay: no args, or an empty path, is a valid
+// empty state rather than a miss.
+func TestInitKustomizeKustomizationKeepsBareFastPaths(t *testing.T) {
+	rt, _ := newMultiFileTestRuntime(t, map[string]string{
+		"kustomization.yaml": "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\n",
+	})
+
+	_, res, err := initKustomizeKustomization(rt, map[string]*llx.RawData{})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+
+	_, res, err = initKustomizeKustomization(rt, map[string]*llx.RawData{"path": llx.StringData("")})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+}
+
+// BUG 4: types.Image has five fields and the provider surfaced four. A
+// `tagSuffix:` override rewrites the tag, but the row read newName="",
+// newTag="", digest="" — an entry that changes nothing. An "every image
+// override must pin a digest" check sees a benign-looking no-op.
+func TestImageTagSuffixIsSurfaced(t *testing.T) {
+	rt, _ := newMultiFileTestRuntime(t, map[string]string{
+		"kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: nginx
+  tagSuffix: -debian
+`,
+	})
+
+	k := onlyKustomization(t, rt)
+	images, err := k.images()
+	require.NoError(t, err)
+	require.Len(t, images, 1)
+
+	img := images[0].(*mqlKustomizeImage)
+	assert.Equal(t, "nginx", img.Name.Data)
+	assert.Equal(t, "-debian", img.TagSuffix.Data, "a tagSuffix override is not a no-op")
+}
+
+// BUG 5: the doc comment on strategicMergePatchEntry promises "a genuine typo
+// still reports as a missing patch file (with a warning from
+// newMqlKustomizePatch)". No such warning existed; a typo'd patch path became
+// an empty strategic-merge patch with no signal at all.
+func TestMissingPatchFileWarns(t *testing.T) {
+	dir := t.TempDir()
+	buf := captureLogs(t)
+
+	p, err := newMqlKustomizePatch(newTestRuntime(), dir, 0, &kustomizeTypes.Patch{Path: "does-not-exist.yaml"}, hintNone)
+	require.NoError(t, err)
+	assert.Equal(t, "does-not-exist.yaml", p.Path.Data)
+	assert.Contains(t, buf.String(), "does-not-exist.yaml")
+}
+
+// BUG 6: the replacementTarget __id was built from the target index within its
+// replacement plus kind/name/fieldPath, but never the parent replacement's own
+// index. Two replacements whose first target shares those selectors produced
+// the same __id, so CreateResource handed back the first instance for the
+// second.
+func TestReplacementTargetIDIncludesParentReplacement(t *testing.T) {
+	rt := newTestRuntime()
+
+	mk := func(index int, fieldPath string) *mqlKustomizeReplacement {
+		r := &mqlKustomizeReplacement{MqlRuntime: rt}
+		r.__id = "kustomize.replacement:kustomization.yaml:" + strconv.Itoa(index)
+		r.kustPath = "kustomization.yaml"
+		r.replacementTargets = []*kustomizeTypes.TargetSelector{{
+			Select:     &kustomizeTypes.Selector{},
+			FieldPaths: []string{fieldPath},
+		}}
+		return r
+	}
+
+	// Same kind (""), same name (""), same fieldPath, different parent.
+	first, err := mk(0, "spec.replicas").targets()
+	require.NoError(t, err)
+	second, err := mk(1, "spec.replicas").targets()
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	require.Len(t, second, 1)
+
+	assert.NotEqual(t,
+		first[0].(*mqlKustomizeReplacementTarget).__id,
+		second[0].(*mqlKustomizeReplacementTarget).__id,
+		"targets of different replacements must not alias in the resource cache")
+}
+
+// BUG 7: mqlKustomizePatch stamped its Internal state after CreateResource
+// without a stampOnce, so a cached instance handed to a second goroutine was
+// written while a concurrent operations() read it. Both sibling resources
+// already guard this with a sync.Once. Detected by `go test -race`.
+func TestPatchInternalStampIsRaceFree(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "patch.yaml"),
+		[]byte("- op: replace\n  path: /spec/replicas\n  value: 3\n"), 0o600))
+	rt := newTestRuntime()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			p, err := newMqlKustomizePatch(rt, dir, 0, &kustomizeTypes.Patch{Path: "patch.yaml"}, hintNone)
+			if err != nil {
+				return
+			}
+			_, _ = p.operations()
+		}()
+	}
+	wg.Wait()
+}

--- a/providers/kustomize/resources/image.go
+++ b/providers/kustomize/resources/image.go
@@ -78,7 +78,11 @@ func newMqlKustomizeImage(runtime *plugin.Runtime, kustPath string, idx int, img
 		"name":    llx.StringData(img.Name),
 		"newName": llx.StringData(img.NewName),
 		"newTag":  llx.StringData(img.NewTag),
-		"digest":  llx.StringData(img.Digest),
+		// tagSuffix is the fifth override slot: it keeps the original tag and
+		// appends to it. Leaving it out made such an entry read as newName="",
+		// newTag="", digest="" — a rewrite that looked like a no-op.
+		"tagSuffix": llx.StringData(img.TagSuffix),
+		"digest":    llx.StringData(img.Digest),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/kustomize/resources/kustomize.go
+++ b/providers/kustomize/resources/kustomize.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 
 	"go.mondoo.com/mql/llx"
@@ -50,16 +51,40 @@ type mqlKustomizeKustomizationInternal struct {
 	stampOnce sync.Once
 }
 
+// mergedLabels gathers every label pair the kustomization adds to its
+// rendered objects. There are two declaration slots and both are live:
+// the legacy `commonLabels` mapping (types.Kustomization.CommonLabels) and
+// the current `labels` list (types.Kustomization.Labels), which is what
+// `kustomize edit fix` writes and what the docs recommend. FixKustomization,
+// which the connection runs after unmarshalling, does not fold one into the
+// other — that fold lives in FixKustomizationPreMarshalling and runs the
+// other direction — so reading only CommonLabels reported {} for an overlay
+// that does label everything it renders.
+//
+// Precedence: the legacy mapping seeds the result and `labels` pairs are
+// merged on top, with a later `labels` entry winning over an earlier one.
+// Kustomize rejects a key that appears in both slots, so the overlap only
+// arises on input kustomize would refuse anyway.
+func mergedLabels(k *kustomizeTypes.Kustomization) map[string]any {
+	labels := make(map[string]any, len(k.CommonLabels))
+	for key, val := range k.CommonLabels {
+		labels[key] = val
+	}
+	for _, l := range k.Labels {
+		for key, val := range l.Pairs {
+			labels[key] = val
+		}
+	}
+	return labels
+}
+
 func newMqlKustomization(runtime *plugin.Runtime, entry *connection.KustomizationEntry) (*mqlKustomizeKustomization, error) {
 	if entry == nil || entry.Kustomization == nil {
 		return nil, errors.New("kustomize: entry has no parsed kustomization")
 	}
 	k := entry.Kustomization
 
-	commonLabels := make(map[string]any, len(k.CommonLabels))
-	for key, val := range k.CommonLabels {
-		commonLabels[key] = val
-	}
+	commonLabels := mergedLabels(k)
 	commonAnnotations := make(map[string]any, len(k.CommonAnnotations))
 	for key, val := range k.CommonAnnotations {
 		commonAnnotations[key] = val
@@ -102,10 +127,13 @@ func newMqlKustomization(runtime *plugin.Runtime, entry *connection.Kustomizatio
 // state stays populated — without this, field accessors would nil-deref
 // on a bare resource constructed only from the `path` arg.
 //
-// Returning `args, nil, nil` for an unknown / empty path matches the
-// "bare resource is a valid empty state" convention used elsewhere in
-// this repo; callers see a resource that satisfies the type but yields
-// errors from the accessors.
+// No args, or an empty path, keeps returning `args, nil, nil`: a bare
+// resource is a valid empty state. A path that matches nothing is a
+// different thing entirely and returns a not-found error — falling
+// through there would have the runtime build the resource from the
+// partial args, leaving every other field UNSET, which surfaces
+// client-side as "primitive with no type information" with nothing
+// pointing at the cause.
 func initKustomizeKustomization(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) == 0 {
 		return args, nil, nil
@@ -132,7 +160,7 @@ func initKustomizeKustomization(runtime *plugin.Runtime, args map[string]*llx.Ra
 			return args, mqlK, nil
 		}
 	}
-	return args, nil, nil
+	return nil, nil, fmt.Errorf("kustomize: no kustomization loaded for path %q", path)
 }
 
 func (k *mqlKustomizeKustomization) id() (string, error) {
@@ -243,12 +271,15 @@ func (k *mqlKustomizeKustomization) replacements() ([]any, error) {
 		return nil, err
 	}
 	var mqlReplacements []any
-	for i, r := range kust.Replacements {
-		mqlR, err := newMqlKustomizeReplacement(k.MqlRuntime, kustPath, i, &r)
+	for i := range kust.Replacements {
+		r := kust.Replacements[i]
+		// One entry can expand into several rows: a `- path:` declaration
+		// names a file that may hold a list of replacements.
+		mqlRs, err := newMqlKustomizeReplacements(k.MqlRuntime, kustPath, i, &r)
 		if err != nil {
 			return nil, err
 		}
-		mqlReplacements = append(mqlReplacements, mqlR)
+		mqlReplacements = append(mqlReplacements, mqlRs...)
 	}
 	return mqlReplacements, nil
 }

--- a/providers/kustomize/resources/kustomize.go
+++ b/providers/kustomize/resources/kustomize.go
@@ -65,8 +65,23 @@ type mqlKustomizeKustomizationInternal struct {
 // merged on top, with a later `labels` entry winning over an earlier one.
 // Kustomize rejects a key that appears in both slots, so the overlap only
 // arises on input kustomize would refuse anyway.
+//
+// The fold is deliberately lossy in one respect. A `labels` entry also carries
+// IncludeSelectors and IncludeTemplates, both defaulting to false, whereas the
+// legacy CommonLabels is documented as applying "to all objects and selectors"
+// and so always rewrites selectors. Flattening to one map therefore cannot
+// distinguish a metadata-only label from one that also rewrites a workload's
+// selector. That is the right trade here: commonLabels is the field policies
+// already reference, and every pair in it really is added to the rendered
+// objects. Exposing the two booleans needs its own field rather than a
+// kustomize.label sub-resource, which would carry no natural key and no
+// reference to another resource.
 func mergedLabels(k *kustomizeTypes.Kustomization) map[string]any {
-	labels := make(map[string]any, len(k.CommonLabels))
+	size := len(k.CommonLabels)
+	for _, l := range k.Labels {
+		size += len(l.Pairs)
+	}
+	labels := make(map[string]any, size)
 	for key, val := range k.CommonLabels {
 		labels[key] = val
 	}

--- a/providers/kustomize/resources/kustomize.lr
+++ b/providers/kustomize/resources/kustomize.lr
@@ -39,6 +39,12 @@ kustomize.kustomization @defaults("path") {
   // Name suffix applied to all resources
   nameSuffix string
   // Common labels added to all resources
+  //
+  // Every label pair the kustomization adds to the objects it renders,
+  // gathered from both declaration syntaxes: the legacy `commonLabels`
+  // mapping and the current `labels` list, whose `pairs` entries are folded
+  // in on top of it. A pair declared in `labels` wins when the same key
+  // appears in both, and a later `labels` entry wins over an earlier one.
   commonLabels map[string]string
   // Common annotations added to all resources
   commonAnnotations map[string]string
@@ -168,6 +174,13 @@ kustomize.image @defaults("name newTag") {
   newName string
   // New tag
   newTag string
+  // Tag suffix appended to the original tag
+  //
+  // Set by a `tagSuffix:` entry, which keeps the original tag and appends
+  // this string to it, for example `-debian`. It is an alternative to
+  // newTag and digest, so an entry that leaves all three of those empty
+  // still rewrites the image reference.
+  tagSuffix string
   // New digest (mutually exclusive with newTag)
   digest string
 }
@@ -214,6 +227,15 @@ private kustomize.resource @defaults("kind name") {
 // manifest set, which matters when a single source drives security-relevant
 // fields such as image tags, names, or annotations.
 private kustomize.replacement @defaults("sourcePath") {
+  // Replacement file path
+  //
+  // Set when the entry is declared as `- path: file.yaml` instead of
+  // inline, naming the file (relative to the kustomization directory) that
+  // holds the source and targets. Empty for an inline declaration. The
+  // field stays populated even when the file cannot be read, so a
+  // dangling reference is visible rather than reading as a replacement
+  // that substitutes nothing.
+  path string
   // Source field path (e.g., ".metadata.name")
   sourcePath string
   // Source resource kind

--- a/providers/kustomize/resources/kustomize.lr
+++ b/providers/kustomize/resources/kustomize.lr
@@ -45,6 +45,10 @@ kustomize.kustomization @defaults("path") {
   // mapping and the current `labels` list, whose `pairs` entries are folded
   // in on top of it. A pair declared in `labels` wins when the same key
   // appears in both, and a later `labels` entry wins over an earlier one.
+  // The map reports which pairs are added, not how far they reach: a
+  // `labels` entry may set includeSelectors or includeTemplates to control
+  // whether it also rewrites selectors and pod templates, and those flags
+  // are not represented here.
   commonLabels map[string]string
   // Common annotations added to all resources
   commonAnnotations map[string]string

--- a/providers/kustomize/resources/kustomize.lr.go
+++ b/providers/kustomize/resources/kustomize.lr.go
@@ -260,6 +260,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"kustomize.image.newTag": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlKustomizeImage).GetNewTag()).ToDataRes(types.String)
 	},
+	"kustomize.image.tagSuffix": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlKustomizeImage).GetTagSuffix()).ToDataRes(types.String)
+	},
 	"kustomize.image.digest": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlKustomizeImage).GetDigest()).ToDataRes(types.String)
 	},
@@ -283,6 +286,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"kustomize.resource.manifest": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlKustomizeResource).GetManifest()).ToDataRes(types.Dict)
+	},
+	"kustomize.replacement.path": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlKustomizeReplacement).GetPath()).ToDataRes(types.String)
 	},
 	"kustomize.replacement.sourcePath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlKustomizeReplacement).GetSourcePath()).ToDataRes(types.String)
@@ -505,6 +511,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlKustomizeImage).NewTag, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"kustomize.image.tagSuffix": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlKustomizeImage).TagSuffix, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"kustomize.image.digest": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlKustomizeImage).Digest, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -543,6 +553,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"kustomize.replacement.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlKustomizeReplacement).__id, ok = v.Value.(string)
+		return
+	},
+	"kustomize.replacement.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlKustomizeReplacement).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"kustomize.replacement.sourcePath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1097,10 +1111,11 @@ type mqlKustomizeImage struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlKustomizeImageInternal it will be used here
-	Name    plugin.TValue[string]
-	NewName plugin.TValue[string]
-	NewTag  plugin.TValue[string]
-	Digest  plugin.TValue[string]
+	Name      plugin.TValue[string]
+	NewName   plugin.TValue[string]
+	NewTag    plugin.TValue[string]
+	TagSuffix plugin.TValue[string]
+	Digest    plugin.TValue[string]
 }
 
 // createKustomizeImage creates a new instance of this resource
@@ -1145,6 +1160,10 @@ func (c *mqlKustomizeImage) GetNewName() *plugin.TValue[string] {
 
 func (c *mqlKustomizeImage) GetNewTag() *plugin.TValue[string] {
 	return &c.NewTag
+}
+
+func (c *mqlKustomizeImage) GetTagSuffix() *plugin.TValue[string] {
+	return &c.TagSuffix
 }
 
 func (c *mqlKustomizeImage) GetDigest() *plugin.TValue[string] {
@@ -1230,6 +1249,7 @@ type mqlKustomizeReplacement struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlKustomizeReplacementInternal
+	Path       plugin.TValue[string]
 	SourcePath plugin.TValue[string]
 	SourceKind plugin.TValue[string]
 	SourceName plugin.TValue[string]
@@ -1266,6 +1286,10 @@ func (c *mqlKustomizeReplacement) MqlName() string {
 
 func (c *mqlKustomizeReplacement) MqlID() string {
 	return c.__id
+}
+
+func (c *mqlKustomizeReplacement) GetPath() *plugin.TValue[string] {
+	return &c.Path
 }
 
 func (c *mqlKustomizeReplacement) GetSourcePath() *plugin.TValue[string] {

--- a/providers/kustomize/resources/kustomize.lr.versions
+++ b/providers/kustomize/resources/kustomize.lr.versions
@@ -15,6 +15,7 @@ kustomize.image.digest 13.0.0
 kustomize.image.name 13.0.0
 kustomize.image.newName 13.0.0
 kustomize.image.newTag 13.0.0
+kustomize.image.tagSuffix 13.1.16
 kustomize.kustomization 13.0.0
 kustomize.kustomization.apiVersion 13.0.0
 kustomize.kustomization.commonAnnotations 13.0.0
@@ -50,6 +51,7 @@ kustomize.patch.targetName 13.0.0
 kustomize.patch.targetNamespace 13.0.0
 kustomize.patch.targetVersion 13.0.0
 kustomize.replacement 13.0.0
+kustomize.replacement.path 13.1.16
 kustomize.replacement.sourceKind 13.0.0
 kustomize.replacement.sourceName 13.0.0
 kustomize.replacement.sourcePath 13.0.0

--- a/providers/kustomize/resources/patch.go
+++ b/providers/kustomize/resources/patch.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
@@ -46,6 +47,13 @@ type jsonPatchOp struct {
 type mqlKustomizePatchInternal struct {
 	format string
 	ops    []jsonPatchOp
+	// stampOnce guards the post-construction write of format and ops.
+	// CreateResource may return a cached instance for concurrent callers
+	// with the same __id; stampOnce ensures the stamp happens exactly once
+	// across those goroutines, so it never races a concurrent operations()
+	// read. Matches the pattern in newMqlKustomization and
+	// newMqlKustomizeReplacement.
+	stampOnce sync.Once
 }
 
 // strategicMergePatchEntry turns one legacy `patchesStrategicMerge` entry into
@@ -105,37 +113,28 @@ func newMqlKustomizePatch(runtime *plugin.Runtime, kustPath string, index int, p
 	if len(raw) == 0 && p.Path != "" {
 		// Best-effort read; a missing/unreadable file falls back to
 		// strategic-merge with no operations rather than failing the audit.
-		// Constrain the read to the kustomization directory so a malicious
-		// patch path (e.g. "../../etc/passwd") — or a symlink inside the
-		// directory whose target is outside it — can't escape the scan root.
-		// Both the base and the candidate are symlink-resolved before the
-		// containment check so a symlinked scan root (e.g. /tmp on macOS,
-		// which resolves to /private/tmp) doesn't cause false rejections.
-		full := filepath.Join(kustPath, p.Path)
-		// Prefer symlink-resolved paths for the containment check (this catches
-		// a symlink inside the directory whose target escapes it). When symlink
-		// resolution fails for any reason other than the target being a
-		// resolvable escape — e.g. a broken/unresolvable symlink component in
-		// kustPath itself — fall back to a lexical containment check so a
-		// perfectly readable patch file isn't silently dropped and misclassified
-		// as an empty strategic-merge patch.
-		base, target := filepath.Clean(kustPath), filepath.Clean(full)
-		if rb, err1 := filepath.EvalSymlinks(kustPath); err1 == nil {
-			if rt, err2 := filepath.EvalSymlinks(full); err2 == nil {
-				base, target = rb, rt
-			}
-		}
-		if rel, err := filepath.Rel(base, target); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		// The read is constrained to the kustomization directory so a
+		// malicious patch path (e.g. "../../etc/passwd") can't escape the
+		// scan root; see resolveContainedPath.
+		if target, ok := resolveContainedPath(kustPath, p.Path); ok {
 			data, readErr := os.ReadFile(target)
 			switch {
 			case readErr == nil:
 				raw = data
 				content = string(data)
-			case !os.IsNotExist(readErr):
-				// A genuinely missing file is the expected best-effort case; any
-				// other read failure would silently misclassify the patch, so
-				// surface it.
-				log.Warn().Err(readErr).Str("path", p.Path).Msg("kustomize: could not read patch file; treating it as an empty patch")
+			case os.IsNotExist(readErr):
+				// A patch that names a file which isn't there changes nothing
+				// during rendering, and kustomize itself fails the build. Say
+				// so: reporting it as an empty patch with no signal lets a
+				// policy iterating `patches.operations` pass vacuously on what
+				// is really a typo.
+				log.Warn().Str("path", p.Path).Str("kustomization", kustPath).
+					Msg("kustomize: patch file does not exist; treating it as an empty patch")
+			default:
+				// Any other read failure would silently misclassify the patch,
+				// so surface it too.
+				log.Warn().Err(readErr).Str("path", p.Path).
+					Msg("kustomize: could not read patch file; treating it as an empty patch")
 			}
 		} else {
 			log.Warn().Str("path", p.Path).Msg("kustomize: patch path escapes the kustomization directory; ignoring")
@@ -163,8 +162,10 @@ func newMqlKustomizePatch(runtime *plugin.Runtime, kustPath string, index int, p
 		return nil, err
 	}
 	mqlP := res.(*mqlKustomizePatch)
-	mqlP.format = format
-	mqlP.ops = ops
+	mqlP.stampOnce.Do(func() {
+		mqlP.format = format
+		mqlP.ops = ops
+	})
 	return mqlP, nil
 }
 

--- a/providers/kustomize/resources/paths.go
+++ b/providers/kustomize/resources/paths.go
@@ -1,0 +1,42 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// resolveContainedPath resolves rel against baseDir and returns the path to
+// read, refusing anything that lands outside baseDir. It is shared by every
+// place a kustomization names a sibling file to read (patches, replacements),
+// so a malicious or mistaken reference such as "../../etc/passwd" — or a
+// symlink inside the directory whose target escapes it — can't reach past the
+// scan root.
+//
+// Both the base and the candidate are symlink-resolved before the containment
+// check so a symlinked scan root (e.g. /tmp on macOS, which resolves to
+// /private/tmp) doesn't cause false rejections. When symlink resolution fails
+// for any reason other than a resolvable escape — a broken or unresolvable
+// component in baseDir itself, or a candidate that simply doesn't exist yet —
+// it falls back to a lexical containment check so a perfectly readable file
+// isn't silently dropped.
+func resolveContainedPath(baseDir, rel string) (string, bool) {
+	full := filepath.Join(baseDir, rel)
+	base, target := filepath.Clean(baseDir), filepath.Clean(full)
+	if rb, err := filepath.EvalSymlinks(baseDir); err == nil {
+		if rt, err := filepath.EvalSymlinks(full); err == nil {
+			base, target = rb, rt
+		}
+	}
+
+	relPath, err := filepath.Rel(base, target)
+	if err != nil {
+		return "", false
+	}
+	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return target, true
+}

--- a/providers/kustomize/resources/replacement.go
+++ b/providers/kustomize/resources/replacement.go
@@ -4,12 +4,16 @@
 package resources
 
 import (
+	"fmt"
+	"os"
 	"strconv"
 	"sync"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	kustomizeTypes "sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/yaml"
 )
 
 type mqlKustomizeReplacementInternal struct {
@@ -22,9 +26,103 @@ type mqlKustomizeReplacementInternal struct {
 	stampOnce sync.Once
 }
 
-func newMqlKustomizeReplacement(runtime *plugin.Runtime, kustPath string, index int, r *kustomizeTypes.ReplacementField) (*mqlKustomizeReplacement, error) {
-	id := "kustomize.replacement:" + kustPath + ":" + strconv.Itoa(index)
+// newMqlKustomizeReplacements turns one `replacements:` entry into its rows.
+//
+// A types.ReplacementField is a types.Replacement plus a Path. When the entry
+// is declared as `- path: file.yaml` the inline Source and Targets are both
+// nil and Path is the only field carrying information, so reading just the
+// inline shape produced a row that reported a replacement injecting nothing,
+// from nowhere, into nothing — and an audit over `replacements` passed
+// vacuously on it.
+//
+// The referenced file holds either a single replacement mapping or a list of
+// them (kustomize accepts both, see ReplacementTransformerPlugin.Config), so
+// one entry can expand into several rows. `path` stays populated on every row,
+// including the ones produced when the file can't be read, so a dangling
+// reference is visible rather than reading as an empty replacement.
+func newMqlKustomizeReplacements(runtime *plugin.Runtime, kustPath string, index int, rf *kustomizeTypes.ReplacementField) ([]any, error) {
+	baseID := "kustomize.replacement:" + kustPath + ":" + strconv.Itoa(index)
 
+	// An inline declaration (kustomize refuses an entry that carries both a
+	// path and inline content).
+	if rf.Path == "" || rf.Source != nil || len(rf.Targets) > 0 {
+		mqlR, err := newMqlKustomizeReplacement(runtime, kustPath, baseID, rf.Path, &rf.Replacement)
+		if err != nil {
+			return nil, err
+		}
+		return []any{mqlR}, nil
+	}
+
+	repls, err := loadReplacementFile(kustPath, rf.Path)
+	if err != nil {
+		log.Warn().Err(err).Str("path", rf.Path).Str("kustomization", kustPath).
+			Msg("kustomize: could not read replacement file; reporting the reference only")
+		// Still emit a row so the file reference itself is queryable.
+		mqlR, cerr := newMqlKustomizeReplacement(runtime, kustPath, baseID, rf.Path, &kustomizeTypes.Replacement{})
+		if cerr != nil {
+			return nil, cerr
+		}
+		return []any{mqlR}, nil
+	}
+
+	mqlReplacements := make([]any, 0, len(repls))
+	for j := range repls {
+		id := baseID + ":" + strconv.Itoa(j)
+		mqlR, err := newMqlKustomizeReplacement(runtime, kustPath, id, rf.Path, &repls[j])
+		if err != nil {
+			return nil, err
+		}
+		mqlReplacements = append(mqlReplacements, mqlR)
+	}
+	return mqlReplacements, nil
+}
+
+// loadReplacementFile reads a `- path:` replacement declaration. The read is
+// constrained to the kustomization directory by the same containment guard the
+// patch reader uses, so `path: ../../etc/passwd` is refused.
+func loadReplacementFile(kustPath, relPath string) ([]kustomizeTypes.Replacement, error) {
+	target, ok := resolveContainedPath(kustPath, relPath)
+	if !ok {
+		return nil, fmt.Errorf("replacement path %q escapes the kustomization directory", relPath)
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		return nil, err
+	}
+	return decodeReplacementFile(data)
+}
+
+// decodeReplacementFile decodes a replacement file, which holds either a
+// single replacement mapping or a list of them. Kustomize decodes it with
+// sigs.k8s.io/yaml (YAML through JSON), which is what makes the inlined ResId
+// inside a source or target selector resolve; use the same decoder so the
+// provider's reading matches what kustomize actually applies.
+func decodeReplacementFile(data []byte) ([]kustomizeTypes.Replacement, error) {
+	var probe any
+	if err := yaml.Unmarshal(data, &probe); err != nil {
+		return nil, err
+	}
+
+	switch probe.(type) {
+	case []any:
+		var repls []kustomizeTypes.Replacement
+		if err := yaml.Unmarshal(data, &repls); err != nil {
+			return nil, err
+		}
+		return repls, nil
+	case map[string]any:
+		var repl kustomizeTypes.Replacement
+		if err := yaml.Unmarshal(data, &repl); err != nil {
+			return nil, err
+		}
+		return []kustomizeTypes.Replacement{repl}, nil
+	default:
+		return nil, fmt.Errorf("unsupported replacement file content: expected a mapping or a list")
+	}
+}
+
+func newMqlKustomizeReplacement(runtime *plugin.Runtime, kustPath, id, path string, r *kustomizeTypes.Replacement) (*mqlKustomizeReplacement, error) {
 	sourcePath := ""
 	sourceKind := ""
 	sourceName := ""
@@ -37,6 +135,7 @@ func newMqlKustomizeReplacement(runtime *plugin.Runtime, kustPath string, index 
 
 	res, err := CreateResource(runtime, "kustomize.replacement", map[string]*llx.RawData{
 		"__id":       llx.StringData(id),
+		"path":       llx.StringData(path),
 		"sourcePath": llx.StringData(sourcePath),
 		"sourceKind": llx.StringData(sourceKind),
 		"sourceName": llx.StringData(sourceName),
@@ -75,7 +174,12 @@ func (r *mqlKustomizeReplacement) targets() ([]any, error) {
 			fieldPaths = []string{""}
 		}
 		for j, fp := range fieldPaths {
-			id := "kustomize.replacementTarget:" + r.kustPath + ":" + strconv.Itoa(i) + ":" + kind + ":" + name + ":" + strconv.Itoa(j) + ":" + fp
+			// Prefix with the parent replacement's __id, the way
+			// kustomize.patch.operation does. Keyed only on the target index
+			// plus kind/name/fieldPath, two replacements whose first targets
+			// share those selectors produced the same __id and the second was
+			// served the first's cached instance.
+			id := r.__id + "/target[" + strconv.Itoa(i) + "][" + strconv.Itoa(j) + "]"
 
 			res, err := CreateResource(r.MqlRuntime, "kustomize.replacementTarget", map[string]*llx.RawData{
 				"__id":      llx.StringData(id),


### PR DESCRIPTION
Eight schema-fidelity bugs in the `kustomize` provider. They share a shape: a real, valid kustomization reads as benign, so a policy over it passes vacuously. Each fix landed behind a test that was confirmed failing first.

## 1. `commonLabels` reported `{}` for the modern `labels:` syntax

`types.Kustomization` has two label slots: `CommonLabels map[string]string` (marked `// Deprecated: Use the Labels field instead`) and `Labels []Label`. The provider read only the deprecated one. `FixKustomization`, which the connection runs after unmarshalling, does not fold `Labels` into `CommonLabels` — that fold lives in `FixKustomizationPreMarshalling` and runs the other direction.

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
labels:
- pairs:
    app: web
    env: prod
  includeSelectors: true
```

This is what `kustomize edit fix` produces and what the docs recommend. `commonLabels` read `{}` even though every rendered object carries both labels. A "must carry an owner label" check failed on compliant input; a deny-list check passed on nothing. With both syntaxes present, only the legacy one surfaced.

Both slots now feed `commonLabels`: the legacy mapping seeds the map, `labels[*].pairs` merge on top, later entries winning. Kustomize rejects a key declared in both, so the overlap only arises on input it would refuse anyway. Precedence is documented on `mergedLabels` and in the field's schema comment.

## 2. `replacements: - path: file.yaml` produced a completely blank row

`types.ReplacementField` is a `Replacement` plus a `Path string`. When a replacement is declared by file reference, `Source` and `Targets` are both nil and `Path` is the only field carrying information — and `Path` was never read and was not in the schema.

```yaml
# kustomization.yaml
replacements:
- path: repl.yaml
```
```yaml
# repl.yaml
source:
  kind: ConfigMap
  name: app-config
  fieldPath: data.version
targets:
- select:
    kind: Deployment
    name: web
  fieldPaths:
  - spec.template.spec.containers.0.image
```

The row read `sourcePath="" sourceKind="" sourceName="" targets=0`: a replacement injecting nothing, from nowhere, into nothing. Anything auditing `replacements` passed vacuously on a replacement that rewrites a container image.

The file is now read and decoded with `sigs.k8s.io/yaml`, the same decoder kustomize's `ReplacementTransformerPlugin.Config` uses (which is what makes the inlined `ResId` in a selector resolve). A replacement file may hold a single mapping or a list of them; kustomize accepts both, so both expand — one entry can produce several rows, with distinct `__id`s.

The read reuses the patch reader's path-containment guard, now extracted to `resolveContainedPath` in `resources/paths.go` (symlink-resolved containment with a lexical fallback), so `path: ../../etc/passwd` is still refused. A new `path string` field on `kustomize.replacement` keeps the file reference visible even when the read fails, and the failure warns instead of emitting a blank row.

## 3. `initKustomizeKustomization` fell through to a husk on a lookup miss

The init ended with `return args, nil, nil` after searching for a matching path and finding none. The runtime then built the resource from the partial args, leaving every other field UNSET — not null, unset — which surfaces client-side as `llx: encountered a primitive with no type information, coercing to null` with nothing pointing at the cause. The sibling `initKustomizeImage` already returns a not-found error.

It now returns `kustomize: no kustomization loaded for path %q`. The legitimate bare-resource fast paths (no args, empty path) are unchanged and covered by a test. `TestInitKustomizeKustomization_UnknownPathFieldsErrorCleanly` in `provider_test.go`, which encoded the old fall-through, was rewritten to assert the miss is reported.

## 4. `tagSuffix` image overrides read as a no-op

`types.Image` has five fields: `Name`, `NewName`, `TagSuffix`, `NewTag`, `Digest`. The provider surfaced four.

```yaml
images:
- name: nginx
  tagSuffix: -debian
```

The row read `newName="" newTag="" digest=""` — an entry that changes nothing — when it actually rewrites the tag. An "every image override must pin a digest" check saw a benign-looking no-op. `tagSuffix string` is now in the schema and populated.

## 5. A missing patch file silently became an empty patch

```yaml
patches:
- path: does-not-exist.yaml
  target:
    kind: Deployment
```

Produced `content=""`, `format="strategicMerge"`, and no log line at all — while the doc comment on `strategicMergePatchEntry` explicitly promised "a genuine typo still reports as a missing patch file (with a warning from `newMqlKustomizePatch`)". A policy iterating `patches.operations` passed vacuously on a typo. The `os.IsNotExist` branch now warns, naming the path and the kustomization.

`content` deliberately stays `""` rather than becoming null: a null there would make a deny-list assertion (`patches.all(content != "…")`) pass vacuously under MQL's three-valued logic, trading one silent pass for another. The warning plus the already-present `path` field is the signal.

## 6. `kustomize.replacementTarget.__id` omitted the replacement index

The key was built from the target index within its replacement plus the kustomization path, kind, name and fieldPath — but never the parent replacement's own index. Two `replacements:` entries whose first targets share kind/name/fieldPath produced an identical `__id`, so `CreateResource` returned the cached first instance for the second. Latent today only because all three declared fields are in the key; it becomes real aliasing the moment a field is added. Now prefixed with the parent's `__id`, matching `kustomize.patch.operation`.

## 7. `mqlKustomizePatch` Internal state was stamped without `stampOnce`

`format` and `ops` were written after `CreateResource`, which can hand a cached instance to concurrent callers, racing a concurrent `operations()` read. Both sibling resources (`mqlKustomizeKustomizationInternal`, `mqlKustomizeReplacementInternal`) already had a `sync.Once` for exactly this. Confirmed as a real `WARNING: DATA RACE` on `patch.go:166-167` before the fix; `go test -race ./...` is clean after.

## 8. Two kustomization files in one directory

`loadSingleKustomization` looped the recognized filenames and took the first that read. Kustomize's own loader (`target.LoadKustFile`) counts matches and hard-errors on more than one. With both `kustomization.yaml` and `Kustomization` present, mql reported the first file's static fields while `resources()` failed with krusty's "Found multiple kustomization files under: …" — a directory reported as half-valid. The loader now counts and refuses, mirroring kustomize.

## Schema

Two new fields, `kustomize.image.tagSuffix` and `kustomize.replacement.path`, at `13.1.16` (provider `config.go` is at `13.1.15`; no version bump in this PR). Regenerated with `mqlr generate`.

## Tests

New, each confirmed failing against `main` first:

| test | file |
|---|---|
| `TestCommonLabelsIncludesModernLabelsSyntax` | `resources/fidelity_test.go` |
| `TestCommonLabelsMergesLegacyAndModernSyntax` | `resources/fidelity_test.go` |
| `TestReplacementDeclaredByFileIsResolved` | `resources/fidelity_test.go` |
| `TestReplacementFileWithListYieldsEveryEntry` | `resources/fidelity_test.go` |
| `TestReplacementFileEscapingKustomizationDirIsRefused` | `resources/fidelity_test.go` |
| `TestReplacementFileMissingSurfacesPathAndWarns` | `resources/fidelity_test.go` |
| `TestInitKustomizeKustomizationUnknownPathErrors` | `resources/fidelity_test.go` |
| `TestInitKustomizeKustomizationKeepsBareFastPaths` | `resources/fidelity_test.go` (guard: the valid empty state stays) |
| `TestImageTagSuffixIsSurfaced` | `resources/fidelity_test.go` |
| `TestMissingPatchFileWarns` | `resources/fidelity_test.go` |
| `TestReplacementTargetIDIncludesParentReplacement` | `resources/fidelity_test.go` |
| `TestPatchInternalStampIsRaceFree` | `resources/fidelity_test.go` (fails under `-race` before the fix) |
| `TestLoadSingleKustomization_MultipleFilesIsAnError` | `connection/connection_test.go` |
| `TestLoadSingleKustomization_AlternateFilenameStillLoads` | `connection/connection_test.go` (guard) |

`newMultiFileTestRuntime(t, map[string]string)` is the new multi-file sibling of `newImageTestRuntime`: it materializes several files into a temp directory and connects a real `KustomizeConnection`, which is what the cross-file declarations (a replacement by `path:`, a patch pointing at a sibling YAML) need.

`TestInitKustomizeKustomization_UnknownPathFieldsErrorCleanly` was rewritten as `TestInitKustomizeKustomization_UnknownPathIsNotFound` — it asserted the fall-through that bug 3 removes.

`go test ./...` and `go test -race ./...` are both green in `providers/kustomize`; `golangci-lint run ./...` reports 0 issues.

## Follow-ups not in this PR

- **Remote `resources:` URL fetching.** A kustomization may pull resources over HTTP; deciding whether mql should follow those needs a product call about an opt-in connection option, not a code fix.
- **Repo-relative paths for git-cloned assets.** A kustomization discovered through a git clone keys its `__id` on the temporary checkout directory, so the id is not stable across scans.
- **Base-vs-overlay double counting**, `scanSkipDirs` logging, and surfacing paths the scan could not parse.
