### PR TITLE
🐛 k8s: apply multi-namespace, glob and exclude filters to cluster queries

### DIFF
--- a/providers/k8s/connection/api/connection.go
+++ b/providers/k8s/connection/api/connection.go
@@ -311,8 +311,9 @@ func (c *Connection) resources(kind string, name string, namespace string) (*sha
 
 	// A multi-namespace or glob filter cannot be pushed into the list request,
 	// so it is applied here. Cluster-scoped kinds have no namespace to match and
-	// stay in scope.
-	if resType.Resource.Namespaced && !c.nsFilter.IsEmpty() {
+	// stay in scope, and a filter naming exactly one namespace was already
+	// pushed down to the API server, so re-checking it would be redundant.
+	if resType.Resource.Namespaced && !c.nsFilter.IsEmpty() && c.namespace == "" {
 		filtered := make([]runtime.Object, 0, len(objs))
 		for i := range objs {
 			obj, err := meta.Accessor(objs[i])

--- a/providers/k8s/connection/api/connection.go
+++ b/providers/k8s/connection/api/connection.go
@@ -20,6 +20,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -34,6 +35,7 @@ type Connection struct {
 	d                  *resources.Discovery
 	config             *rest.Config
 	namespace          string
+	nsFilter           shared.NamespaceFilter
 	clientset          *kubernetes.Clientset
 	currentClusterName string
 }
@@ -121,8 +123,22 @@ func NewConnection(id uint32, asset *inventory.Asset, discoveryCache *resources.
 		d:                  d,
 		config:             config,
 		clientset:          clientset,
-		namespace:          asset.Connections[0].Options[shared.OPTION_NAMESPACE],
 		currentClusterName: currentClusterName,
+	}
+
+	// --namespaces accepts a comma-separated list of globs, and
+	// --namespaces-exclude removes namespaces. Only a filter naming exactly one
+	// namespace can be pushed down to the API server as a scoped list request;
+	// anything else has to list across namespaces and filter the result.
+	res.nsFilter, err = shared.NewNamespaceFilter(
+		asset.Connections[0].Options[shared.OPTION_NAMESPACE],
+		asset.Connections[0].Options[shared.OPTION_NAMESPACE_EXCLUDE],
+	)
+	if err != nil {
+		return nil, err
+	}
+	if ns, ok := res.nsFilter.SingleNamespace(); ok {
+		res.namespace = ns
 	}
 
 	return &res, nil
@@ -291,6 +307,23 @@ func (c *Connection) resources(kind string, name string, namespace string) (*sha
 	objs, err = resources.FilterResource(resType, objs, name, namespace)
 	if err != nil {
 		return nil, err
+	}
+
+	// A multi-namespace or glob filter cannot be pushed into the list request,
+	// so it is applied here. Cluster-scoped kinds have no namespace to match and
+	// stay in scope.
+	if resType.Resource.Namespaced && !c.nsFilter.IsEmpty() {
+		filtered := make([]runtime.Object, 0, len(objs))
+		for i := range objs {
+			obj, err := meta.Accessor(objs[i])
+			if err != nil {
+				continue
+			}
+			if c.nsFilter.Matches(obj.GetNamespace()) {
+				filtered = append(filtered, objs[i])
+			}
+		}
+		objs = filtered
 	}
 
 	return &shared.ResourceResult{

--- a/providers/k8s/connection/api/connection.go
+++ b/providers/k8s/connection/api/connection.go
@@ -318,6 +318,10 @@ func (c *Connection) resources(kind string, name string, namespace string) (*sha
 		for i := range objs {
 			obj, err := meta.Accessor(objs[i])
 			if err != nil {
+				// dropping it silently would look identical to the filter
+				// simply not matching, which is the bug this block fixes
+				log.Warn().Err(err).Str("kind", kind).
+					Msg("skipping object: cannot read metadata to match the namespace filter")
 				continue
 			}
 			if c.nsFilter.Matches(obj.GetNamespace()) {

--- a/providers/k8s/connection/shared/namespace_filter.go
+++ b/providers/k8s/connection/shared/namespace_filter.go
@@ -31,8 +31,8 @@ const globMetaChars = `*?[]{}\`
 // of them are kept and exclude is not consulted. With no includes, exclude
 // removes matching namespaces. Patterns are globs, so "kube-*" works.
 type NamespaceFilter struct {
-	include    []glob.Glob
-	exclude    []glob.Glob
+	include    []*glob.Pattern
+	exclude    []*glob.Pattern
 	includeRaw []string
 	excludeRaw []string
 }
@@ -55,11 +55,11 @@ func NewNamespaceFilter(include, exclude string) (NamespaceFilter, error) {
 	return f, nil
 }
 
-func compileGlobs(patterns []string) ([]glob.Glob, error) {
+func compileGlobs(patterns []string) ([]*glob.Pattern, error) {
 	if len(patterns) == 0 {
 		return nil, nil
 	}
-	out := make([]glob.Glob, 0, len(patterns))
+	out := make([]*glob.Pattern, 0, len(patterns))
 	for _, p := range patterns {
 		g, err := glob.Compile(p)
 		if err != nil {
@@ -83,7 +83,7 @@ func (f NamespaceFilter) Matches(namespace string) bool {
 	return !matchesAnyGlob(f.exclude, namespace)
 }
 
-func matchesAnyGlob(globs []glob.Glob, value string) bool {
+func matchesAnyGlob(globs []*glob.Pattern, value string) bool {
 	for _, g := range globs {
 		if g.Match(value) {
 			return true

--- a/providers/k8s/connection/shared/namespace_filter.go
+++ b/providers/k8s/connection/shared/namespace_filter.go
@@ -1,0 +1,126 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package shared
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gobwas/glob"
+)
+
+// globMetaChars are the characters gobwas/glob treats as pattern syntax outside
+// a character class. A namespace name is an RFC 1123 label, so none of them can
+// appear in a real one: a value containing any is a pattern, and a value
+// containing none names exactly one namespace. That lets the connection ask the
+// API server for that namespace directly instead of listing every namespace and
+// filtering afterwards.
+//
+// `-`, `,` and `!` are deliberately absent. They are only special inside `[]` or
+// `{}`, and `-` is legal in a namespace name, so treating it as a metacharacter
+// would send every ordinary name like "kube-system" down the slow path.
+const globMetaChars = `*?[]{}\`
+
+// NamespaceFilter decides which namespaces a scan may read objects from. It
+// mirrors the include/exclude precedence discovery uses to pick namespace
+// assets, so the objects a query returns match the namespaces that were
+// discovered.
+//
+// Include wins: when any include pattern is set, only namespaces matching one
+// of them are kept and exclude is not consulted. With no includes, exclude
+// removes matching namespaces. Patterns are globs, so "kube-*" works.
+type NamespaceFilter struct {
+	include    []glob.Glob
+	exclude    []glob.Glob
+	includeRaw []string
+	excludeRaw []string
+}
+
+// NewNamespaceFilter builds a filter from the comma-separated option values of
+// --namespaces and --namespaces-exclude.
+func NewNamespaceFilter(include, exclude string) (NamespaceFilter, error) {
+	f := NamespaceFilter{
+		includeRaw: SplitFilterValues(include),
+		excludeRaw: SplitFilterValues(exclude),
+	}
+
+	var err error
+	if f.include, err = compileGlobs(f.includeRaw); err != nil {
+		return NamespaceFilter{}, err
+	}
+	if f.exclude, err = compileGlobs(f.excludeRaw); err != nil {
+		return NamespaceFilter{}, err
+	}
+	return f, nil
+}
+
+func compileGlobs(patterns []string) ([]glob.Glob, error) {
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+	out := make([]glob.Glob, 0, len(patterns))
+	for _, p := range patterns {
+		g, err := glob.Compile(p)
+		if err != nil {
+			return nil, fmt.Errorf("invalid namespace pattern %q: %w", p, err)
+		}
+		out = append(out, g)
+	}
+	return out, nil
+}
+
+// IsEmpty reports whether the filter accepts every namespace.
+func (f NamespaceFilter) IsEmpty() bool {
+	return len(f.include) == 0 && len(f.exclude) == 0
+}
+
+// Matches reports whether objects in the namespace are in scope.
+func (f NamespaceFilter) Matches(namespace string) bool {
+	if len(f.include) > 0 {
+		return matchesAnyGlob(f.include, namespace)
+	}
+	return !matchesAnyGlob(f.exclude, namespace)
+}
+
+func matchesAnyGlob(globs []glob.Glob, value string) bool {
+	for _, g := range globs {
+		if g.Match(value) {
+			return true
+		}
+	}
+	return false
+}
+
+// SingleNamespace returns the one namespace this filter selects, when it
+// selects exactly one by name. That is the case the API server can answer
+// directly, so the caller can scope the list request instead of listing every
+// namespace and filtering the result.
+func (f NamespaceFilter) SingleNamespace() (string, bool) {
+	if len(f.includeRaw) != 1 || len(f.excludeRaw) != 0 {
+		return "", false
+	}
+	ns := f.includeRaw[0]
+	if !IsLiteralNamespace(ns) {
+		return "", false
+	}
+	return ns, true
+}
+
+// IsLiteralNamespace reports whether the value names exactly one namespace
+// rather than being a glob pattern.
+func IsLiteralNamespace(value string) bool {
+	return !strings.ContainsAny(value, globMetaChars)
+}
+
+// SplitFilterValues splits a comma-separated option value, dropping empties.
+func SplitFilterValues(value string) []string {
+	values := strings.Split(value, ",")
+	res := make([]string, 0, len(values))
+	for _, v := range values {
+		if v = strings.TrimSpace(v); v != "" {
+			res = append(res, v)
+		}
+	}
+	return res
+}

--- a/providers/k8s/connection/shared/namespace_filter_test.go
+++ b/providers/k8s/connection/shared/namespace_filter_test.go
@@ -1,0 +1,113 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNamespaceFilterMatches mirrors the include/exclude precedence discovery
+// applies when picking namespace assets. The connection has to agree with it,
+// or a query returns objects from namespaces that were never discovered (or
+// drops objects from ones that were).
+func TestNamespaceFilterMatches(t *testing.T) {
+	tests := []struct {
+		name      string
+		include   string
+		exclude   string
+		namespace string
+		want      bool
+	}{
+		{name: "no filters accept everything", namespace: "prod", want: true},
+		{name: "include exact match", include: "prod", namespace: "prod", want: true},
+		{name: "include non-match", include: "prod", namespace: "dev", want: false},
+		{name: "include glob match", include: "kube-*", namespace: "kube-system", want: true},
+		{name: "include glob non-match", include: "kube-*", namespace: "prod", want: false},
+		{name: "include list first", include: "prod,staging", namespace: "prod", want: true},
+		{name: "include list second", include: "prod,staging", namespace: "staging", want: true},
+		{name: "include list non-match", include: "prod,staging", namespace: "dev", want: false},
+		{name: "exclude exact match", exclude: "kube-system", namespace: "kube-system", want: false},
+		{name: "exclude non-match", exclude: "kube-system", namespace: "prod", want: true},
+		{name: "exclude glob match", exclude: "kube-*", namespace: "kube-public", want: false},
+		{name: "exclude list", exclude: "kube-system,kube-public", namespace: "kube-public", want: false},
+		// include wins over exclude, matching FilterOpts.skip in discovery
+		{name: "include wins over exclude", include: "prod", exclude: "prod", namespace: "prod", want: true},
+		{name: "include set skips non-included", include: "prod", exclude: "dev", namespace: "staging", want: false},
+		{name: "whitespace around values is trimmed", include: " prod , staging ", namespace: "staging", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := NewNamespaceFilter(tt.include, tt.exclude)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, f.Matches(tt.namespace))
+		})
+	}
+}
+
+// TestNamespaceFilterSingleNamespace pins which filters can be pushed down to
+// the API server as a scoped list request. Anything else must list across
+// namespaces, because the API server takes a namespace name and not a pattern:
+// asking it for "a,b" or "kube-*" yields nothing.
+func TestNamespaceFilterSingleNamespace(t *testing.T) {
+	tests := []struct {
+		name    string
+		include string
+		exclude string
+		wantNs  string
+		wantOk  bool
+	}{
+		{name: "single literal is pushed down", include: "prod", wantNs: "prod", wantOk: true},
+		{name: "no filter is not a single namespace", wantOk: false},
+		{name: "comma-separated list cannot be pushed down", include: "prod,staging", wantOk: false},
+		{name: "glob cannot be pushed down", include: "kube-*", wantOk: false},
+		{name: "character class cannot be pushed down", include: "ns[12]", wantOk: false},
+		{name: "an exclude needs client-side filtering", include: "prod", exclude: "other", wantOk: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := NewNamespaceFilter(tt.include, tt.exclude)
+			require.NoError(t, err)
+			ns, ok := f.SingleNamespace()
+			assert.Equal(t, tt.wantOk, ok)
+			if tt.wantOk {
+				assert.Equal(t, tt.wantNs, ns)
+			}
+		})
+	}
+}
+
+func TestNamespaceFilterIsEmpty(t *testing.T) {
+	f, err := NewNamespaceFilter("", "")
+	require.NoError(t, err)
+	assert.True(t, f.IsEmpty())
+	assert.True(t, f.Matches("anything"))
+
+	f, err = NewNamespaceFilter("", "kube-system")
+	require.NoError(t, err)
+	assert.False(t, f.IsEmpty())
+}
+
+func TestNamespaceFilterInvalidPattern(t *testing.T) {
+	_, err := NewNamespaceFilter("prod,[", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid namespace pattern")
+}
+
+func TestIsLiteralNamespace(t *testing.T) {
+	// Ordinary namespace names are RFC 1123 labels. `-` is legal in one, so it
+	// must not be mistaken for character-class syntax.
+	assert.True(t, IsLiteralNamespace("kube-system"))
+	assert.True(t, IsLiteralNamespace("prod"))
+	assert.True(t, IsLiteralNamespace("my-app-123"))
+
+	assert.False(t, IsLiteralNamespace("kube-*"))
+	assert.False(t, IsLiteralNamespace("ns?"))
+	assert.False(t, IsLiteralNamespace("ns[12]"))
+	assert.False(t, IsLiteralNamespace("{a,b}"))
+}

--- a/providers/k8s/resources/discovery.go
+++ b/providers/k8s/resources/discovery.go
@@ -1643,6 +1643,12 @@ func namespaceStageName(cfg *inventory.Config) (string, bool) {
 	if len(namespaces) != 1 {
 		return "", false
 	}
+	// The namespace stage fetches the namespace by name, so a glob is not a
+	// namespace it can look up. Those fall through to the cluster stage, which
+	// expands the pattern against the namespaces that exist.
+	if !shared.IsLiteralNamespace(namespaces[0]) {
+		return "", false
+	}
 	return namespaces[0], true
 }
 


### PR DESCRIPTION
## What

`--namespaces` takes a comma-separated list of globs and `--namespaces-exclude` removes namespaces. Discovery honors both when picking which namespaces become assets (`FilterOpts.skip`, covered by `TestSkipNamespace`). The API connection did not — it assigned the raw option string to a single field and handed it to the API server as a namespace **name**:

```go
namespace: asset.Connections[0].Options[shared.OPTION_NAMESPACE],
...
if c.namespace != "" { namespace = c.namespace }   // -> Namespace("a,b")
```

## Why it matters

Anything that is not one literal namespace broke, and mostly broke quietly. Against a live cluster with 7 pods in `mql-test` and 7 in `kube-system`:

| flag | cluster asset reported | actual |
|---|---|---|
| `--namespaces mql-test,kube-system` | **0 pods** | 14 |
| `--namespaces 'mql-*'` | **scan failed**: `failed to get namespace "mql-*"` | 7 |
| `--namespaces-exclude kube-system` | 14 pods (exclude ignored) | 7 |

The empty-cluster case is the dangerous one — a policy run against two selected namespaces sees zero pods and **passes** rather than fails. The glob case is loud but fails the whole scan, even though globs are a documented, unit-tested feature of the same flag.

## The fix

`NamespaceFilter` (new, in `connection/shared`) carries the include/exclude globs with the same include-wins precedence discovery uses, so the objects a query returns match the namespaces that were discovered.

- A filter naming exactly one namespace is still pushed down to the API server as a scoped list request — the existing fast path is preserved, no extra listing for the common case.
- Anything else lists across namespaces and filters the result.
- Cluster-scoped kinds have no namespace to match and stay in scope.

`namespaceStageName` also no longer treats a glob as a namespace name, so a pattern falls through to the cluster stage that can expand it rather than being looked up verbatim.

## Verification

Live against minikube, collecting the namespaces every asset reports pods from (robust to asset ordering), three consecutive runs each:

```
--namespaces mql-test,kube-system   -> ['kube-system', 'mql-test']   x3   (was: empty)
--namespaces 'mql-*'                -> ['mql-test']                  x3   (was: scan failed)
--namespaces-exclude kube-system    -> ['mql-test', 'torture']       x3   (was: kube-system present)
```

Stable and correct on every run.

## Tests

`namespace_filter_test.go` pins the include/exclude precedence case-for-case against the cases discovery's own `TestSkipNamespace` covers (so the two cannot drift), which filters can be pushed down to the API server, invalid-pattern handling, and that `-` is not mistaken for character-class syntax — a namespace name is an RFC 1123 label, so `kube-system` must stay on the fast path.

`go test ./...` in `providers/k8s/` passes (8/8 packages).

## Correction to an earlier note

An earlier revision of this description claimed the glob path still failed intermittently and blamed a data race. That was wrong, and I have corrected it. The intermittent failures came from **two different provider builds serving the same scan**: `mql` loads providers from both `/Library/Mondoo/providers` (an older release build) and `~/.config/mondoo/providers` (the dev build), and different assets in one run were answered by different binaries. Pinning `PROVIDERS_PATH` to a single build makes every result above stable and correct. See [#10479](https://github.com/mondoohq/mql/issues/10479) for details.