### PR TITLE
🐛 terraform: stop the resource layer from crashing, colliding, and returning empty

### DIFF
--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -138,7 +140,19 @@ func (t *mqlTerraform) ensureCache() error {
 	if ok && conn != nil {
 		if parser := conn.Parser(); parser != nil {
 			files := parser.Files()
+			// Sort the paths before building the block list. parser.Files() is a
+			// Go map, so ranging it directly randomizes block order per process
+			// — and several accessors take a last-writer-wins value while
+			// iterating (terraform.settings.backend most visibly). A policy
+			// asserting backend["type"] == "s3" against a configuration with two
+			// `terraform {}` blocks therefore passed or failed by coin flip.
+			paths := make([]string, 0, len(files))
 			for k := range files {
+				paths = append(paths, k)
+			}
+			sort.Strings(paths)
+
+			for _, k := range paths {
 				f := files[k]
 				bs, err := listHclBlocks(t.MqlRuntime, f.Body, f)
 				if err != nil {
@@ -182,29 +196,46 @@ func (t *mqlTerraform) ensureCache() error {
 		}
 
 		// labels must be pre-initialized
-		name := block.terraformID()
-		t.blocksByName[name] = block
+		key := block.blockKey()
+		if key == "" {
+			// Label-less blocks (terraform {}, locals {}, moved {}) have no
+			// identity of their own. Mapping them all to one empty key made
+			// every one of them report every other one's edges as related.
+			continue
+		}
+		t.blocksByName[key] = block
 	}
 
 	// We need blocks by name before we can jump into
 	// related blocks, because we need to access them
 	// via their name
+	edges := map[string]map[*mqlTerraformBlock]struct{}{}
+	addEdge := func(key string, to *mqlTerraformBlock) {
+		set, ok := edges[key]
+		if !ok {
+			set = map[*mqlTerraformBlock]struct{}{}
+			edges[key] = set
+		}
+		if _, dup := set[to]; dup {
+			return
+		}
+		set[to] = struct{}{}
+		t.relatedBlocks[key] = append(t.relatedBlocks[key], to)
+	}
+
 	for i := range blocks {
 		block := blocks[i].(*mqlTerraformBlock)
-		name := block.terraformID()
-
-		rel, err := listRelatedBlocks(t, block.block.Data.Body)
-		if err != nil {
-			return err
+		key := block.blockKey()
+		if key == "" {
+			continue
 		}
 
-		// connect from this block to all related blocks...
-		t.relatedBlocks[name] = append(t.relatedBlocks[name], rel...)
-		// ... and also connect the inverse (related to this block)
-		for i := range rel {
-			relBlock := rel[i]
-			relName := relBlock.terraformID()
-			t.relatedBlocks[relName] = append(t.relatedBlocks[relName], block)
+		rel := listRelatedBlocks(t, block)
+		for j := range rel {
+			// connect from this block to all related blocks...
+			addEdge(key, rel[j])
+			// ... and also connect the inverse (related to this block)
+			addEdge(rel[j].blockKey(), block)
 		}
 	}
 
@@ -212,29 +243,127 @@ func (t *mqlTerraform) ensureCache() error {
 	return nil
 }
 
-func listRelatedBlocks(t *mqlTerraform, rawBody any) ([]*mqlTerraformBlock, error) {
-	var res []*mqlTerraformBlock
-	switch body := rawBody.(type) {
-	case *hclsyntax.Body:
-		for _, v := range body.Attributes {
-			refs := getReferences(v.Expr, &hcl.EvalContext{
-				Functions: hclFunctions(),
-			})
-			// we need the resource name and its ID at least
-			if len(refs) < 2 {
-				continue
-			}
-
-			refName := strings.Join(refs[0:2], "\x00")
-			if t.blocksByName[refName] == nil { // do not add nil blocks
-				continue
-			}
-			res = append(res, t.blocksByName[refName])
-		}
-	case hcl.Body:
-		return nil, errors.New("cannot yet list related blocks for regular hcl Body")
+// listRelatedBlocks collects the blocks a block's body references.
+//
+// It walks nested blocks as well as top-level attributes (an `ingress { ... }`
+// rule naming a security group is the canonical reference shape and was
+// previously invisible), and it uses hcl.Expression.Variables(), which returns
+// every traversal in an expression tree — so references buried in templates,
+// function calls, lists and conditionals are found too.
+func listRelatedBlocks(t *mqlTerraform, block *mqlTerraformBlock) []*mqlTerraformBlock {
+	if block.block.State != plugin.StateIsSet || block.block.Data == nil {
+		return nil
 	}
-	return res, nil
+	body, ok := block.block.Data.Body.(*hclsyntax.Body)
+	if !ok {
+		// JSON-syntax (.tf.json) bodies carry no typed expression tree, so they
+		// contribute no related edges. This has to degrade rather than fail:
+		// ensureCache is the single entry point behind blocks(), providers(),
+		// datasources(), variables(), outputs(), terraform.resources and
+		// terraform.settings, so one unsupported body used to break every
+		// terraform.* accessor on the asset — including for the native .tf
+		// files beside it.
+		return nil
+	}
+
+	dir := block.blockDir()
+	var res []*mqlTerraformBlock
+	seen := map[*mqlTerraformBlock]struct{}{}
+
+	var walk func(b *hclsyntax.Body)
+	walk = func(b *hclsyntax.Body) {
+		for _, attr := range b.Attributes {
+			for _, traversal := range attr.Expr.Variables() {
+				key := referenceKey(dir, traversalNames(traversal))
+				if key == "" {
+					continue
+				}
+				ref := t.blocksByName[key]
+				if ref == nil || ref == block {
+					continue
+				}
+				if _, dup := seen[ref]; dup {
+					continue
+				}
+				seen[ref] = struct{}{}
+				res = append(res, ref)
+			}
+		}
+		for _, nested := range b.Blocks {
+			walk(nested.Body)
+		}
+	}
+	walk(body)
+
+	return res
+}
+
+// traversalNames renders the leading name path of a traversal
+// (`data.aws_subnet.ec2[x].zone` -> data, aws_subnet, ec2). An index step ends
+// the path, since anything past it addresses into a value rather than naming a
+// block.
+func traversalNames(traversal hcl.Traversal) []string {
+	res := make([]string, 0, len(traversal))
+	for _, step := range traversal {
+		switch v := step.(type) {
+		case hcl.TraverseRoot:
+			res = append(res, v.Name)
+		case hcl.TraverseAttr:
+			res = append(res, v.Name)
+		default:
+			return res
+		}
+	}
+	return res
+}
+
+// blockGraphKey builds the identity a block is tracked under in the block
+// graph: the directory that declares it, its block type, and its labels.
+//
+// The directory matters because it is Terraform's module boundary. The
+// connection walks the whole tree, so a root `main.tf` and a
+// `modules/vpc/main.tf` that both declare `resource "aws_s3_bucket" "this"`
+// used to share one key — and both buckets then reported the same related
+// list containing both modules' policies, so "every bucket has a policy" could
+// pass for a bucket that has none.
+func blockGraphKey(dir, blockType string, labels ...string) string {
+	return dir + "\x00" + blockType + "\x00" + strings.Join(labels, "\x00")
+}
+
+// referenceKey turns a reference traversal into the graph key of the block it
+// points at, or "" when it does not name a block we track.
+func referenceKey(dir string, names []string) string {
+	if len(names) == 0 {
+		return ""
+	}
+	switch names[0] {
+	case "data":
+		// data.<type>.<name>
+		if len(names) < 3 {
+			return ""
+		}
+		return blockGraphKey(dir, "data", names[1], names[2])
+	case "module":
+		if len(names) < 2 {
+			return ""
+		}
+		return blockGraphKey(dir, "module", names[1])
+	case "var":
+		if len(names) < 2 {
+			return ""
+		}
+		return blockGraphKey(dir, "variable", names[1])
+	case "local", "count", "each", "self", "path", "terraform":
+		// locals live in a label-less `locals` block that has no identity of
+		// its own; the rest are not blocks at all.
+		return ""
+	default:
+		// <type>.<name> for a managed resource
+		if len(names) < 2 {
+			return ""
+		}
+		return blockGraphKey(dir, "resource", names[0], names[1])
+	}
 }
 
 func (t *mqlTerraform) providers() ([]any, error) {
@@ -320,12 +449,23 @@ func newMqlHclBlock(runtime *plugin.Runtime, block *hcl.Block, file *hcl.File) (
 		return nil, err
 	}
 	r := res.(*mqlTerraformBlock)
-	r.block = plugin.TValue[*hcl.Block]{State: plugin.StateIsSet, Data: block}
-	r.cachedFile = plugin.TValue[*hcl.File]{State: plugin.StateIsSet, Data: file}
-	return r, err
+	// CreateResource returns the ALREADY CACHED instance when the __id matches,
+	// so this stamping runs on a shared struct: two goroutines reaching the same
+	// block through terraform.blocks and terraform.file(path).blocks used to
+	// write these fields concurrently. Stamp exactly once, which also publishes
+	// the writes to every later reader of the cached instance.
+	r.stampOnce.Do(func() {
+		r.block = plugin.TValue[*hcl.Block]{State: plugin.StateIsSet, Data: block}
+		r.cachedFile = plugin.TValue[*hcl.File]{State: plugin.StateIsSet, Data: file}
+	})
+	return r, nil
 }
 
 type mqlTerraformBlockInternal struct {
+	// stampOnce guards the one-time population of the fields below, which
+	// happens after CreateResource and therefore possibly on a shared,
+	// already-cached instance.
+	stampOnce  sync.Once
 	block      plugin.TValue[*hcl.Block]
 	cachedFile plugin.TValue[*hcl.File]
 }
@@ -424,7 +564,7 @@ func (g *mqlTerraformBlock) context() (*mqlTerraformContext, error) {
 	return cobj.(*mqlTerraformContext), nil
 }
 
-func (g *mqlTerraformBlock) terraformID() string {
+func (g *mqlTerraformBlock) blockLabels() []string {
 	labels := g.Labels.Data
 	var namearr []string
 	for i := range labels {
@@ -432,7 +572,26 @@ func (g *mqlTerraformBlock) terraformID() string {
 			namearr = append(namearr, s)
 		}
 	}
-	return strings.Join(namearr, "\x00")
+	return namearr
+}
+
+// blockDir returns the directory of the file declaring this block, which is
+// the Terraform module the block belongs to.
+func (g *mqlTerraformBlock) blockDir() string {
+	if g.block.State != plugin.StateIsSet || g.block.Data == nil {
+		return ""
+	}
+	return filepath.Dir(g.block.Data.DefRange.Filename)
+}
+
+// blockKey is this block's identity in the terraform singleton's block graph.
+// It returns "" for label-less blocks, which have no identity to key on.
+func (g *mqlTerraformBlock) blockKey() string {
+	labels := g.blockLabels()
+	if len(labels) == 0 {
+		return ""
+	}
+	return blockGraphKey(g.blockDir(), g.Type.Data, labels...)
 }
 
 func (t *mqlTerraformBlock) nameLabel() (string, error) {
@@ -502,12 +661,17 @@ func initTerraformResources(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	// terraform.resources("...") selector instances (mondoohq/mql#8966).
 	id := "terraform.resources"
 	if matchResource != nil || matchName != nil {
+		// Qualify each component by the argument key it came from.
+		// RawData.String() renders a string identically whichever key it came
+		// from, so hashing the bare values made terraform.resources(resource: X)
+		// and terraform.resources(name: X) share a cache key and the second
+		// query silently return the first one's list.
 		s := checksums.New
 		if matchResource != nil {
-			s = s.Add(resourceArg.String())
+			s = s.Add("resource").Add(resourceArg.String())
 		}
 		if matchName != nil {
-			s = s.Add(nameArg.String())
+			s = s.Add("name").Add(nameArg.String())
 		}
 		id = s.String()
 	}
@@ -807,24 +971,41 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		// TODO: are we sure we want to do this?
 		return strings.Join(res, ".")
 	case *hclsyntax.FunctionCallExpr:
-		results := []any{}
-		subVal, err := t.Value(ctx)
-		if err == nil && subVal.Type() == cty.String {
-			if t.Name == "jsonencode" {
-				// Decode into `any` so both a JSON object (`jsonencode({...})`)
-				// and a JSON array (`jsonencode([...])`) resolve. Unmarshalling
-				// into a map[string]any silently failed for a top-level array,
-				// leaving the argument empty so a check iterating the encoded
-				// list saw nothing and passed vacuously. appendCtyResult keeps
-				// the object case list-wrapped while flattening a decoded list
-				// into the result so it stays iterable.
-				var res any
-				if err := json.Unmarshal([]byte(subVal.AsString()), &res); err == nil {
-					appendCtyResult(&results, res)
+		// AsString panics on a null AND on an unknown value, and an unknown one
+		// reaches here whenever the function resolves but an argument does not
+		// (`jsonencode(<unknown>)` returns cty.UnknownVal with no diagnostic at
+		// all). Guard on known/non-null before touching the value.
+		if subVal, diags := t.Value(ctx); !diags.HasErrors() && subVal.IsKnown() && !subVal.IsNull() {
+			if subVal.Type() == cty.String {
+				results := []any{}
+				if t.Name == "jsonencode" {
+					// Decode into `any` so both a JSON object (`jsonencode({...})`)
+					// and a JSON array (`jsonencode([...])`) resolve. Unmarshalling
+					// into a map[string]any silently failed for a top-level array,
+					// leaving the argument empty so a check iterating the encoded
+					// list saw nothing and passed vacuously. appendCtyResult keeps
+					// the object case list-wrapped while flattening a decoded list
+					// into the result so it stays iterable.
+					var res any
+					if err := json.Unmarshal([]byte(subVal.AsString()), &res); err == nil {
+						appendCtyResult(&results, res)
+					}
+					return results
 				}
-			} else {
 				results = append(results, subVal.AsString())
+				return results
 			}
+			return ctyValueToGo(subVal)
+		}
+		// The function table registers only a small set of pure functions, so
+		// `format`, `merge`, `join`, `lookup`, `try`, `coalesce`, ... all fail
+		// with "Call to unknown function". Surface what the arguments reference,
+		// the way ConditionalExpr does, rather than returning an empty list: a
+		// tag-governance check reading arguments["tags"] on a
+		// `merge(var.common_tags, {...})` value otherwise saw nothing at all.
+		results := []any{}
+		for _, arg := range t.Args {
+			appendCtyResult(&results, getCtyValue(arg, ctx))
 		}
 		return results
 	case *hclsyntax.ConditionalExpr:
@@ -846,6 +1027,9 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		appendCtyResult(&results, getCtyValue(t.FalseResult, ctx))
 		return results
 	case *hclsyntax.ForExpr:
+		if val, diags := t.Value(ctx); !diags.HasErrors() && val.IsKnown() && !val.IsNull() {
+			return ctyValueToGo(val)
+		}
 		results := []any{}
 		appendCtyResult(&results, getCtyValue(t.CollExpr, ctx))
 		if t.KeyExpr != nil {
@@ -857,11 +1041,21 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		}
 		return results
 	case *hclsyntax.IndexExpr:
+		if val, diags := t.Value(ctx); !diags.HasErrors() && val.IsKnown() && !val.IsNull() {
+			return ctyValueToGo(val)
+		}
 		results := []any{}
 		appendCtyResult(&results, getCtyValue(t.Collection, ctx))
 		appendCtyResult(&results, getCtyValue(t.Key, ctx))
 		return results
 	case *hclsyntax.BinaryOpExpr:
+		// Evaluate the operation so the RESULT is surfaced, not the operands.
+		// `8080 + 1` read as [8080, 1] and `8080 > 80` as [8080, 80], which
+		// defeats every scalar comparison a policy writes against them.
+		// ConditionalExpr and UnaryOpExpr already did this; these arms did not.
+		if val, diags := t.Value(ctx); !diags.HasErrors() && val.IsKnown() && !val.IsNull() {
+			return ctyValueToGo(val)
+		}
 		results := []any{}
 		appendCtyResult(&results, getCtyValue(t.LHS, ctx))
 		appendCtyResult(&results, getCtyValue(t.RHS, ctx))
@@ -877,6 +1071,9 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		}
 		return getCtyValue(t.Val, ctx)
 	case *hclsyntax.SplatExpr:
+		if val, diags := t.Value(ctx); !diags.HasErrors() && val.IsKnown() && !val.IsNull() {
+			return ctyValueToGo(val)
+		}
 		results := []any{}
 		appendCtyResult(&results, getCtyValue(t.Source, ctx))
 		appendCtyResult(&results, getCtyValue(t.Each, ctx))
@@ -943,7 +1140,7 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		// single string. Attempt that first; otherwise fall back to surfacing the
 		// individual parts/references below (the historical behavior when off).
 		if ctx != nil && len(ctx.Variables) > 0 {
-			if subVal, diags := t.Value(ctx); !diags.HasErrors() && subVal.Type() == cty.String {
+			if subVal, diags := t.Value(ctx); !diags.HasErrors() && subVal.IsKnown() && !subVal.IsNull() && subVal.Type() == cty.String {
 				return subVal.AsString()
 			}
 		}
@@ -990,28 +1187,6 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		return v
 	default:
 		log.Warn().Msgf("unknown type %T", t)
-		return nil
-	}
-}
-
-func getReferences(expr hcl.Expression, ctx *hcl.EvalContext) []string {
-	switch t := expr.(type) {
-	case *hclsyntax.ScopeTraversalExpr:
-		traversal := t.Variables()
-		res := []string{}
-		for i := range traversal {
-			tr := traversal[i]
-			for j := range tr {
-				switch v := tr[j].(type) {
-				case hcl.TraverseRoot:
-					res = append(res, v.Name)
-				case hcl.TraverseAttr:
-					res = append(res, v.Name)
-				}
-			}
-		}
-		return res
-	default:
 		return nil
 	}
 }
@@ -1160,7 +1335,7 @@ func (g *mqlTerraformBlock) related() ([]any, error) {
 
 	terraform.lock.Lock()
 	defer terraform.lock.Unlock()
-	related := terraform.relatedBlocks[g.terraformID()]
+	related := terraform.relatedBlocks[g.blockKey()]
 	res := make([]any, len(related))
 	for i := range related {
 		res[i] = related[i]
@@ -1327,8 +1502,16 @@ func initTerraformSettings(runtime *plugin.Runtime, args map[string]*llx.RawData
 						// Shorthand syntax: aws = "~> 3.74"
 						version = v
 					}
+					// Qualify the cache key by the file that declares the
+					// constraint. This init deliberately collects the
+					// required_providers of EVERY `terraform {}` block in the
+					// tree, so keying on the provider name alone made a root
+					// `aws = "~> 3.0"` and a modules/vpc `aws = "~> 5.0"` hash
+					// to one entry — the list then held the first one twice and
+					// the module's constraint was invisible to a pin check.
 					r, err := CreateResource(runtime, "terraform.settings.requiredProvider",
 						map[string]*llx.RawData{
+							"__id":    llx.StringData("terraform.settings.requiredProvider/" + hb.DefRange.Filename + "/" + name),
 							"name":    llx.StringData(name),
 							"source":  llx.StringData(source),
 							"version": llx.StringData(version),

--- a/providers/terraform/resources/hcl_expr_test.go
+++ b/providers/terraform/resources/hcl_expr_test.go
@@ -1,0 +1,185 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// TestGetCtyValue_UnknownFunctionSurfacesReferences is a regression test for
+// arguments() returning an EMPTY list for any expression built with a function
+// the evaluator does not register.
+//
+// The function table carries only jsondecode/jsonencode, so `format`, `merge`,
+// `join`, `lookup`, `try`, `coalesce`, ... all fail evaluation with "Call to
+// unknown function". The FunctionCallExpr arm returned its empty results slice
+// on that failure with no reference fallback (unlike ScopeTraversalExpr and
+// ConditionalExpr, which do surface references), so `arguments["tags"]` came
+// back as `[]` and a tag-governance check saw nothing to complain about.
+func TestGetCtyValue_UnknownFunctionSurfacesReferences(t *testing.T) {
+	t.Run("format", func(t *testing.T) {
+		attrs := parseAttrs(t, `bucket = format("%s-logs", local.env)`)
+		got, err := hclResolvedAttributesToDict(attrs, nil)
+		require.NoError(t, err)
+		assert.True(t, containsString(got["bucket"], "local.env"),
+			"an unresolvable function call must still surface its argument references, got: %#v", got["bucket"])
+	})
+
+	t.Run("merge", func(t *testing.T) {
+		attrs := parseAttrs(t, `tags = merge(var.common_tags, { Name = "x" })`)
+		got, err := hclResolvedAttributesToDict(attrs, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, got["tags"], "merge() must not resolve to an empty value")
+		assert.True(t, containsString(got["tags"], "var.common_tags"),
+			"merge() must surface var.common_tags, got: %#v", got["tags"])
+		assert.True(t, containsString(got["tags"], "x"),
+			"merge() must surface the inline tag value, got: %#v", got["tags"])
+	})
+
+	t.Run("nested", func(t *testing.T) {
+		attrs := parseAttrs(t, `name = join("-", [var.prefix, lookup(local.names, "primary")])`)
+		got, err := hclResolvedAttributesToDict(attrs, nil)
+		require.NoError(t, err)
+		assert.True(t, containsString(got["name"], "var.prefix"),
+			"nested function calls must surface references, got: %#v", got["name"])
+		assert.True(t, containsString(got["name"], "local.names"),
+			"nested function calls must surface references, got: %#v", got["name"])
+	})
+}
+
+// TestGetCtyValue_JsonencodeStillResolves guards the registered-function path
+// against the reference fallback added above: a call that DOES evaluate must
+// keep returning its value, not its argument references.
+func TestGetCtyValue_JsonencodeStillResolves(t *testing.T) {
+	attrs := parseAttrs(t, `policy = jsonencode({ Version = "2012-10-17" })`)
+	got, err := hclResolvedAttributesToDict(attrs, nil)
+	require.NoError(t, err)
+	list, ok := got["policy"].([]any)
+	require.True(t, ok, "expected a list-wrapped map, got: %#v", got["policy"])
+	require.Len(t, list, 1)
+	assert.Equal(t, "2012-10-17", list[0].(map[string]any)["Version"])
+}
+
+// TestGetCtyValue_OperatorsEvaluateToTheirResult is a regression test for
+// BinaryOpExpr, ForExpr, IndexExpr and SplatExpr returning their OPERANDS
+// rather than the computed result.
+//
+// ConditionalExpr and UnaryOpExpr already try t.Value(ctx) first and only fall
+// back to reference-surfacing; these four never did. So `8080 + 1` read as
+// [8080, 1] instead of 8081 and `8080 > 80` read as [8080, 80] instead of true,
+// which defeats every scalar comparison a policy writes against them.
+func TestGetCtyValue_OperatorsEvaluateToTheirResult(t *testing.T) {
+	t.Run("binary arithmetic", func(t *testing.T) {
+		attrs := parseAttrs(t, `sum = 8080 + 1`)
+		got, err := hclResolvedAttributesToDict(attrs, nil)
+		require.NoError(t, err)
+		assert.Equal(t, float64(8081), got["sum"])
+	})
+
+	t.Run("binary comparison", func(t *testing.T) {
+		attrs := parseAttrs(t, `cmp = 8080 > 80`)
+		got, err := hclResolvedAttributesToDict(attrs, nil)
+		require.NoError(t, err)
+		assert.Equal(t, true, got["cmp"])
+	})
+
+	t.Run("binary over resolved locals", func(t *testing.T) {
+		attrs := parseAttrs(t, `open = local.port == 22`)
+		ctx := resolvingCtx(nil, map[string]cty.Value{"port": cty.NumberIntVal(22)})
+		got, err := hclResolvedAttributesToDict(attrs, ctx)
+		require.NoError(t, err)
+		assert.Equal(t, true, got["open"])
+	})
+
+	t.Run("for expression", func(t *testing.T) {
+		attrs := parseAttrs(t, `forx = [for p in local.list : p + 1]`)
+		ctx := resolvingCtx(nil, map[string]cty.Value{
+			"list": cty.TupleVal([]cty.Value{cty.NumberIntVal(10), cty.NumberIntVal(20)}),
+		})
+		got, err := hclResolvedAttributesToDict(attrs, ctx)
+		require.NoError(t, err)
+		assert.Equal(t, []any{float64(11), float64(21)}, got["forx"])
+	})
+
+	t.Run("index expression", func(t *testing.T) {
+		attrs := parseAttrs(t, `dyn = local.m[local.k]`)
+		ctx := resolvingCtx(nil, map[string]cty.Value{
+			"m": cty.ObjectVal(map[string]cty.Value{"a": cty.NumberIntVal(1), "b": cty.NumberIntVal(2)}),
+			"k": cty.StringVal("a"),
+		})
+		got, err := hclResolvedAttributesToDict(attrs, ctx)
+		require.NoError(t, err)
+		assert.Equal(t, float64(1), got["dyn"])
+	})
+
+	t.Run("splat expression", func(t *testing.T) {
+		attrs := parseAttrs(t, `ids = local.items[*].id`)
+		ctx := resolvingCtx(nil, map[string]cty.Value{
+			"items": cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("one")}),
+				cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("two")}),
+			}),
+		})
+		got, err := hclResolvedAttributesToDict(attrs, ctx)
+		require.NoError(t, err)
+		assert.Equal(t, []any{"one", "two"}, got["ids"])
+	})
+}
+
+// TestGetCtyValue_OperatorsKeepReferenceFallback guards the other half: when an
+// operand cannot be evaluated the arms must keep surfacing references rather
+// than collapsing to nil.
+func TestGetCtyValue_OperatorsKeepReferenceFallback(t *testing.T) {
+	cases := map[string]struct{ src, ref string }{
+		"binary": {`match = var.availability_zone == "account_based"`, "var.availability_zone"},
+		"index":  {`subnet_id = local.subnet_id_by_az_suffix[local.az_suffix]`, "local.subnet_id_by_az_suffix"},
+		"splat":  {`instance_ids = data.aws_instances.all[*].id`, "data.aws_instances.all"},
+		"for":    {`sg_ids = [for sg in data.aws_security_group.ec2 : sg.id]`, "data.aws_security_group.ec2"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			attrs := parseAttrs(t, tc.src)
+			got, err := hclResolvedAttributesToDict(attrs, nil)
+			require.NoError(t, err)
+			for _, v := range got {
+				assert.True(t, containsString(v, tc.ref),
+					"unresolvable %s expression must still surface %s, got: %#v", name, tc.ref, v)
+			}
+		})
+	}
+}
+
+// TestGetCtyValue_UnknownStringDoesNotPanic hardens the three AsString() call
+// sites against unknown cty values. cty.Value.AsString panics on a null AND on
+// an unknown value, and an unknown one reaches these paths whenever a function
+// can be resolved but one of its arguments cannot.
+func TestGetCtyValue_UnknownStringDoesNotPanic(t *testing.T) {
+	// `jsonencode(var.x)` with an unknown var evaluates to an UNKNOWN string
+	// with no diagnostic at all — the exact shape that panics on AsString().
+	attrs := parseAttrs(t, `policy = jsonencode(var.unknown_input)`)
+	ctx := resolvingCtx(map[string]cty.Value{"unknown_input": cty.UnknownVal(cty.String)}, nil)
+
+	require.NotPanics(t, func() {
+		got, err := hclResolvedAttributesToDict(attrs, ctx)
+		require.NoError(t, err)
+		_ = got["policy"]
+	})
+}
+
+// TestGetCtyValue_UnknownTemplateDoesNotPanic covers the TemplateExpr
+// AsString() call site with the same unknown-value shape.
+func TestGetCtyValue_UnknownTemplateDoesNotPanic(t *testing.T) {
+	attrs := parseAttrs(t, `name = "app-${var.env}-bucket"`)
+	ctx := resolvingCtx(map[string]cty.Value{"env": cty.UnknownVal(cty.String)}, nil)
+
+	require.NotPanics(t, func() {
+		got, err := hclResolvedAttributesToDict(attrs, ctx)
+		require.NoError(t, err)
+		assert.NotNil(t, got["name"], "an unknown interpolation must still surface something")
+	})
+}

--- a/providers/terraform/resources/hcl_ids_test.go
+++ b/providers/terraform/resources/hcl_ids_test.go
@@ -1,0 +1,247 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+)
+
+// TestTerraformResources_SelectorArgsAreKeyQualified is a regression test for
+// terraform.resources(resource: X) and terraform.resources(name: X) computing
+// the same __id.
+//
+// The checksum was built from the argument VALUE only, and RawData.String()
+// renders a string identically whichever key it came from, so the two selector
+// forms aliased in the resource cache and the second query silently returned
+// the first one's list. Shared literals like "main", "default" and "this" make
+// that collision an everyday occurrence.
+func TestTerraformResources_SelectorArgsAreKeyQualified(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf": `
+resource "web" "app" {}
+resource "aws_instance" "web" {}
+`,
+	})
+	rt := newRuntimeForDir(t, dir)
+
+	byResource, _, err := initTerraformResources(rt, map[string]*llx.RawData{
+		"resource": llx.StringData("web"),
+	})
+	require.NoError(t, err)
+	byName, _, err := initTerraformResources(rt, map[string]*llx.RawData{
+		"name": llx.StringData("web"),
+	})
+	require.NoError(t, err)
+
+	assert.NotEqual(t, byResource["__id"].Value.(string), byName["__id"].Value.(string),
+		`terraform.resources(resource: "web") and (name: "web") must not share a cache key`)
+
+	// And the lists themselves must differ, which is what the collision hid.
+	resList := byResource["list"].Value.([]any)
+	nameList := byName["list"].Value.([]any)
+	require.Len(t, resList, 1)
+	require.Len(t, nameList, 1)
+	assert.Equal(t, "web", resList[0].(*mqlTerraformBlock).Labels.Data[0])
+	assert.Equal(t, "aws_instance", nameList[0].(*mqlTerraformBlock).Labels.Data[0])
+
+	// A combined selector must be distinct from either single-key form.
+	both, _, err := initTerraformResources(rt, map[string]*llx.RawData{
+		"resource": llx.StringData("web"),
+		"name":     llx.StringData("web"),
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, byResource["__id"].Value.(string), both["__id"].Value.(string))
+	assert.NotEqual(t, byName["__id"].Value.(string), both["__id"].Value.(string))
+}
+
+// blockInDir returns the single block from the cache whose declaring file lives
+// in <root>/<sub> and whose labels match.
+func blockInDir(t *testing.T, blocks []any, root, sub string, labels ...string) *mqlTerraformBlock {
+	t.Helper()
+	want := filepath.Join(root, filepath.FromSlash(sub))
+	var found *mqlTerraformBlock
+	for i := range blocks {
+		b := blocks[i].(*mqlTerraformBlock)
+		if b.block.Data == nil {
+			continue
+		}
+		if filepath.Dir(b.block.Data.DefRange.Filename) != want {
+			continue
+		}
+		if len(b.Labels.Data) != len(labels) {
+			continue
+		}
+		match := true
+		for j := range labels {
+			if b.Labels.Data[j] != labels[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			require.Nil(t, found, "more than one block matched %v in %s", labels, sub)
+			found = b
+		}
+	}
+	require.NotNil(t, found, "no block %v found in %s", labels, sub)
+	return found
+}
+
+// TestTerraformBlock_RelatedDoesNotCrossModules is a regression test for
+// terraformID() colliding across files.
+//
+// The connection walks the whole directory tree, so a root `main.tf` and a
+// `modules/vpc/main.tf` that both declare `resource "aws_s3_bucket" "this"`
+// shared one blocksByName key. Both buckets then reported the same related
+// list containing BOTH policies, so a check like "every bucket has a policy
+// denying insecure transport" passed for the module bucket on the strength of
+// the root bucket's policy.
+func TestTerraformBlock_RelatedDoesNotCrossModules(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf": `
+resource "aws_s3_bucket" "this" {}
+
+resource "aws_s3_bucket_policy" "root" {
+  bucket = aws_s3_bucket.this.id
+  policy = "root-policy"
+}
+`,
+		"modules/vpc/main.tf": `
+resource "aws_s3_bucket" "this" {}
+
+resource "aws_s3_bucket_policy" "module" {
+  bucket = aws_s3_bucket.this.id
+  policy = "module-policy"
+}
+`,
+	})
+	rt := newRuntimeForDir(t, dir)
+	tf := newTerraformSingleton(t, rt)
+
+	blocks, err := tf.blocks()
+	require.NoError(t, err)
+
+	rootBucket := blockInDir(t, blocks, dir, ".", "aws_s3_bucket", "this")
+	moduleBucket := blockInDir(t, blocks, dir, "modules/vpc", "aws_s3_bucket", "this")
+	require.NotSame(t, rootBucket, moduleBucket, "the two buckets must be distinct block instances")
+
+	rootRelated, err := rootBucket.related()
+	require.NoError(t, err)
+	require.Len(t, rootRelated, 1, "the root bucket must only relate to the policy in its own directory")
+	assert.Equal(t, "root", rootRelated[0].(*mqlTerraformBlock).Labels.Data[1])
+
+	moduleRelated, err := moduleBucket.related()
+	require.NoError(t, err)
+	require.Len(t, moduleRelated, 1, "the module bucket must only relate to the policy in its own directory")
+	assert.Equal(t, "module", moduleRelated[0].(*mqlTerraformBlock).Labels.Data[1])
+}
+
+// TestTerraformBlock_LabellessBlocksAreNotConflated is a regression test for
+// every label-less block (`terraform {}`, `locals {}`, `moved {}`) mapping to
+// the same empty terraformID key, which made related() report unrelated blocks.
+func TestTerraformBlock_LabellessBlocksAreNotConflated(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf": `
+terraform {}
+
+locals {
+  env = "prod"
+}
+
+moved {
+  from = aws_s3_bucket.old
+  to   = aws_s3_bucket.new
+}
+
+resource "aws_s3_bucket" "new" {}
+`,
+	})
+	rt := newRuntimeForDir(t, dir)
+	tf := newTerraformSingleton(t, rt)
+
+	blocks, err := tf.blocks()
+	require.NoError(t, err)
+	require.Len(t, blocks, 4)
+
+	for i := range blocks {
+		b := blocks[i].(*mqlTerraformBlock)
+		if b.Type.Data != "terraform" && b.Type.Data != "locals" {
+			continue
+		}
+		related, err := b.related()
+		require.NoError(t, err)
+		assert.Emptyf(t, related,
+			"label-less %q block must not inherit the `moved` block's edges through a shared empty id",
+			b.Type.Data)
+	}
+}
+
+// TestTerraformSettings_BackendIsDeterministic is a regression test for
+// terraform.settings.backend flapping between runs.
+//
+// ensureCache built its block list by ranging over parser.Files(), a Go map
+// whose iteration order is randomized per process, and initTerraformSettings
+// took a last-writer-wins backend while iterating those blocks. With two
+// `terraform {}` blocks carrying a backend, a policy asserting
+// backend["type"] == "s3" passed or failed depending on the run.
+func TestTerraformSettings_BackendIsDeterministic(t *testing.T) {
+	files := map[string]string{
+		"a_backend.tf": "terraform {\n  backend \"s3\" {\n    bucket = \"tf-state\"\n  }\n}\n",
+		"z_backend.tf": "terraform {\n  backend \"local\" {\n    path = \"terraform.tfstate\"\n  }\n}\n",
+	}
+
+	var first string
+	for i := 0; i < 40; i++ {
+		rt := newRuntimeForDir(t, writeTfDir(t, files))
+		args, _, err := initTerraformSettings(rt, map[string]*llx.RawData{})
+		require.NoError(t, err)
+		backend, ok := args["backend"].Value.(map[string]any)
+		require.True(t, ok, "backend must be a dict, got %#v", args["backend"].Value)
+		typ, _ := backend["type"].(string)
+		require.NotEmpty(t, typ)
+		if i == 0 {
+			first = typ
+			continue
+		}
+		require.Equalf(t, first, typ,
+			"terraform.settings.backend must be deterministic across runs (iteration %d)", i)
+	}
+}
+
+// TestTerraformSettings_RequiredProvidersDoNotCollideAcrossFiles is a
+// regression test for terraform.settings.requiredProvider ids keyed on the
+// provider name alone.
+//
+// initTerraformSettings deliberately collects the required_providers of EVERY
+// `terraform {}` block in the tree. When the root pins `aws = "~> 3.0"` and
+// modules/vpc pins `aws = "~> 5.0"`, both entries hashed to the same cache key,
+// so the list contained the first entry twice and the module's constraint was
+// invisible to a supply-chain pin check.
+func TestTerraformSettings_RequiredProvidersDoNotCollideAcrossFiles(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf":             "terraform {\n  required_providers {\n    aws = \"~> 3.0\"\n  }\n}\n",
+		"modules/vpc/main.tf": "terraform {\n  required_providers {\n    aws = \"~> 5.0\"\n  }\n}\n",
+	})
+	rt := newRuntimeForDir(t, dir)
+
+	args, _, err := initTerraformSettings(rt, map[string]*llx.RawData{})
+	require.NoError(t, err)
+
+	list := args["requiredProviders"].Value.([]any)
+	require.Len(t, list, 2)
+
+	versions := map[string]bool{}
+	for i := range list {
+		rp := list[i].(*mqlTerraformSettingsRequiredProvider)
+		assert.Equal(t, "aws", rp.Name.Data, "the user-facing name must stay the bare provider name")
+		versions[rp.Version.Data] = true
+	}
+	assert.Equal(t, map[string]bool{"~> 3.0": true, "~> 5.0": true}, versions,
+		"both version constraints must be visible, not the first one twice")
+}

--- a/providers/terraform/resources/hcl_json_test.go
+++ b/providers/terraform/resources/hcl_json_test.go
@@ -1,0 +1,106 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// writeTfDir writes the given relative paths into a fresh temp dir and returns
+// it. Nested paths (e.g. "modules/vpc/main.tf") create their parent dirs.
+func writeTfDir(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range files {
+		full := filepath.Join(dir, filepath.FromSlash(name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o600))
+	}
+	return dir
+}
+
+// newTerraformSingleton returns the terraform singleton for a runtime.
+func newTerraformSingleton(t *testing.T, rt *plugin.Runtime) *mqlTerraform {
+	t.Helper()
+	tfraw, err := CreateResource(rt, "terraform", map[string]*llx.RawData{})
+	require.NoError(t, err)
+	return tfraw.(*mqlTerraform)
+}
+
+// TestTerraformAccessors_JSONFileDoesNotPoisonEveryAccessor is a regression
+// test for a single `.tf.json` file breaking every terraform.* accessor.
+//
+// hclparse.ParseJSON produces a plain hcl.Body (not *hclsyntax.Body), and
+// listRelatedBlocks returned a hard error for that case. That error propagated
+// out of ensureCache, which is the single entry point behind blocks(),
+// providers(), datasources(), variables(), outputs(), terraform.resources and
+// terraform.settings. So one JSON file — the default CDKTF output layout, and a
+// format the schema advertises support for — made all of them fail, including
+// for the native .tf files sitting beside it.
+func TestTerraformAccessors_JSONFileDoesNotPoisonEveryAccessor(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf": `
+variable "env" { default = "prod" }
+output "bucket" { value = aws_s3_bucket.native.id }
+provider "aws" { region = "us-east-1" }
+data "aws_ami" "ubuntu" { most_recent = true }
+resource "aws_s3_bucket" "native" {}
+`,
+		"cdk.tf.json": `{"resource":{"aws_security_group":{"sg":{"name":"allow-ssh"}}}}`,
+	})
+	rt := newRuntimeForDir(t, dir)
+	tf := newTerraformSingleton(t, rt)
+
+	blocks, err := tf.blocks()
+	require.NoError(t, err, "a .tf.json file must not break terraform.blocks")
+	require.NotEmpty(t, blocks)
+
+	providers, err := tf.providers()
+	require.NoError(t, err, "a .tf.json file must not break terraform.providers")
+	assert.Len(t, providers, 1)
+
+	datasources, err := tf.datasources()
+	require.NoError(t, err, "a .tf.json file must not break terraform.datasources")
+	assert.Len(t, datasources, 1)
+
+	variables, err := tf.variables()
+	require.NoError(t, err, "a .tf.json file must not break terraform.variables")
+	assert.Len(t, variables, 1)
+
+	outputs, err := tf.outputs()
+	require.NoError(t, err, "a .tf.json file must not break terraform.outputs")
+	assert.Len(t, outputs, 1)
+
+	args, _, err := initTerraformResources(rt, map[string]*llx.RawData{})
+	require.NoError(t, err, "a .tf.json file must not break terraform.resources")
+	list := args["list"].Value.([]any)
+	require.NotEmpty(t, list, "the native .tf resource must still be listed")
+
+	// The related() graph must resolve too, rather than erroring out.
+	native := list[0].(*mqlTerraformBlock)
+	_, err = native.related()
+	require.NoError(t, err, "a .tf.json file must not break terraform.block.related")
+}
+
+// TestTerraformSettings_JSONFileDoesNotPoisonInit covers the settings init,
+// which shares the same ensureCache entry point.
+func TestTerraformSettings_JSONFileDoesNotPoisonInit(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf":     "terraform {\n  required_providers {\n    aws = \"~> 3.0\"\n  }\n}\n",
+		"cdk.tf.json": `{"resource":{"aws_security_group":{"sg":{"name":"allow-ssh"}}}}`,
+	})
+	rt := newRuntimeForDir(t, dir)
+
+	args, _, err := initTerraformSettings(rt, map[string]*llx.RawData{})
+	require.NoError(t, err, "a .tf.json file must not break terraform.settings")
+	require.NotNil(t, args)
+	require.Len(t, args["requiredProviders"].Value.([]any), 1)
+}

--- a/providers/terraform/resources/hcl_race_test.go
+++ b/providers/terraform/resources/hcl_race_test.go
@@ -139,3 +139,61 @@ func TestTerraformResources_UnfilteredStableID(t *testing.T) {
 	require.NotEqual(t, selID, sel2["__id"].Value.(string),
 		"distinct terraform.resources(\"type\") selectors must have distinct __ids")
 }
+
+// TestNewMqlHclBlock_ConcurrentStamping is a regression test for a data race in
+// newMqlHclBlock. It wrote r.block and r.cachedFile unconditionally after
+// CreateResource — but CreateResource returns the ALREADY CACHED instance when
+// the __id matches. Two goroutines reaching the same block through
+// terraform.blocks and terraform.file(path).blocks therefore wrote the same
+// struct fields at the same time.
+//
+// Run with -race; the fix must also leave the internals correctly populated.
+func TestNewMqlHclBlock_ConcurrentStamping(t *testing.T) {
+	const iterations = 50
+
+	for i := 0; i < iterations; i++ {
+		rt := newHclRaceRuntime(t)
+
+		tfraw, err := CreateResource(rt, "terraform", map[string]*llx.RawData{})
+		require.NoError(t, err)
+		tf := tfraw.(*mqlTerraform)
+
+		filesRaw, err := tf.files()
+		require.NoError(t, err)
+		require.NotEmpty(t, filesRaw)
+
+		var wg sync.WaitGroup
+		// One goroutine walks every block through the terraform singleton...
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tf.GetBlocks()
+		}()
+		// ... while others re-list the same blocks per file, which hits the
+		// same cached terraform.block instances.
+		for f := range filesRaw {
+			file := filesRaw[f].(*mqlTerraformFile)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				blocks, err := file.blocks()
+				if err != nil {
+					return
+				}
+				for b := range blocks {
+					// Read the internals the other goroutines are stamping.
+					_ = blocks[b].(*mqlTerraformBlock).block.Data
+				}
+			}()
+		}
+		wg.Wait()
+
+		blocks, err := tf.blocks()
+		require.NoError(t, err)
+		for b := range blocks {
+			block := blocks[b].(*mqlTerraformBlock)
+			require.NotNil(t, block.block.Data, "block internals must still be populated")
+			require.NotNil(t, block.cachedFile.Data, "file internals must still be populated")
+		}
+	}
+}

--- a/providers/terraform/resources/hcl_related_test.go
+++ b/providers/terraform/resources/hcl_related_test.go
@@ -1,0 +1,165 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// relatedLabels returns the label tuples of a block's related() list, so tests
+// can assert on the graph without caring about ordering.
+func relatedLabels(t *testing.T, b *mqlTerraformBlock) map[string]bool {
+	t.Helper()
+	related, err := b.related()
+	require.NoError(t, err)
+	out := map[string]bool{}
+	for i := range related {
+		rb := related[i].(*mqlTerraformBlock)
+		key := rb.Type.Data
+		for _, l := range rb.Labels.Data {
+			key += "." + l.(string)
+		}
+		out[key] = true
+	}
+	return out
+}
+
+// TestRelated_ResolvesPrefixedReferences is a regression test for related()
+// only ever resolving managed-resource references.
+//
+// The lookup joined refs[0:2], which forms a valid key only for
+// `<type>.<name>`. A `data.aws_ami.ubuntu.id` reference produced the key
+// `data\x00aws_ami` while the data block's own id is `aws_ami\x00ubuntu`, so
+// data sources, modules and variables never appeared in the graph at all.
+func TestRelated_ResolvesPrefixedReferences(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf": `
+variable "instance_type" { default = "t3.micro" }
+
+data "aws_ami" "ubuntu" { most_recent = true }
+
+module "vpc" { source = "./modules/vpc" }
+
+resource "aws_instance" "web" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = var.instance_type
+  subnet_id     = module.vpc.subnet_id
+}
+`,
+	})
+	rt := newRuntimeForDir(t, dir)
+	tf := newTerraformSingleton(t, rt)
+
+	blocks, err := tf.blocks()
+	require.NoError(t, err)
+	web := blockInDir(t, blocks, dir, ".", "aws_instance", "web")
+
+	got := relatedLabels(t, web)
+	assert.True(t, got["data.aws_ami.ubuntu"], "data.* reference must resolve, got: %v", got)
+	assert.True(t, got["variable.instance_type"], "var.* reference must resolve, got: %v", got)
+	assert.True(t, got["module.vpc"], "module.* reference must resolve, got: %v", got)
+
+	// The inverse edges must be there too.
+	ami := blockInDir(t, blocks, dir, ".", "aws_ami", "ubuntu")
+	assert.True(t, relatedLabels(t, ami)["resource.aws_instance.web"],
+		"the data source must relate back to the resource that uses it")
+}
+
+// TestRelated_ResolvesReferencesInsideNestedBlocks is a regression test for
+// related() walking only body.Attributes. A reference written inside a nested
+// block — the standard shape for a security-group rule — was never seen.
+func TestRelated_ResolvesReferencesInsideNestedBlocks(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf": `
+resource "aws_security_group" "bastion" {
+  name = "bastion"
+}
+
+resource "aws_security_group" "app" {
+  name = "app"
+
+  ingress {
+    from_port       = 22
+    to_port         = 22
+    security_groups = [aws_security_group.bastion.id]
+  }
+}
+`,
+	})
+	rt := newRuntimeForDir(t, dir)
+	tf := newTerraformSingleton(t, rt)
+
+	blocks, err := tf.blocks()
+	require.NoError(t, err)
+	app := blockInDir(t, blocks, dir, ".", "aws_security_group", "app")
+
+	assert.True(t, relatedLabels(t, app)["resource.aws_security_group.bastion"],
+		"a reference inside a nested block must be part of the related graph")
+}
+
+// TestRelated_ResolvesReferencesInsideExpressions is a regression test for
+// getReferences() handling only bare ScopeTraversalExpr. References buried in a
+// template, a list, a conditional or a function call were invisible.
+func TestRelated_ResolvesReferencesInsideExpressions(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf": `
+resource "aws_s3_bucket" "logs" {
+  bucket = "logs"
+}
+
+resource "aws_s3_bucket" "data" {
+  bucket = "data"
+}
+
+resource "aws_s3_bucket_policy" "p" {
+  bucket    = "x-${aws_s3_bucket.logs.id}"
+  targets   = [aws_s3_bucket.data.arn]
+  encoded   = jsonencode({ b = aws_s3_bucket.logs.arn })
+}
+`,
+	})
+	rt := newRuntimeForDir(t, dir)
+	tf := newTerraformSingleton(t, rt)
+
+	blocks, err := tf.blocks()
+	require.NoError(t, err)
+	policy := blockInDir(t, blocks, dir, ".", "aws_s3_bucket_policy", "p")
+
+	got := relatedLabels(t, policy)
+	assert.True(t, got["resource.aws_s3_bucket.logs"],
+		"a reference inside a template/function must resolve, got: %v", got)
+	assert.True(t, got["resource.aws_s3_bucket.data"],
+		"a reference inside a list must resolve, got: %v", got)
+}
+
+// TestRelated_DeduplicatesRepeatedReferences keeps the graph free of duplicate
+// edges now that every traversal in an expression tree is walked: a block
+// referenced twice must appear once.
+func TestRelated_DeduplicatesRepeatedReferences(t *testing.T) {
+	dir := writeTfDir(t, map[string]string{
+		"main.tf": `
+resource "aws_s3_bucket" "b" {
+  bucket = "b"
+}
+
+resource "aws_s3_bucket_policy" "p" {
+  bucket = aws_s3_bucket.b.id
+  policy = aws_s3_bucket.b.arn
+}
+`,
+	})
+	rt := newRuntimeForDir(t, dir)
+	tf := newTerraformSingleton(t, rt)
+
+	blocks, err := tf.blocks()
+	require.NoError(t, err)
+	policy := blockInDir(t, blocks, dir, ".", "aws_s3_bucket_policy", "p")
+
+	related, err := policy.related()
+	require.NoError(t, err)
+	assert.Len(t, related, 1, "a block referenced twice must produce one related edge")
+}

--- a/providers/terraform/resources/terraform.lr.go
+++ b/providers/terraform/resources/terraform.lr.go
@@ -2403,7 +2403,7 @@ func (c *mqlTerraformPlanResourceChange) GetActionReason() *plugin.TValue[string
 type mqlTerraformPlanProposedChange struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlTerraformPlanProposedChangeInternal it will be used here
+	mqlTerraformPlanProposedChangeInternal
 	Address         plugin.TValue[string]
 	Actions         plugin.TValue[[]any]
 	Before          plugin.TValue[any]

--- a/providers/terraform/resources/tfplan.go
+++ b/providers/terraform/resources/tfplan.go
@@ -5,7 +5,9 @@ package resources
 
 import (
 	"encoding/json"
+	"sync"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
@@ -31,10 +33,18 @@ func initTerraformPlan(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	// TODO: This only creates compatibility with v8. Please revisit this section
 	// after https://github.com/mondoohq/mql/issues/1943 is clarified.
 	if plan == nil {
+		// Every static field has to be filled in, not just some. MQL's
+		// three-valued logic makes `terraform.plan { !errored && applyable }`
+		// evaluate to TRUE over two nulls, so leaving applyable/errored unset
+		// let a "the plan is clean" assertion pass on an asset with no plan at
+		// all.
 		return map[string]*llx.RawData{
 			"formatVersion":    llx.StringData(""),
 			"terraformVersion": llx.StringData(""),
 			"resourceChanges":  llx.ArrayData([]any{}, types.Resource("terraform.plan.resourceChange")),
+			"applyable":        llx.BoolData(false),
+			"errored":          llx.BoolData(false),
+			"variables":        llx.ArrayData([]any{}, types.Resource("terraform.plan.variable")),
 		}, nil, nil
 	}
 
@@ -44,7 +54,7 @@ func initTerraformPlan(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	args["errored"] = llx.BoolData(plan.Errored)
 	args["variables"] = llx.ArrayData(
 		variablesToArrayInterface(runtime, plan.Variables),
-		types.Resource("terraform.plan.variables"),
+		types.Resource("terraform.plan.variable"),
 	)
 
 	return args, nil, nil
@@ -119,6 +129,7 @@ func (t *mqlTerraformPlan) resourceChanges() ([]any, error) {
 		}
 
 		lumiChange, err := CreateResource(t.MqlRuntime, "terraform.plan.proposedChange", map[string]*llx.RawData{
+			"__id":            llx.StringData(proposedChangeID(rc.Address, rc.Deposed)),
 			"address":         llx.StringData(rc.Address),
 			"actions":         llx.ArrayData(convert.SliceAnyToInterface[string](rc.Change.Actions), types.String),
 			"before":          llx.MapData(before, types.Any),
@@ -131,6 +142,8 @@ func (t *mqlTerraformPlan) resourceChanges() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		pc := lumiChange.(*mqlTerraformPlanProposedChange)
+		pc.stampOnce.Do(func() { pc.deposed = rc.Deposed })
 
 		r, err := CreateResource(t.MqlRuntime, "terraform.plan.resourceChange", map[string]*llx.RawData{
 			"address":         llx.StringData(rc.Address),
@@ -153,14 +166,34 @@ func (t *mqlTerraformPlan) resourceChanges() ([]any, error) {
 	return list, nil
 }
 
+// Terraform emits a separate resource_changes entry for a deposed object with
+// the SAME address, distinguished only by the `deposed` key. Without it in the
+// id both entries hash to one cache key, so the deposed change is invisible
+// while resourceChanges.length still counts two.
 func (t *mqlTerraformPlanResourceChange) id() (string, error) {
-	id := t.Address
-	return "terraform.plan.resourceChange/address/" + id.Data, nil
+	id := "terraform.plan.resourceChange/address/" + t.Address.Data
+	if t.Deposed.Data != "" {
+		id += "/deposed/" + t.Deposed.Data
+	}
+	return id, nil
 }
 
 func (t *mqlTerraformPlanProposedChange) id() (string, error) {
-	id := t.Address
-	return "terraform.plan.proposedChange/address/" + id.Data, nil
+	id := "terraform.plan.proposedChange/address/" + t.Address.Data
+	if t.deposed != "" {
+		id += "/deposed/" + t.deposed
+	}
+	return id, nil
+}
+
+// mqlTerraformPlanProposedChangeInternal carries the deposed key of the
+// resource change this proposal belongs to. The proposal is not addressable on
+// its own, so it needs the same disambiguation its parent does.
+type mqlTerraformPlanProposedChangeInternal struct {
+	// stampOnce guards the write below: CreateResource returns the cached
+	// instance when the __id matches, so this runs on a possibly-shared struct.
+	stampOnce sync.Once
+	deposed   string
 }
 
 func (t *mqlTerraformPlanConfiguration) id() (string, error) {
@@ -250,16 +283,25 @@ func (t *mqlTerraformPlanConfiguration) resources() ([]any, error) {
 func variablesToArrayInterface(runtime *plugin.Runtime, variables connection.Variables) []any {
 	var list []any
 	for k, v := range variables {
+		// Variable.Value is a json.RawMessage with omitempty, so a variable
+		// serialized as {} arrives as nil and json.Unmarshal(nil, ...) fails.
+		// Skipping it dropped the variable from the list entirely, so an audit
+		// asserting "every declared variable has a value" could not see the one
+		// that does not. Emit it with a null value instead.
 		var value any
-		err := json.Unmarshal(v.Value, &value)
-		if err != nil {
-			continue
+		if len(v.Value) > 0 {
+			if err := json.Unmarshal(v.Value, &value); err != nil {
+				log.Warn().Str("variable", k).Err(err).Msg("cannot decode terraform plan variable value")
+				value = nil
+			}
 		}
+
 		variable, err := CreateResource(runtime, "terraform.plan.variable", map[string]*llx.RawData{
 			"name":  llx.StringData(k),
-			"value": llx.AnyData(value),
+			"value": llx.DictData(value),
 		})
 		if err != nil {
+			log.Error().Str("variable", k).Err(err).Msg("cannot create terraform plan variable")
 			continue
 		}
 
@@ -267,4 +309,15 @@ func variablesToArrayInterface(runtime *plugin.Runtime, variables connection.Var
 	}
 
 	return list
+}
+
+// proposedChangeID mirrors mqlTerraformPlanProposedChange.id(). The creator
+// passes it explicitly because the deposed key lives on the parent resource
+// change, not on the proposal's own fields.
+func proposedChangeID(address, deposed string) string {
+	id := "terraform.plan.proposedChange/address/" + address
+	if deposed != "" {
+		id += "/deposed/" + deposed
+	}
+	return id
 }

--- a/providers/terraform/resources/tfplan_test.go
+++ b/providers/terraform/resources/tfplan_test.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers/terraform/connection"
+	"go.mondoo.com/mql/utils/syncx"
 )
 
 // TestTerraformPlanResourceChanges_NilPlan verifies that resourceChanges() does
@@ -25,4 +27,119 @@ func TestTerraformPlanResourceChanges_NilPlan(t *testing.T) {
 	res, err := p.resourceChanges()
 	require.NoError(t, err)
 	assert.Empty(t, res)
+}
+
+// TestTerraformPlan_NilPlanSetsStaticFields is a regression test for
+// terraform.plan.applyable / .errored / .variables resolving UNSET on an asset
+// with no plan.
+//
+// The nil-plan branch of the init filled in only formatVersion,
+// terraformVersion and resourceChanges. MQL three-valued logic then made
+// `terraform.plan { !errored && applyable }` evaluate to TRUE over two nulls,
+// so a "the plan is clean" assertion passed on an asset that carries no plan
+// at all.
+func TestTerraformPlan_NilPlanSetsStaticFields(t *testing.T) {
+	runtime := &plugin.Runtime{
+		Connection: &connection.Connection{},
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+
+	args, _, err := initTerraformPlan(runtime, map[string]*llx.RawData{})
+	require.NoError(t, err)
+	require.NotNil(t, args)
+
+	require.Contains(t, args, "applyable", "applyable must be set, not left unset")
+	assert.Equal(t, false, args["applyable"].Value)
+	require.Contains(t, args, "errored", "errored must be set, not left unset")
+	assert.Equal(t, false, args["errored"].Value)
+	require.Contains(t, args, "variables", "variables must be set, not left unset")
+	assert.Empty(t, args["variables"].Value)
+}
+
+// TestTerraformPlanResourceChange_DeposedDisambiguatesID is a regression test
+// for the resourceChange / proposedChange ids dropping the `deposed` key.
+//
+// Terraform emits a separate resource_changes entry for a deposed object with
+// the SAME address, distinguished only by `deposed`. Both hashed to one cache
+// key, so the deposed change was invisible while resourceChanges.length still
+// counted two.
+func TestTerraformPlanResourceChange_DeposedDisambiguatesID(t *testing.T) {
+	rt := newRuntimeForPlanJSON(t, `{
+  "format_version": "1.2",
+  "terraform_version": "1.6.0",
+  "resource_changes": [
+    {
+      "address": "aws_instance.web", "mode": "managed", "type": "aws_instance", "name": "web",
+      "change": { "actions": ["update"] }
+    },
+    {
+      "address": "aws_instance.web", "mode": "managed", "type": "aws_instance", "name": "web",
+      "deposed": "abc12345",
+      "change": { "actions": ["delete"] }
+    }
+  ]
+}`)
+
+	obj, err := NewResource(rt, "terraform.plan", map[string]*llx.RawData{})
+	require.NoError(t, err)
+	list, err := obj.(*mqlTerraformPlan).resourceChanges()
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+
+	changeIDs := map[string]bool{}
+	proposedIDs := map[string]bool{}
+	for i := range list {
+		rc := list[i].(*mqlTerraformPlanResourceChange)
+		id, err := rc.id()
+		require.NoError(t, err)
+		changeIDs[id] = true
+
+		pid, err := rc.Change.Data.id()
+		require.NoError(t, err)
+		proposedIDs[pid] = true
+	}
+	assert.Len(t, changeIDs, 2, "a deposed change must not share a cache key with the current change")
+	assert.Len(t, proposedIDs, 2, "the proposed change carries the same collision")
+
+	// And the two entries must really be distinct objects with distinct actions.
+	actions := map[string]bool{}
+	for i := range list {
+		rc := list[i].(*mqlTerraformPlanResourceChange)
+		actions[rc.Change.Data.Actions.Data[0].(string)] = true
+	}
+	assert.Equal(t, map[string]bool{"update": true, "delete": true}, actions)
+}
+
+// TestTerraformPlanVariables_ValuelessVariableIsKept is a regression test for
+// plan variables with no value being dropped entirely.
+//
+// Variable.Value is a json.RawMessage with omitempty, so a variable serialized
+// as {} decodes to nil and json.Unmarshal(nil, ...) fails — and the loop
+// `continue`d, deleting the variable from the list. An audit asserting "every
+// declared variable has a value" therefore could not see the one that does not.
+func TestTerraformPlanVariables_ValuelessVariableIsKept(t *testing.T) {
+	rt := newRuntimeForPlanJSON(t, `{
+  "format_version": "1.2",
+  "terraform_version": "1.6.0",
+  "variables": {
+    "region": { "value": "us-east-1" },
+    "db_password": {}
+  }
+}`)
+
+	args, _, err := initTerraformPlan(rt, map[string]*llx.RawData{})
+	require.NoError(t, err)
+
+	list := args["variables"].Value.([]any)
+	require.Len(t, list, 2, "a variable with no value must still be listed")
+
+	byName := map[string]*mqlTerraformPlanVariable{}
+	for i := range list {
+		v := list[i].(*mqlTerraformPlanVariable)
+		byName[v.Name.Data] = v
+	}
+	require.Contains(t, byName, "db_password")
+	assert.Equal(t, "us-east-1", byName["region"].Value.Data)
+	assert.Nil(t, byName["db_password"].Value.Data,
+		"the valueless variable must read as null, not be missing")
 }

--- a/providers/terraform/resources/tfstate.go
+++ b/providers/terraform/resources/tfstate.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
@@ -35,11 +36,21 @@ func initTerraformState(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	return args, nil, nil
 }
 
+// errNoState is returned by the terraform.state accessors on an asset that
+// carries no state (an HCL or plan asset). conn.State() returns (nil, nil)
+// there, and every accessor below used to check only state.Values — so a
+// terraform.state.* query against such an asset dereferenced a nil state and
+// took the provider down.
+var errNoState = errors.New("cannot find state: this asset does not carry terraform state")
+
 func (t *mqlTerraformState) outputs() ([]any, error) {
 	conn := t.MqlRuntime.Connection.(*connection.Connection)
 	state, err := conn.State()
 	if err != nil {
 		return nil, err
+	}
+	if state == nil {
+		return nil, errNoState
 	}
 
 	if state.Values == nil {
@@ -72,6 +83,10 @@ func (t *mqlTerraformState) rootModule() (*mqlTerraformStateModule, error) {
 		return nil, err
 	}
 
+	if state == nil {
+		return nil, errNoState
+	}
+
 	// A state with `values` present but no `root_module` (e.g. outputs-only or
 	// a trimmed state) decodes to a non-nil Values with a nil RootModule;
 	// guard both so we don't dereference nil.
@@ -92,6 +107,10 @@ func (t *mqlTerraformState) modules() ([]any, error) {
 	state, err := conn.State()
 	if err != nil {
 		return nil, err
+	}
+
+	if state == nil {
+		return nil, errNoState
 	}
 
 	if state.Values == nil || state.Values.RootModule == nil {
@@ -123,6 +142,10 @@ func (t *mqlTerraformState) resources() ([]any, error) {
 	providerState, err := conn.State()
 	if err != nil {
 		return nil, err
+	}
+
+	if providerState == nil {
+		return nil, errNoState
 	}
 
 	if providerState.Values == nil || providerState.Values.RootModule == nil {
@@ -162,14 +185,29 @@ func initTerraformStateOutput(runtime *plugin.Runtime, args map[string]*llx.RawD
 	// check if identifier is there
 	nameRaw := args["identifier"]
 	if nameRaw != nil {
-		name := nameRaw.Value.(string)
-		obj, err := CreateResource(runtime, "terraform.state", nil)
+		// RawData.Value is nil for a null argument, and a bare `.(string)`
+		// assertion on that panics — which crashes the whole scan, since query
+		// blocks run in goroutines.
+		name, ok := nameRaw.Value.(string)
+		if !ok {
+			return nil, nil, errors.New("terraform.state.output requires a string identifier")
+		}
+		// NewResource, not CreateResource: only NewResource runs
+		// initTerraformState, whose "cannot find state" guard is what keeps this
+		// from walking a nil state on an HCL or plan asset. CreateResource also
+		// registered an uninitialized instance under terraform.state's constant
+		// id, so a later correct lookup returned that husk and
+		// terraform.state.formatVersion read as unset.
+		obj, err := NewResource(runtime, "terraform.state", map[string]*llx.RawData{})
 		if err != nil {
 			return nil, nil, err
 		}
 		tfstate := obj.(*mqlTerraformState)
 
 		outputs := tfstate.GetOutputs()
+		if outputs.Error != nil {
+			return nil, nil, outputs.Error
+		}
 		for i := range outputs.Data {
 			o := outputs.Data[i].(*mqlTerraformStateOutput)
 			id := o.Identifier.Data
@@ -177,6 +215,11 @@ func initTerraformStateOutput(runtime *plugin.Runtime, args map[string]*llx.RawD
 				return nil, o, nil
 			}
 		}
+
+		// Falling through here would have the runtime build an output with no
+		// value and no type, whose id collides with nothing useful; report the
+		// miss instead.
+		return nil, nil, fmt.Errorf("terraform.state.output with identifier %q not found", name)
 	}
 
 	return args, nil, nil
@@ -214,9 +257,12 @@ func (t mqlTerraformStateOutput) compute_type() (any, error) {
 func (t *mqlTerraformStateModule) id() (string, error) {
 	address := t.Address
 
-	name := "terraform.module"
+	// A state root module omits its address, so it needs an id of its own. The
+	// previous bare "terraform.module" was also whatever a blank, lookup-miss
+	// module computed, so the two shared a cache key.
+	name := "terraform.state.module/root"
 	if address.Data != "" {
-		name += "/address/" + address.Data
+		name = "terraform.state.module/address/" + address.Data
 	}
 
 	return name, nil
@@ -235,14 +281,23 @@ func initTerraformStateModule(runtime *plugin.Runtime, args map[string]*llx.RawD
 
 	idRaw := args["identifier"]
 	if idRaw != nil {
-		identifier := idRaw.Value.(string)
-		obj, err := CreateResource(runtime, "terraform.state", nil)
+		identifier, ok := idRaw.Value.(string)
+		if !ok {
+			return nil, nil, errors.New("terraform.state.module requires a string identifier")
+		}
+		// See initTerraformStateOutput: NewResource runs initTerraformState,
+		// which both guards the nil state and keeps the terraform.state
+		// singleton from being cached uninitialized.
+		obj, err := NewResource(runtime, "terraform.state", map[string]*llx.RawData{})
 		if err != nil {
 			return nil, nil, err
 		}
 		tfstate := obj.(*mqlTerraformState)
 
 		modules := tfstate.GetModules()
+		if modules.Error != nil {
+			return nil, nil, modules.Error
+		}
 		for i := range modules.Data {
 			o := modules.Data[i].(*mqlTerraformStateModule)
 			id := o.Address.Data
@@ -250,7 +305,11 @@ func initTerraformStateModule(runtime *plugin.Runtime, args map[string]*llx.RawD
 				return nil, o, nil
 			}
 		}
-		delete(args, "identifier")
+
+		// Dropping the identifier and falling through built a module with no
+		// address, whose id was the ROOT module's id — so a typo'd address
+		// silently resolved to the root module's contents.
+		return nil, nil, fmt.Errorf("terraform.state.module with address %q not found", identifier)
 	}
 
 	return args, nil, nil
@@ -334,6 +393,14 @@ func (t *mqlTerraformStateResource) id() (string, error) {
 	name := "terraform.state.resource"
 	if address.Data != "" {
 		name += "/address/" + address.Data
+	}
+
+	// Terraform records a deposed object as a separate entry carrying the SAME
+	// address, distinguished only by deposed_key. Without it both entries hash
+	// to one cache key and the deposed object is invisible while the list still
+	// reports two.
+	if t.DeposedKey.Data != "" {
+		name += "/deposed/" + t.DeposedKey.Data
 	}
 
 	return name, nil

--- a/providers/terraform/resources/tfstate_test.go
+++ b/providers/terraform/resources/tfstate_test.go
@@ -1,0 +1,298 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/terraform/connection"
+	"go.mondoo.com/mql/utils/syncx"
+)
+
+// newRuntimeForStateJSON builds a runtime over a real state connection reading
+// the supplied JSON, mirroring newRuntimeForDir for HCL assets.
+func newRuntimeForStateJSON(t *testing.T, stateJSON string) *plugin.Runtime {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "terraform.tfstate")
+	require.NoError(t, os.WriteFile(path, []byte(stateJSON), 0o600))
+
+	asset := &inventory.Asset{
+		Connections: []*inventory.Config{
+			{Type: "state", Options: map[string]string{"path": path}},
+		},
+	}
+	conn, err := connection.NewStateConnection(1, asset)
+	require.NoError(t, err)
+	return &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+}
+
+// newRuntimeForPlanJSON builds a runtime over a real plan connection reading
+// the supplied JSON.
+func newRuntimeForPlanJSON(t *testing.T, planJSON string) *plugin.Runtime {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "plan.json")
+	require.NoError(t, os.WriteFile(path, []byte(planJSON), 0o600))
+
+	asset := &inventory.Asset{
+		Connections: []*inventory.Config{
+			{Type: "plan", Options: map[string]string{"path": path}},
+		},
+	}
+	conn, err := connection.NewPlanConnection(1, asset)
+	require.NoError(t, err)
+	return &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+}
+
+const stateWithModules = `{
+  "format_version": "1.0",
+  "terraform_version": "1.6.0",
+  "values": {
+    "outputs": {
+      "endpoint": { "sensitive": false, "value": "https://example.com", "type": "string" }
+    },
+    "root_module": {
+      "resources": [
+        { "address": "aws_s3_bucket.root", "mode": "managed", "type": "aws_s3_bucket", "name": "root" }
+      ],
+      "child_modules": [
+        {
+          "address": "module.vpc",
+          "resources": [
+            { "address": "aws_subnet.a", "mode": "managed", "type": "aws_subnet", "name": "a" }
+          ]
+        }
+      ]
+    }
+  }
+}`
+
+// TestTerraformStateOutput_InitOnNonStateAssetDoesNotPanic is a regression test
+// for a nil-pointer crash on terraform.state.output(...) against an HCL asset.
+//
+// The init used CreateResource("terraform.state", nil), which does NOT run
+// initTerraformState, so the "cannot find state" guard was bypassed. conn.State()
+// returns (nil, nil) for HCL and plan assets, and outputs() then dereferenced
+// the nil state.
+func TestTerraformStateOutput_InitOnNonStateAssetDoesNotPanic(t *testing.T) {
+	rt := newRuntimeForDir(t, writeTfDir(t, map[string]string{
+		"main.tf": "resource \"aws_s3_bucket\" \"b\" {}\n",
+	}))
+
+	require.NotPanics(t, func() {
+		_, _, err := initTerraformStateOutput(rt, map[string]*llx.RawData{
+			"identifier": llx.StringData("x"),
+		})
+		assert.Error(t, err, "there is no state on an HCL asset, so the lookup must report that")
+	})
+}
+
+// TestTerraformStateModule_InitOnNonStateAssetDoesNotPanic covers the sibling
+// init, which had the same shape.
+func TestTerraformStateModule_InitOnNonStateAssetDoesNotPanic(t *testing.T) {
+	rt := newRuntimeForDir(t, writeTfDir(t, map[string]string{
+		"main.tf": "resource \"aws_s3_bucket\" \"b\" {}\n",
+	}))
+
+	require.NotPanics(t, func() {
+		_, _, err := initTerraformStateModule(rt, map[string]*llx.RawData{
+			"identifier": llx.StringData("module.vpc"),
+		})
+		assert.Error(t, err, "there is no state on an HCL asset, so the lookup must report that")
+	})
+}
+
+// TestTerraformStateAccessors_NilStateDoNotPanic covers the belt-and-braces
+// guards: every terraform.state collection accessor assumed a non-nil state and
+// only checked state.Values.
+func TestTerraformStateAccessors_NilStateDoNotPanic(t *testing.T) {
+	runtime := &plugin.Runtime{
+		Connection: &connection.Connection{},
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+	newState := func() *mqlTerraformState {
+		s := &mqlTerraformState{}
+		s.MqlRuntime = runtime
+		return s
+	}
+
+	require.NotPanics(t, func() {
+		_, err := newState().outputs()
+		assert.Error(t, err)
+	})
+	require.NotPanics(t, func() {
+		_, err := newState().rootModule()
+		assert.Error(t, err)
+	})
+	require.NotPanics(t, func() {
+		_, err := newState().modules()
+		assert.Error(t, err)
+	})
+	require.NotPanics(t, func() {
+		_, err := newState().resources()
+		assert.Error(t, err)
+	})
+}
+
+// TestTerraformState_OutputLookupDoesNotPoisonTheSingleton is a regression test
+// for the uninitialized terraform.state instance being cached.
+//
+// terraform.state's id() is a constant, so the CreateResource in the output
+// init registered an instance whose formatVersion/terraformVersion were never
+// populated under the shared "terraform.state" cache key. A later, correct
+// NewResource then returned that husk, and formatVersion read as unset —
+// surfacing client-side as "llx: encountered a primitive with no type
+// information". Whether a scan saw it depended purely on query order.
+func TestTerraformState_OutputLookupDoesNotPoisonTheSingleton(t *testing.T) {
+	rt := newRuntimeForStateJSON(t, stateWithModules)
+
+	// Ask for an output FIRST — this is the order that poisoned the cache.
+	_, res, err := initTerraformStateOutput(rt, map[string]*llx.RawData{
+		"identifier": llx.StringData("endpoint"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	// Now resolve the state itself; it must be fully initialized.
+	obj, err := NewResource(rt, "terraform.state", map[string]*llx.RawData{})
+	require.NoError(t, err)
+	state := obj.(*mqlTerraformState)
+	assert.Equal(t, "1.0", state.FormatVersion.Data,
+		"terraform.state.formatVersion must be populated regardless of query order")
+	assert.Equal(t, "1.6.0", state.TerraformVersion.Data)
+}
+
+// TestTerraformState_ModuleLookupDoesNotPoisonTheSingleton is the same
+// regression through terraform.state.module(...).
+func TestTerraformState_ModuleLookupDoesNotPoisonTheSingleton(t *testing.T) {
+	rt := newRuntimeForStateJSON(t, stateWithModules)
+
+	_, res, err := initTerraformStateModule(rt, map[string]*llx.RawData{
+		"identifier": llx.StringData("module.vpc"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	obj, err := NewResource(rt, "terraform.state", map[string]*llx.RawData{})
+	require.NoError(t, err)
+	state := obj.(*mqlTerraformState)
+	assert.Equal(t, "1.0", state.FormatVersion.Data,
+		"terraform.state.formatVersion must be populated regardless of query order")
+}
+
+// TestTerraformStateModule_MissReportsNotFound is a regression test for the
+// lookup-miss husk.
+//
+// On a miss the init deleted "identifier" and returned (args, nil, nil), so the
+// runtime built a module with no address. id() then returned the bare
+// "terraform.module" — exactly the id of the ROOT module, whose address is
+// omitted in state — so the husk and the root module shared a cache key and a
+// typo'd address silently resolved to the root module's contents.
+func TestTerraformStateModule_MissReportsNotFound(t *testing.T) {
+	rt := newRuntimeForStateJSON(t, stateWithModules)
+
+	_, res, err := initTerraformStateModule(rt, map[string]*llx.RawData{
+		"identifier": llx.StringData("module.nope"),
+	})
+	require.Error(t, err, "a module address that does not exist must be reported, not faked")
+	assert.Nil(t, res)
+	assert.Contains(t, err.Error(), "module.nope")
+}
+
+// TestTerraformStateOutput_MissReportsNotFound covers the sibling fall-through.
+func TestTerraformStateOutput_MissReportsNotFound(t *testing.T) {
+	rt := newRuntimeForStateJSON(t, stateWithModules)
+
+	_, res, err := initTerraformStateOutput(rt, map[string]*llx.RawData{
+		"identifier": llx.StringData("nope"),
+	})
+	require.Error(t, err, "an output that does not exist must be reported, not faked")
+	assert.Nil(t, res)
+	assert.Contains(t, err.Error(), "nope")
+}
+
+// TestTerraformStateModule_RootModuleIDIsDistinct pins the root module's id
+// away from the generic husk id it used to share.
+func TestTerraformStateModule_RootModuleIDIsDistinct(t *testing.T) {
+	rt := newRuntimeForStateJSON(t, stateWithModules)
+
+	obj, err := NewResource(rt, "terraform.state", map[string]*llx.RawData{})
+	require.NoError(t, err)
+	root, err := obj.(*mqlTerraformState).rootModule()
+	require.NoError(t, err)
+	require.NotNil(t, root)
+
+	id, err := root.id()
+	require.NoError(t, err)
+	assert.NotEqual(t, "terraform.module", id,
+		"the root module must not use the id a blank module would compute")
+	assert.Contains(t, id, "root")
+}
+
+// TestTerraformStateInits_NullArgumentDoNotPanic is a regression test for the
+// bare `.(string)` assertions on init arguments. The schema enforces the type,
+// but RawData.Value is still nil for a null argument, and
+// `interface{}(nil).(string)` panics — taking the whole scan down, since query
+// blocks run in goroutines.
+func TestTerraformStateInits_NullArgumentDoNotPanic(t *testing.T) {
+	rt := newRuntimeForStateJSON(t, stateWithModules)
+
+	require.NotPanics(t, func() {
+		_, _, _ = initTerraformStateOutput(rt, map[string]*llx.RawData{
+			"identifier": {Value: nil},
+		})
+	})
+	require.NotPanics(t, func() {
+		_, _, _ = initTerraformStateModule(rt, map[string]*llx.RawData{
+			"identifier": {Value: nil},
+		})
+	})
+}
+
+// TestTerraformStateResource_DeposedKeyDisambiguatesID is a regression test for
+// terraform.state.resource ids that ignore deposedKey.
+//
+// Terraform records a deposed object as a separate entry with the SAME address,
+// distinguished only by deposed_key. Both entries hashed to one cache key, so
+// the deposed object was invisible while the list still reported two.
+func TestTerraformStateResource_DeposedKeyDisambiguatesID(t *testing.T) {
+	rt := newRuntimeForStateJSON(t, `{
+  "format_version": "1.0",
+  "terraform_version": "1.6.0",
+  "values": {
+    "root_module": {
+      "resources": [
+        { "address": "aws_instance.web", "mode": "managed", "type": "aws_instance", "name": "web" },
+        { "address": "aws_instance.web", "mode": "managed", "type": "aws_instance", "name": "web", "deposed_key": "abc12345" }
+      ]
+    }
+  }
+}`)
+
+	obj, err := NewResource(rt, "terraform.state", map[string]*llx.RawData{})
+	require.NoError(t, err)
+	list, err := obj.(*mqlTerraformState).resources()
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+
+	ids := map[string]bool{}
+	for i := range list {
+		id, err := list[i].(*mqlTerraformStateResource).id()
+		require.NoError(t, err)
+		ids[id] = true
+	}
+	assert.Len(t, ids, 2, "a deposed object must not share a cache key with the current object")
+}


### PR DESCRIPTION
Seventeen defects in `providers/terraform/resources/`. Every one was reproduced by a test that fails against the current code before the fix landed; no existing test was weakened or removed.

Stacks on #10471 (`fix/terraform-file-discovery`), which fixed the connection layer. Review that one first.

---

## Crashes and total failures

### One `.tf.json` file broke EVERY `terraform.*` accessor

```
dir/main.tf     -> resource "aws_s3_bucket" "native" {}
dir/cdk.tf.json -> {"resource":{"aws_security_group":{"sg":{"name":"allow-ssh"}}}}
```

`hclparse.ParseJSON` produces a plain `hcl.Body`, and `listRelatedBlocks` returned `errors.New("cannot yet list related blocks for regular hcl Body")` for it. That error propagated out of `ensureCache`, which is the single entry point behind `blocks()`, `providers()`, `datasources()`, `variables()`, `outputs()`, `terraform.resources`, `terraform.settings` and `related()`. So one JSON file — the default CDKTF output layout, and a format the schema advertises support for — made all of them fail, including for the native `.tf` files sitting beside it.

A JSON body now contributes no related edges rather than failing the cache build.

### Nil-pointer panic on `terraform.state.output(...)` / `.module(...)`

`terraform.state.output(identifier: "x").value` against an HCL directory took the provider down. The init used `CreateResource("terraform.state", nil)`, which does **not** run init, so `initTerraformState`'s "cannot find state" guard was bypassed; `conn.State()` returns `(nil, nil)` for HCL and plan assets and `outputs()` then dereferenced it. Both sites use `NewResource` now, and `outputs()`, `rootModule()`, `modules()` and `resources()` each guard the nil state themselves instead of only checking `state.Values`.

### The same `CreateResource` poisoned the `terraform.state` singleton

`terraform.state`'s `id()` is a constant, so that uninitialized instance was cached under the shared key and a later correct `NewResource` returned the husk. On a real state asset, asking for an output first made `terraform.state.formatVersion` read as unset afterwards (surfacing as `llx: encountered a primitive with no type information`) — purely a function of query order.

### Bare `.(string)` on init arguments

`RawData.Value` is nil for a null argument and `interface{}(nil).(string)` panics — which kills the whole scan, since query blocks run in goroutines. Both sites use the comma-ok form, matching `initTerraformResources`.

### `AsString()` on a possibly-unknown cty value

`cty.Value.AsString` panics on null **and** on unknown, and `jsonencode(var.x)` with an unknown var returns `cty.UnknownVal(cty.String)` with **no diagnostic at all**, so the existing `err == nil` check waved it through. All three call sites are guarded on `IsKnown() && !IsNull()`, and `hcl.go`'s `err == nil` is now `!diags.HasErrors()` like every sibling arm.

---

## Identity collisions

### `terraform.resources(resource: X)` and `(name: X)` computed the same `__id`

The checksum was built from the argument value only, and `RawData.String()` renders a string identically whichever key it came from. `terraform.resources(resource: "web")` and `terraform.resources(name: "web")` aliased in the cache and the second silently returned the first's list. Shared literals like `main`, `default` and `this` make this an everyday collision. Each component is now key-qualified.

### Block identity ignored the declaring file, so `related()` crossed module boundaries

```
main.tf             -> resource "aws_s3_bucket" "this" {}
                       resource "aws_s3_bucket_policy" "root"   { bucket = aws_s3_bucket.this.id }
modules/vpc/main.tf -> resource "aws_s3_bucket" "this" {}
                       resource "aws_s3_bucket_policy" "module" { bucket = aws_s3_bucket.this.id }
```

The connection walks the whole tree, and the key was just the joined labels, so both buckets shared one entry (last writer wins, and which one won was nondeterministic because `parser.Files()` is a map). Both buckets reported the same related list containing **both** policies, so "every bucket has a policy denying insecure transport" passed for the module bucket on the strength of the root bucket's policy.

Every label-less block (`terraform {}`, `locals {}`, `moved {}`) also shared the empty key and inherited each other's edges.

Keys are now `<declaring dir>\0<block type>\0<labels…>`, and label-less blocks are left out of the graph entirely.

### `terraform.settings.requiredProvider.__id` collided on `name`

```
main.tf             -> terraform { required_providers { aws = "~> 3.0" } }
modules/vpc/main.tf -> terraform { required_providers { aws = "~> 5.0" } }
```

`initTerraformSettings` deliberately loops over **all** `terraform {}` blocks, but the id was the provider name alone, so the list contained the first entry twice and the module's constraint was invisible to a supply-chain pin check. The declaring file path is part of the `__id` now; `name` stays the bare provider name.

### `deposed` dropped from change and resource ids

Terraform emits a separate `resource_changes` entry for a deposed object with the **same** address, distinguished only by `deposed` — which the schema already models. Both entries hashed to one key, so the deposed change was invisible while `resourceChanges.length` still counted two. Fixed on `terraform.plan.resourceChange`, `terraform.plan.proposedChange` and `terraform.state.resource` (which dropped `deposedKey` the same way).

---

## Wrong or missing values

### `arguments()` returned an EMPTY list for any unregistered function

```hcl
bucket = format("%s-logs", local.env)
tags   = merge(var.common_tags, { Name = "x" })
```

The function table registers only `jsondecode`/`jsonencode`, so `format`, `merge`, `join`, `lookup`, `try`, `coalesce`, … all fail with "Call to unknown function". The `FunctionCallExpr` arm returned its empty slice with no reference fallback — unlike `ScopeTraversalExpr` and `ConditionalExpr`, which do surface references — so both of the above read as `[]` and a tag-governance check on `arguments["tags"]` saw nothing to complain about. The arm now falls back to surfacing the argument references.

**Not done:** widening `HCLEvalFunctions` toward Terraform's pure-function set. It would change the resolved value of a large number of existing expressions at once (the `.tf` fixtures lean on `one`, `endswith`, `coalesce`, …) and is a materially bigger behavior change than the rest of this PR; it belongs on its own with its own before/after sweep. The `AsString()` hardening it would have required is included here regardless, so widening later is a one-line change.

### Operators returned their OPERANDS, not the result

`ConditionalExpr` and `UnaryOpExpr` already try `t.Value(ctx)` first and only fall back to reference-surfacing; `BinaryOpExpr`, `ForExpr`, `IndexExpr` and `SplatExpr` never did.

| expression | before | after |
|---|---|---|
| `sum = 8080 + 1` | `[8080, 1]` | `8081` |
| `cmp = 8080 > 80` | `[8080, 80]` | `true` |
| `forx = [for p in local.list : p + 1]` | `[10, 20, "p", 1]` | `[11, 21]` |
| `dyn = local.m[local.k]` | `[{a:1,b:2}, "a"]` | `1` |

Every scalar comparison a policy writes against these was defeated. The reference-surfacing fallback is unchanged for operands that cannot be evaluated.

### `terraform.settings.backend` was nondeterministic across runs

`ensureCache` filled its block list by ranging `parser.Files()`, a Go map, and `initTerraformSettings` takes a last-writer-wins backend while iterating those blocks. With two `terraform {}` blocks carrying a backend, a policy asserting `backend["type"] == "s3"` flaked run to run. File paths are sorted before the block list is built, which also stabilizes the required-provider ordering and several other accessors.

### `terraform.plan.applyable` / `.errored` / `.variables` were UNSET on non-plan assets

The nil-plan branch of the init filled in only `formatVersion`, `terraformVersion` and `resourceChanges`. MQL's three-valued logic makes `terraform.plan { !errored && applyable }` evaluate to **true** over two nulls, so a "the plan is clean" assertion passed on an asset carrying no plan at all. All three are set explicitly now.

(Also corrected the `types.Resource("terraform.plan.variables")` array type marker to the singular resource name on the populated path.)

### Plan variables with no value were silently dropped

`Variable.Value` is a `json.RawMessage` with `omitempty`, so `{"variables":{"db_password":{}}}` makes `json.Unmarshal(nil, …)` fail and the `continue` deleted the variable. An audit asserting "every declared variable has a value" could not see the one that does not. The variable is emitted with a null value now, and the `CreateResource` error is logged rather than swallowed.

### `initTerraformStateModule`'s lookup miss produced a husk that collided with the root module

On a miss the init deleted `identifier` and returned `args, nil, nil`, so the runtime built a module with no address — and `id()` returns the bare `"terraform.module"` when the address is empty, which is exactly the **root** module's id (state root modules omit `address`). A typo'd address silently resolved to the root module's contents. Misses report not-found now, the root module has its own id, and the sibling fall-through in `initTerraformStateOutput` got the same treatment.

### `related()` never resolved `data.*`, `var.*`, `module.*`, or nested blocks

The lookup did `refs[0:2]`, which forms a valid key only for managed resources: `data.aws_ami.ubuntu.id` yielded `data\0aws_ami` while the data block's own id was `aws_ami\0ubuntu`. It also walked only `body.Attributes`, so a reference inside a nested block (`ingress { security_groups = [aws_security_group.x.id] }`) was never seen, and the hand-rolled `getReferences` handled only bare `ScopeTraversalExpr`, so references inside templates, function calls, lists and conditionals were invisible.

The resolver now strips the `data`/`module`/`var` prefix and maps it to the target block type, recurses into nested blocks, and uses `hcl.Expression.Variables()` (which returns every traversal in an expression tree) instead of the hand-rolled walker. Edges are deduplicated, since the same block can be referenced many times.

---

## Data race

`newMqlHclBlock` wrote `r.block` and `r.cachedFile` unconditionally after `CreateResource`, which returns the **already cached** instance when the `__id` matches. Two goroutines reaching the same block through `terraform.blocks` and `terraform.file(path).blocks` wrote the same struct fields concurrently — confirmed by `go test -race`. Stamping now happens under a `sync.Once` on the internal struct, which also publishes the writes to every later reader of the cached instance.

---

## Tests

New files: `hcl_json_test.go`, `hcl_ids_test.go`, `hcl_expr_test.go`, `hcl_related_test.go`, `tfstate_test.go`; additions to `hcl_race_test.go` and `tfplan_test.go`. `tfstate_test.go` adds `newRuntimeForStateJSON` / `newRuntimeForPlanJSON`, modelled on the existing `newRuntimeForDir`, so state and plan assets can be exercised end to end against a real connection.

| test | bug |
|---|---|
| `TestTerraformAccessors_JSONFileDoesNotPoisonEveryAccessor`, `TestTerraformSettings_JSONFileDoesNotPoisonInit` | `.tf.json` poisoning |
| `TestTerraformStateOutput_InitOnNonStateAssetDoesNotPanic`, `TestTerraformStateModule_InitOnNonStateAssetDoesNotPanic`, `TestTerraformStateAccessors_NilStateDoNotPanic` | nil-state panics |
| `TestTerraformState_OutputLookupDoesNotPoisonTheSingleton`, `TestTerraformState_ModuleLookupDoesNotPoisonTheSingleton` | poisoned singleton |
| `TestTerraformResources_SelectorArgsAreKeyQualified` | selector `__id` collision |
| `TestTerraformBlock_RelatedDoesNotCrossModules`, `TestTerraformBlock_LabellessBlocksAreNotConflated` | block-identity collision |
| `TestGetCtyValue_UnknownFunctionSurfacesReferences`, `TestGetCtyValue_JsonencodeStillResolves` | empty function arguments |
| `TestGetCtyValue_OperatorsEvaluateToTheirResult`, `TestGetCtyValue_OperatorsKeepReferenceFallback` | operands vs. result |
| `TestTerraformSettings_BackendIsDeterministic` | nondeterministic backend (40 fresh runtimes) |
| `TestTerraformSettings_RequiredProvidersDoNotCollideAcrossFiles` | required-provider collision |
| `TestNewMqlHclBlock_ConcurrentStamping` | the data race |
| `TestTerraformPlan_NilPlanSetsStaticFields` | unset plan fields |
| `TestTerraformStateModule_MissReportsNotFound`, `TestTerraformStateOutput_MissReportsNotFound`, `TestTerraformStateModule_RootModuleIDIsDistinct` | husk / root-module collision |
| `TestTerraformPlanResourceChange_DeposedDisambiguatesID`, `TestTerraformStateResource_DeposedKeyDisambiguatesID` | deposed id collision |
| `TestTerraformPlanVariables_ValuelessVariableIsKept` | dropped plan variable |
| `TestTerraformStateInits_NullArgumentDoNotPanic` | bare `.(string)` |
| `TestGetCtyValue_UnknownStringDoesNotPanic`, `TestGetCtyValue_UnknownTemplateDoesNotPanic` | `AsString()` on unknown |
| `TestRelated_ResolvesPrefixedReferences`, `TestRelated_ResolvesReferencesInsideNestedBlocks`, `TestRelated_ResolvesReferencesInsideExpressions`, `TestRelated_DeduplicatesRepeatedReferences` | `related()` resolution |

`go test ./...` and `go test -race ./...` are green in `providers/terraform`, as are `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues) and `typos`. `go.mod`/`go.sum` unchanged.

The only generated-code change is one line in `terraform.lr.go`, embedding the new `mqlTerraformPlanProposedChangeInternal` struct (it carries the parent change's deposed key). No `.lr` schema change, no `.lr.versions` change, no version bump.
