### PR TITLE
🐛 bicep: fix a fatal parser crash and eight silent misparses

### DIFF
--- a/providers/bicep/resources/multiline_test.go
+++ b/providers/bicep/resources/multiline_test.go
@@ -1,0 +1,148 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func varByName(t *testing.T, p *parsedBicepFile, name string) parsedVariable {
+	t.Helper()
+	for _, v := range p.variables {
+		if v.name == name {
+			return v
+		}
+	}
+	t.Fatalf("no variable named %q in %+v", name, p.variables)
+	return parsedVariable{}
+}
+
+// A multi-line string opens no bracket, so a statement scanner that continues
+// only while the bracket depth is positive cuts the declaration at the first
+// newline. The remaining lines of the string then re-enter the scanner as
+// top-level statements — and anything in them that looks like a declaration is
+// parsed as one.
+//
+// This is the worst outcome in the taxonomy: the provider reports resources
+// that are not in the deployment at all.
+func TestMultilineStringDoesNotFabricateDeclarations(t *testing.T) {
+	src := `var deployScript = '''
+param ghostParam string = 'injected'
+resource ghostRes 'Microsoft.Storage/storageAccounts@2021-04-01' = {
+  name: 'ghost'
+  properties: {
+    supportsHttpsTrafficOnly: false
+  }
+}
+output ghostOut string = 'leaked'
+'''
+
+resource realRes 'Microsoft.Storage/storageAccounts@2021-04-01' = {
+  name: 'real'
+}
+`
+	p := parseBicep(src)
+
+	var resourceNames []string
+	for _, r := range p.resources {
+		resourceNames = append(resourceNames, r.symbolicName)
+	}
+	assert.Equal(t, []string{"realRes"}, resourceNames,
+		"text inside a multi-line string must not be parsed as a resource declaration")
+
+	assert.Empty(t, p.parameters, "text inside a multi-line string must not become a parameter")
+	assert.Empty(t, p.outputs, "text inside a multi-line string must not become an output")
+}
+
+// The corollary: the multi-line string's own value must survive. A variable
+// holding a deployment script, cloud-init payload, certificate, or policy blob
+// previously read back as the bare opening delimiter.
+func TestMultilineStringValueIsCaptured(t *testing.T) {
+	src := `var script = '''
+#!/bin/bash
+echo hello
+'''
+var after = 'x'
+`
+	p := parseBicep(src)
+
+	script := varByName(t, p, "script")
+	assert.NotEqual(t, "'''", script.expression, "the multi-line string body must not be dropped")
+	assert.Contains(t, script.expression, "echo hello")
+
+	// The declaration that follows the string must still be parsed correctly.
+	after := varByName(t, p, "after")
+	assert.Equal(t, "'x'", after.expression)
+}
+
+// A multi-line default on a param is mangled the same way, which is worse than
+// dropping it: the value reported is a fabricated fragment rather than an
+// obvious absence.
+func TestMultilineParamDefaultIsNotMangled(t *testing.T) {
+	p := parseBicep("param p string = '''\nabc\n'''\n")
+	require.Len(t, p.parameters, 1)
+	assert.NotEqual(t, "'", p.parameters[0].defaultValue,
+		"a multi-line default must not be reported as a stray quote")
+	assert.Contains(t, p.parameters[0].defaultValue, "abc")
+}
+
+// Braces and brackets inside a multi-line string must not be counted by the
+// statement scanner: an unbalanced one would otherwise swallow the rest of the
+// file into a single statement.
+func TestMultilineStringWithUnbalancedBraces(t *testing.T) {
+	src := `var tpl = '''
+{ "unclosed": [
+'''
+var after = 'y'
+`
+	p := parseBicep(src)
+	after := varByName(t, p, "after")
+	assert.Equal(t, "'y'", after.expression,
+		"an unbalanced delimiter inside a multi-line string must not consume later declarations")
+}
+
+// The statement span reported for a multi-line declaration must cover the whole
+// declaration, since it drives the source excerpt shown for a finding.
+func TestMultilineStringStatementSpan(t *testing.T) {
+	stmts := tokenizeBicep("var v = '''\na\nb\n'''\nvar after = 'x'\n")
+	require.GreaterOrEqual(t, len(stmts), 2)
+	assert.Equal(t, 1, stmts[0].startLine)
+	assert.Equal(t, 4, strings.Count(stmts[0].text, "\n")+1,
+		"the first statement must span all four lines of the multi-line declaration")
+	assert.Equal(t, 5, stmts[1].startLine, "the following declaration starts on line 5")
+}
+
+// A multi-line string inside a resource body was already handled (the body's
+// braces keep the statement open); guard against a regression.
+func TestMultilineStringInsideResourceBody(t *testing.T) {
+	src := `resource r 'Microsoft.Compute/virtualMachines@2021-03-01' = {
+  name: 'vm'
+  properties: {
+    script: '''
+    echo hi
+    '''
+  }
+}
+var after = 'z'
+`
+	p := parseBicep(src)
+	require.Len(t, p.resources, 1)
+	assert.Equal(t, "r", p.resources[0].symbolicName)
+	assert.Contains(t, p.resources[0].body, "echo hi")
+	varByName(t, p, "after")
+}
+
+// An unterminated multi-line string must not hang or panic; it consumes the
+// rest of the file, which is the correct reading.
+func TestUnterminatedMultilineString(t *testing.T) {
+	assert.NotPanics(t, func() {
+		p := parseBicep("var v = '''\nnever closed\nresource r 'T@1' = {\n")
+		assert.Empty(t, p.resources,
+			"an unterminated multi-line string runs to end of file, so nothing after it is a declaration")
+	})
+}

--- a/providers/bicep/resources/parser.go
+++ b/providers/bicep/resources/parser.go
@@ -171,19 +171,32 @@ var (
 	// the same reason as paramRe — `output ids string[] = names` has no bare
 	// word before the `=`.
 	outputRe = regexp.MustCompile(`(?m)^output\s+(\w+)\s+(\S.*)$`)
+	// paramHeaderRe and outputHeaderRe match only the declaration header,
+	// anchored to the start of the statement. The value is then taken as the
+	// remaining text, which may span lines when it holds a triple-quoted
+	// string.
+	paramHeaderRe  = regexp.MustCompile(`\Aparam\s+(\w+)\s+`)
+	outputHeaderRe = regexp.MustCompile(`\Aoutput\s+(\w+)\s+`)
 	// Every built-in decorator may also be written through the `sys`
 	// namespace (`@sys.secure()`), which is what Bicep requires when a
 	// user-defined symbol shadows the bare name. `decNS` makes that prefix
 	// optional everywhere so a namespace-qualified `@sys.secure()` is not
 	// silently read as "not secure".
-	descDecRe      = regexp.MustCompile(decNS + `description\('([^']*)'\)`)
-	secureDecRe    = regexp.MustCompile(decNS + `secure\(\)`)
-	allowedDecRe   = regexp.MustCompile(decNS + `allowed\(\[([^\]]*)\]\)`)
-	minLengthDecRe = regexp.MustCompile(decNS + `minLength\(\s*(-?\d+)\s*\)`)
-	maxLengthDecRe = regexp.MustCompile(decNS + `maxLength\(\s*(-?\d+)\s*\)`)
-	minValueDecRe  = regexp.MustCompile(decNS + `minValue\(\s*(-?\d+)\s*\)`)
-	maxValueDecRe  = regexp.MustCompile(decNS + `maxValue\(\s*(-?\d+)\s*\)`)
-	exportDecRe    = regexp.MustCompile(decNS + `export\(\)`)
+	// The value may contain an escaped quote (`@description('The VM\\'s name')`),
+	// so the capture accepts escape pairs. A bare `[^']*` class stopped at the
+	// backslash and then failed to anchor, blanking the whole description.
+	descDecRe   = regexp.MustCompile(decNS + `description\('((?:[^'\\]|\\.)*)'\)`)
+	secureDecRe = regexp.MustCompile(decNS + `secure\(\)`)
+	// allowedDecOpenRe locates the decorator; the argument list is then
+	// delimited with the string-aware scanner. A `[^\]]*` class stopped at the
+	// first `]`, so an allowed value containing one (`'a]b'`) failed the match
+	// entirely and the constraint read as absent rather than partial.
+	allowedDecOpenRe = regexp.MustCompile(decNS + `allowed\(`)
+	minLengthDecRe   = regexp.MustCompile(decNS + `minLength\(\s*(-?\d+)\s*\)`)
+	maxLengthDecRe   = regexp.MustCompile(decNS + `maxLength\(\s*(-?\d+)\s*\)`)
+	minValueDecRe    = regexp.MustCompile(decNS + `minValue\(\s*(-?\d+)\s*\)`)
+	maxValueDecRe    = regexp.MustCompile(decNS + `maxValue\(\s*(-?\d+)\s*\)`)
+	exportDecRe      = regexp.MustCompile(decNS + `export\(\)`)
 
 	// discriminatorDecRe captures the key argument of an
 	// `@discriminator('<key>')` decorator on a tagged-union type.
@@ -319,10 +332,16 @@ func parseBicep(content string) *parsedBicepFile {
 		case "output":
 			// Reassemble multi-line output values (a looped output's
 			// `[for ... : ...]` spans lines) into a single collapsed-whitespace
-			// line so the value regex and loop detector see the whole RHS.
+			// line so the value regex and loop detector see the whole RHS. A
+			// value holding a triple-quoted string keeps its newlines instead:
+			// collapsing them would rewrite the string's contents.
 			outLine := firstLine
 			if len(stmtLines) > 1 {
-				outLine = strings.Join(strings.Fields(strings.Join(stmtLines, " ")), " ")
+				if containsMultilineString(stmt.text) {
+					outLine = stmt.text
+				} else {
+					outLine = strings.Join(strings.Fields(strings.Join(stmtLines, " ")), " ")
+				}
 			}
 			if o, ok := parseOutput(outLine, stmt.decorators); ok {
 				o.startLine, o.endLine = startLine, endLine
@@ -367,8 +386,25 @@ func parseBicep(content string) *parsedBicepFile {
 func reassembleParamStatement(lines []string) string {
 	st := scanState{}
 	parts := make([]string, 0, len(lines))
+	multiline := false
 	for _, l := range lines {
-		parts = append(parts, strings.TrimSpace(stripInlineComment(l, &st)))
+		before := st.inMulti
+		stripped := stripInlineComment(l, &st)
+		if !before && st.inMulti {
+			multiline = true
+		}
+		if multiline {
+			// Inside (or after opening) a triple-quoted string the line breaks
+			// are part of the value. Trimming and space-joining them would
+			// rewrite a multi-line default into a single line, and the earlier
+			// line-anchored value regex reported only the opening delimiter.
+			parts = append(parts, stripped)
+			continue
+		}
+		parts = append(parts, strings.TrimSpace(stripped))
+	}
+	if multiline {
+		return strings.Join(parts, "\n")
 	}
 	return strings.Join(parts, " ")
 }
@@ -396,17 +432,27 @@ func stripInlineComment(s string, st *scanState) string {
 func parseParameter(line string, decorators []string) (parsedParameter, bool) {
 	p := parsedParameter{decorators: decorators}
 
-	m := paramRe.FindStringSubmatch(line)
-	if len(m) < 3 {
+	// The header is matched separately from the value so that a value holding a
+	// triple-quoted string can span lines; paramRe's `.` stops at a newline, so
+	// using it for the value truncated a multi-line default to the bare opening
+	// delimiter and then reported that fragment as the parameter's value.
+	loc := paramHeaderRe.FindStringSubmatchIndex(line)
+	if loc == nil {
 		return parsedParameter{}, false
 	}
 
-	p.name = m[1]
-	rest := strings.TrimSpace(m[2])
+	p.name = line[loc[2]:loc[3]]
+	rest := strings.TrimSpace(line[loc[1]:])
+	if rest == "" {
+		return parsedParameter{}, false
+	}
 	if typ, def, hasDefault := splitDeclAtEquals(rest); hasDefault {
 		p.typ = typ
-		// Strip Bicep single-quote string delimiters
-		if len(def) >= 2 && def[0] == '\'' && def[len(def)-1] == '\'' {
+		// Strip the delimiters only when the whole default is one string
+		// literal. A value that merely begins and ends with a quote, such as
+		// `'prod' == env ? 'Premium' : 'Standard'`, is an expression, and removing
+		// its outer quotes corrupted it into an unbalanced string.
+		if isSingleQuotedLiteral(def) {
 			def = def[1 : len(def)-1]
 		}
 		p.defaultValue = def
@@ -422,9 +468,7 @@ func parseParameter(line string, decorators []string) (parsedParameter, bool) {
 		p.description = m[1]
 	}
 	p.secure = secureDecRe.MatchString(decText)
-	if m := allowedDecRe.FindStringSubmatch(decText); len(m) > 1 {
-		p.allowed = parseAllowedValues(m[1])
-	}
+	p.allowed = extractAllowedValues(decText)
 	p.minLength = parseIntDecorator(decText, minLengthDecRe)
 	p.maxLength = parseIntDecorator(decText, maxLengthDecRe)
 	p.minValue = parseIntDecorator(decText, minValueDecRe)
@@ -452,6 +496,22 @@ func parseIntDecorator(decText string, re *regexp.Regexp) *int64 {
 // allowedValueRe matches individual quoted values like 'foo' or "foo".
 var allowedValueRe = regexp.MustCompile(`'([^']*)'`)
 
+// extractAllowedValues returns the values of an `@allowed([...])` decorator.
+// The closing parenthesis is found with the string-aware scanner so a `]` or
+// `)` inside one of the literals cannot end the list early.
+func extractAllowedValues(decText string) []string {
+	loc := allowedDecOpenRe.FindStringIndex(decText)
+	if loc == nil {
+		return nil
+	}
+	open := loc[1] - 1
+	closeIdx := matchingParenIndex(decText, open)
+	if closeIdx <= open {
+		return nil
+	}
+	return parseAllowedValues(decText[open+1 : closeIdx])
+}
+
 func parseAllowedValues(raw string) []string {
 	// Extract all single-quoted values from the raw content.
 	// This handles both newline-separated and comma-separated formats:
@@ -463,6 +523,31 @@ func parseAllowedValues(raw string) []string {
 		vals = append(vals, m[1])
 	}
 	return vals
+}
+
+// varMultilineHeaderRe matches only the `var <name> =` header, anchored to the
+// start of the statement. The value is taken as the remaining text so it can
+// span lines, which varRe cannot express (its `.` does not match a newline).
+var varMultilineHeaderRe = regexp.MustCompile(`\Avar\s+(\w+)\s*=\s*`)
+
+// parseVariableMultiline parses a `var` declaration whose value contains a
+// triple-quoted string, keeping the string's newlines intact.
+func parseVariableMultiline(text string, decorators []string) parsedVariable {
+	v := parsedVariable{}
+	loc := varMultilineHeaderRe.FindStringSubmatchIndex(text)
+	if loc == nil {
+		// Not a shape we recognize; fall back to the single-line parser so the
+		// declaration is not dropped entirely.
+		return parseVariable(strings.Join(strings.Fields(text), " "), decorators)
+	}
+	v.name = text[loc[2]:loc[3]]
+	v.expression = strings.TrimSpace(text[loc[1]:])
+
+	decText := strings.Join(decorators, "\n")
+	if m := descDecRe.FindStringSubmatch(decText); len(m) > 1 {
+		v.description = m[1]
+	}
+	return v
 }
 
 func parseVariable(line string, decorators []string) parsedVariable {
@@ -502,18 +587,26 @@ func parseVariableDecl(lines []string, startIdx int, decorators []string) (parse
 	st := scanState{}
 	st.feed(first)
 
-	if st.totalDepth() <= 0 {
+	if !st.open() {
 		return parseVariable(first, decorators), startIdx + 1
 	}
 
-	// Value opens a block; reassemble until depth returns to zero.
+	// Value opens a block or a multi-line string; reassemble until it closes.
 	joined := []string{first}
 	i := startIdx + 1
-	for st.totalDepth() > 0 && i < len(lines) {
+	for st.open() && i < len(lines) {
 		t := strings.TrimSpace(lines[i])
 		joined = append(joined, t)
 		st.feed(t)
 		i++
+	}
+
+	// A multi-line string's contents are data, not layout: joining with spaces
+	// and collapsing whitespace would rewrite a shell script or certificate
+	// body into one line. Keep the newlines in that case, and split the
+	// declaration with the delimiter-aware scanner rather than the line regex.
+	if raw := strings.Join(joined, "\n"); containsMultilineString(raw) {
+		return parseVariableMultiline(raw, decorators), i
 	}
 
 	combined := strings.Join(joined, " ")
@@ -707,7 +800,7 @@ func scanStatementEnd(s string) int {
 	}
 	st.feed(s[:nl])
 	pos := nl + 1
-	if st.totalDepth() <= 0 {
+	if !st.open() {
 		return nl
 	}
 	for pos < len(s) {
@@ -723,7 +816,7 @@ func scanStatementEnd(s string) int {
 			return len(s)
 		}
 		pos += next + 1
-		if st.totalDepth() <= 0 {
+		if !st.open() {
 			return pos - 1
 		}
 	}
@@ -776,17 +869,21 @@ func parseModuleDecl(lines []string, startIdx int, decorators []string) (*parsed
 // Bicep requires — so the caller can skip it rather than append a husk.
 func parseOutput(line string, decorators []string) (parsedOutput, bool) {
 	o := parsedOutput{}
-	m := outputRe.FindStringSubmatch(line)
-	if len(m) < 3 {
+	loc := outputHeaderRe.FindStringSubmatchIndex(line)
+	if loc == nil {
+		return parsedOutput{}, false
+	}
+	rest := strings.TrimSpace(line[loc[1]:])
+	if rest == "" {
 		return parsedOutput{}, false
 	}
 
-	typ, expr, hasValue := splitDeclAtEquals(strings.TrimSpace(m[2]))
+	typ, expr, hasValue := splitDeclAtEquals(rest)
 	if !hasValue || typ == "" {
 		return parsedOutput{}, false
 	}
 
-	o.name = m[1]
+	o.name = line[loc[2]:loc[3]]
 	o.typ = typ
 	// A looped output (`output ids array = [for sa in sas: sa.id]`)
 	// produces an array. Intentionally store the per-iteration value
@@ -1328,18 +1425,12 @@ func extractCondition(line string) string {
 	if idx := strings.Index(line, "= if"); idx >= 0 {
 		rest := strings.TrimSpace(line[idx+4:])
 		// Extract the condition expression in parens
+		// matchingParenIndex shares the string-aware lexer, so a `)` inside a
+		// quoted value (`if (tag == 'a)b')`) no longer closes the condition
+		// early and truncate the expression.
 		if strings.HasPrefix(rest, "(") {
-			depth := 0
-			for i, ch := range rest {
-				if ch == '(' {
-					depth++
-				}
-				if ch == ')' {
-					depth--
-					if depth == 0 {
-						return rest[1:i]
-					}
-				}
+			if closeIdx := matchingParenIndex(rest, 0); closeIdx > 0 {
+				return rest[1:closeIdx]
 			}
 		}
 	}
@@ -1391,6 +1482,34 @@ type scanState struct {
 
 func (s *scanState) totalDepth() int { return s.paren + s.bracket + s.brace }
 
+// open reports whether the state is mid-construct and a statement scanner must
+// keep consuming lines.
+//
+// Bracket depth alone is not enough. A triple-quoted multi-line string opens no
+// paren, bracket, or brace, so a depth-only test ended the statement at the
+// first newline and handed the remaining lines of the string back to the
+// scanner as top-level statements. Anything in them that looked like a
+// declaration was then parsed as one, so a deployment script embedded in a
+// variable could fabricate resources, parameters, and outputs that are not part
+// of the template.
+func (s *scanState) open() bool { return s.totalDepth() > 0 || s.inMulti }
+
+// containsMultilineString reports whether s opens a triple-quoted string
+// anywhere outside a comment or another string. Callers use it to decide
+// whether a reassembled statement must keep its newlines: collapsing them would
+// corrupt the string's contents.
+func containsMultilineString(s string) bool {
+	st := scanState{}
+	for i := 0; i < len(s); {
+		before := st.inMulti
+		i = st.stepAt(s, i)
+		if !before && st.inMulti {
+			return true
+		}
+	}
+	return false
+}
+
 // stepAt processes one position in `body` and returns the next index
 // to resume from. It handles the full set of Bicep token states
 // (single-line strings with `\<char>` escapes, triple-quoted
@@ -1417,6 +1536,15 @@ func (s *scanState) stepAt(body string, i int) int {
 	}
 	ch := body[i]
 	if s.inStr != 0 {
+		// A single- or double-quoted Bicep string cannot contain a raw
+		// newline; that is what the triple-quoted form is for. Clearing the
+		// state at the line break keeps one unterminated quote from turning
+		// the rest of a resource body into string content, which made the
+		// resource's properties read as empty.
+		if ch == '\n' {
+			s.inStr = 0
+			return i + 1
+		}
 		// Bicep string escapes: `\\`, `\'`, `\n`, `\$`, etc. The next
 		// byte is literal regardless of what it is, so just skip it.
 		if ch == '\\' && i+1 < len(body) {
@@ -1470,6 +1598,11 @@ func (s *scanState) stepAt(body string, i int) int {
 // running depth counters. Characters inside a string literal or after
 // a top-level `//` comment marker do not affect depth.
 func (s *scanState) feed(line string) {
+	// Callers split on newlines, so the line break that would have closed
+	// an unterminated single-quoted string is not part of line. Reset for
+	// the same reason stepAt resets at an explicit newline. inMulti and
+	// inCmt are deliberately preserved: those constructs do span lines.
+	s.inStr = 0
 	for i := 0; i < len(line); {
 		i = s.stepAt(line, i)
 	}
@@ -1547,6 +1680,10 @@ func (s *scanState) scanForBodyBrace(line string) int {
 // blocks. Anything it can't parse cleanly falls back to a string —
 // audits can still match on the text.
 func parseBicepObject(body string) map[string]any {
+	return parseBicepObjectDepth(body, 0)
+}
+
+func parseBicepObjectDepth(body string, depth int) map[string]any {
 	entries := splitTopLevelEntries(body)
 	out := make(map[string]any, len(entries))
 	for _, entry := range entries {
@@ -1554,7 +1691,7 @@ func parseBicepObject(body string) map[string]any {
 		if !ok {
 			continue
 		}
-		out[unquoteBicepKey(strings.TrimSpace(key))] = parseBicepValue(strings.TrimSpace(value))
+		out[unquoteBicepKey(strings.TrimSpace(key))] = parseBicepValueDepth(strings.TrimSpace(value), depth)
 	}
 	return out
 }
@@ -1574,16 +1711,48 @@ func unquoteBicepKey(k string) string {
 	return k
 }
 
+// maxValueDepth bounds recursion in the object/array value parser, mirroring
+// maxExprDepth in the expression parser. Real Bicep nests properties a handful
+// of levels deep; the cap exists so a deeply nested, possibly adversarial
+// template degrades to raw text instead of driving super-linear work that
+// wedges the scan.
+const maxValueDepth = 200
+
 func parseBicepValue(v string) any {
+	return parseBicepValueDepth(v, 0)
+}
+
+func parseBicepValueDepth(v string, depth int) any {
 	if v == "" {
 		return ""
 	}
+	if depth >= maxValueDepth {
+		return v
+	}
 	switch v[0] {
 	case '{':
-		return parseBicepObject(stripOuter(v, '{', '}'))
+		// stripOuter returns its input unchanged when there is nothing to
+		// strip, which for a lone delimiter makes this a fixed point: the
+		// container parser splits the text into the same single entry and
+		// hands it straight back. That recursion has no base case and
+		// overflows the stack, which is a fatal error the plugin runtime
+		// cannot recover from. Only descend when the text actually shrank.
+		if inner := stripOuter(v, '{', '}'); len(inner) < len(v) {
+			return parseBicepObjectDepth(inner, depth+1)
+		}
+		return v
 	case '[':
-		return parseBicepArray(stripOuter(v, '[', ']'))
+		if inner := stripOuter(v, '[', ']'); len(inner) < len(v) {
+			return parseBicepArrayDepth(inner, depth+1)
+		}
+		return v
 	case '\'', '"':
+		// A triple-quoted multi-line string needs all three delimiters
+		// removed; stripping a single quote from each end left stray `''`
+		// bookends on every embedded script, certificate, or policy body.
+		if len(v) >= 6 && strings.HasPrefix(v, "'''") && strings.HasSuffix(v, "'''") {
+			return v[3 : len(v)-3]
+		}
 		if len(v) >= 2 && v[len(v)-1] == v[0] {
 			return v[1 : len(v)-1]
 		}
@@ -1640,10 +1809,14 @@ func stripLiteralQuotes(s string) string {
 }
 
 func parseBicepArray(body string) []any {
+	return parseBicepArrayDepth(body, 0)
+}
+
+func parseBicepArrayDepth(body string, depth int) []any {
 	entries := splitTopLevelEntries(body)
 	out := make([]any, 0, len(entries))
 	for _, e := range entries {
-		out = append(out, parseBicepValue(strings.TrimSpace(e)))
+		out = append(out, parseBicepValueDepth(strings.TrimSpace(e), depth))
 	}
 	return out
 }
@@ -1684,6 +1857,13 @@ func splitTopLevelEntries(body string) []string {
 	}
 	i := 0
 	for i < len(body) {
+		// A single- or double-quoted string cannot span lines in Bicep, so a
+		// newline closes an unterminated one. Without this, one stray quote
+		// merged every following entry into the malformed one and the
+		// object's remaining keys disappeared.
+		if body[i] == '\n' && st.inStr != 0 && !st.inMulti && !st.inCmt {
+			st.inStr = 0
+		}
 		// Special cases only fire when we're not inside any string,
 		// and only at top-level depth so nested object/array entries
 		// preserve their commas and newlines.
@@ -1717,28 +1897,32 @@ func splitTopLevelEntries(body string) []string {
 	return entries
 }
 
-// tagsEntryRe matches one `key: 'value'` line inside a `tags: { ... }` block.
-// Keys can be bare identifiers (`env`) or single-quoted strings (`'env-1'`);
-// only literal single-quoted values are captured — expression-valued tags
-// like `env: parameters('env')` are skipped because the dict shape on the
-// resource gives audits a way to reach them in raw form.
-var tagsEntryRe = regexp.MustCompile(`(?m)^\s*(?:'([^']+)'|(\w[\w-]*))\s*:\s*'([^']*)'\s*,?\s*$`)
-
 // extractTags pulls a `tags: { ... }` block out of a resource body and
 // returns the literal key/value pairs as a map. Expression-valued tags are
 // dropped; the resource's `properties` dict still surfaces the raw text.
+//
+// Entries are split with the shared string-aware scanner rather than matched
+// one per line. A line-anchored pattern required every pair to sit alone on
+// its own line, so the inline form `tags: { env: 'prod', owner: 'x' }` matched
+// nothing and a correctly tagged resource reported no tags at all.
 func extractTags(body string) map[string]string {
 	raw := extractFieldBlock(body, "tags")
 	if raw == "" {
 		return nil
 	}
 	tags := map[string]string{}
-	for _, m := range tagsEntryRe.FindAllStringSubmatch(raw, -1) {
-		key := m[1]
-		if key == "" {
-			key = m[2]
+	for _, entry := range splitTopLevelEntries(raw) {
+		key, value, ok := splitFirstColon(entry)
+		if !ok {
+			continue
 		}
-		tags[key] = m[3]
+		value = strings.TrimSpace(value)
+		// Only literal values are surfaced here. An expression-valued tag
+		// stays reachable through the resource's raw properties dict.
+		if !isSingleQuotedLiteral(value) {
+			continue
+		}
+		tags[unquoteBicepKey(strings.TrimSpace(key))] = value[1 : len(value)-1]
 	}
 	if len(tags) == 0 {
 		return nil

--- a/providers/bicep/resources/parserfidelity_test.go
+++ b/providers/bicep/resources/parserfidelity_test.go
@@ -1,0 +1,153 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func firstResource(t *testing.T, src string) parsedResource {
+	t.Helper()
+	p := parseBicep(src)
+	require.Len(t, p.resources, 1, "expected exactly one resource in:\n%s", src)
+	return p.resources[0]
+}
+
+func firstParam(t *testing.T, src string) parsedParameter {
+	t.Helper()
+	p := parseBicep(src)
+	require.Len(t, p.parameters, 1, "expected exactly one parameter in:\n%s", src)
+	return p.parameters[0]
+}
+
+// Tags written inline on one line are valid Bicep and common. A per-line
+// anchored regex matched none of them, so a correctly tagged resource reported
+// no tags at all and a governance policy failed it.
+func TestExtractTagsLayouts(t *testing.T) {
+	cases := []struct {
+		name string
+		tags string
+		want map[string]string
+	}{
+		{
+			name: "inline multiple pairs",
+			tags: "  tags: { env: 'prod', owner: 'platform' }",
+			want: map[string]string{"env": "prod", "owner": "platform"},
+		},
+		{
+			name: "inline single pair",
+			tags: "  tags: { env: 'prod' }",
+			want: map[string]string{"env": "prod"},
+		},
+		{
+			name: "multi-line newline separated",
+			tags: "  tags: {\n    env: 'prod'\n    owner: 'platform'\n  }",
+			want: map[string]string{"env": "prod", "owner": "platform"},
+		},
+		{
+			name: "multi-line comma separated",
+			tags: "  tags: {\n    env: 'prod',\n    owner: 'platform'\n  }",
+			want: map[string]string{"env": "prod", "owner": "platform"},
+		},
+		{
+			name: "trailing line comment",
+			tags: "  tags: {\n    env: 'prod' // the environment\n    owner: 'platform'\n  }",
+			want: map[string]string{"env": "prod", "owner": "platform"},
+		},
+		{
+			name: "quoted key",
+			tags: "  tags: { 'cost-center': '1234' }",
+			want: map[string]string{"cost-center": "1234"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			src := "resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {\n  name: 'mysa'\n" + c.tags + "\n}\n"
+			assert.Equal(t, c.want, firstResource(t, src).tags)
+		})
+	}
+}
+
+// Expression-valued tags stay out of the literal map, as documented.
+func TestExtractTagsSkipsExpressions(t *testing.T) {
+	src := "resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {\n  name: 'mysa'\n  tags: { env: toLower(envName), owner: 'platform' }\n}\n"
+	assert.Equal(t, map[string]string{"owner": "platform"}, firstResource(t, src).tags)
+}
+
+// The condition scanner counted parentheses without honoring string literals,
+// so a `)` inside a quoted value truncated the expression.
+func TestExtractConditionIsStringAware(t *testing.T) {
+	cases := []struct {
+		line string
+		want string
+	}{
+		{"resource r 'T@2020-01-01' = if (env == 'prod') {", "env == 'prod'"},
+		{"resource r 'T@2020-01-01' = if (tag == 'a)b') {", "tag == 'a)b'"},
+		{"resource r 'T@2020-01-01' = if (contains(name, ')')) {", "contains(name, ')')"},
+		{"resource r 'T@2020-01-01' = {", ""},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, extractCondition(c.line), "input: %s", c.line)
+	}
+}
+
+// A default that merely begins and ends with a quote is not a single literal;
+// stripping the outer quotes corrupted it into an unbalanced string.
+func TestParameterDefaultQuoteStripping(t *testing.T) {
+	assert.Equal(t, "eastus", firstParam(t, "param loc string = 'eastus'\n").defaultValue)
+
+	got := firstParam(t, "param sku string = 'prod' == env ? 'Premium' : 'Standard'\n").defaultValue
+	assert.Equal(t, "'prod' == env ? 'Premium' : 'Standard'", got,
+		"an expression that only starts and ends with a quote must not be unquoted")
+
+	assert.Equal(t, "isProd ? 'prod' : 'dev'",
+		firstParam(t, "param env string = isProd ? 'prod' : 'dev'\n").defaultValue)
+}
+
+// A description containing an escaped quote matched nothing, so the whole
+// description read as absent.
+func TestDescriptionDecoratorWithEscapedQuote(t *testing.T) {
+	assert.Equal(t, "Plain description",
+		firstParam(t, "@description('Plain description')\nparam p string\n").description)
+
+	got := firstParam(t, "@description('The VM\\'s admin username')\nparam adminUser string\n").description
+	assert.NotEmpty(t, got, "an escaped quote must not blank the description")
+	assert.Contains(t, got, "admin username")
+}
+
+// An allowed-values list containing a `]` inside a literal matched nothing, so
+// the entire constraint read as absent and a policy asserting it passed
+// vacuously.
+func TestAllowedDecoratorWithBracketInLiteral(t *testing.T) {
+	assert.Equal(t, []string{"a", "c"},
+		firstParam(t, "@allowed([ 'a', 'c' ])\nparam x string\n").allowed)
+
+	assert.Equal(t, []string{"a]b", "c"},
+		firstParam(t, "@allowed([ 'a]b', 'c' ])\nparam x string\n").allowed)
+}
+
+// A single-quoted string cannot span lines in Bicep. Leaking the in-string
+// state across a newline turned the rest of a resource body into one string
+// value, so its properties read as empty and an audit over them passed
+// vacuously.
+func TestUnterminatedStringDoesNotSwallowResourceBody(t *testing.T) {
+	src := `resource r 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: 'unterminated
+  location: 'eastus'
+  properties: {
+    allowBlobPublicAccess: true
+  }
+}
+`
+	r := firstResource(t, src)
+	assert.Equal(t, "'eastus'", r.location,
+		"a declaration after an unterminated string must still parse")
+
+	props := parseBicepObject(bodyObjectInner(r.body))
+	assert.Contains(t, props, "properties",
+		"the resource body must not collapse into a single string value")
+}

--- a/providers/bicep/resources/tokenizer.go
+++ b/providers/bicep/resources/tokenizer.go
@@ -93,7 +93,7 @@ func tokenizeBicep(content string) []bicepStatement {
 			st := scanState{}
 			st.feed(trimmed)
 			i++
-			for st.totalDepth() > 0 && i < len(lines) {
+			for st.open() && i < len(lines) {
 				t := strings.TrimSpace(lines[i])
 				decLine += "\n" + t
 				st.feed(t)
@@ -140,7 +140,7 @@ func tokenizeBicep(content string) []bicepStatement {
 		bodyLines = append(bodyLines, lines[i])
 		st.feed(lines[i])
 		i++
-		for st.totalDepth() > 0 && i < len(lines) {
+		for st.open() && i < len(lines) {
 			bodyLines = append(bodyLines, lines[i])
 			st.feed(lines[i])
 			i++

--- a/providers/bicep/resources/valueparser_test.go
+++ b/providers/bicep/resources/valueparser_test.go
@@ -1,0 +1,112 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withinBudget runs fn and fails if it has not finished in time. A runaway
+// value parser shows up as a hang here rather than as a panic, and an
+// unbounded recursion shows up as a Go stack overflow, which is a fatal error
+// that recover() cannot catch — so the deadline is the only safe way to assert
+// on it from inside the test binary.
+func withinBudget(t *testing.T, budget time.Duration, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(budget):
+		t.Fatalf("value parser did not finish within %s", budget)
+	}
+}
+
+// A lone `[` is a fixed point for the value parser: stripping the outer
+// brackets off a one-byte string returns it unchanged, so the array parser
+// hands the same text back to the value parser forever.
+func TestParseBicepValueLoneOpenBracketTerminates(t *testing.T) {
+	withinBudget(t, 5*time.Second, func() {
+		assert.Equal(t, "[", parseBicepValue("["))
+	})
+}
+
+func TestParseBicepValueLoneOpenBraceTerminates(t *testing.T) {
+	withinBudget(t, 5*time.Second, func() {
+		parseBicepValue("{")
+	})
+}
+
+// The production route to that fixed point: an unbalanced `[` in a resource
+// body. `splitTopLevelEntries` only ends an entry at depth 0, so the entry
+// after an unclosed bracket runs to end of input and arrives as a bare "[".
+func TestUnbalancedBracketInResourceBodyTerminates(t *testing.T) {
+	sources := []string{
+		"resource r 'T@2020-01-01' = {\n  foo: [\n}\n",
+		"resource r 'T@2020-01-01' = {\n  properties: {\n    ips: [\n  }\n}\n",
+		"resource r 'T@2020-01-01' = {\n  properties: {\n    rules: [ { name: 'x', ports: [ } ]\n  }\n}\n",
+		"module m './m.bicep' = {\n  params: {\n    x: [\n  }\n}\n",
+	}
+	for _, src := range sources {
+		withinBudget(t, 5*time.Second, func() {
+			p := parseBicep(src)
+			for _, r := range p.resources {
+				parseBicepObject(bodyObjectInner(r.body))
+			}
+			for _, m := range p.modules {
+				parseBicepObject(extractFieldBlock(m.body, "params"))
+			}
+		})
+	}
+}
+
+// Deeply nested values must degrade rather than drive super-linear work, the
+// same way the expression parser already bounds itself with maxExprDepth.
+func TestParseBicepValueDeepNestingIsBounded(t *testing.T) {
+	v := strings.Repeat("[", 40000) + strings.Repeat("]", 40000)
+	withinBudget(t, 5*time.Second, func() {
+		parseBicepValue(v)
+	})
+
+	obj := strings.Repeat("{ a: ", 20000) + "1" + strings.Repeat(" }", 20000)
+	withinBudget(t, 5*time.Second, func() {
+		parseBicepValue(obj)
+	})
+}
+
+// A well-formed nested value must still parse correctly after the bound.
+func TestParseBicepValueStillParsesNestedStructures(t *testing.T) {
+	v := parseBicepValue("{ a: [ 'x', { b: 2 } ], c: true }")
+	m, ok := v.(map[string]any)
+	require.True(t, ok, "expected an object, got %T", v)
+
+	arr, ok := m["a"].([]any)
+	require.True(t, ok, "expected an array, got %T", m["a"])
+	require.Len(t, arr, 2)
+	assert.Equal(t, "x", arr[0])
+
+	inner, ok := arr[1].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(2), inner["b"])
+	assert.Equal(t, true, m["c"])
+}
+
+// A triple-quoted value lost exactly one quote from each side, leaving stray
+// ” bookends on every embedded script or certificate body.
+func TestParseBicepValueTripleQuoted(t *testing.T) {
+	got := parseBicepObject("scriptContent: '''\n  echo hi\n'''")
+	require.Contains(t, got, "scriptContent")
+	s, ok := got["scriptContent"].(string)
+	require.True(t, ok)
+	assert.Equal(t, "\n  echo hi\n", s)
+	assert.NotContains(t, s, "''")
+}


### PR DESCRIPTION
Nine defects in the hand-rolled Bicep parser, found by auditing it against
untrusted input (the provider parses whatever `.bicep` files are in a
repository, so malformed and adversarial input is the normal case).

Every fix ships with a regression test that fails on `main`.

## Fatal: an unbalanced `[` kills the scan process

```bicep
resource r 'T@2020-01-01' = {
  foo: [
}
```

```
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow
  parseBicepArray  parser.go:1646
  parseBicepValue  parser.go:1585
  ... repeats until the 1 GB limit
```

`stripOuter` returns its input unchanged when there is nothing to strip, so a
lone `[` is a fixed point: `splitTopLevelEntries` yields the same single entry
and the value parser recurses on itself forever. `splitTopLevelEntries` only
ends an entry at depth 0, so any unclosed bracket produces that bare `"["`.

This matters more than an ordinary panic. The SDK wraps `GetData` in
`recoverPanic`, so a panic degrades to one failed field — but a stack overflow
is a Go **fatal error**, unrecoverable by design, so it bypasses that net and
takes down the plugin subprocess mid-scan. Three lines of work-in-progress
Bicep are enough.

The value parser now descends only when the text actually shrank, and carries
a depth bound mirroring the expression parser's existing `maxExprDepth`, so
deeply nested input degrades to raw text rather than driving quadratic work
(measured before the bound: 40 000 nested brackets took 6.9 s, 80 000 took
27.6 s — clean O(n²)).

## Fabricated data: a multi-line string can invent resources

```bicep
var deployScript = '''
resource ghostRes 'Microsoft.Storage/storageAccounts@2021-04-01' = {
  name: 'ghost'
  properties: {
    supportsHttpsTrafficOnly: false
  }
}
'''
```

`bicep.resources` reported `ghostRes` — a storage account that exists only as
text inside a string literal — while the real variable's value read back as
`'''`.

The statement scanner continued only while `paren + bracket + brace > 0`. A
triple-quoted string opens none of those, so the statement was cut at the first
newline and the remaining lines of the string re-entered the scanner as
top-level statements. `scanState` already tracked `inMulti`; nothing consulted
it.

The same gap ran the other way. An unbalanced brace inside such a string —
ordinary in cloud-init, embedded policy JSON, or a deployment script — swallowed
every following declaration:

```bicep
var cloudInit = '''
write_files:
  - content: {
'''

resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
  name: 'critical'
  properties: { allowBlobPublicAccess: true }
}
```

reported **zero** resources, so "no storage account allows public blob access"
passed vacuously.

Six copies of the depth-only test are replaced with one `scanState.open()`
predicate. The declaration parsers were also taught to keep a multi-line value's
newlines, since collapsing them rewrites a shell script or certificate into a
single line, and a multi-line `param` default previously read back as a bare
`'`.

## Silent data loss and misparses

| Input | Before | Now |
|---|---|---|
| `tags: { env: 'prod', owner: 'x' }` | **no tags at all** — the entry pattern was anchored per line, so the inline form matched nothing and a tag-governance policy failed a correctly tagged resource | both pairs |
| `name: 'unterminated` followed by more keys | the in-string state leaked across the newline, so the rest of the body became string content and `properties` read as **empty** — an audit over it passed vacuously | later keys parse; damage confined to the malformed line |
| `@description('The VM\'s name')` | **empty description** — the capture class could not cross the escape, so the match failed outright | full text |
| `@allowed([ 'a]b', 'c' ])` | **no allowed values** — a policy asserting the constraint passed vacuously | `["a]b", "c"]` |
| `param sku string = 'prod' == env ? 'Premium' : 'Standard'` | outer quotes stripped, leaving an unbalanced string | unchanged |
| `= if (tag == 'a)b') {` | condition truncated to `tag == 'a` | full condition |
| `scriptContent: '''…'''` | stray `''` bookends on the value | clean contents |

Each of these is a case where the parser produced a confident wrong answer
rather than an error, which is the failure mode that matters most here: an
empty result reads as "nothing to flag".

## Tests

Three new files, 20 cases:

- `multiline_test.go` — no fabricated declarations, the string body survives, a
  multi-line `param` default is not mangled, unbalanced delimiters inside the
  string do not consume later declarations, statement spans are right, and two
  negative controls (a multi-line string inside a resource body, which already
  worked, and an unterminated one, which must run to end of file).
- `valueparser_test.go` — the lone `[` terminates, four production routes to it
  terminate, deep nesting is bounded, well-formed nested values still parse, and
  triple-quoted values keep their contents. The recursion cases assert against a
  deadline, since a stack overflow cannot be caught with `recover`.
- `parserfidelity_test.go` — tags across six layouts (plus expression-valued
  tags still excluded), condition parsing, default-quote stripping, the two
  decorator regexes, and the unterminated-string case.

`go test ./...` is green across `connection`, `provider`, and `resources`,
including the existing ~4,500 lines of parser tests.

Separately, I ran a mutation/truncation harness over the parser entry points
before and after — ~188,000 inputs (prefix truncations of every `testdata`
fixture, random mutations over a Bicep-hostile alphabet, and pathological
nesting) — with no panics, hangs, or fatal errors. That harness is not part of
the PR; it is how the depth-bound and `open()` changes were checked for
regressions, since both touch a scanner every walker in the file shares.
