### PR TITLE
🐛 k8s: keep an Ingress's other TLS entries when one certificate is unreadable

### DIFF
--- a/providers/k8s/resources/ingress.go
+++ b/providers/k8s/resources/ingress.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
@@ -361,7 +362,15 @@ func getTLS(ingress *networkingv1.Ingress, objId string, runtime *plugin.Runtime
 
 			certs := secret.GetCertificates()
 			if certs.Error != nil {
-				return nil, errors.New("error getting certificate data from Secret")
+				// A Secret whose tls.crt is absent or not parseable as PEM is a
+				// property of this one entry, not of the Ingress. Skip it and keep
+				// the remaining entries, the same way a missing Secret and a Secret
+				// with no TLS data are handled.
+				log.Debug().Err(certs.Error).
+					Str("ingress", ingress.Name).
+					Str("secret", tls.SecretName).
+					Msg("skipping ingress TLS entry whose certificate could not be read")
+				continue
 			}
 			if certs.Data == nil || len(certs.Data) == 0 {
 				// no TLS data in Secret referenced

--- a/providers/k8s/resources/ingress_tls_test.go
+++ b/providers/k8s/resources/ingress_tls_test.go
@@ -1,0 +1,89 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/utils/syncx"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// tlsSecret builds a k8s.secret whose certificates field is already resolved,
+// so getTLS reads it without needing the core provider's shared certificate
+// resource.
+func ingressTLSSecret(t *testing.T, runtime *plugin.Runtime, name string, certs []any, certErr error) *mqlK8sSecret {
+	t.Helper()
+	r, err := CreateResource(runtime, "k8s.secret", map[string]*llx.RawData{
+		"id":        llx.StringData("secret:default:" + name),
+		"name":      llx.StringData(name),
+		"namespace": llx.StringData("default"),
+	})
+	require.NoError(t, err)
+	s := r.(*mqlK8sSecret)
+	s.Certificates = plugin.TValue[[]any]{Data: certs, Error: certErr, State: plugin.StateIsSet}
+	return s
+}
+
+// TestGetTLSDegradesPerEntry pins that one unreadable certificate does not take
+// the Ingress's other TLS entries with it.
+//
+// getTLS used to return an error for the whole field the moment any referenced
+// Secret failed to yield a certificate, so an Ingress carrying a single
+// placeholder or not-yet-issued certificate reported no TLS configuration at
+// all rather than the entries that were fine. Its own comment already said the
+// intent was to "keep trying to process as much as we can", which is what the
+// missing-Secret and empty-data paths do.
+func TestGetTLSDegradesPerEntry(t *testing.T) {
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+
+	secrets := []any{
+		ingressTLSSecret(t, runtime, "tls-broken", nil, errors.New("certificate has invalid pem data")),
+		ingressTLSSecret(t, runtime, "tls-good", []any{"cert"}, nil),
+		ingressTLSSecret(t, runtime, "tls-empty", nil, nil),
+	}
+	getSecrets := func() *plugin.TValue[[]any] {
+		return &plugin.TValue[[]any]{Data: secrets, State: plugin.StateIsSet}
+	}
+
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: "mixed", Namespace: "default"},
+		Spec: networkingv1.IngressSpec{
+			TLS: []networkingv1.IngressTLS{
+				{Hosts: []string{"broken.example.com"}, SecretName: "tls-broken"},
+				{Hosts: []string{"good.example.com"}, SecretName: "tls-good"},
+				{Hosts: []string{"empty.example.com"}, SecretName: "tls-empty"},
+				{Hosts: []string{"absent.example.com"}, SecretName: "tls-absent"},
+			},
+		},
+	}
+
+	out, err := getTLS(ing, "ingress:default:mixed", runtime, getSecrets)
+	require.NoError(t, err, "one bad certificate must not fail the whole tls field")
+	require.Len(t, out, 1, "only the entry with a readable certificate is returned")
+
+	entry := out[0].(*mqlK8sIngresstls)
+	assert.Equal(t, []any{"good.example.com"}, entry.Hosts.Data)
+	assert.Equal(t, []any{"cert"}, entry.Certificates.Data)
+}
+
+// TestGetTLSNoEntries keeps the empty case explicit: an Ingress without TLS
+// yields an empty list and no error.
+func TestGetTLSNoEntries(t *testing.T) {
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	getSecrets := func() *plugin.TValue[[]any] {
+		return &plugin.TValue[[]any]{Data: []any{}, State: plugin.StateIsSet}
+	}
+	ing := &networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "none", Namespace: "default"}}
+
+	out, err := getTLS(ing, "ingress:default:none", runtime, getSecrets)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}


### PR DESCRIPTION
## What

`getTLS` aborted the entire `tls` field the moment any referenced Secret failed to yield a certificate:

```go
certs := secret.GetCertificates()
if certs.Error != nil {
    return nil, errors.New("error getting certificate data from Secret")
}
```

## Why it matters

A Secret whose `tls.crt` is a CSR, a truncated file, or anything else that is not parseable PEM is common while cert-manager has yet to issue — and it is a property of that one entry, not of the Ingress. One such entry made the Ingress report **no TLS configuration at all**, discarding every other entry that was fine, so a policy over `ingress.tls` could not evaluate.

The function's own comment already described the intended behaviour, and the missing-Secret and empty-data paths right below it implement exactly that:

```go
// There is the potential for no Secret to be found or that a Secret
// is found ... but either improperly-formatted or simply not containing
// TLS data. In either event just keep trying to process as much as we can.
```

The fixed error string also named neither the Ingress nor the Secret at fault, so there was nothing to act on. The skipped entry is now logged with both.

## Verification

Live against a minikube cluster, with an Ingress holding one valid certificate and one malformed one:

```
$ mql run k8s -c 'k8s.ingresses.where(name=="ing-mixed") { name tls { hosts } }'

before:  "tls": "Error: error getting certificate data from Secret"
after:   "tls": [ { "hosts": ["good.example.com"] } ]
```

## Tests

`ingress_tls_test.go` drives `getTLS` directly with an injected Secret collection covering all four cases in one Ingress: a Secret whose certificate errors, one with a valid certificate, one with no TLS data, and a reference to a Secret that does not exist. Only the valid entry is returned and the field does not error.

Driving `getTLS` directly rather than through a manifest fixture is deliberate — `k8s.secret.certificates` resolves the core provider's shared `certificates` resource, which a bare test runtime cannot provide (it panics in `CreateSharedResource`). Pre-resolving each Secret's `Certificates` TValue keeps the test on the branching logic this PR changes.

Verified the test has teeth — reverting the change fails it:

```
Error:    Received unexpected error
Messages: one bad certificate must not fail the whole tls field
```

`go test ./...` in `providers/k8s/` passes (8/8 packages).