### PR TITLE
🐎 terraform: close the stamp races on state modules and outputs

### DIFF
--- a/providers/terraform/resources/tfstate.go
+++ b/providers/terraform/resources/tfstate.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync/atomic"
 
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
@@ -69,7 +70,7 @@ func (t *mqlTerraformState) outputs() ([]any, error) {
 			return nil, err
 		}
 		so := r.(*mqlTerraformStateOutput)
-		so.output = output
+		so.output.Store(output)
 		list = append(list, r)
 	}
 
@@ -174,7 +175,17 @@ func (t *mqlTerraformState) resources() ([]any, error) {
 }
 
 type mqlTerraformStateOutputInternal struct {
-	output *connection.Output
+	// output is stamped after CreateResource, which hands back the ALREADY
+	// CACHED instance when the __id matches. plugin.GetOrCompute is
+	// unsynchronized, so two goroutines resolving terraform.state.outputs both
+	// miss its IsSet check, both run the accessor and both reach this write
+	// while value() and compute_type() read it.
+	//
+	// An atomic rather than a sync.Once around the write: the runtime caches
+	// the instance BEFORE the stamp runs, so a reader that picks it up from
+	// that cache has no happens-before edge to the stamp and a write-side
+	// guard alone would leave it racing.
+	output atomic.Pointer[connection.Output]
 }
 
 func initTerraformStateOutput(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -231,24 +242,26 @@ func (t *mqlTerraformStateOutput) id() (string, error) {
 }
 
 func (t *mqlTerraformStateOutput) value() (any, error) {
-	if t.output == nil {
+	output := t.output.Load()
+	if output == nil {
 		return nil, nil
 	}
 
 	var value any
-	if err := json.Unmarshal(t.output.Value, &value); err != nil {
+	if err := json.Unmarshal(output.Value, &value); err != nil {
 		return nil, err
 	}
 	return value, nil
 }
 
-func (t mqlTerraformStateOutput) compute_type() (any, error) {
-	if t.output == nil {
+func (t *mqlTerraformStateOutput) compute_type() (any, error) {
+	output := t.output.Load()
+	if output == nil {
 		return nil, nil
 	}
 
 	var typ any
-	if err := json.Unmarshal([]byte(t.output.Type), &typ); err != nil {
+	if err := json.Unmarshal([]byte(output.Type), &typ); err != nil {
 		return nil, err
 	}
 	return typ, nil
@@ -316,17 +329,28 @@ func initTerraformStateModule(runtime *plugin.Runtime, args map[string]*llx.RawD
 }
 
 type mqlTerraformStateModuleInternal struct {
-	module *connection.Module
+	// module is stamped after CreateResource, which hands back the ALREADY
+	// CACHED instance when the __id matches. The same module is reachable
+	// three ways -- terraform.state.modules walks the whole tree,
+	// terraform.state.rootModule takes the root and rootModule.childModules
+	// takes each child -- and each is a separate field resolution that runs in
+	// its own goroutine, so both this write and the reads below cross
+	// goroutines.
+	//
+	// An atomic rather than a sync.Once around the write, for the reason given
+	// on mqlTerraformStateOutputInternal.output.
+	module atomic.Pointer[connection.Module]
 }
 
 func (t *mqlTerraformStateModule) resources() ([]any, error) {
-	if t.module == nil {
+	module := t.module.Load()
+	if module == nil {
 		return nil, nil
 	}
 
 	var list []any
-	for i := range t.module.Resources {
-		resource := t.module.Resources[i]
+	for i := range module.Resources {
+		resource := module.Resources[i]
 		r, err := newMqlResource(t.MqlRuntime, resource)
 		if err != nil {
 			return nil, err
@@ -346,7 +370,7 @@ func newMqlModule(runtime *plugin.Runtime, module *connection.Module) (*mqlTerra
 	}
 
 	tmr := r.(*mqlTerraformStateModule)
-	tmr.module = module
+	tmr.module.Store(module)
 
 	return tmr, nil
 }
@@ -371,13 +395,14 @@ func newMqlResource(runtime *plugin.Runtime, resource *connection.Resource) (plu
 }
 
 func (t *mqlTerraformStateModule) childModules() ([]any, error) {
-	if t.module == nil {
+	module := t.module.Load()
+	if module == nil {
 		return nil, nil
 	}
 
 	var list []any
-	for i := range t.module.ChildModules {
-		r, err := newMqlModule(t.MqlRuntime, t.module.ChildModules[i])
+	for i := range module.ChildModules {
+		r, err := newMqlModule(t.MqlRuntime, module.ChildModules[i])
 		if err != nil {
 			return nil, err
 		}

--- a/providers/terraform/resources/tfstate_race_test.go
+++ b/providers/terraform/resources/tfstate_race_test.go
@@ -1,0 +1,161 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+)
+
+// TestNewMqlModule_ConcurrentStamping is a regression test for a data race in
+// newMqlModule, the sibling of the one fixed in newMqlHclBlock.
+//
+// newMqlModule wrote tmr.module unconditionally after CreateResource, but
+// CreateResource returns the ALREADY CACHED instance when the __id matches. The
+// same *connection.Module is reachable three ways -- terraform.state.modules
+// walks the whole tree, terraform.state.rootModule takes the root, and
+// rootModule.childModules takes each child -- and each of those is a separate
+// field resolution that can run in its own goroutine. So two goroutines wrote
+// the same struct field while a third read it in resources() / childModules().
+//
+// The goroutines call the accessor bodies (modules, rootModule, childModules)
+// rather than the generated Get* wrappers on purpose: plugin.GetOrCompute is
+// itself unsynchronized, and routing through it would report that separate,
+// SDK-wide TValue race instead of this one.
+//
+// Run with -race to surface a regression; the assertions afterwards catch the
+// user-visible symptom, a module whose internals never got populated and whose
+// resources therefore come back empty.
+func TestNewMqlModule_ConcurrentStamping(t *testing.T) {
+	const iterations = 50
+
+	for i := 0; i < iterations; i++ {
+		rt := newRuntimeForStateJSON(t, stateWithModules)
+
+		stateRaw, err := CreateResource(rt, "terraform.state", map[string]*llx.RawData{})
+		require.NoError(t, err)
+		state := stateRaw.(*mqlTerraformState)
+
+		var wg sync.WaitGroup
+
+		// Writer 1: the flattened walk stamps every module in the tree.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = state.modules()
+		}()
+
+		// Writer 2: the root module, then its children -- the same structs the
+		// flattened walk is stamping.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			root, err := state.rootModule()
+			if err != nil || root == nil {
+				return
+			}
+			children, err := root.childModules()
+			if err != nil {
+				return
+			}
+			for c := range children {
+				// Read the internals the other goroutines are stamping.
+				_ = children[c].(*mqlTerraformStateModule).module.Load()
+			}
+		}()
+
+		// Writer 3: a second flattened walk, which hands back the same cached
+		// instances and re-stamps them. This is what the terraform.state.module
+		// address lookup does internally.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			modules, err := state.modules()
+			if err != nil {
+				return
+			}
+			for m := range modules {
+				_, _ = modules[m].(*mqlTerraformStateModule).resources()
+			}
+		}()
+
+		// Reader: picks the instance straight out of the runtime cache, the way
+		// the runtime does when it resolves a field on an already-created
+		// resource. This one never calls newMqlModule, so it has no
+		// happens-before edge to the stamp -- CreateResource caches the
+		// instance BEFORE the caller stamps it. A write-side-only guard leaves
+		// this read racing.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			key := "terraform.state.module\x00terraform.state.module/address/module.vpc"
+			for a := 0; a < 200; a++ {
+				cached, ok := rt.Resources.Get(key)
+				if !ok {
+					continue
+				}
+				_, _ = cached.(*mqlTerraformStateModule).resources()
+				_, _ = cached.(*mqlTerraformStateModule).childModules()
+				return
+			}
+		}()
+
+		wg.Wait()
+
+		modules, err := state.modules()
+		require.NoError(t, err)
+		require.Len(t, modules, 2, "root module plus module.vpc")
+		for m := range modules {
+			module := modules[m].(*mqlTerraformStateModule)
+			require.NotNil(t, module.module.Load(), "module internals must still be populated")
+		}
+	}
+}
+
+// TestNewMqlStateOutput_ConcurrentStamping covers the same shape in outputs().
+//
+// plugin.GetOrCompute is unsynchronized -- it checks IsSet, computes, then
+// assigns -- so two goroutines resolving terraform.state.outputs both miss the
+// check and both run the accessor body. The second CreateResource returns the
+// cached terraform.state.output, and both goroutines then wrote so.output while
+// value() and type read it.
+func TestNewMqlStateOutput_ConcurrentStamping(t *testing.T) {
+	const iterations = 50
+
+	for i := 0; i < iterations; i++ {
+		rt := newRuntimeForStateJSON(t, stateWithModules)
+
+		stateRaw, err := CreateResource(rt, "terraform.state", map[string]*llx.RawData{})
+		require.NoError(t, err)
+		state := stateRaw.(*mqlTerraformState)
+
+		var wg sync.WaitGroup
+		for g := 0; g < 4; g++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				outputs, err := state.outputs()
+				if err != nil {
+					return
+				}
+				for o := range outputs {
+					// Reads the internal the other goroutines are stamping.
+					_, _ = outputs[o].(*mqlTerraformStateOutput).value()
+				}
+			}()
+		}
+		wg.Wait()
+
+		outputs, err := state.outputs()
+		require.NoError(t, err)
+		require.Len(t, outputs, 1)
+		for o := range outputs {
+			output := outputs[o].(*mqlTerraformStateOutput)
+			require.NotNil(t, output.output.Load(), "output internals must still be populated")
+		}
+	}
+}


### PR DESCRIPTION
Addresses the additional finding on #10480's review: `newMqlModule` stamps `tmr.module` after `CreateResource` without a guard, the same pattern that PR fixed in `newMqlHclBlock`.

Stacked on `fix/terraform-file-discovery` (#10471), since the code it fixes lives there.

## The module race

```go
tmr := r.(*mqlTerraformStateModule)
tmr.module = module
```

`CreateResource` returns the **already cached** instance when the `__id` matches, so that write lands on a struct other goroutines already hold. The same `*connection.Module` is reachable three ways:

- `terraform.state.modules` walks the whole tree
- `terraform.state.rootModule` takes the root
- `rootModule.childModules` takes each child

Each is a separate field resolution running in its own goroutine, so two of them write the field while a third reads it in `resources()` / `childModules()`.

## The output race, same shape one function up

`terraform.state.output` stamps `so.output` the same way. That one looks single-path — only `outputs()` writes it — but `plugin.GetOrCompute` (`providers-sdk/v1/plugin/runtime.go:263`) is unsynchronized: it checks `IsSet`, computes, then assigns, with no lock. Two goroutines resolving `terraform.state.outputs` both miss the check, both run the accessor body, and both stamp `so.output` while `value()` and `compute_type()` read it.

A sweep of the rest of the provider found no other unguarded stamps; `hcl.go` and `tfplan.go` were already covered by #10480.

## Why `atomic.Pointer` and not `sync.Once`

The review suggested the `stampOnce` guard, and that is the right tool in `hcl.go` and `tfplan.go`, where the stamped fields are `plugin.TValue[…]` structs that cannot be assigned atomically. Both internals here are plain pointers, so `atomic.Pointer` is a drop-in — and it is the stronger fix:

`CreateResource` publishes the instance to `runtime.Resources` **before** the caller stamps it:

```go
runtime.Resources.Set(id, res)   // published here
return res, nil
}
// ... caller stamps here
```

So a reader that picks the instance up from that cache has a happens-before edge only up to the `Set`, never to the stamp. A write-side-only guard serializes the writers but leaves that reader racing. The regression test covers exactly that reader — a goroutine that pulls the module out of `runtime.Resources` and never calls `newMqlModule`.

`compute_type` moves to a pointer receiver; a value receiver would copy the atomic.

## Verification

Both tests fail before the fix and pass after. Confirmed non-vacuous by temporarily swapping the atomics for an unsynchronized shim with the same `Load`/`Store` API — 20 `DATA RACE` reports, both tests red.

```
$ go test -race -count=1 ./... # providers/terraform
ok  	go.mondoo.com/mql/providers/terraform/connection	2.107s
ok  	go.mondoo.com/mql/providers/terraform/provider	2.061s
ok  	go.mondoo.com/mql/providers/terraform/resources	4.968s
```

The module test drives the accessor bodies (`modules`, `rootModule`, `childModules`) rather than the generated `Get*` wrappers on purpose: routing through `GetOrCompute` reports that separate, SDK-wide `TValue` race instead of this one. That race is real but provider-agnostic and out of scope here.

No schema change — internal structs only, so no codegen or `.lr.versions` entries.
