### PR TITLE
🐛 os: give a mounted host root its AWS cloud identity

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -313,6 +313,13 @@ Examples:
 					Desc:    "Path to a local file or directory for the connection to use",
 					Option:  plugin.FlagOption_Deprecated,
 				},
+				{
+					Long:    shared.HostRootOption,
+					Type:    plugin.FlagType_Bool,
+					Default: "false",
+					Desc:    "The mounted path is the root file system of this machine, not a snapshot of another one. Lets cloud identity detection read the local instance metadata service. Do not set it for a mount that came from a different machine.",
+					Option:  plugin.FlagOption_Hidden,
+				},
 			},
 		},
 		{

--- a/providers/os/connection/shared/shared.go
+++ b/providers/os/connection/shared/shared.go
@@ -45,6 +45,19 @@ const (
 	Type_Device            ConnectionType = "device"
 
 	ContainerProxyOption string = "container-proxy"
+
+	// HostRootOption marks a filesystem connection whose mounted path is the
+	// root filesystem of the machine cnspec is running on -- the Kubernetes
+	// node scan, which bind-mounts / into the scan pod, is the canonical case.
+	//
+	// It exists because a filesystem connection alone cannot tell "this is my
+	// own host, mounted elsewhere" from "this is a snapshot of some other
+	// machine". Identity lookups that reach out to the local instance metadata
+	// service are only correct for the former; for the latter they would answer
+	// with the *scanner's* identity and silently attribute the scan to the
+	// wrong machine. Callers must therefore opt in explicitly, and only when
+	// they know the mount is the live local root.
+	HostRootOption string = "host-root"
 )
 
 type OSFamily string

--- a/providers/os/id/aws/aws.go
+++ b/providers/os/id/aws/aws.go
@@ -25,6 +25,42 @@ func readValue(conn shared.Connection, fPath string) string {
 	return string(content)
 }
 
+// bottlerocketPlatform is the platform name the os-release detector assigns to
+// Bottlerocket hosts.
+const bottlerocketPlatform = "bottlerocket"
+
+// bottlerocketAWSVariantPrefix is the VARIANT_ID prefix Bottlerocket uses for
+// its AWS images: aws-k8s-1.34, aws-ecs-2, aws-dev, and their -fips suffixes.
+const bottlerocketAWSVariantPrefix = "aws-"
+
+// isBottlerocketOnAWS reports whether the platform is a Bottlerocket AWS image.
+//
+// Bottlerocket ships no cloud-init, so none of the markers Detect looks for on
+// a mounted filesystem exist on it: there is no /etc/cloud/cloud.cfg, and the
+// /sys DMI files are a pseudo-filesystem that a bind-mounted host root does not
+// carry either. Without this check every Bottlerocket node scanned through a
+// filesystem connection -- which is how the Kubernetes node scan works -- comes
+// back as "not AWS", leaving the `cloud` resource with no provider and its
+// instance metadata erroring out with "unknown provider information".
+//
+// VARIANT_ID is a sound substitute. Bottlerocket builds one image per target
+// platform and names the variant after it (aws-*, vmware-*, metal-*), so an
+// aws- prefix on a Bottlerocket host means the machine is an EC2 instance. The
+// platform name is checked too, because the prefix only carries that meaning
+// under Bottlerocket's variant naming scheme.
+func isBottlerocketOnAWS(p *inventory.Platform) bool {
+	if !strings.EqualFold(p.GetName(), bottlerocketPlatform) {
+		return false
+	}
+
+	variant := p.GetLabels()["variant-id"]
+	if variant == "" {
+		variant = p.GetMetadata()["variant-id"]
+	}
+
+	return strings.HasPrefix(strings.ToLower(variant), bottlerocketAWSVariantPrefix)
+}
+
 func Detect(conn shared.Connection, p *inventory.Platform) (string, string, []string) {
 	var values []string
 	if conn.Type() == shared.Type_FileSystem {
@@ -71,11 +107,13 @@ func Detect(conn shared.Connection, p *inventory.Platform) (string, string, []st
 		}
 	}
 
-	isAws := false
-	for _, v := range values {
-		if strings.Contains(strings.ToLower(v), "amazon") {
-			isAws = true
-			break
+	isAws := isBottlerocketOnAWS(p)
+	if !isAws {
+		for _, v := range values {
+			if strings.Contains(strings.ToLower(v), "amazon") {
+				isAws = true
+				break
+			}
 		}
 	}
 

--- a/providers/os/id/aws/aws_test.go
+++ b/providers/os/id/aws/aws_test.go
@@ -68,3 +68,68 @@ func TestDetectContainer(t *testing.T) {
 	require.Len(t, related, 1)
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/aws/accounts/172746783610", related[0])
 }
+
+func TestIsBottlerocketOnAWS(t *testing.T) {
+	tests := []struct {
+		name     string
+		platform *inventory.Platform
+		want     bool
+	}{
+		{
+			// The variant EKS nodes run, and the case this exists for: no
+			// cloud-init on disk, so nothing else marks the host as AWS.
+			name: "bottlerocket aws-k8s variant via labels",
+			platform: &inventory.Platform{
+				Name:   "bottlerocket",
+				Labels: map[string]string{"variant-id": "aws-k8s-1.34"},
+			},
+			want: true,
+		},
+		{
+			name: "bottlerocket aws-ecs variant via metadata",
+			platform: &inventory.Platform{
+				Name:     "bottlerocket",
+				Metadata: map[string]string{"variant-id": "aws-ecs-2-fips"},
+			},
+			want: true,
+		},
+		{
+			name: "bottlerocket vmware variant is not aws",
+			platform: &inventory.Platform{
+				Name:   "bottlerocket",
+				Labels: map[string]string{"variant-id": "vmware-k8s-1.34"},
+			},
+			want: false,
+		},
+		{
+			name: "bottlerocket metal variant is not aws",
+			platform: &inventory.Platform{
+				Name:   "bottlerocket",
+				Labels: map[string]string{"variant-id": "metal-k8s-1.34"},
+			},
+			want: false,
+		},
+		{
+			name:     "bottlerocket without a variant",
+			platform: &inventory.Platform{Name: "bottlerocket"},
+			want:     false,
+		},
+		{
+			// The aws- prefix only carries platform meaning under
+			// Bottlerocket's variant naming, so it must not be trusted
+			// anywhere else.
+			name: "non-bottlerocket platform with an aws- variant",
+			platform: &inventory.Platform{
+				Name:   "amazonlinux",
+				Labels: map[string]string{"variant-id": "aws-something"},
+			},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, isBottlerocketOnAWS(test.platform))
+		})
+	}
+}

--- a/providers/os/id/awsec2/awsec2.go
+++ b/providers/os/id/awsec2/awsec2.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/providers/os/connection/mock"
 	"go.mondoo.com/mql/providers/os/connection/shared"
@@ -26,18 +27,14 @@ type InstanceIdentifier interface {
 }
 
 func Resolve(conn shared.Connection, pf *inventory.Platform) (InstanceIdentifier, error) {
-	cfg, err := awsConfig(conn)
-	if err != nil {
-		// for local environments we must have a config, or it won't work
-		if conn.Type() == shared.Type_Local {
-			return nil, errors.Wrap(err, "cannot not determine AWS environment")
-		}
-
-		// over a remote connection, we can try without the config
-		return NewCommandInstanceMetadata(conn, pf, nil), nil
-	}
+	cfg, cfgErr := awsConfig(conn)
 
 	if conn.Type() == shared.Type_Local {
+		// for local environments we must have a config, or it won't work
+		if cfgErr != nil {
+			return nil, errors.Wrap(cfgErr, "cannot not determine AWS environment")
+		}
+
 		// TODO: Dom: Since a mocked local is not considered local in the original
 		// code, we are not testing this code path. Also the original only had
 		// mock and non-mock, where the v9 plugin system introduces hybrid modes.
@@ -45,6 +42,7 @@ func Resolve(conn shared.Connection, pf *inventory.Platform) (InstanceIdentifier
 		if _, ok := conn.(*mock.Connection); !ok {
 			return NewLocal(cfg), nil
 		}
+		return NewCommandInstanceMetadata(conn, pf, &cfg), nil
 	}
 
 	// A mounted host root describes the machine we are already running on, so
@@ -58,10 +56,25 @@ func Resolve(conn shared.Connection, pf *inventory.Platform) (InstanceIdentifier
 	// image, a volume detached from a different machine -- IMDS would answer
 	// with the scanner's own identity and silently attribute the scan to the
 	// wrong instance. See shared.HostRootOption.
+	//
+	// This is checked before cfgErr is acted on because a failed configuration
+	// load must not send a host root to the command reader, which cannot run
+	// anything: the metadata service needs neither credentials nor a region, so
+	// the zero config still answers. A usable config only improves the instance
+	// name lookup, which already degrades to the instance ID on its own.
 	if isHostRootMount(conn) {
 		if _, ok := conn.(*mock.Connection); !ok {
+			if cfgErr != nil {
+				log.Debug().Err(cfgErr).
+					Msg("no AWS configuration; reading instance metadata without one")
+			}
 			return NewLocal(cfg), nil
 		}
+	}
+
+	if cfgErr != nil {
+		// over a remote connection, we can try without the config
+		return NewCommandInstanceMetadata(conn, pf, nil), nil
 	}
 
 	return NewCommandInstanceMetadata(conn, pf, &cfg), nil

--- a/providers/os/id/awsec2/awsec2.go
+++ b/providers/os/id/awsec2/awsec2.go
@@ -46,7 +46,40 @@ func Resolve(conn shared.Connection, pf *inventory.Platform) (InstanceIdentifier
 			return NewLocal(cfg), nil
 		}
 	}
+
+	// A mounted host root describes the machine we are already running on, so
+	// the local IMDS answer is its answer. It needs its own branch because the
+	// command reader below shells out to curl, and a filesystem connection has
+	// no command execution at all -- it returns ErrRunCommandNotImplemented, so
+	// every identity lookup fails and the asset ends up with no cloud identity.
+	//
+	// The gate is deliberately an explicit caller assertion rather than a guess
+	// from the connection: for any other mounted filesystem -- a snapshot, an
+	// image, a volume detached from a different machine -- IMDS would answer
+	// with the scanner's own identity and silently attribute the scan to the
+	// wrong instance. See shared.HostRootOption.
+	if isHostRootMount(conn) {
+		if _, ok := conn.(*mock.Connection); !ok {
+			return NewLocal(cfg), nil
+		}
+	}
+
 	return NewCommandInstanceMetadata(conn, pf, &cfg), nil
+}
+
+// isHostRootMount reports whether the connection is a filesystem connection
+// that the caller marked as the root filesystem of the local machine.
+func isHostRootMount(conn shared.Connection) bool {
+	if conn.Type() != shared.Type_FileSystem {
+		return false
+	}
+
+	asset := conn.Asset()
+	if asset == nil || len(asset.Connections) == 0 {
+		return false
+	}
+
+	return asset.Connections[0].GetOptions()[shared.HostRootOption] == "true"
 }
 
 // awsConfig looks at the connection to see if it has additional options that need

--- a/providers/os/id/awsec2/awsec2_test.go
+++ b/providers/os/id/awsec2/awsec2_test.go
@@ -63,3 +63,27 @@ func TestIsHostRootMount(t *testing.T) {
 		assert.False(t, isHostRootMount(conn))
 	})
 }
+
+func TestResolveUsesInProcessMetadataForAHostRoot(t *testing.T) {
+	pf := &inventory.Platform{Name: "bottlerocket", Family: []string{"linux", "unix", "os"}}
+
+	t.Run("host root reads metadata in-process", func(t *testing.T) {
+		// The command reader cannot run anything over a filesystem connection,
+		// so a host root has to reach the metadata service directly.
+		conn := newFsConnection(t, map[string]string{shared.HostRootOption: "true"})
+
+		identifier, err := Resolve(conn, pf)
+		require.NoError(t, err)
+		assert.IsType(t, &LocalEc2InstanceMetadata{}, identifier)
+	})
+
+	t.Run("any other mount keeps the command reader", func(t *testing.T) {
+		// Without the opt-in the mount may belong to a different machine, and
+		// the metadata service would answer with this one's identity.
+		conn := newFsConnection(t, nil)
+
+		identifier, err := Resolve(conn, pf)
+		require.NoError(t, err)
+		assert.IsType(t, &CommandInstanceMetadata{}, identifier)
+	})
+}

--- a/providers/os/id/awsec2/awsec2_test.go
+++ b/providers/os/id/awsec2/awsec2_test.go
@@ -1,0 +1,65 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package awsec2
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/fs"
+	"go.mondoo.com/mql/providers/os/connection/shared"
+)
+
+// newFsConnection builds a filesystem connection over an empty in-memory
+// filesystem, carrying the given connection options.
+func newFsConnection(t *testing.T, options map[string]string) shared.Connection {
+	t.Helper()
+
+	conf := &inventory.Config{
+		Type:    shared.Type_FileSystem.String(),
+		Host:    "/mnt/host",
+		Options: options,
+	}
+	asset := &inventory.Asset{Connections: []*inventory.Config{conf}}
+
+	conn, err := fs.NewFileSystemConnectionWithFs(0, conf, asset, "/mnt/host", nil, afero.NewMemMapFs())
+	require.NoError(t, err)
+	return conn
+}
+
+func TestIsHostRootMount(t *testing.T) {
+	t.Run("opted in", func(t *testing.T) {
+		conn := newFsConnection(t, map[string]string{shared.HostRootOption: "true"})
+		assert.True(t, isHostRootMount(conn))
+	})
+
+	t.Run("no options at all", func(t *testing.T) {
+		// A plain `cnspec scan filesystem --path ...`: the mount may be a
+		// snapshot of an entirely different machine, so IMDS must not be
+		// consulted.
+		conn := newFsConnection(t, nil)
+		assert.False(t, isHostRootMount(conn))
+	})
+
+	t.Run("option present but not true", func(t *testing.T) {
+		conn := newFsConnection(t, map[string]string{shared.HostRootOption: "false"})
+		assert.False(t, isHostRootMount(conn))
+	})
+
+	t.Run("asset without connections", func(t *testing.T) {
+		conf := &inventory.Config{
+			Type:    shared.Type_FileSystem.String(),
+			Host:    "/mnt/host",
+			Options: map[string]string{shared.HostRootOption: "true"},
+		}
+		conn, err := fs.NewFileSystemConnectionWithFs(
+			0, conf, &inventory.Asset{}, "/mnt/host", nil, afero.NewMemMapFs())
+		require.NoError(t, err)
+
+		assert.False(t, isHostRootMount(conn))
+	})
+}

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -529,6 +529,17 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 			} else {
 				// In this case asset.Name should already be set via the inventory
 				asset.PlatformIds = []string{pID}
+				// The inventory may know identifiers for this machine that no
+				// detector can reach through a mount. The Kubernetes node scan
+				// is the case this exists for: it reads the node's cloud
+				// instance ID from the Kubernetes API and passes it down here,
+				// because a scan pod cannot reach the instance metadata
+				// service. Appending rather than replacing keeps both the
+				// Kubernetes identity and the cloud one on the asset, which is
+				// what lets it resolve to the asset the cloud integration
+				// already discovered instead of becoming a second asset for
+				// the same machine.
+				asset.PlatformIds = append(asset.PlatformIds, injectedPlatformIDs(conf)...)
 			}
 
 		// Do not expose mock connection as a supported type
@@ -693,4 +704,27 @@ func parseContainerSubcommand(subcommand, target string, conf *inventory.Config)
 		conf.Type = shared.Type_DockerContainer.String()
 		conf.Host = target
 	}
+}
+
+// injectedPlatformIDs returns the platform identifiers a caller passed through
+// the inventory in the inject-platform-ids option, skipping empty entries.
+//
+// Empty entries are expected rather than exceptional: callers template the
+// value (e.g. `{{ getenv "MONDOO_AWS_PLATFORM_ID" }}`), and a host with no such
+// identity resolves it to an empty string. Treating that as an identifier
+// would put a meaningless "" on the asset.
+func injectedPlatformIDs(conf *inventory.Config) []string {
+	raw := conf.GetOptions()[device.PlatformIdInject]
+	if raw == "" {
+		return nil
+	}
+
+	ids := make([]string, 0, 1)
+	for _, id := range strings.Split(raw, ",") {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
 }

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -726,5 +726,8 @@ func injectedPlatformIDs(conf *inventory.Config) []string {
 			ids = append(ids, id)
 		}
 	}
+	if len(ids) == 0 {
+		return nil
+	}
 	return ids
 }

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -204,6 +204,15 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		conf.Options["disable-cache"] = strconv.FormatBool(disableCache.RawData().Value.(bool))
 	}
 
+	// Only recorded when the caller opts in: the absence of the key and an
+	// explicit "false" mean the same thing, and writing it unconditionally
+	// would put a misleading host-root=false on every other connector.
+	if hostRoot, ok := flags[shared.HostRootOption]; ok {
+		if enabled, isBool := hostRoot.RawData().Value.(bool); isBool && enabled {
+			conf.Options[shared.HostRootOption] = "true"
+		}
+	}
+
 	if containerProxy, ok := flags[shared.ContainerProxyOption]; ok {
 		proxyVal := containerProxy.RawData().Value.(string)
 		if proxyVal != "" {

--- a/providers/os/provider/provider_test.go
+++ b/providers/os/provider/provider_test.go
@@ -212,7 +212,7 @@ func TestInjectedPlatformIDs(t *testing.T) {
 		{
 			name: "only separators",
 			conf: &inventory.Config{Options: map[string]string{device.PlatformIdInject: " , "}},
-			want: []string{},
+			want: nil,
 		},
 		{
 			name: "option absent",

--- a/providers/os/provider/provider_test.go
+++ b/providers/os/provider/provider_test.go
@@ -14,6 +14,7 @@ import (
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers-sdk/v1/vault"
+	"go.mondoo.com/mql/providers/os/connection/device"
 	"go.mondoo.com/mql/providers/os/id/ids"
 )
 
@@ -179,4 +180,55 @@ func TestConnect_ContainerImage(t *testing.T) {
 	assert.Equal(t, "Alpine Linux v3.19", connectResp.Asset.Platform.Title)
 	assert.Equal(t, "container-image", connectResp.Asset.Platform.Kind)
 	assert.Equal(t, "docker-image", connectResp.Asset.Platform.Runtime)
+}
+
+func TestInjectedPlatformIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		conf *inventory.Config
+		want []string
+	}{
+		{
+			name: "single id",
+			conf: &inventory.Config{Options: map[string]string{
+				device.PlatformIdInject: "//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/959975882244/regions/eu-central-1/instances/i-0a8caeccfd813a595",
+			}},
+			want: []string{"//platformid.api.mondoo.app/runtime/aws/ec2/v1/accounts/959975882244/regions/eu-central-1/instances/i-0a8caeccfd813a595"},
+		},
+		{
+			name: "comma separated",
+			conf: &inventory.Config{Options: map[string]string{
+				device.PlatformIdInject: "//platformid.api.mondoo.app/a, //platformid.api.mondoo.app/b",
+			}},
+			want: []string{"//platformid.api.mondoo.app/a", "//platformid.api.mondoo.app/b"},
+		},
+		{
+			// The expected shape when a caller templates the value and the
+			// host has no such identity -- it must not become an identifier.
+			name: "empty value",
+			conf: &inventory.Config{Options: map[string]string{device.PlatformIdInject: ""}},
+			want: nil,
+		},
+		{
+			name: "only separators",
+			conf: &inventory.Config{Options: map[string]string{device.PlatformIdInject: " , "}},
+			want: []string{},
+		},
+		{
+			name: "option absent",
+			conf: &inventory.Config{Options: map[string]string{"path": "/mnt/host"}},
+			want: nil,
+		},
+		{
+			name: "no options",
+			conf: &inventory.Config{},
+			want: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, injectedPlatformIDs(test.conf))
+		})
+	}
 }


### PR DESCRIPTION
Part of the fix for **mondoohq/mondoo-operator#1630** — a Kubernetes node and the cloud VM behind it become two separate assets. Pairs with **mondoohq/mondoo-operator#1632**, which produces the identifier the second commit here carries.

Two commits, both about a node scanned over a filesystem connection to a bind-mounted host root.

---

## 1. `🐛 os: detect AWS on Bottlerocket and on a mounted host root`

Neither half of AWS cloud detection survives a filesystem connection:

- The only marker `Detect` reads for a mounted Linux filesystem is `/etc/cloud/cloud.cfg`. **Bottlerocket ships no cloud-init**, so the read comes back empty and `isAws` stays false. Its `/sys` DMI files are a pseudo-filesystem that a bind-mounted root does not carry either, so there is no second chance.
- Even once a host is recognized as AWS, `awsec2` reads the instance identity document by shelling out to `curl`. A filesystem connection has no command execution — `RunCommand` returns `ErrRunCommandNotImplemented` — so every lookup fails, and the `awsecs` and `awsebs` fallbacks behind it are cloud-init and SSM shaped too.

The result is an EC2 instance with no cloud identity at all: `cloud { provider instance { ... } }` errors with `unknown provider information`, the asset reports kind `baremetal` rather than a cloud VM, and nothing shows which AWS account the node belongs to.

**Detect now recognizes a Bottlerocket AWS image from its `VARIANT_ID`.** Bottlerocket builds one image per target platform and names the variant after it (`aws-*`, `vmware-*`, `metal-*`), so an `aws-` prefix on a Bottlerocket host means the machine is an EC2 instance. The platform name is checked too, because the prefix only carries that meaning under Bottlerocket's naming scheme.

**`awsec2.Resolve` now talks to IMDS in-process** — the same reader local connections already use — when the connection is a filesystem mount the caller marked with the new `host-root` option.

That gate is an explicit caller assertion rather than something inferred from the connection. For any other mounted filesystem — a snapshot, an image, a volume detached from another machine — IMDS would answer with the *scanner's* own identity and silently attribute the scan to the wrong instance. `host-root` is exposed as a hidden `--host-root` flag on the filesystem connector and read from the connection options.

## 2. `🐛 os: honour inject-platform-ids on filesystem connections`

A filesystem connection given a platform ID in its inventory **replaced** the asset's identifier list with that single value. Right for the identifier itself, but it left no way for a caller to hand down identity it knows and no detector can reach through a mount.

Filesystem connections now read `inject-platform-ids` — the option device connections already use for the same purpose — and **append** its entries after the connection identifier. The node therefore keeps its Kubernetes identity and gains its cloud one, which is what lets it resolve to the asset a cloud integration already discovered rather than becoming a second asset for the same machine.

Empty entries are skipped. Callers template this value (e.g. `{{ getenv "MONDOO_AWS_PLATFORM_ID" }}`), and a host with no such identity resolves it to an empty string, which must not become an identifier.

---

## Which path applies where

Commit 2 is the one that matters for Kubernetes node scanning, because it needs no network access at all — the operator reads the node's cloud identity from the Kubernetes API and passes it down.

Commit 1's IMDS path needs the metadata hop limit to be 2 or more, which is **not** the default: Karpenter and the EKS managed node group module both default `httpPutResponseHopLimit` to 1, so a scan pod that is not on the host network cannot reach IMDS. It remains the right answer for filesystem scans that are not driven by the operator, and the Bottlerocket detection in it is unconditional.
