### PR TITLE
🐛 os: follow tar hardlinks so OSTree and bootc images are readable

### DIFF
--- a/providers/os/connection/tar/fs.go
+++ b/providers/os/connection/tar/fs.go
@@ -55,13 +55,9 @@ func (fs *FS) Open(path string) (afero.File, error) {
 		return nil, os.ErrNotExist
 	}
 
-	if h.Typeflag == tar.TypeSymlink {
-		resolvedPath := fs.resolveSymlink(h)
-		log.Debug().Str("path", path).Str("resolved", Abs(resolvedPath)).Msg("file is a symlink, resolved it")
-		h, ok = fs.FileMap[Abs(resolvedPath)]
-		if !ok {
-			return nil, os.ErrNotExist
-		}
+	h, ok = fs.resolveHeader(h)
+	if !ok {
+		return nil, os.ErrNotExist
 	}
 
 	reader, err := fs.open(h)
@@ -114,23 +110,87 @@ func (fs *FS) Chown(name string, uid, gid int) error {
 }
 
 func (fs *FS) stat(header *tar.Header) (os.FileInfo, error) {
-	statHeader := header
-	if header.Typeflag == tar.TypeSymlink {
-		path := fs.resolveSymlink(header)
-		h, ok := fs.FileMap[Abs(path)]
-		if !ok {
-			return nil, errors.New("could not find " + path)
-		}
-		statHeader = h
+	statHeader, ok := fs.resolveHeader(header)
+	if !ok {
+		return nil, errors.New("could not resolve " + header.Name + " -> " + header.Linkname)
 	}
 	return statHeader.FileInfo(), nil
 }
 
+// maxLinkHops bounds link resolution. A tar can carry a symlink cycle, and
+// following one forever would hang the scan on a malformed or hostile image.
+const maxLinkHops = 32
+
+// resolveHeader follows link entries to the one that actually holds the bytes,
+// and reports whether it found it.
+//
+// The two link kinds resolve differently. A symlink's target is interpreted
+// relative to the directory the link sits in, the way it would be on a real
+// filesystem. A hardlink's Linkname is a path inside the archive itself,
+// always relative to the archive root.
+//
+// Following hardlinks is what makes OSTree and bootc images readable. They
+// keep the bytes in the ostree object store and expose every real path as a
+// hardlink to it:
+//
+//	sysroot/ostree/repo/objects/a2/69745d...file   the content
+//	usr/lib/os-release                             hardlink to it
+//	etc/os-release                                 symlink to ../usr/lib/os-release
+//
+// A hardlink entry carries Size 0 and no payload of its own, so reading it
+// without following the link yields an empty file rather than an error. That
+// left /etc/os-release empty on Fedora CoreOS, Fedora bootc and the uBlue
+// images, so detection named no platform and every one of them was reported
+// as "scratch": a container image with no packages and no findings.
+//
+// The chain is followed rather than resolved once, because the path detection
+// opens is a symlink whose target is itself a hardlink.
+func (fs *FS) resolveHeader(header *tar.Header) (*tar.Header, bool) {
+	h := header
+
+	// The path the entry is being reached through. A hardlink is another name
+	// for the same inode rather than a pointer to a path, so a relative
+	// symlink reached through one resolves against the directory of the name
+	// we came in on, not the directory of the entry that stores it. On an
+	// OSTree image /etc/redhat-release is a hardlink to an object that is
+	// itself a symlink to "fedora-release": that has to land on
+	// /etc/fedora-release, not on a sibling of the object in the store.
+	accessPath := header.Name
+
+	for range maxLinkHops {
+		var target string
+		switch h.Typeflag {
+		case tar.TypeSymlink:
+			target = Abs(fs.resolveSymlinkFrom(accessPath, h.Linkname))
+			accessPath = target
+			log.Debug().Str("path", h.Name).Str("resolved", target).Msg("file is a symlink, resolved it")
+		case tar.TypeLink:
+			target = Abs(h.Linkname)
+			log.Debug().Str("path", h.Name).Str("resolved", target).Msg("file is a hardlink, resolved it")
+		default:
+			return h, true
+		}
+
+		next, ok := fs.FileMap[target]
+		if !ok || next == h {
+			return nil, false
+		}
+		h = next
+	}
+
+	log.Warn().Str("file", header.Name).Msg("tar> giving up on a link chain that does not end")
+	return nil, false
+}
+
 // resolve symlink file
 func (fs *FS) resolveSymlink(header *tar.Header) string {
-	dest := header.Name
-	link := header.Linkname
+	return fs.resolveSymlinkFrom(header.Name, header.Linkname)
+}
 
+// resolveSymlinkFrom resolves a symlink target against the path the link is
+// being accessed through. That path is usually the entry's own name, but not
+// when the link was reached through a hardlink: see resolveHeader.
+func (fs *FS) resolveSymlinkFrom(dest string, link string) string {
 	var path string
 	if filepath.IsAbs(link) {
 		var err error
@@ -157,13 +217,15 @@ func (fs *FS) open(header *tar.Header) (io.Reader, error) {
 	}
 	defer f.Close()
 
-	path := header.Name
-	if header.Typeflag == tar.TypeSymlink {
-		path = fs.resolveSymlink(header)
+	// Open and stat resolve before calling this, but resolve again so the
+	// content read is correct no matter which entry the caller arrived with.
+	resolved, ok := fs.resolveHeader(header)
+	if !ok {
+		return nil, os.ErrNotExist
 	}
 
 	// extract file from tar stream
-	reader, err := fsutil.ExtractFileFromTarStream(path, f)
+	reader, err := fsutil.ExtractFileFromTarStream(resolved.Name, f)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/connection/tar/fs.go
+++ b/providers/os/connection/tar/fs.go
@@ -182,11 +182,6 @@ func (fs *FS) resolveHeader(header *tar.Header) (*tar.Header, bool) {
 	return nil, false
 }
 
-// resolve symlink file
-func (fs *FS) resolveSymlink(header *tar.Header) string {
-	return fs.resolveSymlinkFrom(header.Name, header.Linkname)
-}
-
 // resolveSymlinkFrom resolves a symlink target against the path the link is
 // being accessed through. That path is usually the entry's own name, but not
 // when the link was reached through a hardlink: see resolveHeader.
@@ -207,6 +202,9 @@ func (fs *FS) resolveSymlinkFrom(dest string, link string) string {
 	return path
 }
 
+// open reads the bytes of header out of the archive. header must already be
+// resolved by resolveHeader: a link entry carries no payload of its own, so
+// reading one directly would yield an empty file.
 func (fs *FS) open(header *tar.Header) (io.Reader, error) {
 	log.Debug().Str("file", header.Name).Msg("tar> load file content")
 
@@ -217,15 +215,8 @@ func (fs *FS) open(header *tar.Header) (io.Reader, error) {
 	}
 	defer f.Close()
 
-	// Open and stat resolve before calling this, but resolve again so the
-	// content read is correct no matter which entry the caller arrived with.
-	resolved, ok := fs.resolveHeader(header)
-	if !ok {
-		return nil, os.ErrNotExist
-	}
-
 	// extract file from tar stream
-	reader, err := fsutil.ExtractFileFromTarStream(resolved.Name, f)
+	reader, err := fsutil.ExtractFileFromTarStream(header.Name, f)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/connection/tar/hardlink_test.go
+++ b/providers/os/connection/tar/hardlink_test.go
@@ -1,0 +1,193 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package tar_test
+
+import (
+	archivetar "archive/tar"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/tar"
+)
+
+const osReleaseBody = "NAME=\"Fedora Linux\"\nID=fedora\nVERSION_ID=42\n"
+
+// writeOSTreeStyleTar builds the layout every OSTree/bootc image ships: the
+// real content lives in the ostree object store, the visible path is a tar
+// hardlink to it, and /etc/os-release is a symlink to that hardlink.
+//
+//	sysroot/ostree/repo/objects/ab/cdef.file   regular file, holds the bytes
+//	usr/lib/os-release                         hardlink -> the object above
+//	etc/os-release                             symlink  -> ../usr/lib/os-release
+func writeOSTreeStyleTar(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "ostree.tar")
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	tw := archivetar.NewWriter(f)
+	object := "sysroot/ostree/repo/objects/ab/cdef.file"
+
+	require.NoError(t, tw.WriteHeader(&archivetar.Header{
+		Name:     object,
+		Typeflag: archivetar.TypeReg,
+		Mode:     0o644,
+		Size:     int64(len(osReleaseBody)),
+	}))
+	_, err = tw.Write([]byte(osReleaseBody))
+	require.NoError(t, err)
+
+	// a hardlink entry carries no payload of its own: size is 0 and the real
+	// path is in Linkname
+	require.NoError(t, tw.WriteHeader(&archivetar.Header{
+		Name:     "usr/lib/os-release",
+		Typeflag: archivetar.TypeLink,
+		Linkname: object,
+		Mode:     0o644,
+	}))
+
+	require.NoError(t, tw.WriteHeader(&archivetar.Header{
+		Name:     "etc/os-release",
+		Typeflag: archivetar.TypeSymlink,
+		Linkname: "../usr/lib/os-release",
+		Mode:     0o777,
+	}))
+
+	require.NoError(t, tw.Close())
+	return path
+}
+
+func ostreeConn(t *testing.T, path string) *tar.Connection {
+	t.Helper()
+	c, err := tar.NewConnection(0, &inventory.Config{
+		Type:    "tar",
+		Options: map[string]string{tar.OPTION_FILE: path},
+	}, &inventory.Asset{})
+	require.NoError(t, err)
+	return c
+}
+
+// A hardlinked file reads as empty: the header the entry carries has Size 0,
+// so extracting by that entry's own name yields no bytes. Every OSTree and
+// bootc image (Fedora CoreOS, Fedora bootc, the uBlue images) stores
+// /usr/lib/os-release this way, which left the whole platform undetected and
+// reported container images as "scratch".
+func TestTarHardlinkContent(t *testing.T) {
+	c := ostreeConn(t, writeOSTreeStyleTar(t))
+
+	f, err := c.FileSystem().Open("/usr/lib/os-release")
+	require.NoError(t, err)
+	defer f.Close()
+
+	content, err := io.ReadAll(f)
+	require.NoError(t, err)
+	assert.Equal(t, osReleaseBody, string(content), "hardlink must read the content of its target")
+}
+
+func TestTarHardlinkStatSize(t *testing.T) {
+	c := ostreeConn(t, writeOSTreeStyleTar(t))
+
+	stat, err := c.FileSystem().Stat("/usr/lib/os-release")
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(osReleaseBody)), stat.Size(), "hardlink must report its target's size")
+}
+
+// The path detection actually opens: a symlink whose target is a hardlink.
+func TestTarSymlinkToHardlinkContent(t *testing.T) {
+	c := ostreeConn(t, writeOSTreeStyleTar(t))
+
+	f, err := c.FileSystem().Open("/etc/os-release")
+	require.NoError(t, err)
+	defer f.Close()
+
+	content, err := io.ReadAll(f)
+	require.NoError(t, err)
+	assert.Equal(t, osReleaseBody, string(content), "symlink to a hardlink must read through both")
+}
+
+const fedoraReleaseBody = "Fedora release 44 (Fedora CoreOS)\n"
+
+// A hardlink whose target is a symlink with a relative link, which is what
+// /etc/redhat-release is on an OSTree image:
+//
+//	etc/fedora-release                    the content
+//	sysroot/ostree/repo/objects/e8/..file symlink -> fedora-release
+//	etc/redhat-release                    hardlink -> the object above
+//
+// A hardlink names an inode, not a path, so "fedora-release" has to resolve
+// against /etc, the directory the file is being reached through, and not
+// against the object store the symlink physically lives in. Resolving it the
+// other way looks for /sysroot/ostree/repo/objects/e8/fedora-release, which
+// does not exist, and the redhat family then declines the whole subtree.
+func TestTarHardlinkToRelativeSymlink(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ostree-release.tar")
+	f, err := os.Create(path)
+	require.NoError(t, err)
+
+	tw := archivetar.NewWriter(f)
+	object := "sysroot/ostree/repo/objects/e8/1400dd.file"
+
+	require.NoError(t, tw.WriteHeader(&archivetar.Header{
+		Name:     "etc/fedora-release",
+		Typeflag: archivetar.TypeReg,
+		Mode:     0o644,
+		Size:     int64(len(fedoraReleaseBody)),
+	}))
+	_, err = tw.Write([]byte(fedoraReleaseBody))
+	require.NoError(t, err)
+
+	require.NoError(t, tw.WriteHeader(&archivetar.Header{
+		Name:     object,
+		Typeflag: archivetar.TypeSymlink,
+		Linkname: "fedora-release",
+		Mode:     0o777,
+	}))
+	require.NoError(t, tw.WriteHeader(&archivetar.Header{
+		Name:     "etc/redhat-release",
+		Typeflag: archivetar.TypeLink,
+		Linkname: object,
+		Mode:     0o644,
+	}))
+	require.NoError(t, tw.Close())
+	require.NoError(t, f.Close())
+
+	c := ostreeConn(t, path)
+
+	rf, err := c.FileSystem().Open("/etc/redhat-release")
+	require.NoError(t, err)
+	defer rf.Close()
+
+	content, err := io.ReadAll(rf)
+	require.NoError(t, err)
+	assert.Equal(t, fedoraReleaseBody, string(content))
+}
+
+// A link chain that never terminates must fail rather than hang the scan.
+func TestTarLinkCycleTerminates(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cycle.tar")
+	f, err := os.Create(path)
+	require.NoError(t, err)
+
+	tw := archivetar.NewWriter(f)
+	require.NoError(t, tw.WriteHeader(&archivetar.Header{
+		Name: "a", Typeflag: archivetar.TypeSymlink, Linkname: "/b", Mode: 0o777,
+	}))
+	require.NoError(t, tw.WriteHeader(&archivetar.Header{
+		Name: "b", Typeflag: archivetar.TypeSymlink, Linkname: "/a", Mode: 0o777,
+	}))
+	require.NoError(t, tw.Close())
+	require.NoError(t, f.Close())
+
+	c := ostreeConn(t, path)
+
+	_, err = c.FileSystem().Open("/a")
+	assert.Error(t, err, "a symlink cycle must not resolve")
+}

--- a/providers/os/resources/packages/rpm_packages.go
+++ b/providers/os/resources/packages/rpm_packages.go
@@ -425,6 +425,7 @@ func (rpm *RpmPkgManager) staticList() ([]Package, error) {
 		"/var/lib/rpm/rpmdb.sqlite",          // used on fedora 33-35 and mageia
 		"/var/lib/rpm/Packages",              // used on fedora 32
 		"/var/lib/rpm/Packages.db",           // used on openeuler
+		"/usr/share/rpm/rpmdb.sqlite",        // used on ostree images (fedora coreos, bootc, uBlue)
 	}
 	var tmpRpmDBFile string
 	var detectedPath string


### PR DESCRIPTION
Every OSTree-based image — Fedora CoreOS, Fedora bootc, the uBlue images, and by extension CentOS and RHEL bootc — scanned as `scratch`: no platform, no family, no packages, **and no error**. A container image with a clean bill of health that was never actually read.

## Root cause

The tar filesystem resolved symlinks but not hardlinks. OSTree keeps the bytes in its object store and exposes every real path as a hardlink to it:

```
sysroot/ostree/repo/objects/a2/69745d…file   the content
usr/lib/os-release                           hardlink to it
etc/os-release                               symlink to ../usr/lib/os-release
```

A hardlink entry carries `Size 0` and no payload of its own, so extracting it by its own name returns an **empty file rather than an error**. `/etc/os-release` read as `""`, detection named no platform, and `platform_resolver.go` renames an unidentified container image to `scratch`.

## Two things beyond adding the type

**Resolution has to follow a chain, not resolve once.** The path detection actually opens is a symlink whose target is itself a hardlink, so a single hop lands on the hardlink and still reads empty.

**A hardlink names an inode, not a path.** A relative symlink reached *through* a hardlink resolves against the directory the file is being reached through, not the directory of the entry that stores it. `/etc/redhat-release` is a hardlink to an object that is itself a symlink to `fedora-release`: that has to land on `/etc/fedora-release`, not on a sibling of the object in the store. Resolving it the other way left the redhat family declining the whole subtree even after os-release parsed correctly.

The chain walk is bounded and a cycle now fails instead of hanging the scan.

## The rpmdb path

`rpm_packages.go` gains `/usr/share/rpm/rpmdb.sqlite`, where rpm-ostree keeps the database. Without it these images detected correctly and still reported **zero packages** — the same false clean report in a new place, which is why it belongs in this PR rather than a follow-up.

## Measured against the real images

| image | platform | packages |
|---|---|---|
| `quay.io/fedora/fedora-coreos:stable` | `scratch` → `fedora` | 0 → **456** |
| `quay.io/fedora/fedora-bootc:42` | `scratch` → `fedora` | 0 → **530** |
| `ghcr.io/ublue-os/bluefin:latest` | `scratch` → `bluefin` (family `redhat`) | — |

## Tests

`hardlink_test.go` builds the OSTree layout synthetically, so the regression is pinned without a 1.5GB fixture: hardlink content, hardlink stat size, symlink→hardlink, hardlink→relative-symlink, and a cycle that must terminate. All four content tests fail on main.

## Follow-up, not in this PR

`bluefin` resolves with family `redhat` but its own name, which is not in the platform catalog — the uBlue images are an open-ended set of IDs (`bluefin`, `bazzite`, `aurora`, …). Worth deciding separately whether they normalize to `fedora` or get catalogued.
