### PR TITLE
🐛 k8s: resolve automountServiceAccountToken against the ServiceAccount

### DIFF
--- a/providers/k8s/resources/k8s.go
+++ b/providers/k8s/resources/k8s.go
@@ -10,8 +10,9 @@ import (
 )
 
 type mqlK8sInternal struct {
-	lock        sync.Mutex
-	nodesByName map[string]*mqlK8sNode
+	lock                  sync.Mutex
+	nodesByName           map[string]*mqlK8sNode
+	serviceAccountsByName map[string]*mqlK8sServiceaccount
 }
 
 func (k *mqlK8s) serverVersion() (any, error) {

--- a/providers/k8s/resources/pod.go
+++ b/providers/k8s/resources/pod.go
@@ -393,11 +393,7 @@ func (k *mqlK8sPod) automountServiceAccountToken() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if spec.AutomountServiceAccountToken == nil {
-		// Defaults to true when unset.
-		return true, nil
-	}
-	return *spec.AutomountServiceAccountToken, nil
+	return effectiveAutomountServiceAccountToken(k.MqlRuntime, spec, k.Namespace.Data), nil
 }
 
 func (k *mqlK8sPod) hostNetwork() (bool, error) {

--- a/providers/k8s/resources/serviceaccount_automount.go
+++ b/providers/k8s/resources/serviceaccount_automount.go
@@ -1,0 +1,89 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+// Resolving whether an API token is mounted needs both the pod spec and the
+// ServiceAccount it runs as. Kubernetes applies the pod-level setting when it
+// is present, otherwise the ServiceAccount's, otherwise its default of true.
+//
+// Unlike imagePullSecrets, which the ServiceAccount admission controller copies
+// into the pod spec, the automount decision is never written back to the spec:
+// the controller simply omits the projected token volume. Reading the spec
+// alone therefore reports "token mounted" for every workload hardened by
+// setting automountServiceAccountToken: false on the ServiceAccount, which is
+// the recommended way to disable it for a whole namespace.
+
+import (
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// automountFromSpecAndAccount applies the Kubernetes precedence rule: the
+// pod-level setting wins, then the ServiceAccount's, and an unset value at both
+// levels means the default, true.
+func automountFromSpecAndAccount(podLevel, accountLevel *bool) bool {
+	if podLevel != nil {
+		return *podLevel
+	}
+	if accountLevel != nil {
+		return *accountLevel
+	}
+	return true
+}
+
+// podServiceAccountName returns the ServiceAccount a pod spec runs as, falling
+// back to the deprecated field and then to "default", which is what Kubernetes
+// assigns when the spec names none.
+func podServiceAccountName(spec *corev1.PodSpec) string {
+	if spec == nil {
+		return "default"
+	}
+	if spec.ServiceAccountName != "" {
+		return spec.ServiceAccountName
+	}
+	if spec.DeprecatedServiceAccount != "" {
+		return spec.DeprecatedServiceAccount
+	}
+	return "default"
+}
+
+// serviceAccountAutomount returns the named ServiceAccount's automount setting,
+// or nil when the account cannot be resolved. It reads the already-fetched
+// ServiceAccount collection rather than looking each account up individually,
+// so it costs no extra API calls.
+func serviceAccountAutomount(runtime *plugin.Runtime, namespace, name string) *bool {
+	index, err := namespacedByName[*mqlK8sServiceaccount](
+		runtime, func(x *mqlK8s) *plugin.TValue[[]any] { return x.GetServiceaccounts() })
+	if err != nil {
+		// A scan without permission to list ServiceAccounts cannot tell what the
+		// account asks for, so the Kubernetes default applies.
+		log.Debug().Err(err).Msg("cannot list service accounts to resolve automountServiceAccountToken")
+		return nil
+	}
+	sa, ok := index[namespace+"/"+name]
+	if !ok || sa == nil {
+		return nil
+	}
+	v := sa.GetAutomountServiceAccountToken()
+	if v.Error != nil {
+		log.Debug().Err(v.Error).Str("serviceaccount", name).Msg("cannot read automountServiceAccountToken")
+		return nil
+	}
+	value := v.Data
+	return &value
+}
+
+// effectiveAutomountServiceAccountToken reports whether Kubernetes mounts an API
+// token for a workload running under the given pod spec.
+func effectiveAutomountServiceAccountToken(runtime *plugin.Runtime, spec *corev1.PodSpec, namespace string) bool {
+	var podLevel *bool
+	if spec != nil {
+		podLevel = spec.AutomountServiceAccountToken
+	}
+	if podLevel != nil {
+		return *podLevel
+	}
+	return automountFromSpecAndAccount(nil, serviceAccountAutomount(runtime, namespace, podServiceAccountName(spec)))
+}

--- a/providers/k8s/resources/serviceaccount_automount.go
+++ b/providers/k8s/resources/serviceaccount_automount.go
@@ -16,6 +16,7 @@ package resources
 
 import (
 	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -49,13 +50,45 @@ func podServiceAccountName(spec *corev1.PodSpec) string {
 	return "default"
 }
 
+// serviceAccountIndex returns the cluster's ServiceAccounts indexed by
+// namespace/name, building the index once per scan. Every workload resolves its
+// account through here, so rebuilding it per workload would cost one pass over
+// every ServiceAccount per workload.
+//
+// Two cold callers can both build it; that is harmless because they produce the
+// same content and the underlying list is already deduplicated by the runtime.
+// The lock only keeps a reader from observing a half-assigned map.
+func (k *mqlK8s) serviceAccountIndex() (map[string]*mqlK8sServiceaccount, error) {
+	k.lock.Lock()
+	cached := k.serviceAccountsByName
+	k.lock.Unlock()
+	if cached != nil {
+		return cached, nil
+	}
+
+	index, err := namespacedByName[*mqlK8sServiceaccount](
+		k.MqlRuntime, func(x *mqlK8s) *plugin.TValue[[]any] { return x.GetServiceaccounts() })
+	if err != nil {
+		return nil, err
+	}
+
+	k.lock.Lock()
+	k.serviceAccountsByName = index
+	k.lock.Unlock()
+	return index, nil
+}
+
 // serviceAccountAutomount returns the named ServiceAccount's automount setting,
 // or nil when the account cannot be resolved. It reads the already-fetched
 // ServiceAccount collection rather than looking each account up individually,
 // so it costs no extra API calls.
 func serviceAccountAutomount(runtime *plugin.Runtime, namespace, name string) *bool {
-	index, err := namespacedByName[*mqlK8sServiceaccount](
-		runtime, func(x *mqlK8s) *plugin.TValue[[]any] { return x.GetServiceaccounts() })
+	o, err := CreateResource(runtime, "k8s", map[string]*llx.RawData{})
+	if err != nil {
+		log.Debug().Err(err).Msg("cannot reach the k8s resource to resolve automountServiceAccountToken")
+		return nil
+	}
+	index, err := o.(*mqlK8s).serviceAccountIndex()
 	if err != nil {
 		// A scan without permission to list ServiceAccounts cannot tell what the
 		// account asks for, so the Kubernetes default applies.
@@ -82,8 +115,12 @@ func effectiveAutomountServiceAccountToken(runtime *plugin.Runtime, spec *corev1
 	if spec != nil {
 		podLevel = spec.AutomountServiceAccountToken
 	}
-	if podLevel != nil {
-		return *podLevel
+
+	// The account only matters when the spec is silent, so skip the lookup
+	// entirely when the pod already decided.
+	var accountLevel *bool
+	if podLevel == nil {
+		accountLevel = serviceAccountAutomount(runtime, namespace, podServiceAccountName(spec))
 	}
-	return automountFromSpecAndAccount(nil, serviceAccountAutomount(runtime, namespace, podServiceAccountName(spec)))
+	return automountFromSpecAndAccount(podLevel, accountLevel)
 }

--- a/providers/k8s/resources/serviceaccount_automount_test.go
+++ b/providers/k8s/resources/serviceaccount_automount_test.go
@@ -1,0 +1,67 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TestAutomountFromSpecAndAccount pins the Kubernetes precedence rule. The
+// account level used to be ignored entirely, so a workload whose ServiceAccount
+// disables automounting was reported as mounting a token.
+func TestAutomountFromSpecAndAccount(t *testing.T) {
+	tests := []struct {
+		name    string
+		pod     *bool
+		account *bool
+		want    bool
+	}{
+		{name: "neither set defaults to true", want: true},
+		{name: "pod true", pod: boolPtr(true), want: true},
+		{name: "pod false", pod: boolPtr(false), want: false},
+		{name: "account false applies when pod is unset", account: boolPtr(false), want: false},
+		{name: "account true applies when pod is unset", account: boolPtr(true), want: true},
+		{name: "pod true overrides account false", pod: boolPtr(true), account: boolPtr(false), want: true},
+		{name: "pod false overrides account true", pod: boolPtr(false), account: boolPtr(true), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, automountFromSpecAndAccount(tt.pod, tt.account))
+		})
+	}
+}
+
+// TestPodServiceAccountName pins which account a pod spec runs as, since that
+// is the account whose automount setting applies.
+func TestPodServiceAccountName(t *testing.T) {
+	tests := []struct {
+		name string
+		spec *corev1.PodSpec
+		want string
+	}{
+		{name: "nil spec", spec: nil, want: "default"},
+		{name: "empty spec falls back to default", spec: &corev1.PodSpec{}, want: "default"},
+		{name: "serviceAccountName wins", spec: &corev1.PodSpec{ServiceAccountName: "app"}, want: "app"},
+		{
+			name: "deprecated field is honored when the current one is empty",
+			spec: &corev1.PodSpec{DeprecatedServiceAccount: "legacy"},
+			want: "legacy",
+		},
+		{
+			name: "current field wins over deprecated",
+			spec: &corev1.PodSpec{ServiceAccountName: "app", DeprecatedServiceAccount: "legacy"},
+			want: "app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, podServiceAccountName(tt.spec))
+		})
+	}
+}

--- a/providers/k8s/resources/workload_security.go
+++ b/providers/k8s/resources/workload_security.go
@@ -168,14 +168,6 @@ func specUsesHostPath(spec *corev1.PodSpec) bool {
 	return false
 }
 
-func specAutomountServiceAccountToken(spec *corev1.PodSpec) bool {
-	if spec == nil {
-		return false
-	}
-	// Defaults to true when unset.
-	return spec.AutomountServiceAccountToken == nil || *spec.AutomountServiceAccountToken
-}
-
 // effectiveSeccompType resolves the seccomp profile type that applies to a
 // container: a container-level profile wins over the pod-level default, and an
 // empty string means no profile is set at either level.
@@ -343,7 +335,10 @@ func (k *mqlK8sDeployment) securitySpec() (*corev1.PodSpec, error) {
 
 func (k *mqlK8sDeployment) automountServiceAccountToken() (bool, error) {
 	spec, err := k.securitySpec()
-	return boolFromSpec(spec, err, specAutomountServiceAccountToken)
+	if err != nil {
+		return false, err
+	}
+	return effectiveAutomountServiceAccountToken(k.MqlRuntime, spec, k.Namespace.Data), nil
 }
 
 func (k *mqlK8sDeployment) hostNetwork() (bool, error) {
@@ -437,7 +432,10 @@ func (k *mqlK8sDaemonset) securitySpec() (*corev1.PodSpec, error) {
 
 func (k *mqlK8sDaemonset) automountServiceAccountToken() (bool, error) {
 	spec, err := k.securitySpec()
-	return boolFromSpec(spec, err, specAutomountServiceAccountToken)
+	if err != nil {
+		return false, err
+	}
+	return effectiveAutomountServiceAccountToken(k.MqlRuntime, spec, k.Namespace.Data), nil
 }
 
 func (k *mqlK8sDaemonset) hostNetwork() (bool, error) {
@@ -531,7 +529,10 @@ func (k *mqlK8sStatefulset) securitySpec() (*corev1.PodSpec, error) {
 
 func (k *mqlK8sStatefulset) automountServiceAccountToken() (bool, error) {
 	spec, err := k.securitySpec()
-	return boolFromSpec(spec, err, specAutomountServiceAccountToken)
+	if err != nil {
+		return false, err
+	}
+	return effectiveAutomountServiceAccountToken(k.MqlRuntime, spec, k.Namespace.Data), nil
 }
 
 func (k *mqlK8sStatefulset) hostNetwork() (bool, error) {
@@ -625,7 +626,10 @@ func (k *mqlK8sReplicaset) securitySpec() (*corev1.PodSpec, error) {
 
 func (k *mqlK8sReplicaset) automountServiceAccountToken() (bool, error) {
 	spec, err := k.securitySpec()
-	return boolFromSpec(spec, err, specAutomountServiceAccountToken)
+	if err != nil {
+		return false, err
+	}
+	return effectiveAutomountServiceAccountToken(k.MqlRuntime, spec, k.Namespace.Data), nil
 }
 
 func (k *mqlK8sReplicaset) hostNetwork() (bool, error) {
@@ -719,7 +723,10 @@ func (k *mqlK8sJob) securitySpec() (*corev1.PodSpec, error) {
 
 func (k *mqlK8sJob) automountServiceAccountToken() (bool, error) {
 	spec, err := k.securitySpec()
-	return boolFromSpec(spec, err, specAutomountServiceAccountToken)
+	if err != nil {
+		return false, err
+	}
+	return effectiveAutomountServiceAccountToken(k.MqlRuntime, spec, k.Namespace.Data), nil
 }
 
 func (k *mqlK8sJob) hostNetwork() (bool, error) {
@@ -813,7 +820,10 @@ func (k *mqlK8sCronjob) securitySpec() (*corev1.PodSpec, error) {
 
 func (k *mqlK8sCronjob) automountServiceAccountToken() (bool, error) {
 	spec, err := k.securitySpec()
-	return boolFromSpec(spec, err, specAutomountServiceAccountToken)
+	if err != nil {
+		return false, err
+	}
+	return effectiveAutomountServiceAccountToken(k.MqlRuntime, spec, k.Namespace.Data), nil
 }
 
 func (k *mqlK8sCronjob) hostNetwork() (bool, error) {

--- a/providers/k8s/resources/workload_security_test.go
+++ b/providers/k8s/resources/workload_security_test.go
@@ -60,7 +60,9 @@ func TestWorkloadSecurityRollups_NilSpec(t *testing.T) {
 		assert.Empty(t, specAddedCapabilities(nil), "addedCapabilities")
 		assert.False(t, specUsesHostNamespaces(nil), "usesHostNamespaces")
 		assert.False(t, specUsesHostPath(nil), "usesHostPath")
-		assert.False(t, specAutomountServiceAccountToken(nil), "automountServiceAccountToken")
+		// The automount decision now also consults the ServiceAccount; the part
+		// that reads the spec must still tolerate a nil one.
+		assert.Equal(t, "default", podServiceAccountName(nil), "podServiceAccountName")
 		assert.False(t, specUsesUnconfinedSeccomp(nil), "usesUnconfinedSeccomp")
 		assert.False(t, specHasSeccompProfile(nil), "hasSeccompProfile")
 	})


### PR DESCRIPTION
## What

Kubernetes decides whether to mount an API token from two places: the pod spec's `automountServiceAccountToken` when it is set, otherwise the **ServiceAccount's**, otherwise the default `true`. The provider only read the pod spec:

```go
if spec.AutomountServiceAccountToken == nil {
    return true, nil   // <- ignores the ServiceAccount
}
```

## Why it matters

This misses the case the setting is most often used in. Disabling automounting **on the ServiceAccount** is the recommended way to turn it off for everything running under that account, instead of repeating the field on every pod template. Every workload hardened that way was reported as still mounting a token.

Verified on a live cluster — a ServiceAccount with `automountServiceAccountToken: false`, and pods that do not set it themselves:

```
$ kubectl get sa app-sa -o jsonpath='{.automountServiceAccountToken}'
false
$ kubectl get pod -l app=web -o json | jq '[.items[0].spec.volumes[].name]'
["cfg","sec"]           # no kube-api-access volume -> no token is mounted

before:  k8s.pod.automountServiceAccountToken -> true    # wrong
after:   k8s.pod.automountServiceAccountToken -> false   # matches the cluster
```

A policy asserting "pods must not automount ServiceAccount tokens" failed on pods that were correctly hardened.

Note the asymmetry that makes this easy to miss: `imagePullSecrets` **are** copied into the pod spec by the ServiceAccount admission controller (I confirmed `consumedSecrets` picks them up correctly), so reading the spec works for those. The automount decision is never written back — the controller just omits the projected token volume — so the spec cannot answer it, for live pods or for manifests.

## Scope

The same spec-only helper backed the `deployment`, `daemonset`, `statefulset`, `replicaset`, `job`, and `cronjob` rollups, so all seven resources are fixed. `k8s.serviceaccount.automountServiceAccountToken` was already correct and is unchanged.

The ServiceAccount is resolved from the already-fetched collection via the existing `namespacedByName` helper rather than a per-workload `NewResource` lookup, so this adds no API calls. A scan without permission to list ServiceAccounts falls back to the Kubernetes default rather than failing the field.

## Tests

`serviceaccount_automount_test.go` pins the precedence rule across all seven combinations of (pod set/unset, account set/unset), and pins `podServiceAccountName` including the `default` fallback and the deprecated `serviceAccount` field. The nil-spec guard in `workload_security_test.go` is retained, pointed at the new structure.

`go test ./...` in `providers/k8s/` passes (8/8 packages).

## Found alongside

- The deployment rollup intermittently still showed the old value on the first run after the fix; that is [#10479](https://github.com/mondoohq/mql/issues/10479) (the `GetOrCompute` race), not this change — it reads `false` consistently across repeated runs.
- `k8s.configmap` exposes `.data` but not `.binaryData`, so a ConfigMap key stored as binary is invisible. That is a missing field rather than a wrong value, so I left it out of this PR.