### PR TITLE
🐛 bicep: ARM template discovery, nested resources, and stamp races

### DIFF
--- a/providers/bicep/connection/connection.go
+++ b/providers/bicep/connection/connection.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -27,7 +28,7 @@ type BicepConnection struct {
 	path            string
 	bicepFiles      []*BicepFile
 	bicepParamFiles []*BicepParamFile
-	armTemplate     *ARMTemplate
+	armTemplates    []*ARMTemplateFile
 	closer          func()
 }
 
@@ -43,14 +44,70 @@ type BicepParamFile struct {
 	Content string
 }
 
+// ARMTemplateFile pairs a parsed ARM template with the path it was read from.
+// A scanned directory can hold several templates, and each needs its own path
+// to build a stable, non-colliding resource id.
+type ARMTemplateFile struct {
+	Path     string
+	Template *ARMTemplate
+}
+
 // ARMTemplate holds a parsed ARM template JSON.
+//
+// Resources is kept raw because ARM has two encodings for it: the classic
+// array, and the object keyed by symbolic name that `bicep build` emits for
+// any template declaring "languageVersion": "2.0". ResourceList decodes both.
 type ARMTemplate struct {
-	Schema         string                     `json:"$schema"`
-	ContentVersion string                     `json:"contentVersion"`
-	Parameters     map[string]json.RawMessage `json:"parameters"`
-	Variables      map[string]json.RawMessage `json:"variables"`
-	Resources      []json.RawMessage          `json:"resources"`
-	Outputs        map[string]json.RawMessage `json:"outputs"`
+	Schema          string                     `json:"$schema"`
+	ContentVersion  string                     `json:"contentVersion"`
+	LanguageVersion string                     `json:"languageVersion"`
+	Parameters      map[string]json.RawMessage `json:"parameters"`
+	Variables       map[string]json.RawMessage `json:"variables"`
+	Resources       json.RawMessage            `json:"resources"`
+	Outputs         map[string]json.RawMessage `json:"outputs"`
+}
+
+// ARMResource is one entry of a template's `resources`. SymbolicName is the
+// object key for a symbolic-name (languageVersion 2.0) template and empty for
+// the classic array form, where a resource has no name of its own in the
+// template beyond its position.
+type ARMResource struct {
+	SymbolicName string
+	Raw          json.RawMessage
+}
+
+// ResourceList decodes `resources` in whichever of the two ARM encodings the
+// template uses. Object-form entries are returned in key-sorted order so the
+// materialized resource list is deterministic.
+func (t *ARMTemplate) ResourceList() []ARMResource {
+	if len(t.Resources) == 0 {
+		return nil
+	}
+
+	var arr []json.RawMessage
+	if err := json.Unmarshal(t.Resources, &arr); err == nil {
+		out := make([]ARMResource, 0, len(arr))
+		for _, raw := range arr {
+			out = append(out, ARMResource{Raw: raw})
+		}
+		return out
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(t.Resources, &obj); err != nil {
+		log.Warn().Err(err).Msg("ARM template `resources` is neither an array nor a symbolic-name object")
+		return nil
+	}
+	names := make([]string, 0, len(obj))
+	for name := range obj {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]ARMResource, 0, len(names))
+	for _, name := range names {
+		out = append(out, ARMResource{SymbolicName: name, Raw: obj[name]})
+	}
+	return out
 }
 
 func NewBicepConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*BicepConnection, error) {
@@ -112,9 +169,9 @@ func NewBicepConnection(id uint32, asset *inventory.Asset, conf *inventory.Confi
 			return nil, err
 		}
 		conn.bicepParamFiles = paramFiles
-		// Check for ARM template JSON in the directory
-		conn.armTemplate = findARMTemplate(bicepPath)
-		if len(files) == 0 && len(paramFiles) == 0 && conn.armTemplate == nil {
+		// Check for ARM template JSON anywhere in the directory tree
+		conn.armTemplates = findARMTemplates(bicepPath)
+		if len(files) == 0 && len(paramFiles) == 0 && len(conn.armTemplates) == 0 {
 			return nil, errors.New("no .bicep, .bicepparam, or ARM template JSON files found at " + bicepPath)
 		}
 	} else if strings.HasSuffix(bicepPath, ".json") {
@@ -123,7 +180,7 @@ func NewBicepConnection(id uint32, asset *inventory.Asset, conf *inventory.Confi
 		if err != nil {
 			return nil, err
 		}
-		conn.armTemplate = tmpl
+		conn.armTemplates = []*ARMTemplateFile{{Path: bicepPath, Template: tmpl}}
 	} else if strings.HasSuffix(bicepPath, ".bicepparam") {
 		// Single .bicepparam parameter file
 		content, err := os.ReadFile(bicepPath)
@@ -167,8 +224,29 @@ func (c *BicepConnection) BicepParamFiles() []*BicepParamFile {
 	return c.bicepParamFiles
 }
 
+// ARMTemplate returns the first discovered ARM template, or nil when the scan
+// found none. It stays the right answer for a direct `bicep <file>.json`
+// connection; use ARMTemplates to reach every template in a scanned tree.
 func (c *BicepConnection) ARMTemplate() *ARMTemplate {
-	return c.armTemplate
+	if len(c.armTemplates) == 0 {
+		return nil
+	}
+	return c.armTemplates[0].Template
+}
+
+// ARMTemplatePath returns the path the first discovered ARM template was read
+// from, or "" when the scan found none.
+func (c *BicepConnection) ARMTemplatePath() string {
+	if len(c.armTemplates) == 0 {
+		return ""
+	}
+	return c.armTemplates[0].Path
+}
+
+// ARMTemplates returns every ARM template the scan discovered, each with the
+// path it came from, in path-sorted order.
+func (c *BicepConnection) ARMTemplates() []*ARMTemplateFile {
+	return c.armTemplates
 }
 
 func (c *BicepConnection) Path() string {
@@ -180,7 +258,14 @@ func loadBicepFiles(dir string) ([]*BicepFile, error) {
 
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return err
+			// An unreadable entry must not abort the whole scan; skip it the
+			// same way an unreadable file is skipped below. info is nil on an
+			// error, so fall back to SkipDir only when we can tell it's a dir.
+			log.Warn().Err(err).Str("path", path).Msg("skipping unreadable path")
+			if info != nil && info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		if info.IsDir() {
 			return nil
@@ -207,7 +292,14 @@ func loadBicepParamFiles(dir string) ([]*BicepParamFile, error) {
 
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return err
+			// An unreadable entry must not abort the whole scan; skip it the
+			// same way an unreadable file is skipped below. info is nil on an
+			// error, so fall back to SkipDir only when we can tell it's a dir.
+			log.Warn().Err(err).Str("path", path).Msg("skipping unreadable path")
+			if info != nil && info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		if info.IsDir() {
 			return nil
@@ -229,29 +321,45 @@ func loadBicepParamFiles(dir string) ([]*BicepParamFile, error) {
 	return files, nil
 }
 
-func findARMTemplate(dir string) *ARMTemplate {
-	// Look for common ARM template filenames
-	candidates := []string{
-		"azuredeploy.json",
-		"mainTemplate.json",
-		"template.json",
-		"main.json",
-	}
-	for _, name := range candidates {
-		path := filepath.Join(dir, name)
+// findARMTemplates walks the tree for JSON files that parse as ARM deployment
+// templates. Discovery is recursive and name-agnostic to match how `.bicep`
+// and `.bicepparam` files are already found: an `infra/azuredeploy.json` or an
+// `arm/storage.prod.json` is just as much a template as a root `main.json`.
+// Every match is kept, each carrying its own path.
+func findARMTemplates(dir string) []*ARMTemplateFile {
+	var out []*ARMTemplateFile
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			log.Warn().Err(err).Str("path", path).Msg("skipping unreadable path")
+			if info != nil && info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".json") {
+			return nil
+		}
 		tmpl, err := loadARMTemplate(path)
-		if err == nil {
-			return tmpl
+		if err != nil {
+			// Most JSON in a repo is not an ARM template (package.json,
+			// settings, fixtures), so a failed schema check is unremarkable
+			// and logged at debug. Only a read error is worth a warning.
+			log.Debug().Err(err).Str("path", path).Msg("json file is not an ARM deployment template")
+			return nil
 		}
-		// A missing candidate is expected; a present-but-malformed template
-		// (invalid JSON or failing the deploymentTemplate check) is not — log
-		// it so a broken azuredeploy.json isn't silently indistinguishable
-		// from "no template here".
-		if !os.IsNotExist(err) {
-			log.Warn().Err(err).Str("path", path).Msg("failed to load ARM template candidate")
-		}
+		out = append(out, &ARMTemplateFile{Path: path, Template: tmpl})
+		return nil
+	})
+	if err != nil {
+		log.Warn().Err(err).Str("dir", dir).Msg("failed to walk directory for ARM templates")
 	}
-	return nil
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out
 }
 
 func loadARMTemplate(path string) (*ARMTemplate, error) {

--- a/providers/bicep/connection/connection_test.go
+++ b/providers/bicep/connection/connection_test.go
@@ -4,6 +4,7 @@
 package connection
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -49,4 +50,181 @@ func TestDiscoverSingleBicepParamFile(t *testing.T) {
 	require.Len(t, conn.BicepParamFiles(), 1)
 	assert.Equal(t, path, conn.BicepParamFiles()[0].Path)
 	assert.Empty(t, conn.BicepFiles())
+}
+
+// writeFile writes content at dir/rel, creating parent directories.
+func writeFile(t *testing.T, dir, rel, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, rel)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+const insecureStorageTemplate = `{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-01-01",
+      "name": "stinsecure",
+      "location": "eastus",
+      "properties": { "supportsHttpsTrafficOnly": false }
+    }
+  ]
+}`
+
+// F1: an ARM template in a subdirectory must be discovered. `.bicep` files are
+// already found recursively, so a template under `infra/` going missing makes
+// every ARM policy pass vacuously.
+func TestDiscoverARMTemplateInSubdirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.bicep", "param location string = 'eastus'\n")
+	tmplPath := writeFile(t, dir, "infra/azuredeploy.json", insecureStorageTemplate)
+
+	conn, err := newTestConnection(t, dir)
+	require.NoError(t, err)
+
+	require.NotNil(t, conn.ARMTemplate(), "template under infra/ must be discovered")
+	require.Len(t, conn.ARMTemplates(), 1)
+	assert.Equal(t, tmplPath, conn.ARMTemplates()[0].Path)
+}
+
+// F1: discovery must not be limited to four hardcoded filenames.
+func TestDiscoverARMTemplateWithNonStandardName(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.bicep", "param location string = 'eastus'\n")
+	writeFile(t, dir, "arm/storage.prod.json", insecureStorageTemplate)
+
+	conn, err := newTestConnection(t, dir)
+	require.NoError(t, err)
+
+	require.Len(t, conn.ARMTemplates(), 1)
+	assert.Equal(t, "storage.prod.json", filepath.Base(conn.ARMTemplates()[0].Path))
+}
+
+// F1: every ARM template in the tree must be kept, each carrying its own path.
+func TestDiscoverMultipleARMTemplates(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "azuredeploy.json", insecureStorageTemplate)
+	writeFile(t, dir, "modules/network.json", insecureStorageTemplate)
+	writeFile(t, dir, "modules/deploy.json", insecureStorageTemplate)
+
+	conn, err := newTestConnection(t, dir)
+	require.NoError(t, err)
+
+	tmpls := conn.ARMTemplates()
+	require.Len(t, tmpls, 3)
+	// Deterministic, path-sorted order.
+	bases := []string{
+		filepath.Base(tmpls[0].Path),
+		filepath.Base(tmpls[1].Path),
+		filepath.Base(tmpls[2].Path),
+	}
+	assert.Equal(t, []string{"azuredeploy.json", "deploy.json", "network.json"}, bases)
+}
+
+// F1: a directory holding only an ARM template must connect. It previously
+// failed with "no .bicep, .bicepparam, or ARM template JSON files found"
+// whenever the template was not one of the four hardcoded root filenames.
+func TestConnectARMTemplateOnlyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "arm/deploy.json", insecureStorageTemplate)
+
+	conn, err := newTestConnection(t, dir)
+	require.NoError(t, err)
+	require.NotNil(t, conn.ARMTemplate())
+}
+
+// F1: unrelated JSON in the tree must not be mistaken for an ARM template.
+func TestNonTemplateJSONIsIgnored(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.bicep", "param location string = 'eastus'\n")
+	writeFile(t, dir, "package.json", `{"name":"x","version":"1.0.0"}`)
+	writeFile(t, dir, "broken.json", `{ this is not json `)
+
+	conn, err := newTestConnection(t, dir)
+	require.NoError(t, err)
+	assert.Empty(t, conn.ARMTemplates())
+	assert.Nil(t, conn.ARMTemplate())
+}
+
+const symbolicNameTemplate = `{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "resources": {
+    "storageAccount": {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-01-01",
+      "name": "stsymbolic",
+      "location": "eastus",
+      "properties": { "supportsHttpsTrafficOnly": false }
+    },
+    "appService": {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2023-01-01",
+      "name": "app-symbolic",
+      "location": "eastus"
+    }
+  }
+}`
+
+// F2: `bicep build` emits languageVersion 2.0 templates whose `resources` is a
+// JSON object keyed by symbolic name. Rejecting them wholesale skipped the
+// entire template.
+func TestLoadSymbolicNameTemplate(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.json", symbolicNameTemplate)
+
+	conn, err := newTestConnection(t, dir)
+	require.NoError(t, err)
+
+	tmpl := conn.ARMTemplate()
+	require.NotNil(t, tmpl, "a languageVersion 2.0 template must load")
+
+	list := tmpl.ResourceList()
+	require.Len(t, list, 2)
+	// Symbolic-name order is deterministic (key-sorted).
+	assert.Equal(t, "appService", list[0].SymbolicName)
+	assert.Equal(t, "storageAccount", list[1].SymbolicName)
+}
+
+// F2: the classic array form must keep working, with an empty symbolic name.
+func TestLoadArrayFormTemplate(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "azuredeploy.json", insecureStorageTemplate)
+
+	conn, err := newTestConnection(t, dir)
+	require.NoError(t, err)
+
+	list := conn.ARMTemplate().ResourceList()
+	require.Len(t, list, 1)
+	assert.Empty(t, list[0].SymbolicName)
+}
+
+// F7: one unreadable directory must not abort the whole scan. The file-read
+// path three lines below already logs and continues.
+func TestUnreadableDirectoryDoesNotAbortScan(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	dir := t.TempDir()
+	writeFile(t, dir, "main.bicep", "param location string = 'eastus'\n")
+	writeFile(t, dir, "sub/other.bicep", "param x string = 'y'\n")
+	writeFile(t, dir, "azuredeploy.json", insecureStorageTemplate)
+
+	locked := filepath.Join(dir, "locked")
+	require.NoError(t, os.MkdirAll(locked, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(locked, "hidden.bicep"), []byte("param z string = 'q'\n"), 0o644))
+	require.NoError(t, os.Chmod(locked, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	conn, err := newTestConnection(t, dir)
+	require.NoError(t, err, "an unreadable subdirectory must not make the asset unscannable")
+
+	// The readable files are still found; only the locked subtree is skipped.
+	require.Len(t, conn.BicepFiles(), 2)
+	require.NotNil(t, conn.ARMTemplate())
 }

--- a/providers/bicep/resources/aliasimport_test.go
+++ b/providers/bicep/resources/aliasimport_test.go
@@ -1,0 +1,61 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/bicep/connection"
+)
+
+// F6: `import { sku as skuAlias } from './shared.bicep'` stores the symbol
+// verbatim as "sku as skuAlias", so filtering the target file's declarations
+// by exact name never matches and the import resolves to nothing.
+func TestImportAliasedSymbolsResolve(t *testing.T) {
+	dir := filepath.Join("testdata", "aliasimport")
+	asset := &inventory.Asset{
+		Connections: []*inventory.Config{
+			{Type: "bicep", Options: map[string]string{"path": dir}},
+		},
+	}
+	conn, err := connection.NewBicepConnection(0, asset, asset.Connections[0])
+	require.NoError(t, err)
+	runtime := &plugin.Runtime{
+		Connection: conn,
+		Resources:  &mapResources{m: map[string]plugin.Resource{}},
+	}
+
+	var imp *mqlBicepImport
+	for _, f := range conn.BicepFiles() {
+		if filepath.Base(f.Path) != "main.bicep" {
+			continue
+		}
+		mqlF, err := newMqlBicepFile(runtime, f)
+		require.NoError(t, err)
+		imps, err := mqlF.imports()
+		require.NoError(t, err)
+		require.Len(t, imps, 1)
+		imp = imps[0].(*mqlBicepImport)
+	}
+	require.NotNil(t, imp, "main.bicep not found")
+
+	target, err := imp.targetFile()
+	require.NoError(t, err)
+	require.NotNil(t, target, "the aliased import's target file resolves fine")
+
+	types, err := imp.resolvedTypes()
+	require.NoError(t, err)
+	require.Len(t, types, 1, "an aliased type import must resolve to the underlying type")
+	assert.Equal(t, "sku", types[0].(*mqlBicepType).Name.Data)
+
+	funcs, err := imp.resolvedFunctions()
+	require.NoError(t, err)
+	require.Len(t, funcs, 1, "an aliased function import must resolve to the underlying function")
+	assert.Equal(t, "buildName", funcs[0].(*mqlBicepFunction).Name.Data)
+}

--- a/providers/bicep/resources/arm_template.go
+++ b/providers/bicep/resources/arm_template.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
@@ -18,7 +19,14 @@ import (
 	"go.mondoo.com/mql/types"
 )
 
+// stampOnce guards the Internal fields: CreateResource returns the CACHED
+// instance for an id already in the runtime cache, and the same template id is
+// reached concurrently from bicep.template, bicep.templates, and a nested
+// resource's linkedTemplate. It also serves as the lazy-populate gate for a
+// resource reconstructed across the gRPC boundary, where the Internal fields
+// come back zeroed.
 type mqlBicepTemplateInternal struct {
+	stampOnce   sync.Once
 	armTemplate *connection.ARMTemplate
 	cachePath   string
 }
@@ -31,8 +39,10 @@ func newMqlBicepTemplate(runtime *plugin.Runtime, filePath string, tmpl *connect
 		return nil, err
 	}
 	mqlT := res.(*mqlBicepTemplate)
-	mqlT.armTemplate = tmpl
-	mqlT.cachePath = filePath
+	mqlT.stampOnce.Do(func() {
+		mqlT.armTemplate = tmpl
+		mqlT.cachePath = filePath
+	})
 	return mqlT, nil
 }
 
@@ -43,6 +53,7 @@ func newMqlBicepTemplate(runtime *plugin.Runtime, filePath string, tmpl *connect
 // a non-unique id would cause every such reconstruction to collide on
 // the same cache entry.
 func (t *mqlBicepTemplate) id() (string, error) {
+	t.ensureStamped()
 	path := t.cachePath
 	if path == "" {
 		if conn, ok := t.MqlRuntime.Connection.(*connection.BicepConnection); ok {
@@ -55,25 +66,30 @@ func (t *mqlBicepTemplate) id() (string, error) {
 	return "bicep.template:" + path, nil
 }
 
+// ensureStamped populates the Internal fields exactly once, either from the
+// creator's arguments or, when the resource was reconstructed via StoreData
+// across gRPC with its Internal fields zeroed, by re-fetching from the
+// connection. Running both through the same sync.Once keeps concurrent
+// accessors on a cached instance from racing each other.
+func (t *mqlBicepTemplate) ensureStamped() {
+	t.stampOnce.Do(func() {
+		// Guard the assertion: on a non-Bicep runtime (e.g. recording/replay)
+		// there's nothing to re-fetch — leave the fields empty rather than
+		// panicking, matching the comma-ok cast in id().
+		conn, ok := t.MqlRuntime.Connection.(*connection.BicepConnection)
+		if !ok {
+			return
+		}
+		if tmpl := conn.ARMTemplate(); tmpl != nil {
+			t.armTemplate = tmpl
+			t.cachePath = conn.ARMTemplatePath()
+		}
+	})
+}
+
 func (t *mqlBicepTemplate) getARMTemplate() *connection.ARMTemplate {
-	if t.armTemplate != nil {
-		return t.armTemplate
-	}
-	// Re-fetch from connection when Internal struct wasn't populated
-	// (happens when resource is reconstructed via StoreData across gRPC).
-	// Guard the assertion: on a non-Bicep runtime (e.g. recording/replay)
-	// there's nothing to re-fetch — return nil rather than panicking, matching
-	// the comma-ok cast in id().
-	conn, ok := t.MqlRuntime.Connection.(*connection.BicepConnection)
-	if !ok {
-		return nil
-	}
-	tmpl := conn.ARMTemplate()
-	if tmpl != nil {
-		t.armTemplate = tmpl
-		t.cachePath = conn.Path()
-	}
-	return tmpl
+	t.ensureStamped()
+	return t.armTemplate
 }
 
 func (t *mqlBicepTemplate) schema() (string, error) {
@@ -236,19 +252,29 @@ func (t *mqlBicepTemplate) newMqlBicepTemplateOutput(name string, raw json.RawMe
 	return res.(*mqlBicepTemplateOutput), nil
 }
 
+// resources materializes the template's top-level resources. Like its
+// parameters/variables/outputs siblings it returns an empty slice (not nil)
+// when the template is unavailable or declares none.
 func (t *mqlBicepTemplate) resources() ([]any, error) {
 	tmpl := t.getARMTemplate()
 	if tmpl == nil {
-		return nil, nil
+		return []any{}, nil
 	}
-	var mqlResources []any
-	for i, raw := range tmpl.Resources {
+	list := tmpl.ResourceList()
+	mqlResources := make([]any, 0, len(list))
+	for i, entry := range list {
 		var obj map[string]any
-		if err := json.Unmarshal(raw, &obj); err != nil {
+		if err := json.Unmarshal(entry.Raw, &obj); err != nil {
 			log.Warn().Err(err).Int("index", i).Msg("failed to unmarshal ARM template resource")
 			continue
 		}
-		mqlR, err := newMqlBicepTemplateResource(t.MqlRuntime, t.cachePath, i, obj)
+		// A symbolic-name (languageVersion 2.0) template names each resource,
+		// so the key is its identity; the classic array form has only position.
+		key := entry.SymbolicName
+		if key == "" {
+			key = strconv.Itoa(i)
+		}
+		mqlR, err := newMqlBicepTemplateResource(t.MqlRuntime, t.cachePath, key, obj)
 		if err != nil {
 			log.Warn().Err(err).Int("index", i).Msg("failed to create ARM template resource")
 			continue
@@ -264,24 +290,48 @@ func (t *mqlBicepTemplate) resources() ([]any, error) {
 // synthetic id used to build a non-colliding `bicep.template` for it. Both are
 // nil/empty for resources that carry no inline nested template (ordinary
 // resources, or deployments that use an external `templateLink`).
+// It also caches the resource's own `resources` array so the nested-children
+// accessor can materialize them, and the owning template's path so each child
+// keeps the same id shape as its parent. stampOnce guards every field:
+// CreateResource returns the CACHED instance for an id already in the runtime
+// cache, so an unguarded stamp races with a concurrent reader of the same
+// instance.
 type mqlBicepTemplateResourceInternal struct {
+	stampOnce    sync.Once
 	linkedTmpl   *connection.ARMTemplate
 	linkedTmplID string
+	nestedRaw    []any
+	templatePath string
 }
 
-func newMqlBicepTemplateResource(runtime *plugin.Runtime, templatePath string, index int, obj map[string]any) (*mqlBicepTemplateResource, error) {
+// newMqlBicepTemplateResource builds one bicep.template.resource. `key`
+// identifies the resource within its parent collection: the symbolic name for
+// a languageVersion 2.0 template, the positional index for the classic array
+// form, and `<parentKey>/<index>` for a nested child.
+func newMqlBicepTemplateResource(runtime *plugin.Runtime, templatePath string, key string, obj map[string]any) (*mqlBicepTemplateResource, error) {
 	typ, _ := obj["type"].(string)
 	apiVersion, _ := obj["apiVersion"].(string)
 	name, _ := obj["name"].(string)
 	location, _ := obj["location"].(string)
-	condition, _ := obj["condition"].(string)
+	condition := armCondition(obj["condition"])
 
 	var dependsOn []any
 	if deps, ok := obj["dependsOn"].([]any); ok {
 		for _, d := range deps {
-			if s, ok := d.(string); ok {
-				dependsOn = append(dependsOn, s)
+			dependsOn = append(dependsOn, armDependency(d))
+		}
+	}
+
+	tags := map[string]any{}
+	if raw, ok := obj["tags"].(map[string]any); ok {
+		for k, v := range raw {
+			if sv, ok := v.(string); ok {
+				tags[k] = sv
+				continue
 			}
+			// ARM tag values are strings, but a template may put an expression
+			// object or number there; render it rather than dropping the tag.
+			tags[k] = armDependency(v)
 		}
 	}
 
@@ -314,7 +364,7 @@ func newMqlBicepTemplateResource(runtime *plugin.Runtime, templatePath string, i
 		properties = manifest["properties"]
 	}
 
-	id := "bicep.template.resource:" + templatePath + ":" + typ + ":" + name + ":" + strconv.Itoa(index)
+	id := "bicep.template.resource:" + templatePath + ":" + typ + ":" + name + ":" + key
 
 	// Extract an inline nested deployment template, if any. Only a
 	// `Microsoft.Resources/deployments` resource whose `properties.template`
@@ -334,16 +384,94 @@ func newMqlBicepTemplateResource(runtime *plugin.Runtime, templatePath string, i
 		"copyMode":      llx.StringData(copyMode),
 		"copyBatchSize": llx.IntDataPtr(copyBatchSize),
 		"properties":    llx.DictData(properties),
+		"tags":          llx.MapData(tags, types.String),
 		"dependsOn":     llx.ArrayData(dependsOn, types.String),
 		"manifest":      llx.DictData(manifest),
 	})
 	if err != nil {
 		return nil, err
 	}
+	// A classic ARM resource may carry its own `resources` array of children:
+	// Microsoft.Web/sites to config/web, Microsoft.Sql/servers to
+	// auditingSettings and firewallRules, Microsoft.Storage/storageAccounts to
+	// blobServices. Cache it for the nested accessor to materialize.
+	nestedRaw, _ := obj["resources"].([]any)
+
 	mqlRes := res.(*mqlBicepTemplateResource)
-	mqlRes.linkedTmpl = linkedTmpl
-	mqlRes.linkedTmplID = id + "/linkedTemplate"
+	mqlRes.stampOnce.Do(func() {
+		mqlRes.linkedTmpl = linkedTmpl
+		mqlRes.linkedTmplID = id + "/linkedTemplate"
+		mqlRes.nestedRaw = nestedRaw
+		mqlRes.templatePath = templatePath
+	})
 	return mqlRes, nil
+}
+
+// armCondition renders an ARM `condition`. The field is boolean-valued and is
+// usually written as an expression string, but a literal true/false is legal
+// and appears in generated templates. Reporting a present-but-non-string
+// condition as "" would read as "unconditional" — the exact opposite of what
+// `"condition": false` means.
+func armCondition(v any) string {
+	switch c := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return c
+	case bool:
+		return strconv.FormatBool(c)
+	default:
+		return renderARMValue(v)
+	}
+}
+
+// armDependency renders one `dependsOn` entry. ARM permits an object form
+// alongside the usual resourceId expression string, and symbolic-name
+// templates use `[reference(...)]` objects; rendering the object to its raw
+// JSON text keeps the dependency edge instead of dropping it.
+func armDependency(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return renderARMValue(v)
+}
+
+// renderARMValue turns a decoded JSON value back into compact JSON text.
+func renderARMValue(v any) string {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to render ARM value as JSON text")
+		return ""
+	}
+	return string(raw)
+}
+
+// resources materializes this resource's nested child resources. Each child
+// gets a parent-qualified id so children under different parents never collide
+// in the cache, and children may declare children of their own.
+func (a *mqlBicepTemplateResource) resources() ([]any, error) {
+	out := make([]any, 0, len(a.nestedRaw))
+	for i, child := range a.nestedRaw {
+		obj, ok := child.(map[string]any)
+		if !ok {
+			log.Warn().Int("index", i).Str("parent", a.Name.Data).Msg("nested ARM resource is not an object")
+			continue
+		}
+		mqlChild, err := newMqlBicepTemplateResource(a.MqlRuntime, a.templatePath, a.childKey(i), obj)
+		if err != nil {
+			log.Warn().Err(err).Int("index", i).Str("parent", a.Name.Data).Msg("failed to create nested ARM template resource")
+			continue
+		}
+		out = append(out, mqlChild)
+	}
+	return out, nil
+}
+
+// childKey builds the parent-qualified key for the i-th nested child. The
+// parent's own id already encodes its type, name, and key, so appending the
+// index is enough to stay unique across the whole template.
+func (a *mqlBicepTemplateResource) childKey(i int) string {
+	return a.__id + "/" + strconv.Itoa(i)
 }
 
 // extractInlineTemplate returns the inline nested ARM template carried by a

--- a/providers/bicep/resources/armfidelity_test.go
+++ b/providers/bicep/resources/armfidelity_test.go
@@ -1,0 +1,348 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/bicep/connection"
+)
+
+// armFixtureRuntime writes an ARM template into a temp dir and returns a
+// runtime backed by a real BicepConnection scanning it, plus the connection.
+func armFixtureRuntime(t *testing.T, files map[string]string) *plugin.Runtime {
+	t.Helper()
+	dir := t.TempDir()
+	for rel, content := range files {
+		path := filepath.Join(dir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	}
+	asset := &inventory.Asset{
+		Connections: []*inventory.Config{
+			{Type: "bicep", Options: map[string]string{"path": dir}},
+		},
+	}
+	conn, err := connection.NewBicepConnection(0, asset, asset.Connections[0])
+	require.NoError(t, err)
+	return &plugin.Runtime{
+		Connection: conn,
+		Resources:  &mapResources{m: map[string]plugin.Resource{}},
+	}
+}
+
+// firstTemplate materializes the connection's first ARM template.
+func firstTemplate(t *testing.T, runtime *plugin.Runtime) *mqlBicepTemplate {
+	t.Helper()
+	conn := runtime.Connection.(*connection.BicepConnection)
+	require.NotEmpty(t, conn.ARMTemplates())
+	mqlT, err := newMqlBicepTemplate(runtime, conn.ARMTemplates()[0].Path, conn.ARMTemplate())
+	require.NoError(t, err)
+	return mqlT
+}
+
+func templateResources(t *testing.T, runtime *plugin.Runtime) []*mqlBicepTemplateResource {
+	t.Helper()
+	list, err := firstTemplate(t, runtime).resources()
+	require.NoError(t, err)
+	out := make([]*mqlBicepTemplateResource, 0, len(list))
+	for _, r := range list {
+		out = append(out, r.(*mqlBicepTemplateResource))
+	}
+	return out
+}
+
+const armHeader = `"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",`
+
+// F4: ARM's `condition` is boolean-valued. A literal false means the resource
+// is NEVER deployed, but the comma-ok string assertion swallowed it and left
+// "", which the schema documents as "unconditional".
+func TestARMResourceLiteralBooleanCondition(t *testing.T) {
+	runtime := armFixtureRuntime(t, map[string]string{"azuredeploy.json": `{
+  ` + armHeader + `
+  "resources": [
+    {
+      "condition": false,
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-01-01",
+      "name": "stnever"
+    },
+    {
+      "condition": true,
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-01-01",
+      "name": "stalways"
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-01-01",
+      "name": "stplain"
+    }
+  ]
+}`})
+
+	byName := map[string]*mqlBicepTemplateResource{}
+	for _, r := range templateResources(t, runtime) {
+		byName[r.Name.Data] = r
+	}
+
+	assert.Equal(t, "false", byName["stnever"].Condition.Data,
+		"a literal false condition must not be reported as unconditional")
+	assert.Equal(t, "true", byName["stalways"].Condition.Data)
+	assert.Empty(t, byName["stplain"].Condition.Data, "a genuinely absent condition stays empty")
+}
+
+// F8: resources() must return an empty list, not nil, matching the documented
+// convention its parameters/variables/outputs siblings already follow.
+func TestARMTemplateEmptyResourcesIsEmptyList(t *testing.T) {
+	runtime := armFixtureRuntime(t, map[string]string{"azuredeploy.json": `{
+  ` + armHeader + `
+  "resources": []
+}`})
+
+	list, err := firstTemplate(t, runtime).resources()
+	require.NoError(t, err)
+	assert.NotNil(t, list, "an empty resources array must yield an empty list, not nil")
+	assert.Empty(t, list)
+
+	// A bicep.template with no ARM template behind it (no Bicep connection to
+	// re-fetch from) behaves the same way.
+	detached, err := newMqlBicepTemplate(testRuntime(), "detached", nil)
+	require.NoError(t, err)
+	empty, err := detached.resources()
+	require.NoError(t, err)
+	assert.NotNil(t, empty, "an absent template must yield an empty list, not nil")
+}
+
+// F9: ARM permits an object form of dependsOn, and symbolic-name templates use
+// `[reference(...)]` objects. Dropping them silently loses graph edges.
+func TestARMResourceNonStringDependsOn(t *testing.T) {
+	runtime := armFixtureRuntime(t, map[string]string{"azuredeploy.json": `{
+  ` + armHeader + `
+  "resources": [
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2023-01-01",
+      "name": "app",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', 'st1')]",
+        { "$ref": "storageAccount" }
+      ]
+    }
+  ]
+}`})
+
+	res := templateResources(t, runtime)
+	require.Len(t, res, 1)
+	deps := res[0].DependsOn.Data
+	require.Len(t, deps, 2, "an object dependsOn entry must not be dropped")
+	assert.Equal(t, "[resourceId('Microsoft.Storage/storageAccounts', 'st1')]", deps[0])
+	assert.Equal(t, `{"$ref":"storageAccount"}`, deps[1],
+		"an object entry is rendered to its raw JSON text")
+}
+
+// F2: a symbolic-name template's resource id must carry the symbolic name
+// rather than a bare positional index.
+func TestARMSymbolicNameInResourceID(t *testing.T) {
+	runtime := armFixtureRuntime(t, map[string]string{"main.json": `{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "resources": {
+    "primarySa": {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-01-01",
+      "name": "stsym"
+    }
+  }
+}`})
+
+	res := templateResources(t, runtime)
+	require.Len(t, res, 1)
+	assert.True(t, strings.HasSuffix(res[0].__id, ":primarySa"),
+		"the symbolic key is the resource's identity in a languageVersion 2.0 template, got %q", res[0].__id)
+}
+
+// F3: a classic ARM resource may carry its own `resources` array of children:
+// Microsoft.Web/sites to config/web, Microsoft.Sql/servers to auditingSettings
+// and firewallRules, Microsoft.Storage/storageAccounts to blobServices. Only
+// top-level resources were materialized, so a policy on
+// Microsoft.Web/sites/config matched nothing and passed vacuously, while the
+// equivalent query against Bicep source found it.
+func TestARMResourceNestedChildren(t *testing.T) {
+	runtime := armFixtureRuntime(t, map[string]string{"azuredeploy.json": `{
+  ` + armHeader + `
+  "resources": [
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2023-01-01",
+      "name": "app",
+      "location": "eastus",
+      "resources": [
+        {
+          "type": "config",
+          "apiVersion": "2023-01-01",
+          "name": "web",
+          "properties": {
+            "ftpsState": "AllAllowed",
+            "minTlsVersion": "1.0"
+          },
+          "resources": [
+            {
+              "type": "grandchild",
+              "apiVersion": "2023-01-01",
+              "name": "deep"
+            }
+          ]
+        },
+        {
+          "type": "config",
+          "apiVersion": "2023-01-01",
+          "name": "appsettings"
+        }
+      ]
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-01-01",
+      "name": "st1"
+    }
+  ]
+}`})
+
+	top := templateResources(t, runtime)
+	require.Len(t, top, 2, "nested children are not top-level resources")
+
+	var site *mqlBicepTemplateResource
+	var storage *mqlBicepTemplateResource
+	for _, r := range top {
+		switch r.Type.Data {
+		case "Microsoft.Web/sites":
+			site = r
+		case "Microsoft.Storage/storageAccounts":
+			storage = r
+		}
+	}
+	require.NotNil(t, site)
+	require.NotNil(t, storage)
+
+	children, err := site.resources()
+	require.NoError(t, err)
+	require.Len(t, children, 2, "the nested config children must be materialized")
+
+	web := children[0].(*mqlBicepTemplateResource)
+	assert.Equal(t, "config", web.Type.Data)
+	assert.Equal(t, "web", web.Name.Data)
+	props, ok := web.Properties.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "AllAllowed", props["ftpsState"])
+	assert.Equal(t, "1.0", props["minTlsVersion"])
+
+	// Children of children resolve the same way.
+	grandchildren, err := web.resources()
+	require.NoError(t, err)
+	require.Len(t, grandchildren, 1)
+	assert.Equal(t, "deep", grandchildren[0].(*mqlBicepTemplateResource).Name.Data)
+
+	// Each child's id is parent-qualified, so same-typed children under
+	// different parents never collide.
+	assert.NotEqual(t, web.__id, children[1].(*mqlBicepTemplateResource).__id)
+	assert.True(t, strings.HasPrefix(web.__id, "bicep.template.resource:"))
+	assert.Contains(t, web.__id, site.__id)
+
+	// A resource with no children yields an empty list, not nil.
+	none, err := storage.resources()
+	require.NoError(t, err)
+	assert.NotNil(t, none)
+	assert.Empty(t, none)
+}
+
+// The tags field must exist on bicep.template.resource so one tagging policy
+// covers both Bicep source and compiled ARM JSON.
+func TestARMResourceTags(t *testing.T) {
+	runtime := armFixtureRuntime(t, map[string]string{"azuredeploy.json": `{
+  ` + armHeader + `
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-01-01",
+      "name": "sttagged",
+      "tags": { "env": "prod", "owner": "platform" }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-01-01",
+      "name": "stuntagged"
+    }
+  ]
+}`})
+
+	byName := map[string]*mqlBicepTemplateResource{}
+	for _, r := range templateResources(t, runtime) {
+		byName[r.Name.Data] = r
+	}
+
+	assert.Equal(t, map[string]any{"env": "prod", "owner": "platform"}, byName["sttagged"].Tags.Data)
+	assert.Empty(t, byName["stuntagged"].Tags.Data, "an untagged resource reports no tags, not null")
+}
+
+// F1: every discovered ARM template must be reachable, each carrying the
+// resources of its own file.
+func TestBicepTemplatesAccessor(t *testing.T) {
+	storage := `{
+  ` + armHeader + `
+  "resources": [
+    { "type": "Microsoft.Storage/storageAccounts", "apiVersion": "2023-01-01", "name": "st1" }
+  ]
+}`
+	network := `{
+  ` + armHeader + `
+  "resources": [
+    { "type": "Microsoft.Network/virtualNetworks", "apiVersion": "2023-05-01", "name": "vnet1" }
+  ]
+}`
+	runtime := armFixtureRuntime(t, map[string]string{
+		"azuredeploy.json":     storage,
+		"modules/network.json": network,
+	})
+
+	root, err := CreateResource(runtime, "bicep", map[string]*llx.RawData{})
+	require.NoError(t, err)
+	bicepRes := root.(*mqlBicep)
+
+	all, err := bicepRes.templates()
+	require.NoError(t, err)
+	require.Len(t, all, 2, "both templates in the tree must be surfaced")
+
+	// Each template carries only its own resources, so the two must not share
+	// a cache id.
+	first := all[0].(*mqlBicepTemplate)
+	second := all[1].(*mqlBicepTemplate)
+	assert.NotEqual(t, first.__id, second.__id)
+
+	firstRes, err := first.resources()
+	require.NoError(t, err)
+	require.Len(t, firstRes, 1)
+	assert.Equal(t, "st1", firstRes[0].(*mqlBicepTemplateResource).Name.Data)
+
+	secondRes, err := second.resources()
+	require.NoError(t, err)
+	require.Len(t, secondRes, 1)
+	assert.Equal(t, "vnet1", secondRes[0].(*mqlBicepTemplateResource).Name.Data)
+
+	// The singular accessor keeps working and points at the first template.
+	single, err := bicepRes.template()
+	require.NoError(t, err)
+	require.NotNil(t, single)
+	assert.Equal(t, first.__id, single.__id)
+}

--- a/providers/bicep/resources/bicep.go
+++ b/providers/bicep/resources/bicep.go
@@ -77,14 +77,33 @@ func (r *mqlBicep) paramFiles() ([]any, error) {
 	return mqlFiles, nil
 }
 
+// template returns the first ARM template the scan discovered. It stays the
+// right answer for a direct `bicep <file>.json` connection, where the scan
+// yields exactly one; a tree holding several is reached through templates.
 func (r *mqlBicep) template() (*mqlBicepTemplate, error) {
 	conn := r.MqlRuntime.Connection.(*connection.BicepConnection)
-	armTmpl := conn.ARMTemplate()
-	if armTmpl == nil {
+	tmpls := conn.ARMTemplates()
+	if len(tmpls) == 0 {
 		r.Template.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
-	return newMqlBicepTemplate(r.MqlRuntime, conn.Path(), armTmpl)
+	return newMqlBicepTemplate(r.MqlRuntime, tmpls[0].Path, tmpls[0].Template)
+}
+
+// templates returns every ARM template the scan discovered, each keyed by its
+// own path so a repo with more than one has all of them audited.
+func (r *mqlBicep) templates() ([]any, error) {
+	conn := r.MqlRuntime.Connection.(*connection.BicepConnection)
+	tmpls := conn.ARMTemplates()
+	out := make([]any, 0, len(tmpls))
+	for _, t := range tmpls {
+		mqlT, err := newMqlBicepTemplate(r.MqlRuntime, t.Path, t.Template)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mqlT)
+	}
+	return out, nil
 }
 
 type mqlBicepFileInternal struct {

--- a/providers/bicep/resources/bicep.lr
+++ b/providers/bicep/resources/bicep.lr
@@ -25,8 +25,19 @@ bicep {
   resources() []bicep.resource
   // All Bicep parameter (.bicepparam) files found
   paramFiles() []bicep.paramFile
-  // Compiled ARM template (if available via JSON or bicep build)
+  // Compiled ARM template
+  //
+  // The first ARM template JSON the scan discovered, or the one named directly
+  // when the connection points at a single .json file. Null when the scan found
+  // no ARM template. Use templates to reach every template in a scanned tree.
   template() bicep.template
+  // All ARM templates found
+  //
+  // Every JSON file under the scanned path that parses as an ARM deployment
+  // template, in path-sorted order, so a repo holding several (for example
+  // `infra/azuredeploy.json` alongside `modules/network.json`) has all of them
+  // audited rather than only the first.
+  templates() []bicep.template
 }
 
 // Bicep source file
@@ -745,9 +756,25 @@ bicep.template.resource @defaults("type name") {
   location string
   // Full resource properties as dict
   properties dict
+  // Resource tags
+  //
+  // The resource's `tags` object, empty when the resource declares none. The
+  // same shape `bicep.resource.tags` carries, so one tagging policy covers both
+  // Bicep source and compiled ARM JSON.
+  tags map[string]string
   // Dependencies
+  //
+  // The resource's `dependsOn` entries. ARM permits an object form alongside
+  // the usual resourceId expression string, and a symbolic-name template uses
+  // `[reference(...)]` objects; an object entry is rendered to its raw JSON
+  // text so no dependency edge is lost.
   dependsOn []string
-  // ARM deployment condition expression; empty when the resource is unconditional
+  // ARM deployment condition
+  //
+  // The resource's `condition`, empty only when the resource declares none and
+  // is therefore unconditional. ARM's condition is boolean-valued and usually
+  // written as an expression string, but a literal is legal and is reported as
+  // "true" or "false"; "false" means the resource is never deployed.
   condition string
   // Name of the ARM `copy` iteration block; empty when the resource is not copied
   copyName string
@@ -765,6 +792,15 @@ bicep.template.resource @defaults("type name") {
   // `templateLink` deployment (not resolvable offline) and for non-deployment
   // resources.
   linkedTemplate() bicep.template
+  // Nested child resources
+  //
+  // Child resources declared inside this resource's own `resources` array, the
+  // standard ARM encoding for `Microsoft.Web/sites` to `config/web`,
+  // `Microsoft.Sql/servers` to `auditingSettings` and `firewallRules`, and
+  // `Microsoft.Storage/storageAccounts` to `blobServices`. Empty when the
+  // resource declares no children. Children may declare children of their own,
+  // resolved the same way.
+  resources() []bicep.template.resource
   // Full manifest
   manifest dict
 }

--- a/providers/bicep/resources/bicep.lr.go
+++ b/providers/bicep/resources/bicep.lr.go
@@ -204,6 +204,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.template": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicep).GetTemplate()).ToDataRes(types.Resource("bicep.template"))
 	},
+	"bicep.templates": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicep).GetTemplates()).ToDataRes(types.Array(types.Resource("bicep.template")))
+	},
 	"bicep.file.path": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepFile).GetPath()).ToDataRes(types.String)
 	},
@@ -660,6 +663,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"bicep.template.resource.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepTemplateResource).GetProperties()).ToDataRes(types.Dict)
 	},
+	"bicep.template.resource.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepTemplateResource).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"bicep.template.resource.dependsOn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepTemplateResource).GetDependsOn()).ToDataRes(types.Array(types.String))
 	},
@@ -680,6 +686,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"bicep.template.resource.linkedTemplate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepTemplateResource).GetLinkedTemplate()).ToDataRes(types.Resource("bicep.template"))
+	},
+	"bicep.template.resource.resources": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlBicepTemplateResource).GetResources()).ToDataRes(types.Array(types.Resource("bicep.template.resource")))
 	},
 	"bicep.template.resource.manifest": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlBicepTemplateResource).GetManifest()).ToDataRes(types.Dict)
@@ -723,6 +732,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"bicep.template": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicep).Template, ok = plugin.RawToTValue[*mqlBicepTemplate](v.Value, v.Error)
+		return
+	},
+	"bicep.templates": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicep).Templates, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"bicep.file.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1405,6 +1418,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlBicepTemplateResource).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"bicep.template.resource.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepTemplateResource).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"bicep.template.resource.dependsOn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepTemplateResource).DependsOn, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -1431,6 +1448,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"bicep.template.resource.linkedTemplate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlBicepTemplateResource).LinkedTemplate, ok = plugin.RawToTValue[*mqlBicepTemplate](v.Value, v.Error)
+		return
+	},
+	"bicep.template.resource.resources": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlBicepTemplateResource).Resources, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"bicep.template.resource.manifest": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1486,6 +1507,7 @@ type mqlBicep struct {
 	Resources  plugin.TValue[[]any]
 	ParamFiles plugin.TValue[[]any]
 	Template   plugin.TValue[*mqlBicepTemplate]
+	Templates  plugin.TValue[[]any]
 }
 
 // createBicep creates a new instance of this resource
@@ -1586,6 +1608,22 @@ func (c *mqlBicep) GetTemplate() *plugin.TValue[*mqlBicepTemplate] {
 		}
 
 		return c.template()
+	})
+}
+
+func (c *mqlBicep) GetTemplates() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Templates, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep", c.__id, "templates")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.templates()
 	})
 }
 
@@ -3517,6 +3555,7 @@ type mqlBicepTemplateResource struct {
 	Name           plugin.TValue[string]
 	Location       plugin.TValue[string]
 	Properties     plugin.TValue[any]
+	Tags           plugin.TValue[map[string]any]
 	DependsOn      plugin.TValue[[]any]
 	Condition      plugin.TValue[string]
 	CopyName       plugin.TValue[string]
@@ -3524,6 +3563,7 @@ type mqlBicepTemplateResource struct {
 	CopyMode       plugin.TValue[string]
 	CopyBatchSize  plugin.TValue[int64]
 	LinkedTemplate plugin.TValue[*mqlBicepTemplate]
+	Resources      plugin.TValue[[]any]
 	Manifest       plugin.TValue[any]
 }
 
@@ -3579,6 +3619,10 @@ func (c *mqlBicepTemplateResource) GetProperties() *plugin.TValue[any] {
 	return &c.Properties
 }
 
+func (c *mqlBicepTemplateResource) GetTags() *plugin.TValue[map[string]any] {
+	return &c.Tags
+}
+
 func (c *mqlBicepTemplateResource) GetDependsOn() *plugin.TValue[[]any] {
 	return &c.DependsOn
 }
@@ -3616,6 +3660,22 @@ func (c *mqlBicepTemplateResource) GetLinkedTemplate() *plugin.TValue[*mqlBicepT
 		}
 
 		return c.linkedTemplate()
+	})
+}
+
+func (c *mqlBicepTemplateResource) GetResources() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Resources, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("bicep.template.resource", c.__id, "resources")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.resources()
 	})
 }
 

--- a/providers/bicep/resources/bicep.lr.versions
+++ b/providers/bicep/resources/bicep.lr.versions
@@ -157,6 +157,8 @@ bicep.template.resource.location 13.0.0
 bicep.template.resource.manifest 13.0.0
 bicep.template.resource.name 13.0.0
 bicep.template.resource.properties 13.0.0
+bicep.template.resource.resources 13.4.13
+bicep.template.resource.tags 13.4.13
 bicep.template.resource.type 13.0.0
 bicep.template.resources 13.0.0
 bicep.template.schema 13.0.0
@@ -164,6 +166,7 @@ bicep.template.variable 13.1.2
 bicep.template.variable.name 13.1.2
 bicep.template.variable.value 13.1.2
 bicep.template.variables 13.0.0
+bicep.templates 13.4.13
 bicep.type 13.1.2
 bicep.type.decorators 13.1.2
 bicep.type.definition 13.1.2

--- a/providers/bicep/resources/idcollision_test.go
+++ b/providers/bicep/resources/idcollision_test.go
@@ -1,0 +1,43 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// F10: two declarations sharing a symbolic name in one file produced the same
+// `__id`, so the cache handed the second list entry the FIRST declaration's
+// data. The input is invalid Bicep, but the id must still be collision-proof.
+func TestDuplicateSymbolicNamesGetDistinctIDs(t *testing.T) {
+	src := `resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: 'first'
+  location: 'eastus'
+}
+
+resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: 'second'
+  location: 'westus'
+}
+`
+	parsed := parseBicep(src)
+	require.Len(t, parsed.resources, 2)
+
+	runtime := testRuntime()
+	resolver := newSymbolResolver("dup.bicep", parsed)
+	list, err := createMqlResources(runtime, "dup.bicep", parsed.resources, resolver)
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+
+	first := list[0].(*mqlBicepResource)
+	second := list[1].(*mqlBicepResource)
+
+	assert.NotEqual(t, first.__id, second.__id, "duplicate symbolic names must not share a cache id")
+	assert.Equal(t, "first", first.Name.Data)
+	assert.Equal(t, "second", second.Name.Data,
+		"the second declaration must report its own data, not the first's")
+}

--- a/providers/bicep/resources/mql_resources.go
+++ b/providers/bicep/resources/mql_resources.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
@@ -19,7 +20,8 @@ import (
 // lazy resolvedType() accessor can resolve the declared `type` name to the
 // same-file `bicep.type` it names.
 type mqlBicepParameterInternal struct {
-	resolver *symbolResolver
+	stampOnce sync.Once
+	resolver  *symbolResolver
 }
 
 func createMqlParameters(runtime *plugin.Runtime, filePath string, params []parsedParameter, resolver *symbolResolver) ([]any, error) {
@@ -51,7 +53,12 @@ func createMqlParameters(runtime *plugin.Runtime, filePath string, params []pars
 		if err != nil {
 			return nil, err
 		}
-		res.(*mqlBicepParameter).resolver = resolver
+		// CreateResource returns the CACHED instance when this __id is already
+		// in the runtime cache, and the same declaration is reached
+		// concurrently from bicep.file.parameters and the symbol resolver.
+		// stampOnce keeps the write race-free and happens-before any reader.
+		mqlP := res.(*mqlBicepParameter)
+		mqlP.stampOnce.Do(func() { mqlP.resolver = resolver })
 		mqlParams = append(mqlParams, res)
 	}
 	return mqlParams, nil
@@ -76,7 +83,8 @@ func (p *mqlBicepParameter) resolvedType() (*mqlBicepType, error) {
 // lazy expressionTree() accessor can resolve the root identifiers its nodes
 // reference to same-file declarations.
 type mqlBicepVariableInternal struct {
-	resolver *symbolResolver
+	stampOnce sync.Once
+	resolver  *symbolResolver
 }
 
 func createMqlVariables(runtime *plugin.Runtime, filePath string, vars []parsedVariable, resolver *symbolResolver) ([]any, error) {
@@ -98,7 +106,8 @@ func createMqlVariables(runtime *plugin.Runtime, filePath string, vars []parsedV
 		if err != nil {
 			return nil, err
 		}
-		res.(*mqlBicepVariable).resolver = resolver
+		mqlV := res.(*mqlBicepVariable)
+		mqlV.stampOnce.Do(func() { mqlV.resolver = resolver })
 		mqlVars = append(mqlVars, res)
 	}
 	return mqlVars, nil
@@ -113,8 +122,9 @@ func createMqlVariables(runtime *plugin.Runtime, filePath string, vars []parsedV
 // root identifiers to same-file declarations. Nested child resources inherit
 // the same resolver since symbols stay file-scoped regardless of nesting.
 type mqlBicepResourceInternal struct {
-	nested   []parsedResource
-	resolver *symbolResolver
+	stampOnce sync.Once
+	nested    []parsedResource
+	resolver  *symbolResolver
 	// propertiesBody is the raw text of the resource's `properties: { ... }`
 	// block (between the outer braces), kept so propertyExpressions() can
 	// re-walk it with quoting intact — the parsed `properties` dict has already
@@ -133,7 +143,7 @@ func createMqlResources(runtime *plugin.Runtime, filePath string, resources []pa
 		if err != nil {
 			return nil, err
 		}
-		res, err := newMqlBicepResource(runtime, "bicep.resource:"+filePath+":"+r.symbolicName, r, resolver, ctx)
+		res, err := newMqlBicepResource(runtime, bicepResourceID(filePath, r), r, resolver, ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -231,11 +241,23 @@ func newMqlBicepResource(runtime *plugin.Runtime, id string, r parsedResource, r
 		return nil, err
 	}
 	mqlRes := res.(*mqlBicepResource)
-	mqlRes.nested = r.nested
-	mqlRes.resolver = resolver
-	mqlRes.propertiesBody = propertiesBody
-	mqlRes.rawName = r.name
+	mqlRes.stampOnce.Do(func() {
+		mqlRes.nested = r.nested
+		mqlRes.resolver = resolver
+		mqlRes.propertiesBody = propertiesBody
+		mqlRes.rawName = r.name
+	})
 	return mqlRes, nil
+}
+
+// bicepResourceID builds the cache id of a top-level resource declaration.
+// The declaration's start line is part of the key because a symbolic name is
+// not guaranteed unique within a file: two `resource sa ...` declarations are
+// invalid Bicep the compiler rejects, but on that input a name-only id made
+// both list entries alias the first declaration's data. The line makes the id
+// collision-proof at no cost.
+func bicepResourceID(filePath string, r parsedResource) string {
+	return "bicep.resource:" + filePath + ":" + r.symbolicName + ":" + strconv.Itoa(r.startLine)
 }
 
 // resources materializes this resource's nested child resources. Each child
@@ -263,6 +285,7 @@ func (r *mqlBicepResource) resources() ([]any, error) {
 // file that declared this module; a relative `source` is resolved against its
 // directory by the target() accessor.
 type mqlBicepModuleInternal struct {
+	stampOnce      sync.Once
 	resolver       *symbolResolver
 	owningFilePath string
 	// paramsBody is the raw text of the module's `params: { ... }` block,
@@ -310,9 +333,11 @@ func createMqlModules(runtime *plugin.Runtime, filePath string, modules []parsed
 			return nil, err
 		}
 		mqlMod := res.(*mqlBicepModule)
-		mqlMod.resolver = resolver
-		mqlMod.owningFilePath = filePath
-		mqlMod.paramsBody = paramsBody
+		mqlMod.stampOnce.Do(func() {
+			mqlMod.resolver = resolver
+			mqlMod.owningFilePath = filePath
+			mqlMod.paramsBody = paramsBody
+		})
 		mqlModules = append(mqlModules, res)
 	}
 	return mqlModules, nil
@@ -323,7 +348,8 @@ func createMqlModules(runtime *plugin.Runtime, filePath string, modules []parsed
 // child resources without re-parsing. The synthetic `__id` of each child is
 // derived from its parent's id (`<exprId>/arg[<i>]`, `<exprId>/seg[<i>]`).
 type mqlBicepExpressionInternal struct {
-	node *exprNode
+	stampOnce sync.Once
+	node      *exprNode
 	// resolver is the owning file's symbol table, threaded down from the
 	// declaration whose value this expression is. It lets referenceKind and
 	// the referenced*() accessors resolve `target` (the root identifier of a
@@ -351,8 +377,10 @@ func newMqlBicepExpression(runtime *plugin.Runtime, parentID string, node *exprN
 		return nil, err
 	}
 	mqlExpr := res.(*mqlBicepExpression)
-	mqlExpr.node = node
-	mqlExpr.resolver = resolver
+	mqlExpr.stampOnce.Do(func() {
+		mqlExpr.node = node
+		mqlExpr.resolver = resolver
+	})
 	return mqlExpr, nil
 }
 
@@ -513,8 +541,9 @@ func (m *mqlBicepModule) conditionTree() (*mqlBicepExpression, error) {
 // into a bicep.expression with symbol resolution intact (the same resolver the
 // owning resource/module's scalar expression trees thread through).
 type mqlBicepPropertyExpressionInternal struct {
-	raw      string
-	resolver *symbolResolver
+	stampOnce sync.Once
+	raw       string
+	resolver  *symbolResolver
 }
 
 // propertyExpressionEntry is one flattened string leaf of a properties/params
@@ -596,8 +625,10 @@ func newMqlBicepPropertyExpressions(runtime *plugin.Runtime, parentID, accessor,
 			return nil, err
 		}
 		mqlPE := res.(*mqlBicepPropertyExpression)
-		mqlPE.raw = e.raw
-		mqlPE.resolver = resolver
+		mqlPE.stampOnce.Do(func() {
+			mqlPE.raw = e.raw
+			mqlPE.resolver = resolver
+		})
 		out = append(out, mqlPE)
 	}
 	return out, nil
@@ -688,7 +719,8 @@ func (m *mqlBicepModule) target() (*mqlBicepFile, error) {
 // lazy expressionTree() accessor can resolve referenced root identifiers to
 // same-file declarations.
 type mqlBicepOutputInternal struct {
-	resolver *symbolResolver
+	stampOnce sync.Once
+	resolver  *symbolResolver
 }
 
 func createMqlOutputs(runtime *plugin.Runtime, filePath string, outputs []parsedOutput, resolver *symbolResolver) ([]any, error) {
@@ -711,7 +743,8 @@ func createMqlOutputs(runtime *plugin.Runtime, filePath string, outputs []parsed
 		if err != nil {
 			return nil, err
 		}
-		res.(*mqlBicepOutput).resolver = resolver
+		mqlO := res.(*mqlBicepOutput)
+		mqlO.stampOnce.Do(func() { mqlO.resolver = resolver })
 		mqlOutputs = append(mqlOutputs, res)
 	}
 	return mqlOutputs, nil
@@ -736,6 +769,7 @@ func (o *mqlBicepOutput) resolvedType() (*mqlBicepType, error) {
 // properties() accessor can materialize them without re-parsing the raw
 // definition.
 type mqlBicepTypeInternal struct {
+	stampOnce       sync.Once
 	cacheProperties []parsedTypeProperty
 }
 
@@ -758,7 +792,8 @@ func createMqlTypes(runtime *plugin.Runtime, filePath string, types_ []parsedTyp
 		if err != nil {
 			return nil, err
 		}
-		res.(*mqlBicepType).cacheProperties = t.properties
+		mqlT := res.(*mqlBicepType)
+		mqlT.stampOnce.Do(func() { mqlT.cacheProperties = t.properties })
 		mqlTypes = append(mqlTypes, res)
 	}
 	return mqlTypes, nil
@@ -814,6 +849,7 @@ func createMqlFunctions(runtime *plugin.Runtime, filePath string, functions []pa
 // import; a relative `source` is resolved against its directory by the
 // targetFile() accessor.
 type mqlBicepImportInternal struct {
+	stampOnce      sync.Once
 	owningFilePath string
 }
 
@@ -834,7 +870,8 @@ func createMqlImports(runtime *plugin.Runtime, filePath string, imports []parsed
 		if err != nil {
 			return nil, err
 		}
-		res.(*mqlBicepImport).owningFilePath = filePath
+		mqlImp := res.(*mqlBicepImport)
+		mqlImp.stampOnce.Do(func() { mqlImp.owningFilePath = filePath })
 		mqlImports = append(mqlImports, res)
 	}
 	return mqlImports, nil
@@ -943,12 +980,28 @@ func (i *mqlBicepImport) resolvedFunctions() ([]any, error) {
 
 // importSymbolSet turns the `symbols` list (an []any of strings) into a lookup
 // set for filtering a target file's types/functions on a named import.
+//
+// A `{ ... }` import element may rename what it pulls in
+// (`import { sku as skuAlias } from './shared.bicep'`), and the parser stores
+// the element verbatim, so the entry arrives as "sku as skuAlias". What the
+// target file declares is the name before the alias, so that is what has to be
+// matched; without the split an aliased import resolves to nothing at all.
+//
+// The alias is split here rather than at parse time because the parser is
+// being changed concurrently on another branch. Splitting it in the parser
+// would be cleaner, and would also let `symbols` report the imported names
+// without their aliases.
 func importSymbolSet(symbols []any) map[string]bool {
 	set := make(map[string]bool, len(symbols))
 	for _, s := range symbols {
-		if name, ok := s.(string); ok {
-			set[name] = true
+		name, ok := s.(string)
+		if !ok {
+			continue
 		}
+		if idx := strings.Index(name, " as "); idx >= 0 {
+			name = strings.TrimSpace(name[:idx])
+		}
+		set[name] = true
 	}
 	return set
 }

--- a/providers/bicep/resources/resolver.go
+++ b/providers/bicep/resources/resolver.go
@@ -143,7 +143,7 @@ func (r *symbolResolver) resource(runtime *plugin.Runtime, target string) (*mqlB
 	if err != nil {
 		return nil, err
 	}
-	return newMqlBicepResource(runtime, "bicep.resource:"+r.filePath+":"+res.symbolicName, res, r, ctx)
+	return newMqlBicepResource(runtime, bicepResourceID(r.filePath, res), res, r, ctx)
 }
 
 // module builds (or returns the cached) bicep.module the target names, or nil

--- a/providers/bicep/resources/resolver_test.go
+++ b/providers/bicep/resources/resolver_test.go
@@ -81,8 +81,16 @@ func findParam(parsed *parsedBicepFile, name string) parsedParameter {
 // exprFor builds a bicep.expression resource for a raw expression string,
 // wired with the given resolver, the way expressionTreeFor does.
 func exprFor(t *testing.T, runtime *plugin.Runtime, resolver *symbolResolver, raw string) *mqlBicepExpression {
+	return exprForID(t, runtime, resolver, "test:"+raw, raw)
+}
+
+// exprForID is exprFor with an explicit cache id. Two expressions wired with
+// DIFFERENT resolvers must not share an id: CreateResource returns the cached
+// instance for an id it already holds, so the second call would read the first
+// call's resolver.
+func exprForID(t *testing.T, runtime *plugin.Runtime, resolver *symbolResolver, id, raw string) *mqlBicepExpression {
 	node := parseExpression(raw)
-	expr, err := newMqlBicepExpression(runtime, "test:"+raw, node, resolver)
+	expr, err := newMqlBicepExpression(runtime, id, node, resolver)
 	require.NoError(t, err)
 	return expr
 }
@@ -249,8 +257,11 @@ func TestExpressionReferenceResolution(t *testing.T) {
 
 	t.Run("unparented expression with nil resolver resolves to empty", func(t *testing.T) {
 		// Defensive: a node built without a resolver (e.g. reconstructed
-		// across gRPC) must not panic and resolves to the empty kind.
-		expr := exprFor(t, runtime, nil, "namePrefix")
+		// across gRPC) must not panic and resolves to the empty kind. It needs
+		// its own cache id: an earlier subtest already built "namePrefix" WITH
+		// a resolver, and a resource is stamped once, by whichever caller
+		// created it.
+		expr := exprForID(t, runtime, nil, "test:nilresolver:namePrefix", "namePrefix")
 		assertOnlyKind(t, expr, "")
 	})
 }

--- a/providers/bicep/resources/stamprace_test.go
+++ b/providers/bicep/resources/stamprace_test.go
@@ -1,0 +1,214 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/bicep/connection"
+)
+
+// syncResources is a concurrency-safe resource cache, so a `-race` report from
+// the test below is attributable to the provider's Internal-field stamps and
+// not to the test harness's own map.
+type syncResources struct {
+	mu sync.Mutex
+	m  map[string]plugin.Resource
+}
+
+func (r *syncResources) Get(key string) (plugin.Resource, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	v, ok := r.m[key]
+	return v, ok
+}
+
+func (r *syncResources) Set(key string, value plugin.Resource) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.m[key] = value
+}
+
+const raceFixture = `import { sku } from './shared.bicep'
+
+@description('Where to deploy')
+param location string = 'eastus'
+
+var storageName = 'st${uniqueString(location)}'
+
+type policy = {
+  name: string
+  enabled: bool
+}
+
+resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageName
+  location: location
+  tags: {
+    env: 'prod'
+  }
+  properties: {
+    supportsHttpsTrafficOnly: true
+    minimumTlsVersion: 'TLS1_2'
+  }
+
+  resource blobSvc 'blobServices@2023-01-01' = {
+    name: 'default'
+    properties: {
+      deleteRetentionPolicy: {
+        enabled: true
+      }
+    }
+  }
+}
+
+module net './shared.bicep' = {
+  name: 'net'
+  params: {
+    location: location
+  }
+}
+
+output saId string = sa.id
+`
+
+const raceShared = `@export()
+type sku = 'Standard_LRS'
+
+@export()
+func buildName(prefix string) string => '${prefix}-x'
+
+param location string = 'eastus'
+`
+
+// F5: the generated CreateResource RETURNS THE CACHED INSTANCE when the __id
+// already exists, and every creator then writes its Internal fields into that
+// shared instance unconditionally. The same __id is reached concurrently from
+// bicep.resources, bicep.files.resources, and the symbol resolver, so the
+// stamps race with readers of the same fields.
+//
+// This test only fails under `-race`; it is the reproducer for the 39 reports
+// the audit recorded.
+func TestConcurrentMaterializationIsRaceFree(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.bicep"), []byte(raceFixture), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "shared.bicep"), []byte(raceShared), 0o644))
+
+	asset := &inventory.Asset{
+		Connections: []*inventory.Config{
+			{Type: "bicep", Options: map[string]string{"path": dir}},
+		},
+	}
+	conn, err := connection.NewBicepConnection(0, asset, asset.Connections[0])
+	require.NoError(t, err)
+	runtime := &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncResources{m: map[string]plugin.Resource{}},
+	}
+
+	root, err := CreateResource(runtime, "bicep", map[string]*llx.RawData{})
+	require.NoError(t, err)
+	bicepRes := root.(*mqlBicep)
+
+	// Every worker walks the same declarations, so each __id is created once
+	// and then re-fetched from the cache by the others while they stamp it.
+	const workers = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, workers*8)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			flat, err := bicepRes.resources()
+			if err != nil {
+				errs <- err
+				return
+			}
+			for _, r := range flat {
+				res := r.(*mqlBicepResource)
+				if _, err := res.resources(); err != nil {
+					errs <- err
+				}
+				if _, err := res.propertyExpressions(); err != nil {
+					errs <- err
+				}
+				if _, err := res.nameTree(); err != nil {
+					errs <- err
+				}
+			}
+
+			files, err := bicepRes.files()
+			if err != nil {
+				errs <- err
+				return
+			}
+			for _, f := range files {
+				mqlF := f.(*mqlBicepFile)
+				if _, err := mqlF.resources(); err != nil {
+					errs <- err
+				}
+				if _, err := mqlF.parameters(); err != nil {
+					errs <- err
+				}
+				if _, err := mqlF.variables(); err != nil {
+					errs <- err
+				}
+				if _, err := mqlF.types(); err != nil {
+					errs <- err
+				}
+				imps, err := mqlF.imports()
+				if err != nil {
+					errs <- err
+					continue
+				}
+				for _, imp := range imps {
+					// targetFile() reads the import's stamped owningFilePath.
+					// resolvedTypes() is deliberately NOT called here: it goes
+					// through the generated GetTargetFile getter, and
+					// plugin.GetOrCompute writes the shared TValue field
+					// unsynchronized. That is SDK-wide behavior in every
+					// provider's generated getters, not an Internal-field
+					// stamp, and the executor computes a given field on a
+					// given resource once rather than from several goroutines.
+					if _, err := imp.(*mqlBicepImport).targetFile(); err != nil {
+						errs <- err
+					}
+				}
+				mods, err := mqlF.modules()
+				if err != nil {
+					errs <- err
+					continue
+				}
+				for _, m := range mods {
+					if _, err := m.(*mqlBicepModule).paramExpressions(); err != nil {
+						errs <- err
+					}
+				}
+				outs, err := mqlF.outputs()
+				if err != nil {
+					errs <- err
+					continue
+				}
+				for _, o := range outs {
+					if _, err := o.(*mqlBicepOutput).expressionTree(); err != nil {
+						errs <- err
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}

--- a/providers/bicep/resources/testdata/aliasimport/main.bicep
+++ b/providers/bicep/resources/testdata/aliasimport/main.bicep
@@ -1,0 +1,5 @@
+// Aliased named import: the imported symbol is renamed in this file, but the
+// symbol it pulls from the target is still `sku` / `buildName`.
+import { sku as skuAlias, buildName as makeName } from './shared.bicep'
+
+param location string = 'westeurope'

--- a/providers/bicep/resources/testdata/aliasimport/shared.bicep
+++ b/providers/bicep/resources/testdata/aliasimport/shared.bicep
@@ -1,0 +1,10 @@
+// Shared library exporting a type and a function, imported under aliases.
+
+@export()
+type sku = 'Standard_LRS' | 'Premium_LRS'
+
+@export()
+type tier = 'hot' | 'cool' | 'archive'
+
+@export()
+func buildName(prefix string, suffix string) string => '${prefix}-${suffix}'


### PR DESCRIPTION
Ten confirmed defects in the bicep provider's ARM-template and MQL-resource layer. Each was reproduced with a failing test before the fix; every fix is green, and `go test -race ./...` is clean across repeated runs.

Independent of #10476 (`fix/bicep-multiline-strings`) but touches the same provider. This PR deliberately does not edit `parser.go` or `tokenizer.go`, which that PR is changing.

---

## F1 — ARM template discovery was root-only, name-limited, and single-valued

`findARMTemplate` joined four hardcoded filenames onto the root directory and returned on the first hit, while `.bicep` and `.bicepparam` files were already discovered by a recursive walk.

```
repo/
  main.bicep
  infra/azuredeploy.json     <- invisible
```

```json
{
  "$schema": "...deploymentTemplate.json#",
  "resources": [{
    "type": "Microsoft.Storage/storageAccounts",
    "name": "stinsecure",
    "properties": { "supportsHttpsTrafficOnly": false }
  }]
}
```

**Impact:** the scan connected fine and listed the Bicep files, but `bicep.template` was null, so the insecure storage account was invisible and every ARM policy passed vacuously. `deploy.json`, `arm/storage.json`, and `azuredeploy.prod.json` were invisible even at the root. Only one template per scan was ever kept. If the ARM template was the *only* file, the connection failed outright with the misleading `no .bicep, .bicepparam, or ARM template JSON files found`.

**Fix:** walk recursively for `*.json`, attempt `loadARMTemplate` on each, keep every file that passes the `deploymentTemplate` schema check, each carrying its own path. Surfaced through a new `bicep.templates` accessor; the singular `bicep.template` stays (it is the right answer for the direct-file-argument case) and points at the first discovered template. A failed schema check logs at debug — most JSON in a repo is not an ARM template.

## F2 — symbolic-name (languageVersion 2.0) templates were rejected wholesale

`Resources []json.RawMessage` accepted only the array form. `bicep build` emits an object keyed by symbolic name for any template using symbolic names, as does the Azure Verified Modules toolchain:

```json
{
  "$schema": "...deploymentTemplate.json#",
  "languageVersion": "2.0",
  "resources": {
    "storageAccount": { "type": "Microsoft.Storage/storageAccounts", "name": "stsym" }
  }
}
```

**Impact:** `json.Unmarshal` failed, `loadARMTemplate` errored, and the entire template was skipped with only a log warning.

**Fix:** `Resources` is now `json.RawMessage`, decoded by `ResourceList()` which accepts both shapes (object entries in key-sorted order for determinism). The symbolic key folds into the resource's identity, which also gives `bicep.template.resource` a better `__id` than its positional index.

## F3 — nested ARM child resources were never materialized

Only the template's top-level `resources` was iterated. A classic ARM resource may carry its own `resources` array — the standard encoding for `Microsoft.Web/sites` → `config/web`, `Microsoft.Sql/servers` → `auditingSettings`/`firewallRules`, `Microsoft.Storage/storageAccounts` → `blobServices`.

```json
{
  "type": "Microsoft.Web/sites",
  "name": "app",
  "resources": [{
    "type": "config",
    "name": "web",
    "properties": { "ftpsState": "AllAllowed", "minTlsVersion": "1.0" }
  }]
}
```

**Impact:** one resource was reported, so a policy on `Microsoft.Web/sites/config` matched nothing and passed vacuously. The equivalent query against Bicep source found it — the two input paths disagreed, since `bicep.resource` has a `resources` accessor and `bicep.template.resource` did not.

**Fix:** `bicep.template.resource` gains `resources() []bicep.template.resource`, caching `obj["resources"]` on the Internal struct and materializing children with a parent-qualified `__id`, exactly as `mqlBicepResource.resources()` does. Recurses, so children of children resolve.

## F4 — a boolean ARM `condition` was silently dropped

`condition, _ := obj["condition"].(string)`. ARM's `condition` is boolean-valued; usually an expression string, but a literal is legal and appears in generated templates.

```json
{ "condition": false, "type": "Microsoft.Storage/storageAccounts", "name": "stnever" }
```

**Impact:** a resource that is *never deployed* reported `condition == ""`, which the schema documents as "unconditional" — the exact opposite.

**Fix:** type-switch, rendering a bool via `strconv.FormatBool`. The `condition` doc comment now says so.

## F5 — data race stamping Internal fields on cached resource instances

The generated `CreateResource` **returns the cached instance** when the `__id` already exists, and every creator then wrote its Internal fields into it unconditionally. The same `__id` is reached concurrently from `bicep.resources`, `bicep.files.resources`, and `symbolResolver.resource`.

**Impact:** `-race` reported 35 distinct races on this branch's reproducer, at exactly the audited lines (`mql_resources.go:234-237`, `:313-315`, `:354-355`, `:599-600`, `:761`, `:898`) — including a read at `:607` racing a write at `:235`. Beyond the race itself, a second stamp overwrites a live instance's resolver and cached body, so a concurrent reader can see another declaration's state.

**Fix:** each Internal struct gains the `sync.Once` guard `newMqlBicepFile` already had and documented. `mqlBicepTemplate` folds its lazy gRPC-reconstruction re-fetch into the same `Once`, so the creator stamp and the fallback populate cannot race each other.

## F6 — an aliased named import resolved to zero types and functions

```bicep
import { sku as skuAlias, buildName as makeName } from './shared.bicep'
```

`parseImportDecl` stores each `{ ... }` element verbatim, so the symbol arrives as `"sku as skuAlias"`, and `resolvedTypes()` filters the target file's types by exact name.

**Impact:** `resolvedTypes` and `resolvedFunctions` were empty while `targetFile` resolved correctly. The schema documents empty as "no resolvable target file", so a user reads it as "this import brings in nothing".

**Fix:** split on ` as ` when building the wanted-symbol set in `importSymbolSet`. The cleaner fix is in `parser.go:1167` (it would also let `symbols` report the imported names without aliases), but that file is being changed by #10476 — a code comment records why it lives here.

## F7 — one unreadable directory aborted the entire scan

The `filepath.Walk` callbacks did `if err != nil { return err }`, while an unreadable *file* three lines below was logged and skipped.

**Impact:** a repo containing one `chmod 000` subdirectory made the whole asset unscannable.

**Fix:** log and continue, returning `filepath.SkipDir` for a directory — matching the file-read behavior immediately below.

## F8 — `bicep.template.resources` returned nil where its siblings return an empty list

`parameters()`/`variables()`/`outputs()` all return `[]any{}`, and a comment states that convention. `resources()` returned nil both for an absent template and for a template with an empty `resources` array.

**Fix:** `return []any{}, nil`, and initialize with `make([]any, 0, len(list))`.

## F9 — `dependsOn` entries that are not strings were dropped silently

ARM permits an object form, and symbolic-name templates use `[reference(...)]` objects.

```json
"dependsOn": [ "[resourceId(...)]", { "$ref": "storageAccount" } ]
```

**Impact:** the dependency graph silently lost edges.

**Fix:** an object entry is rendered to its raw JSON text, so the edge survives.

## F10 — duplicate symbolic names in one file aliased to the first resource

```bicep
resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = { name: 'first' }
resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = { name: 'second' }
```

**Impact:** both entries built `bicep.resource:<file>:sa`, so the second reported `name: "first"`. The input is invalid Bicep the compiler rejects, hence low severity.

**Fix:** a shared `bicepResourceID` helper appends the declaration's start line. Used by both `createMqlResources` and `symbolResolver.resource` so the resolver still returns the *same* cached instance.

## Documentation defects found in the same audit

- `bicep.lr:28` claimed the ARM template was available "via JSON or bicep build". There is no `bicep build` path anywhere in the provider. Rewritten.
- `bicep.template.resource` had no `tags` field while `bicep.resource` does, so a tagging policy written against Bicep source returned nothing against an equivalent ARM template. Added and populated from the manifest.

---

## Tests

Every fix has a test that failed against the pre-fix code for the stated reason. `providers/bicep/connection/connection_test.go` (extended):

| Test | Covers |
|---|---|
| `TestDiscoverARMTemplateInSubdirectory` | F1 recursion |
| `TestDiscoverARMTemplateWithNonStandardName` | F1 name limit |
| `TestDiscoverMultipleARMTemplates` | F1 single-valued |
| `TestConnectARMTemplateOnlyDirectory` | F1 misleading connect failure |
| `TestNonTemplateJSONIsIgnored` | F1 no false positives (`package.json`, malformed JSON) |
| `TestLoadSymbolicNameTemplate` | F2 object form |
| `TestLoadArrayFormTemplate` | F2 array form regression |
| `TestUnreadableDirectoryDoesNotAbortScan` | F7 |

`providers/bicep/resources/armfidelity_test.go` (new):

| Test | Covers |
|---|---|
| `TestARMResourceLiteralBooleanCondition` | F4 |
| `TestARMTemplateEmptyResourcesIsEmptyList` | F8 |
| `TestARMResourceNonStringDependsOn` | F9 |
| `TestARMSymbolicNameInResourceID` | F2 identity |
| `TestARMResourceNestedChildren` | F3, including grandchildren and parent-qualified ids |
| `TestARMResourceTags` | `tags` field |
| `TestBicepTemplatesAccessor` | F1 `templates`, and that singular `template` still works |

`providers/bicep/resources/aliasimport_test.go` (new, with `testdata/aliasimport/`): `TestImportAliasedSymbolsResolve` — F6.

`providers/bicep/resources/idcollision_test.go` (new): `TestDuplicateSymbolicNamesGetDistinctIDs` — F10. Pre-fix this asserted the observable symptom directly: the second declaration reported `"first"`.

`providers/bicep/resources/stamprace_test.go` (new): `TestConcurrentMaterializationIsRaceFree` — F5. Eight workers walk the same declarations through `bicep.resources`, `bicep.files.*`, and the resolver. The harness uses a mutex-protected resource cache so any report is attributable to the provider, not the test. Fails only under `-race`; produced 35 reports before the fix.

### One existing test changed

`resolver_test.go`'s `unparented expression with nil resolver resolves to empty` subtest **depended on the bug**: an earlier subtest built `test:namePrefix` *with* a resolver, and the subtest relied on the unguarded second stamp clobbering the cached instance's resolver back to nil. With the `sync.Once` guard the first stamp wins. The assertion is unchanged — the subtest now uses its own cache id, so it genuinely exercises a nil-resolver instance instead of a clobbered one. No test was weakened or deleted.

### Results

```
$ go test ./...
ok  	go.mondoo.com/mql/providers/bicep/connection
ok  	go.mondoo.com/mql/providers/bicep/provider
ok  	go.mondoo.com/mql/providers/bicep/resources

$ go test -race -count=2 ./...   # x3
ok  	go.mondoo.com/mql/providers/bicep/connection
ok  	go.mondoo.com/mql/providers/bicep/provider
ok  	go.mondoo.com/mql/providers/bicep/resources
```

`golangci-lint run ./...` reports 0 issues; `gofmt`, `go vet`, and `go mod tidy` are clean.

### Verified interactively

Against `repo/main.bicep` + `repo/infra/azuredeploy.json`:

```
$ mql run bicep ./repo -c "bicep.template { schema resources { type name condition tags } }"
resources: [
  0: { condition: "false"  tags: { env: "prod" }  name: "stinsecure"  type: "Microsoft.Storage/storageAccounts" }
  1: { condition: ""       tags: {}               name: "app"         type: "Microsoft.Web/sites" }
]

$ mql run bicep ./repo -c "bicep.templates { resources.where(type == 'Microsoft.Web/sites') { name resources { type name properties } } }"
resources: [ 0: { properties: { ftpsState: "AllAllowed"  minTlsVersion: "1.0" }  type: "config"  name: "web" } ]
```

And against a `languageVersion: "2.0"` template, which does not load at all on `main`:

```
$ mql run bicep ./repo2 -c "bicep.template.resources { type name dependsOn }"
0: { name: "app"    dependsOn: [ 0: "{\"$ref\":\"storageAccount\"}" ]  type: "Microsoft.Web/sites" }
1: { name: "stsym"  dependsOn: []                                      type: "Microsoft.Storage/storageAccounts" }
```

## Schema

Three additions, all at `13.4.13` (config.go is at `13.4.12`; `Version` is **not** bumped here):

```
bicep.templates
bicep.template.resource.resources
bicep.template.resource.tags
```

## Follow-ups not in this PR

- **`plugin.GetOrCompute` writes its shared `TValue` unsynchronized.** Surfaced by the F5 reproducer when it called `resolvedTypes()`, which routes through the generated `GetTargetFile`. This is SDK-wide behavior in every provider's generated getters rather than an Internal-field stamp, and the executor computes a given field on a given resource once, so the reproducer was narrowed to the stamps and a comment records why. Worth a separate look at the SDK level.
- **O(n²) blowup in `flattenObjectExpressions`** on deeply nested property objects.
- **`newMqlBicepFile` re-parses the file on every materialization** (perf).
- **`getARMTemplate()`'s fallback can hand a linked template the root template's data.** Latent; only reachable via a recording path that is not implemented today. This PR points the fallback at `ARMTemplatePath()` rather than `Path()`, which narrows but does not close it.
- **`parseImportDecl` should split the ` as ` alias at parse time** (F6's cleaner fix), which would also let `symbols` report imported names without their aliases. Left alone to stay off #10476's files.
