### PR TITLE
🐛 os: detect Anolis OS, OpenCloudOS, deepin and openKylin

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -188,6 +188,20 @@ var cos = &PlatformResolver{
 	},
 }
 
+// OpenCloudOS is the Tencent-backed CentOS successor. It is rpm based, but it
+// ships /etc/system-release ("OpenCloudOS release 9.0") and no
+// /etc/redhat-release, so the redhat family declines it before any of that
+// family's children get a look. It resolves here instead, the way amazonlinux
+// and azurelinux do, and packages.go names it alongside them so it still gets
+// the rpm package manager.
+var opencloudos = &PlatformResolver{
+	Name:     "opencloudos",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		return pf.Name == "opencloudos", nil
+	},
+}
+
 // Talos is an API-managed Kubernetes host: it ships no shell, no /bin or
 // /sbin, and no package database, so nothing here can be derived from a
 // command. /etc/os-release is the whole of what detection can read.
@@ -494,6 +508,30 @@ var kdeneon = &PlatformResolver{
 	},
 }
 
+// deepin ships dpkg/apt and /etc/debian_version, but its os-release carries
+// ID=deepin and no ID_LIKE, so the debian resolver, which requires ID=debian,
+// never claims it. It resolves inside the debian family for the package
+// manager and the debian-specific resources to be selected.
+var deepin = &PlatformResolver{
+	Name:     "deepin",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		return pf.Name == "deepin", nil
+	},
+}
+
+// openKylin ships dpkg/apt but no /etc/debian_version at all, so it cannot be
+// reached through the debian resolver, which opens that file first. The
+// debian family itself claims every linux host, so matching on the name here
+// is what puts it in the family and selects dpkg.
+var openkylin = &PlatformResolver{
+	Name:     "openkylin",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		return pf.Name == "openkylin", nil
+	},
+}
+
 // elxr is a Debian derivative (os-release carries ID=elxr, ID_LIKE=debian).
 // It ships dpkg/apt, so it has to resolve inside the debian family for the
 // package manager and the debian-specific resources to be selected.
@@ -668,6 +706,19 @@ var centos = &PlatformResolver{
 		}
 
 		return true, nil
+	},
+}
+
+// Anolis OS is the Alibaba-backed CentOS successor. It ships
+// /etc/redhat-release ("Anolis OS release 8.8") and an rpm database, so it
+// resolves inside the redhat family and picks up the rpm package manager.
+// It declares ID_LIKE="rhel fedora centos", so it is resolved before centos,
+// whose last resort is the mere existence of /etc/centos-release.
+var anolis = &PlatformResolver{
+	Name:     "anolis",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		return pf.Name == "anolis", nil
 	},
 }
 
@@ -1398,7 +1449,7 @@ var redhatFamily = &PlatformResolver{
 	// so it also has to be resolved before redhat.
 	// NOTE: cloudlinux runs before centos, whose last resort is the mere existence of
 	// /etc/centos-release, which a rebuild may ship for compatibility
-	Children: []*PlatformResolver{oracle, rhcos, rhel, cloudlinux, centos, fedora, scientific, eurolinux, nobara, qubes},
+	Children: []*PlatformResolver{oracle, rhcos, rhel, cloudlinux, anolis, centos, fedora, scientific, eurolinux, nobara, qubes},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		f, err := conn.FileSystem().Open("/etc/redhat-release")
 		if err != nil {
@@ -1446,7 +1497,7 @@ var redhatFamily = &PlatformResolver{
 var debianFamily = &PlatformResolver{
 	Name:     "debian",
 	IsFamily: true,
-	Children: []*PlatformResolver{mxlinux, debian, ubuntu, raspbian, kali, linuxmint, popos, elementary, zorin, parrot, cumulus, gardenlinux, tails, kdeneon, elxr},
+	Children: []*PlatformResolver{mxlinux, debian, ubuntu, raspbian, kali, linuxmint, popos, elementary, zorin, parrot, cumulus, gardenlinux, tails, kdeneon, elxr, deepin, openkylin},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		return true, nil
 	},
@@ -1508,7 +1559,7 @@ var linuxFamily = &PlatformResolver{
 	IsFamily: true,
 	// NOTE: altlinux runs before the redhat family, whose members probe
 	// /etc/redhat-release and /etc/fedora-release, both of which ALT ships.
-	Children: []*PlatformResolver{archFamily, altlinux, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, wizos, alpine, wolfi, nixos, gentoo, voidlinux, clearlinux, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, cos, flatcar, talos, cirros, defaultLinux},
+	Children: []*PlatformResolver{archFamily, altlinux, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, wizos, alpine, wolfi, nixos, gentoo, voidlinux, clearlinux, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, cos, flatcar, talos, opencloudos, cirros, defaultLinux},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		detected := false
 		osrd := NewOSReleaseDetector(conn)

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -1478,6 +1478,57 @@ func TestTalosIsClaimedByItsOwnResolver(t *testing.T) {
 		"a container image claimed only by the generic resolver is reported as scratch")
 }
 
+// Anolis OS, OpenCloudOS, deepin and openKylin all set an ID no resolver
+// claimed, so detection fell to the generic resolver and every one of their
+// container images was reported as "scratch": no family, and so no package
+// manager and no findings.
+//
+// Each lands in a different place, and the family is the point: it is what
+// selects rpm or dpkg further down.
+
+func TestAnolisDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-anolis-8.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "anolis", di.Name, "os name should be identified")
+	assert.Equal(t, "Anolis OS 8.8", di.Title, "os title should be identified")
+	assert.Equal(t, "8.8", di.Version, "os version should be identified")
+	assert.Equal(t, []string{"redhat", "linux", "unix", "os"}, di.Family)
+}
+
+// OpenCloudOS ships no /etc/redhat-release, so the redhat family declines it
+// before its children are consulted. It resolves as a platform of its own and
+// packages.go names it to get the rpm package manager back.
+func TestOpenCloudOSDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-opencloudos-9.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "opencloudos", di.Name, "os name should be identified")
+	assert.Equal(t, "OpenCloudOS 9.0", di.Title, "os title should be identified")
+	assert.Equal(t, "9.0", di.Version, "os version should be identified")
+	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
+}
+
+func TestDeepinDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-deepin-25.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "deepin", di.Name, "os name should be identified")
+	assert.Equal(t, "Deepin 25", di.Title, "os title should be identified")
+	assert.Equal(t, "25", di.Version, "os version should be identified")
+	assert.Equal(t, []string{"debian", "linux", "unix", "os"}, di.Family)
+}
+
+func TestOpenKylinDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-openkylin-3.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "openkylin", di.Name, "os name should be identified")
+	assert.Equal(t, "openKylin 3.0", di.Title, "os title should be identified")
+	assert.Equal(t, "3.0", di.Version, "os version should be identified")
+	assert.Equal(t, []string{"debian", "linux", "unix", "os"}, di.Family)
+}
+
 func TestEndeavourOSContainerDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-endeavouros.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/device_type.go
+++ b/providers/os/detector/device_type.go
@@ -63,9 +63,11 @@ var containerVariantIDPrefixes = []string{
 // desktopPlatformNames lists platform names (from os-release ID) that are
 // inherently desktop-oriented distributions.
 var desktopPlatformNames = map[string]bool{
+	"deepin":     true,
 	"elementary": true,
 	"linuxmint":  true,
 	"nobara":     true,
+	"openkylin":  true,
 	"pop":        true,
 	"steamos":    true,
 	"zorin":      true,

--- a/providers/os/detector/testdata/detect-anolis-8.toml
+++ b/providers/os/detector/testdata/detect-anolis-8.toml
@@ -1,0 +1,25 @@
+# openanolis/anolisos:8.8. Anolis ships /etc/redhat-release, which is what the
+# redhat family gates its whole subtree on.
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[files."/etc/os-release"]
+content = """
+NAME="Anolis OS"
+VERSION="8.8"
+ID="anolis"
+ID_LIKE="rhel fedora centos"
+VERSION_ID="8.8"
+PLATFORM_ID="platform:an8"
+PRETTY_NAME="Anolis OS 8.8"
+ANSI_COLOR="0;31"
+HOME_URL="https://openanolis.cn/"
+"""
+
+[files."/etc/redhat-release"]
+content = """
+Anolis OS release 8.8
+"""

--- a/providers/os/detector/testdata/detect-deepin-25.toml
+++ b/providers/os/detector/testdata/detect-deepin-25.toml
@@ -1,0 +1,24 @@
+# linuxdeepin/deepin:latest. os-release carries ID=deepin and no ID_LIKE, so
+# the debian resolver never claims it even though /etc/debian_version is here.
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[files."/etc/os-release"]
+content = """
+PRETTY_NAME="Deepin 25"
+NAME="Deepin"
+VERSION_CODENAME=crimson
+ID=deepin
+HOME_URL="https://www.deepin.org/"
+BUG_REPORT_URL="https://bbs.deepin.org"
+VERSION_ID="25"
+VERSION="25"
+"""
+
+[files."/etc/debian_version"]
+content = """
+trixie/sid
+"""

--- a/providers/os/detector/testdata/detect-opencloudos-9.toml
+++ b/providers/os/detector/testdata/detect-opencloudos-9.toml
@@ -1,0 +1,28 @@
+# opencloudos/opencloudos:9.0. Deliberately carries no /etc/redhat-release:
+# OpenCloudOS ships only /etc/system-release, which is why the redhat family
+# declines it and it has to resolve as a platform of its own.
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[files."/etc/os-release"]
+content = """
+NAME="OpenCloudOS"
+VERSION="9.0"
+ID="opencloudos"
+ID_LIKE="opencloudos"
+VERSION_ID="9.0"
+PLATFORM_ID="platform:oc9"
+PRETTY_NAME="OpenCloudOS 9.0"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:opencloudos:opencloudos:9"
+HOME_URL="https://www.opencloudos.org/"
+BUG_REPORT_URL="https://bugs.opencloudos.tech/"
+"""
+
+[files."/etc/system-release"]
+content = """
+OpenCloudOS release 9.0
+"""

--- a/providers/os/detector/testdata/detect-openkylin-3.toml
+++ b/providers/os/detector/testdata/detect-openkylin-3.toml
@@ -1,0 +1,21 @@
+# openkylin/openkylin:latest. Ships dpkg but no /etc/debian_version at all,
+# so the debian resolver cannot reach it: it opens that file first.
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[files."/etc/os-release"]
+content = """
+NAME="openKylin"
+FULL_NAME="openKylin"
+VERSION="3.0 (huanghe)"
+VERSION_US="3.0 (huanghe)"
+ID=openkylin
+PRETTY_NAME="openKylin 3.0"
+VERSION_ID="3.0"
+HOME_URL="https://www.openkylin.top/"
+VERSION_CODENAME=huanghe
+PRODUCT_FEATURES=3
+"""

--- a/providers/os/resources/packages/packages.go
+++ b/providers/os/resources/packages/packages.go
@@ -130,7 +130,9 @@ func ResolveSystemPkgManagers(conn shared.Connection) ([]OperatingSystemPkgManag
 	// an error on a system with a populated rpm database.
 	case asset.Platform.Name == "altlinux":
 		fallthrough
-	case asset.Platform.Name == "amazonlinux" || asset.Platform.Name == "photon" || asset.Platform.Name == "wrlinux" || asset.Platform.Name == "bottlerocket" || asset.Platform.Name == "azurelinux":
+	// opencloudos is rpm based but ships no /etc/redhat-release, so the redhat
+	// family declines it and it resolves as a platform of its own
+	case asset.Platform.Name == "amazonlinux" || asset.Platform.Name == "photon" || asset.Platform.Name == "wrlinux" || asset.Platform.Name == "bottlerocket" || asset.Platform.Name == "azurelinux" || asset.Platform.Name == "opencloudos":
 		fallthrough
 	case asset.Platform.IsFamily("redhat") ||
 		asset.Platform.IsFamily("euler") ||


### PR DESCRIPTION
All four set an `ID` no resolver claimed, so detection fell to the generic resolver and every one of their container images was reported as `scratch`: no family, so no package manager, so an empty package list and **no findings** on a system that was never read.

Found by sweeping real container base images against the detector; same bug class as #10459 (openSUSE MicroOS) and #10462 (Talos).

## Measured against the real images

| image | platform | packages |
|---|---|---|
| `openanolis/anolisos:8.8` | `scratch` → `anolis` | 0 → **182** |
| `opencloudos/opencloudos:9.0` | `scratch` → `opencloudos` | 0 → **131** |
| `linuxdeepin/deepin:latest` | `scratch` → `deepin` | 0 → **161** |
| `openkylin/openkylin:latest` | `scratch` → `openkylin` | 0 → **108** |

Anolis OS (Alibaba) and OpenCloudOS (Tencent) are the two CentOS successors most of that migration went to; deepin and openKylin are mainstream desktop distributions.

## Placement

Each lands in a different place, and the family is the point — it is what selects rpm or dpkg further down. The placement is **not** guessable from the distro's lineage, so each was checked against the image rather than assumed:

- **Anolis** ships `/etc/redhat-release` (`Anolis OS release 8.8`), which is what the redhat family gates its whole subtree on, so it resolves as a member. Placed before `centos`, whose last resort is the mere existence of `/etc/centos-release`, because Anolis declares `ID_LIKE="rhel fedora centos"`.
- **OpenCloudOS** is rpm based but ships only `/etc/system-release`, **no** `/etc/redhat-release` — so the redhat family declines it before any child is consulted. It resolves as a platform of its own, and `packages.go` names it next to `amazonlinux`/`azurelinux` so it still gets the rpm package manager.
- **deepin** ships dpkg and `/etc/debian_version`, but its os-release carries `ID=deepin` and no `ID_LIKE`, so the `debian` resolver — which requires `ID=debian` — never claims it.
- **openKylin** ships dpkg and **no `/etc/debian_version` at all**, so it cannot be reached through the `debian` resolver, which opens that file first. The debian family claims every linux host, so matching the name is what selects dpkg.

## device_type

deepin and openKylin are desktop distributions and need to be named: the classifier defaults to server and neither title carries a keyword to correct it. Anolis and OpenCloudOS need no entry — server is already the default.

## Fixtures

Content is verbatim from the images, including the details that drive placement: the Anolis fixture carries `/etc/redhat-release`, and the OpenCloudOS fixture deliberately carries only `/etc/system-release`, so a future change that moves it into the redhat family fails the test rather than silently losing its packages.
