### PR TITLE
✨ sbom: give Package a license model that can tell declared from concluded

### DIFF
--- a/sbom/cyclonedx.go
+++ b/sbom/cyclonedx.go
@@ -125,6 +125,26 @@ func (ccx *CycloneDX) convertToCycloneDx(bom *Sbom) (*cyclonedx.BOM, error) {
 		}
 		emitted[ref] = true
 
+		// Concluded licenses and copyright are evidence, not assertion: they were
+		// read out of the files the package ships rather than stated by it, and
+		// CycloneDX has a place that says exactly that.
+		if concluded := cycloneDXLicenseList(concludedLicenses(pkg)); concluded != nil {
+			if evidence == nil {
+				evidence = &cyclonedx.Evidence{}
+			}
+			evidence.Licenses = concluded
+		}
+		if len(pkg.Copyright) > 0 {
+			if evidence == nil {
+				evidence = &cyclonedx.Evidence{}
+			}
+			copyrights := make([]cyclonedx.Copyright, 0, len(pkg.Copyright))
+			for _, c := range pkg.Copyright {
+				copyrights = append(copyrights, cyclonedx.Copyright{Text: c})
+			}
+			evidence.Copyright = &copyrights
+		}
+
 		bomPkg := cyclonedx.Component{
 			BOMRef:      ref,
 			Type:        cyclonedx.ComponentTypeLibrary,
@@ -134,7 +154,11 @@ func (ccx *CycloneDX) convertToCycloneDx(bom *Sbom) (*cyclonedx.BOM, error) {
 			CPE:         cpe,
 			Evidence:    evidence,
 			Description: pkg.Description,
-			Licenses:    cycloneDXLicenses(pkg.License),
+			Licenses:    cycloneDXDeclared(pkg),
+			Copyright:   strings.Join(pkg.Copyright, "\n"),
+		}
+		if pkg.Supplier != "" {
+			bomPkg.Supplier = &cyclonedx.OrganizationalEntity{Name: pkg.Supplier}
 		}
 		if pkg.Scope == PackageScopeDev {
 			bomPkg.Scope = cyclonedx.ScopeExcluded
@@ -340,6 +364,71 @@ var familyMap = map[string][]string{
 	"alpine":  {"linux", "unix", "os"},
 	"fedora":  {"linux", "unix", "os"},
 	"rhel":    {"linux", "unix", "os"},
+}
+
+// cycloneDXDeclared renders the licenses a package declares, preferring the
+// structured list and falling back to the legacy scalar.
+//
+// The fallback is what lets consumers migrate without a flag day: a producer
+// that has not yet populated Licenses still renders exactly as it did before.
+func cycloneDXDeclared(pkg *Package) *cyclonedx.Licenses {
+	if l := cycloneDXLicenseList(declaredLicenses(pkg)); l != nil {
+		return l
+	}
+	return cycloneDXLicenses(pkg.License)
+}
+
+// declaredLicenses returns the package's declared entries. An entry whose
+// acquisition the producer did not set counts as declared: it is what the
+// scalar always meant, so an unset value keeps the old reading rather than
+// silently demoting a license to evidence.
+func declaredLicenses(pkg *Package) []*License {
+	var out []*License
+	for _, l := range pkg.Licenses {
+		if l.GetAcquisition() != LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// concludedLicenses returns the entries read from the files a package ships.
+func concludedLicenses(pkg *Package) []*License {
+	var out []*License
+	for _, l := range pkg.Licenses {
+		if l.GetAcquisition() == LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// cycloneDXLicenseList renders license entries into the CycloneDX shape each
+// one's populated field calls for, dropping entries that carry no value.
+//
+// The three shapes are mutually exclusive in the schema, which is why the
+// producer says which kind it has rather than the renderer guessing: a value
+// already known to be an expression must not be emitted as an id.
+func cycloneDXLicenseList(licenses []*License) *cyclonedx.Licenses {
+	out := make(cyclonedx.Licenses, 0, len(licenses))
+	for _, l := range licenses {
+		switch {
+		case strings.TrimSpace(l.GetExpression()) != "":
+			out = append(out, cyclonedx.LicenseChoice{Expression: strings.TrimSpace(l.GetExpression())})
+		case strings.TrimSpace(l.GetSpdxId()) != "":
+			out = append(out, cyclonedx.LicenseChoice{
+				License: &cyclonedx.License{ID: strings.TrimSpace(l.GetSpdxId())},
+			})
+		case strings.TrimSpace(l.GetName()) != "":
+			out = append(out, cyclonedx.LicenseChoice{
+				License: &cyclonedx.License{Name: strings.TrimSpace(l.GetName())},
+			})
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return &out
 }
 
 // cycloneDXLicenses renders a package's declared license as a CycloneDX license

--- a/sbom/license_render_test.go
+++ b/sbom/license_render_test.go
@@ -206,3 +206,174 @@ func TestLicenseContentIsDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// The model extension exists for one case: a package whose own manifest
+// declares one license while the files it ships say another. Flattening the two
+// into a single value is what the scalar forced, and it is the error that
+// matters most in a compliance document — it asserts a grant the shipped code
+// does not make.
+
+func splitLicenseBom() *Sbom {
+	return &Sbom{
+		Generator: &Generator{Vendor: "Mondoo, Inc", Name: "test", Version: "1"},
+		Asset:     &Asset{Name: "test-asset", Platform: &Platform{Name: "linux", Version: "1"}},
+		Packages: []*Package{{
+			Name: "disagrees", Version: "1.0.0", Purl: "pkg:npm/disagrees@1.0.0",
+			// The scalar stays populated, as the migration contract requires.
+			License: "MIT",
+			Licenses: []*License{
+				{SpdxId: "MIT", Acquisition: LicenseAcquisition_LICENSE_ACQUISITION_DECLARED, Confidence: 1},
+				{
+					SpdxId:      "AGPL-3.0-only",
+					Acquisition: LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED,
+					Confidence:  0.98,
+					Location:    "node_modules/disagrees/LICENSE",
+				},
+			},
+			Copyright: []string{"Copyright (c) 2019 Example Corp"},
+			Supplier:  "Example Corp",
+		}},
+	}
+}
+
+func renderBom(t *testing.T, format string, bom *Sbom) string {
+	t.Helper()
+	var b strings.Builder
+	h := New(format)
+	if h == nil {
+		t.Fatalf("no handler for %q", format)
+	}
+	if err := h.Render(&b, bom); err != nil {
+		t.Fatalf("render %s: %v", format, err)
+	}
+	return b.String()
+}
+
+func TestCycloneDXSeparatesDeclaredFromConcluded(t *testing.T) {
+	var doc struct {
+		Components []struct {
+			Name     string `json:"name"`
+			Licenses []struct {
+				License    *struct{ ID, Name string } `json:"license"`
+				Expression string                     `json:"expression"`
+			} `json:"licenses"`
+			Copyright string `json:"copyright"`
+			Supplier  *struct {
+				Name string `json:"name"`
+			} `json:"supplier"`
+			Evidence *struct {
+				Licenses []struct {
+					License *struct{ ID, Name string } `json:"license"`
+				} `json:"licenses"`
+				Copyright []struct {
+					Text string `json:"text"`
+				} `json:"copyright"`
+			} `json:"evidence"`
+		} `json:"components"`
+	}
+	if err := json.Unmarshal([]byte(renderBom(t, "cyclonedx-json", splitLicenseBom())), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// The document also carries the asset's platform component; the package is
+	// the one under test.
+	var c = doc.Components[0]
+	found := false
+	for _, comp := range doc.Components {
+		if comp.Name == "disagrees" {
+			c, found = comp, true
+		}
+	}
+	if !found {
+		t.Fatalf("no component named disagrees in %d components", len(doc.Components))
+	}
+
+	// Declared is an assertion the package makes about itself.
+	if len(c.Licenses) != 1 || c.Licenses[0].License == nil || c.Licenses[0].License.ID != "MIT" {
+		t.Errorf("licenses = %+v, want the declared MIT", c.Licenses)
+	}
+	// Concluded is evidence: it was read out of a file rather than stated.
+	if c.Evidence == nil || len(c.Evidence.Licenses) != 1 ||
+		c.Evidence.Licenses[0].License == nil || c.Evidence.Licenses[0].License.ID != "AGPL-3.0-only" {
+		t.Errorf("evidence.licenses = %+v, want the concluded AGPL-3.0-only", c.Evidence)
+	}
+	if c.Copyright != "Copyright (c) 2019 Example Corp" {
+		t.Errorf("copyright = %q", c.Copyright)
+	}
+	if c.Evidence == nil || len(c.Evidence.Copyright) != 1 {
+		t.Errorf("evidence.copyright = %+v, want the statement that was found", c.Evidence)
+	}
+	if c.Supplier == nil || c.Supplier.Name != "Example Corp" {
+		t.Errorf("supplier = %+v", c.Supplier)
+	}
+}
+
+func TestSPDXConcludedIsNotAnEchoOfDeclared(t *testing.T) {
+	out := renderBom(t, "spdx-json", splitLicenseBom())
+	var doc struct {
+		Packages []struct {
+			LicenseDeclared  string `json:"licenseDeclared"`
+			LicenseConcluded string `json:"licenseConcluded"`
+			CopyrightText    string `json:"copyrightText"`
+			Supplier         string `json:"supplier"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(doc.Packages) != 1 {
+		t.Fatalf("packages = %d, want 1", len(doc.Packages))
+	}
+	p := doc.Packages[0]
+	if p.LicenseDeclared != "MIT" {
+		t.Errorf("licenseDeclared = %q, want MIT", p.LicenseDeclared)
+	}
+	if p.LicenseConcluded != "AGPL-3.0-only" {
+		t.Errorf("licenseConcluded = %q, want AGPL-3.0-only — the shipped text is the grant", p.LicenseConcluded)
+	}
+	if p.CopyrightText != "Copyright (c) 2019 Example Corp" {
+		t.Errorf("copyrightText = %q", p.CopyrightText)
+	}
+	if !strings.Contains(p.Supplier, "Example Corp") {
+		t.Errorf("supplier = %q", p.Supplier)
+	}
+}
+
+// TestLegacyScalarStillRenders is the migration contract: a producer that has
+// not adopted the structured list renders exactly as it did before.
+func TestLegacyScalarStillRenders(t *testing.T) {
+	cdx := renderTo(t, "cyclonedx-json")
+	for _, want := range []string{`"MIT"`, `"MIT OR Apache-2.0"`, `"BSD-like, see LICENSE"`} {
+		if !strings.Contains(cdx, want) {
+			t.Errorf("cyclonedx output lost %s", want)
+		}
+	}
+	spdxOut := renderTo(t, "spdx-json")
+	if !strings.Contains(spdxOut, "LicenseRef-Acme-Internal") {
+		t.Error("spdx output lost the LicenseRef identifier")
+	}
+}
+
+// TestSPDXConcludedFallsBackToDeclared: with nothing concluded, echoing the
+// declared value is the honest reading — but it must be the declared value,
+// not NOASSERTION, or a document loses a license it was told about.
+func TestSPDXConcludedFallsBackToDeclared(t *testing.T) {
+	out := renderTo(t, "spdx-json")
+	var doc struct {
+		Packages []struct {
+			Name             string `json:"name"`
+			LicenseDeclared  string `json:"licenseDeclared"`
+			LicenseConcluded string `json:"licenseConcluded"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, p := range doc.Packages {
+		if p.Name == "plain-id" && (p.LicenseDeclared != "MIT" || p.LicenseConcluded != "MIT") {
+			t.Errorf("plain-id: declared=%q concluded=%q, want MIT for both", p.LicenseDeclared, p.LicenseConcluded)
+		}
+		if p.Name == "undeclared" && p.LicenseConcluded != "NOASSERTION" {
+			t.Errorf("undeclared: concluded=%q, want NOASSERTION", p.LicenseConcluded)
+		}
+	}
+}

--- a/sbom/license_render_test.go
+++ b/sbom/license_render_test.go
@@ -377,3 +377,172 @@ func TestSPDXConcludedFallsBackToDeclared(t *testing.T) {
 		}
 	}
 }
+
+// An SPDX license field holds a license *expression*, and that constrains what
+// may go in it: an identifier from the SPDX list, a LicenseRef-* defined in the
+// document, NONE, or NOASSERTION. A free-form name — which is exactly what
+// License.name exists to carry — is none of those, so it needs encoding rather
+// than passing through.
+
+// spdxPackages decodes just the license-bearing fields of an SPDX render.
+func spdxPackages(t *testing.T, pkgs ...*Package) (map[string]struct{ Declared, Concluded string }, map[string]string) {
+	t.Helper()
+	bom := &Sbom{
+		Generator: &Generator{Vendor: "Mondoo, Inc", Name: "test", Version: "1"},
+		Asset:     &Asset{Name: "test-asset", Platform: &Platform{Name: "linux", Version: "1"}},
+		Packages:  pkgs,
+	}
+	var doc struct {
+		Packages []struct {
+			Name             string `json:"name"`
+			LicenseDeclared  string `json:"licenseDeclared"`
+			LicenseConcluded string `json:"licenseConcluded"`
+		} `json:"packages"`
+		HasExtractedLicensingInfos []struct {
+			LicenseID   string `json:"licenseId"`
+			LicenseName string `json:"name"`
+		} `json:"hasExtractedLicensingInfos"`
+	}
+	if err := json.Unmarshal([]byte(renderBom(t, FormatSpdxJSON, bom)), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	byName := map[string]struct{ Declared, Concluded string }{}
+	for _, p := range doc.Packages {
+		byName[p.Name] = struct{ Declared, Concluded string }{p.LicenseDeclared, p.LicenseConcluded}
+	}
+	refs := map[string]string{}
+	for _, e := range doc.HasExtractedLicensingInfos {
+		refs[e.LicenseID] = e.LicenseName
+	}
+	return byName, refs
+}
+
+func declaredNamed(name string, licenses ...*License) *Package {
+	for _, l := range licenses {
+		if l.Acquisition == LicenseAcquisition_LICENSE_ACQUISITION_UNSPECIFIED {
+			l.Acquisition = LicenseAcquisition_LICENSE_ACQUISITION_DECLARED
+		}
+	}
+	return &Package{
+		Name: name, Version: "1.0.0", Purl: "pkg:npm/" + name + "@1.0.0",
+		Licenses: licenses,
+	}
+}
+
+// TestSPDXFreeFormNameBecomesLicenseRef: a name that is not an identifier is
+// emitted as one the document defines, and the original text survives as the
+// definition's name — otherwise the reader has a reference to something the
+// document never says the meaning of.
+func TestSPDXFreeFormNameBecomesLicenseRef(t *testing.T) {
+	pkgs, refs := spdxPackages(t, declaredNamed("free-text", &License{Name: "BSD-like, see LICENSE"}))
+
+	got := pkgs["free-text"].Declared
+	want := "LicenseRef-BSD-like-see-LICENSE"
+	if got != want {
+		t.Errorf("licenseDeclared = %q, want %q", got, want)
+	}
+	if strings.Contains(got, " ") {
+		t.Errorf("licenseDeclared = %q contains a space, which no SPDX license expression may", got)
+	}
+	if name, ok := refs[want]; !ok || name != "BSD-like, see LICENSE" {
+		t.Errorf("hasExtractedLicensingInfos[%q] name = %q (present=%v), want the original text", want, name, ok)
+	}
+}
+
+// TestSPDXNameIsNotJoinedRawIntoAnExpression is the case the join makes worse
+// than a single value: "MIT AND see LICENSE" parses as an expression right up to
+// the operand that is not one, so a consumer either rejects the document or
+// silently reads a license that does not exist.
+func TestSPDXNameIsNotJoinedRawIntoAnExpression(t *testing.T) {
+	pkgs, refs := spdxPackages(t, declaredNamed("mixed",
+		&License{SpdxId: "MIT"},
+		&License{Name: "see LICENSE"},
+	))
+
+	got := pkgs["mixed"].Declared
+	if got == "MIT AND see LICENSE" {
+		t.Fatalf("licenseDeclared = %q — a free-form name was joined in raw", got)
+	}
+	if want := "MIT AND LicenseRef-see-LICENSE"; got != want {
+		t.Errorf("licenseDeclared = %q, want %q", got, want)
+	}
+	if _, ok := refs["LicenseRef-see-LICENSE"]; !ok {
+		t.Errorf("LicenseRef-see-LICENSE is referenced but never defined; refs = %v", refs)
+	}
+}
+
+// TestSPDXParenthesizesOnlyWhatItJoins covers both sides of the grouping rule:
+// a joined expression keeps its operands together, and a value that ends up
+// alone is not wrapped just because a sibling entry carried nothing.
+func TestSPDXParenthesizesOnlyWhatItJoins(t *testing.T) {
+	pkgs, _ := spdxPackages(t,
+		declaredNamed("joined",
+			&License{Expression: "MIT OR Apache-2.0"},
+			&License{SpdxId: "AGPL-3.0-only"},
+		),
+		declaredNamed("alone",
+			&License{Expression: "MIT OR Apache-2.0"},
+			// Carries no value at all, so it renders nothing and must not
+			// change how the entry that does render is grouped.
+			&License{Acquisition: LicenseAcquisition_LICENSE_ACQUISITION_DECLARED},
+		),
+	)
+
+	if want := "(MIT OR Apache-2.0) AND AGPL-3.0-only"; pkgs["joined"].Declared != want {
+		t.Errorf("joined licenseDeclared = %q, want %q — OR must not reassociate across the AND",
+			pkgs["joined"].Declared, want)
+	}
+	if want := "MIT OR Apache-2.0"; pkgs["alone"].Declared != want {
+		t.Errorf("alone licenseDeclared = %q, want %q — a dropped entry added parentheses",
+			pkgs["alone"].Declared, want)
+	}
+}
+
+// TestSPDXLegacyScalarPassesThroughUnchanged pins what the fix deliberately does
+// not change. Producers set the scalar to whatever their package manager
+// reported, and a large share of OS packages report something that is not an
+// SPDX expression; re-encoding those here would rewrite what every existing
+// document says. That migration is a decision, not a side effect, so the scalar
+// path stays byte-for-byte as it was.
+func TestSPDXLegacyScalarPassesThroughUnchanged(t *testing.T) {
+	pkgs, _ := spdxPackages(t, &Package{
+		Name: "scalar-free-text", Version: "1.0.0", Purl: "pkg:npm/scalar-free-text@1.0.0",
+		License: "BSD-like, see LICENSE",
+	})
+	if got := pkgs["scalar-free-text"].Declared; got != "BSD-like, see LICENSE" {
+		t.Errorf("licenseDeclared = %q, want the scalar verbatim", got)
+	}
+}
+
+func TestSPDXLicenseRef(t *testing.T) {
+	for _, tc := range []struct{ name, want string }{
+		{"MIT", "LicenseRef-MIT"},
+		{"BSD-like, see LICENSE", "LicenseRef-BSD-like-see-LICENSE"},
+		{"see LICENSE", "LicenseRef-see-LICENSE"},
+		{"GPL v2+", "LicenseRef-GPL-v2"},
+		{"Apache 2.0", "LicenseRef-Apache-2.0"},
+		// Nothing an identifier can be built from: SPDX has no way to reference
+		// this, so the caller has to drop it rather than emit a bare prefix.
+		{"?? ??", ""},
+		{"", ""},
+	} {
+		if got := spdxLicenseRef(tc.name); got != tc.want {
+			t.Errorf("spdxLicenseRef(%q) = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestSPDXUnreferenceableNameIsDropped: with no identifier to build, the entry
+// cannot be referenced, and a document that names a license it never defines is
+// invalid. NOASSERTION is the honest value.
+func TestSPDXUnreferenceableNameIsDropped(t *testing.T) {
+	pkgs, refs := spdxPackages(t, declaredNamed("unnameable", &License{Name: "?? ??"}))
+	if got := pkgs["unnameable"].Declared; got != "NOASSERTION" {
+		t.Errorf("licenseDeclared = %q, want NOASSERTION", got)
+	}
+	for id := range refs {
+		if id == licenseRefPrefix || id == licenseRefPrefix+"-" {
+			t.Errorf("emitted a bare LicenseRef prefix: %q", id)
+		}
+	}
+}

--- a/sbom/mql_sbom.pb.go
+++ b/sbom/mql_sbom.pb.go
@@ -864,6 +864,29 @@ type Package struct {
 	// SPDX license expression (or upstream-reported license string).
 	// Empty when the backend has no source for it (e.g. Windows registry
 	// — DisplayName carries no license field).
+	//
+	// Deprecated: use 'licenses' (field 31) instead. One string cannot say
+	// whether a license was declared by the package or concluded from the files
+	// it ships, and those two disagreeing is the case a compliance document
+	// exists to surface. It cannot carry more than one license, a confidence, or
+	// the file a conclusion was read from either.
+	//
+	// Still read, and still the only source for most producers. Every renderer
+	// falls back to this field when 'licenses' is empty, so a producer that has
+	// not adopted the list renders exactly as it did before and nothing breaks on
+	// the version that introduces this marker.
+	//
+	// Note what is NOT enforced: nothing populates this field from 'licenses'. A
+	// producer that adopts the list is responsible for continuing to set this
+	// scalar to its first declared entry, or consumers still reading the scalar
+	// will silently see an empty license where one was determined. That is a
+	// convention, not a guarantee the model makes.
+	//
+	// The deprecation says which field new code should read, not that this one
+	// has stopped working. It will not be removed while unmigrated producers
+	// remain.
+	//
+	// Deprecated: Marked as deprecated in mql_sbom.proto.
 	License string `protobuf:"bytes,26,opt,name=license,proto3" json:"license,omitempty"`
 	// Time the package was installed on this asset, RFC3339 format
 	// (e.g. "2024-03-15T00:00:00Z"). Empty when the backend doesn't
@@ -895,8 +918,10 @@ type Package struct {
 	// is the case a compliance document must not flatten, and the scalar has no
 	// room for both values.
 	//
-	// The scalar stays populated with the first declared entry so consumers can
-	// migrate without a flag day.
+	// The scalar is deprecated in favour of this field. A producer adopting this
+	// list should keep the scalar set to its first declared entry so consumers
+	// can migrate without a flag day — the renderers fall back to the scalar, but
+	// nothing populates it from here.
 	Licenses []*License `protobuf:"bytes,31,rep,name=licenses,proto3" json:"licenses,omitempty"`
 	// 'copyright' holds the copyright statements found in the package's license
 	// and notice files. Attribution output needs these: no amount of license
@@ -1030,6 +1055,7 @@ func (x *Package) GetTitle() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in mql_sbom.proto.
 func (x *Package) GetLicense() string {
 	if x != nil {
 		return x.License
@@ -1415,7 +1441,7 @@ const file_mql_sbom_proto_rawDesc = "" +
 	"\x04cpes\x18\x17 \x03(\tR\x04cpes\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xfb\x04\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xff\x04\n" +
 	"\aPackage\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12\"\n" +
@@ -1429,8 +1455,8 @@ const file_mql_sbom_proto_rawDesc = "" +
 	"\x06origin\x18\x16 \x01(\tR\x06origin\x12\x16\n" +
 	"\x06vendor\x18\x17 \x01(\tR\x06vendor\x12\x16\n" +
 	"\x06status\x18\x18 \x01(\tR\x06status\x12\x14\n" +
-	"\x05title\x18\x19 \x01(\tR\x05title\x12\x18\n" +
-	"\alicense\x18\x1a \x01(\tR\alicense\x12!\n" +
+	"\x05title\x18\x19 \x01(\tR\x05title\x12\x1c\n" +
+	"\alicense\x18\x1a \x01(\tB\x02\x18\x01R\alicense\x12!\n" +
 	"\finstall_date\x18\x1b \x01(\tR\vinstallDate\x12\x17\n" +
 	"\abom_ref\x18\x1c \x01(\tR\x06bomRef\x12\x14\n" +
 	"\x05scope\x18\x1d \x01(\tR\x05scope\x12,\n" +

--- a/sbom/mql_sbom.pb.go
+++ b/sbom/mql_sbom.pb.go
@@ -183,6 +183,60 @@ func (ExternalIDType) EnumDescriptor() ([]byte, []int) {
 	return file_mql_sbom_proto_rawDescGZIP(), []int{1}
 }
 
+// LicenseAcquisition is how a license came to be attributed to a package.
+type LicenseAcquisition int32
+
+const (
+	// The producer did not say.
+	LicenseAcquisition_LICENSE_ACQUISITION_UNSPECIFIED LicenseAcquisition = 0
+	// The package's own manifest or lockfile states this license.
+	LicenseAcquisition_LICENSE_ACQUISITION_DECLARED LicenseAcquisition = 1
+	// Read from the license files the package ships, which is the stronger
+	// evidence where the two disagree: the shipped text is the grant.
+	LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED LicenseAcquisition = 2
+)
+
+// Enum value maps for LicenseAcquisition.
+var (
+	LicenseAcquisition_name = map[int32]string{
+		0: "LICENSE_ACQUISITION_UNSPECIFIED",
+		1: "LICENSE_ACQUISITION_DECLARED",
+		2: "LICENSE_ACQUISITION_CONCLUDED",
+	}
+	LicenseAcquisition_value = map[string]int32{
+		"LICENSE_ACQUISITION_UNSPECIFIED": 0,
+		"LICENSE_ACQUISITION_DECLARED":    1,
+		"LICENSE_ACQUISITION_CONCLUDED":   2,
+	}
+)
+
+func (x LicenseAcquisition) Enum() *LicenseAcquisition {
+	p := new(LicenseAcquisition)
+	*p = x
+	return p
+}
+
+func (x LicenseAcquisition) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (LicenseAcquisition) Descriptor() protoreflect.EnumDescriptor {
+	return file_mql_sbom_proto_enumTypes[2].Descriptor()
+}
+
+func (LicenseAcquisition) Type() protoreflect.EnumType {
+	return &file_mql_sbom_proto_enumTypes[2]
+}
+
+func (x LicenseAcquisition) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use LicenseAcquisition.Descriptor instead.
+func (LicenseAcquisition) EnumDescriptor() ([]byte, []int) {
+	return file_mql_sbom_proto_rawDescGZIP(), []int{2}
+}
+
 type EvidenceType int32
 
 const (
@@ -213,11 +267,11 @@ func (x EvidenceType) String() string {
 }
 
 func (EvidenceType) Descriptor() protoreflect.EnumDescriptor {
-	return file_mql_sbom_proto_enumTypes[2].Descriptor()
+	return file_mql_sbom_proto_enumTypes[3].Descriptor()
 }
 
 func (EvidenceType) Type() protoreflect.EnumType {
-	return &file_mql_sbom_proto_enumTypes[2]
+	return &file_mql_sbom_proto_enumTypes[3]
 }
 
 func (x EvidenceType) Number() protoreflect.EnumNumber {
@@ -226,7 +280,7 @@ func (x EvidenceType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use EvidenceType.Descriptor instead.
 func (EvidenceType) EnumDescriptor() ([]byte, []int) {
-	return file_mql_sbom_proto_rawDescGZIP(), []int{2}
+	return file_mql_sbom_proto_rawDescGZIP(), []int{3}
 }
 
 // Sbom (Software Bill of Materials) represents a comprehensive inventory of
@@ -832,7 +886,25 @@ type Package struct {
 	// dependency's Subresource-Integrity value). Populated for ecosystems whose
 	// manifest records them (npm today), empty otherwise. Rendered as CycloneDX
 	// `component.hashes` / SPDX package checksums — tamper-evidence.
-	Hashes        []*Hash `protobuf:"bytes,30,rep,name=hashes,proto3" json:"hashes,omitempty"`
+	Hashes []*Hash `protobuf:"bytes,30,rep,name=hashes,proto3" json:"hashes,omitempty"`
+	// 'licenses' is what is known about this package's licensing, one entry per
+	// license, each carrying how it was learned. It supersedes the 'license'
+	// scalar above, which cannot express the distinction that matters most: what
+	// a package's own manifest *declares* is not always what its shipped files
+	// say. A package declaring MIT while shipping an AGPL-3.0-only license file
+	// is the case a compliance document must not flatten, and the scalar has no
+	// room for both values.
+	//
+	// The scalar stays populated with the first declared entry so consumers can
+	// migrate without a flag day.
+	Licenses []*License `protobuf:"bytes,31,rep,name=licenses,proto3" json:"licenses,omitempty"`
+	// 'copyright' holds the copyright statements found in the package's license
+	// and notice files. Attribution output needs these: no amount of license
+	// identification substitutes for knowing who to credit.
+	Copyright []string `protobuf:"bytes,32,rep,name=copyright,proto3" json:"copyright,omitempty"`
+	// 'supplier' is the entity that supplied the package, as SPDX and CycloneDX
+	// both model it (a name, optionally with an email in angle brackets).
+	Supplier      string `protobuf:"bytes,33,opt,name=supplier,proto3" json:"supplier,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -993,6 +1065,132 @@ func (x *Package) GetHashes() []*Hash {
 	return nil
 }
 
+func (x *Package) GetLicenses() []*License {
+	if x != nil {
+		return x.Licenses
+	}
+	return nil
+}
+
+func (x *Package) GetCopyright() []string {
+	if x != nil {
+		return x.Copyright
+	}
+	return nil
+}
+
+func (x *Package) GetSupplier() string {
+	if x != nil {
+		return x.Supplier
+	}
+	return ""
+}
+
+// License is one license attributed to a package, and how that attribution was
+// arrived at.
+type License struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Exactly one of 'spdx_id', 'expression' and 'name' is set, and which one it
+	// is says what kind of value this is. The distinction is not cosmetic:
+	// CycloneDX models the three mutually exclusively and rejects a document that
+	// puts an expression where an id belongs.
+	//
+	// 'spdx_id' is a bare SPDX identifier, e.g. "MIT".
+	SpdxId string `protobuf:"bytes,1,opt,name=spdx_id,json=spdxId,proto3" json:"spdx_id,omitempty"`
+	// 'expression' is a full SPDX expression, e.g. "MIT OR Apache-2.0".
+	Expression string `protobuf:"bytes,2,opt,name=expression,proto3" json:"expression,omitempty"`
+	// 'name' is a string that is neither — "BSD-like", "see LICENSE". Carrying it
+	// as a name is honest; forcing it into an id would be a claim the source does
+	// not support.
+	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	// 'acquisition' says whether the package declared this license or it was
+	// concluded from the files it ships.
+	Acquisition LicenseAcquisition `protobuf:"varint,4,opt,name=acquisition,proto3,enum=mondoo.sbom.v1.LicenseAcquisition" json:"acquisition,omitempty"`
+	// 'confidence' is how sure the producer is, in (0,1]. A declared license is
+	// 1.0 — it is a statement, not a measurement. A license concluded by matching
+	// text carries the match's own score, so a consumer can tell a certainty from
+	// an inference rather than reading both as the same fact.
+	Confidence float64 `protobuf:"fixed64,5,opt,name=confidence,proto3" json:"confidence,omitempty"`
+	// 'location' is the file this license was read from, relative to the scan
+	// root — the evidence behind a concluded license. Empty for a declared one,
+	// whose source is the manifest already identified by the package.
+	Location      string `protobuf:"bytes,6,opt,name=location,proto3" json:"location,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *License) Reset() {
+	*x = License{}
+	mi := &file_mql_sbom_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *License) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*License) ProtoMessage() {}
+
+func (x *License) ProtoReflect() protoreflect.Message {
+	mi := &file_mql_sbom_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use License.ProtoReflect.Descriptor instead.
+func (*License) Descriptor() ([]byte, []int) {
+	return file_mql_sbom_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *License) GetSpdxId() string {
+	if x != nil {
+		return x.SpdxId
+	}
+	return ""
+}
+
+func (x *License) GetExpression() string {
+	if x != nil {
+		return x.Expression
+	}
+	return ""
+}
+
+func (x *License) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *License) GetAcquisition() LicenseAcquisition {
+	if x != nil {
+		return x.Acquisition
+	}
+	return LicenseAcquisition_LICENSE_ACQUISITION_UNSPECIFIED
+}
+
+func (x *License) GetConfidence() float64 {
+	if x != nil {
+		return x.Confidence
+	}
+	return 0
+}
+
+func (x *License) GetLocation() string {
+	if x != nil {
+		return x.Location
+	}
+	return ""
+}
+
 // Hash is one integrity digest of a package: an algorithm label and its
 // hex-encoded value.
 type Hash struct {
@@ -1007,7 +1205,7 @@ type Hash struct {
 
 func (x *Hash) Reset() {
 	*x = Hash{}
-	mi := &file_mql_sbom_proto_msgTypes[7]
+	mi := &file_mql_sbom_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1019,7 +1217,7 @@ func (x *Hash) String() string {
 func (*Hash) ProtoMessage() {}
 
 func (x *Hash) ProtoReflect() protoreflect.Message {
-	mi := &file_mql_sbom_proto_msgTypes[7]
+	mi := &file_mql_sbom_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1032,7 +1230,7 @@ func (x *Hash) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Hash.ProtoReflect.Descriptor instead.
 func (*Hash) Descriptor() ([]byte, []int) {
-	return file_mql_sbom_proto_rawDescGZIP(), []int{7}
+	return file_mql_sbom_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *Hash) GetAlg() string {
@@ -1063,7 +1261,7 @@ type Evidence struct {
 
 func (x *Evidence) Reset() {
 	*x = Evidence{}
-	mi := &file_mql_sbom_proto_msgTypes[8]
+	mi := &file_mql_sbom_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1075,7 +1273,7 @@ func (x *Evidence) String() string {
 func (*Evidence) ProtoMessage() {}
 
 func (x *Evidence) ProtoReflect() protoreflect.Message {
-	mi := &file_mql_sbom_proto_msgTypes[8]
+	mi := &file_mql_sbom_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1088,7 +1286,7 @@ func (x *Evidence) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Evidence.ProtoReflect.Descriptor instead.
 func (*Evidence) Descriptor() ([]byte, []int) {
-	return file_mql_sbom_proto_rawDescGZIP(), []int{8}
+	return file_mql_sbom_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *Evidence) GetType() EvidenceType {
@@ -1120,7 +1318,7 @@ type Kernel struct {
 
 func (x *Kernel) Reset() {
 	*x = Kernel{}
-	mi := &file_mql_sbom_proto_msgTypes[9]
+	mi := &file_mql_sbom_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1132,7 +1330,7 @@ func (x *Kernel) String() string {
 func (*Kernel) ProtoMessage() {}
 
 func (x *Kernel) ProtoReflect() protoreflect.Message {
-	mi := &file_mql_sbom_proto_msgTypes[9]
+	mi := &file_mql_sbom_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1145,7 +1343,7 @@ func (x *Kernel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Kernel.ProtoReflect.Descriptor instead.
 func (*Kernel) Descriptor() ([]byte, []int) {
-	return file_mql_sbom_proto_rawDescGZIP(), []int{9}
+	return file_mql_sbom_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *Kernel) GetName() string {
@@ -1217,7 +1415,7 @@ const file_mql_sbom_proto_rawDesc = "" +
 	"\x04cpes\x18\x17 \x03(\tR\x04cpes\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8c\x04\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xfb\x04\n" +
 	"\aPackage\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12\"\n" +
@@ -1236,7 +1434,21 @@ const file_mql_sbom_proto_rawDesc = "" +
 	"\finstall_date\x18\x1b \x01(\tR\vinstallDate\x12\x17\n" +
 	"\abom_ref\x18\x1c \x01(\tR\x06bomRef\x12\x14\n" +
 	"\x05scope\x18\x1d \x01(\tR\x05scope\x12,\n" +
-	"\x06hashes\x18\x1e \x03(\v2\x14.mondoo.sbom.v1.HashR\x06hashes\".\n" +
+	"\x06hashes\x18\x1e \x03(\v2\x14.mondoo.sbom.v1.HashR\x06hashes\x123\n" +
+	"\blicenses\x18\x1f \x03(\v2\x17.mondoo.sbom.v1.LicenseR\blicenses\x12\x1c\n" +
+	"\tcopyright\x18  \x03(\tR\tcopyright\x12\x1a\n" +
+	"\bsupplier\x18! \x01(\tR\bsupplier\"\xd8\x01\n" +
+	"\aLicense\x12\x17\n" +
+	"\aspdx_id\x18\x01 \x01(\tR\x06spdxId\x12\x1e\n" +
+	"\n" +
+	"expression\x18\x02 \x01(\tR\n" +
+	"expression\x12\x12\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\x12D\n" +
+	"\vacquisition\x18\x04 \x01(\x0e2\".mondoo.sbom.v1.LicenseAcquisitionR\vacquisition\x12\x1e\n" +
+	"\n" +
+	"confidence\x18\x05 \x01(\x01R\n" +
+	"confidence\x12\x1a\n" +
+	"\blocation\x18\x06 \x01(\tR\blocation\".\n" +
 	"\x04Hash\x12\x10\n" +
 	"\x03alg\x18\x01 \x01(\tR\x03alg\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value\"R\n" +
@@ -1259,7 +1471,11 @@ const file_mql_sbom_proto_rawDesc = "" +
 	"\x18EXTERNAL_ID_TYPE_AWS_ARN\x10\x02\x12\x1c\n" +
 	"\x18EXTERNAL_ID_TYPE_AWS_ORG\x10\x03\x12\x1e\n" +
 	"\x1aEXTERNAL_ID_TYPE_AZURE_SUB\x10\x04\x12\x1d\n" +
-	"\x19EXTERNAL_ID_TYPE_AZURE_ID\x10\x05*E\n" +
+	"\x19EXTERNAL_ID_TYPE_AZURE_ID\x10\x05*~\n" +
+	"\x12LicenseAcquisition\x12#\n" +
+	"\x1fLICENSE_ACQUISITION_UNSPECIFIED\x10\x00\x12 \n" +
+	"\x1cLICENSE_ACQUISITION_DECLARED\x10\x01\x12!\n" +
+	"\x1dLICENSE_ACQUISITION_CONCLUDED\x10\x02*E\n" +
 	"\fEvidenceType\x12\x1d\n" +
 	"\x19EVIDENCE_TYPE_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12EVIDENCE_TYPE_FILE\x10\x01B\x18Z\x16go.mondoo.com/mql/sbomb\x06proto3"
@@ -1276,45 +1492,49 @@ func file_mql_sbom_proto_rawDescGZIP() []byte {
 	return file_mql_sbom_proto_rawDescData
 }
 
-var file_mql_sbom_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_mql_sbom_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_mql_sbom_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_mql_sbom_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_mql_sbom_proto_goTypes = []any{
-	(Status)(0),         // 0: mondoo.sbom.v1.Status
-	(ExternalIDType)(0), // 1: mondoo.sbom.v1.ExternalIDType
-	(EvidenceType)(0),   // 2: mondoo.sbom.v1.EvidenceType
-	(*Sbom)(nil),        // 3: mondoo.sbom.v1.Sbom
-	(*Dependency)(nil),  // 4: mondoo.sbom.v1.Dependency
-	(*Generator)(nil),   // 5: mondoo.sbom.v1.Generator
-	(*ExternalID)(nil),  // 6: mondoo.sbom.v1.ExternalID
-	(*Asset)(nil),       // 7: mondoo.sbom.v1.Asset
-	(*Platform)(nil),    // 8: mondoo.sbom.v1.Platform
-	(*Package)(nil),     // 9: mondoo.sbom.v1.Package
-	(*Hash)(nil),        // 10: mondoo.sbom.v1.Hash
-	(*Evidence)(nil),    // 11: mondoo.sbom.v1.Evidence
-	(*Kernel)(nil),      // 12: mondoo.sbom.v1.Kernel
-	nil,                 // 13: mondoo.sbom.v1.Asset.LabelsEntry
-	nil,                 // 14: mondoo.sbom.v1.Platform.LabelsEntry
+	(Status)(0),             // 0: mondoo.sbom.v1.Status
+	(ExternalIDType)(0),     // 1: mondoo.sbom.v1.ExternalIDType
+	(LicenseAcquisition)(0), // 2: mondoo.sbom.v1.LicenseAcquisition
+	(EvidenceType)(0),       // 3: mondoo.sbom.v1.EvidenceType
+	(*Sbom)(nil),            // 4: mondoo.sbom.v1.Sbom
+	(*Dependency)(nil),      // 5: mondoo.sbom.v1.Dependency
+	(*Generator)(nil),       // 6: mondoo.sbom.v1.Generator
+	(*ExternalID)(nil),      // 7: mondoo.sbom.v1.ExternalID
+	(*Asset)(nil),           // 8: mondoo.sbom.v1.Asset
+	(*Platform)(nil),        // 9: mondoo.sbom.v1.Platform
+	(*Package)(nil),         // 10: mondoo.sbom.v1.Package
+	(*License)(nil),         // 11: mondoo.sbom.v1.License
+	(*Hash)(nil),            // 12: mondoo.sbom.v1.Hash
+	(*Evidence)(nil),        // 13: mondoo.sbom.v1.Evidence
+	(*Kernel)(nil),          // 14: mondoo.sbom.v1.Kernel
+	nil,                     // 15: mondoo.sbom.v1.Asset.LabelsEntry
+	nil,                     // 16: mondoo.sbom.v1.Platform.LabelsEntry
 }
 var file_mql_sbom_proto_depIdxs = []int32{
-	5,  // 0: mondoo.sbom.v1.Sbom.generator:type_name -> mondoo.sbom.v1.Generator
+	6,  // 0: mondoo.sbom.v1.Sbom.generator:type_name -> mondoo.sbom.v1.Generator
 	0,  // 1: mondoo.sbom.v1.Sbom.status:type_name -> mondoo.sbom.v1.Status
-	7,  // 2: mondoo.sbom.v1.Sbom.asset:type_name -> mondoo.sbom.v1.Asset
-	9,  // 3: mondoo.sbom.v1.Sbom.packages:type_name -> mondoo.sbom.v1.Package
-	4,  // 4: mondoo.sbom.v1.Sbom.dependencies:type_name -> mondoo.sbom.v1.Dependency
+	8,  // 2: mondoo.sbom.v1.Sbom.asset:type_name -> mondoo.sbom.v1.Asset
+	10, // 3: mondoo.sbom.v1.Sbom.packages:type_name -> mondoo.sbom.v1.Package
+	5,  // 4: mondoo.sbom.v1.Sbom.dependencies:type_name -> mondoo.sbom.v1.Dependency
 	1,  // 5: mondoo.sbom.v1.ExternalID.type:type_name -> mondoo.sbom.v1.ExternalIDType
-	6,  // 6: mondoo.sbom.v1.Asset.external_ids:type_name -> mondoo.sbom.v1.ExternalID
-	8,  // 7: mondoo.sbom.v1.Asset.platform:type_name -> mondoo.sbom.v1.Platform
-	13, // 8: mondoo.sbom.v1.Asset.labels:type_name -> mondoo.sbom.v1.Asset.LabelsEntry
-	12, // 9: mondoo.sbom.v1.Asset.kernels:type_name -> mondoo.sbom.v1.Kernel
-	14, // 10: mondoo.sbom.v1.Platform.labels:type_name -> mondoo.sbom.v1.Platform.LabelsEntry
-	11, // 11: mondoo.sbom.v1.Package.evidence_list:type_name -> mondoo.sbom.v1.Evidence
-	10, // 12: mondoo.sbom.v1.Package.hashes:type_name -> mondoo.sbom.v1.Hash
-	2,  // 13: mondoo.sbom.v1.Evidence.type:type_name -> mondoo.sbom.v1.EvidenceType
-	14, // [14:14] is the sub-list for method output_type
-	14, // [14:14] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	7,  // 6: mondoo.sbom.v1.Asset.external_ids:type_name -> mondoo.sbom.v1.ExternalID
+	9,  // 7: mondoo.sbom.v1.Asset.platform:type_name -> mondoo.sbom.v1.Platform
+	15, // 8: mondoo.sbom.v1.Asset.labels:type_name -> mondoo.sbom.v1.Asset.LabelsEntry
+	14, // 9: mondoo.sbom.v1.Asset.kernels:type_name -> mondoo.sbom.v1.Kernel
+	16, // 10: mondoo.sbom.v1.Platform.labels:type_name -> mondoo.sbom.v1.Platform.LabelsEntry
+	13, // 11: mondoo.sbom.v1.Package.evidence_list:type_name -> mondoo.sbom.v1.Evidence
+	12, // 12: mondoo.sbom.v1.Package.hashes:type_name -> mondoo.sbom.v1.Hash
+	11, // 13: mondoo.sbom.v1.Package.licenses:type_name -> mondoo.sbom.v1.License
+	2,  // 14: mondoo.sbom.v1.License.acquisition:type_name -> mondoo.sbom.v1.LicenseAcquisition
+	3,  // 15: mondoo.sbom.v1.Evidence.type:type_name -> mondoo.sbom.v1.EvidenceType
+	16, // [16:16] is the sub-list for method output_type
+	16, // [16:16] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_mql_sbom_proto_init() }
@@ -1327,8 +1547,8 @@ func file_mql_sbom_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_mql_sbom_proto_rawDesc), len(file_mql_sbom_proto_rawDesc)),
-			NumEnums:      3,
-			NumMessages:   12,
+			NumEnums:      4,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/sbom/mql_sbom.proto
+++ b/sbom/mql_sbom.proto
@@ -287,6 +287,65 @@ message Package {
   // manifest records them (npm today), empty otherwise. Rendered as CycloneDX
   // `component.hashes` / SPDX package checksums — tamper-evidence.
   repeated Hash hashes = 30;
+  // 'licenses' is what is known about this package's licensing, one entry per
+  // license, each carrying how it was learned. It supersedes the 'license'
+  // scalar above, which cannot express the distinction that matters most: what
+  // a package's own manifest *declares* is not always what its shipped files
+  // say. A package declaring MIT while shipping an AGPL-3.0-only license file
+  // is the case a compliance document must not flatten, and the scalar has no
+  // room for both values.
+  //
+  // The scalar stays populated with the first declared entry so consumers can
+  // migrate without a flag day.
+  repeated License licenses = 31;
+  // 'copyright' holds the copyright statements found in the package's license
+  // and notice files. Attribution output needs these: no amount of license
+  // identification substitutes for knowing who to credit.
+  repeated string copyright = 32;
+  // 'supplier' is the entity that supplied the package, as SPDX and CycloneDX
+  // both model it (a name, optionally with an email in angle brackets).
+  string supplier = 33;
+}
+
+// License is one license attributed to a package, and how that attribution was
+// arrived at.
+message License {
+  // Exactly one of 'spdx_id', 'expression' and 'name' is set, and which one it
+  // is says what kind of value this is. The distinction is not cosmetic:
+  // CycloneDX models the three mutually exclusively and rejects a document that
+  // puts an expression where an id belongs.
+  //
+  // 'spdx_id' is a bare SPDX identifier, e.g. "MIT".
+  string spdx_id = 1;
+  // 'expression' is a full SPDX expression, e.g. "MIT OR Apache-2.0".
+  string expression = 2;
+  // 'name' is a string that is neither — "BSD-like", "see LICENSE". Carrying it
+  // as a name is honest; forcing it into an id would be a claim the source does
+  // not support.
+  string name = 3;
+  // 'acquisition' says whether the package declared this license or it was
+  // concluded from the files it ships.
+  LicenseAcquisition acquisition = 4;
+  // 'confidence' is how sure the producer is, in (0,1]. A declared license is
+  // 1.0 — it is a statement, not a measurement. A license concluded by matching
+  // text carries the match's own score, so a consumer can tell a certainty from
+  // an inference rather than reading both as the same fact.
+  double confidence = 5;
+  // 'location' is the file this license was read from, relative to the scan
+  // root — the evidence behind a concluded license. Empty for a declared one,
+  // whose source is the manifest already identified by the package.
+  string location = 6;
+}
+
+// LicenseAcquisition is how a license came to be attributed to a package.
+enum LicenseAcquisition {
+  // The producer did not say.
+  LICENSE_ACQUISITION_UNSPECIFIED = 0;
+  // The package's own manifest or lockfile states this license.
+  LICENSE_ACQUISITION_DECLARED = 1;
+  // Read from the license files the package ships, which is the stronger
+  // evidence where the two disagree: the shipped text is the grant.
+  LICENSE_ACQUISITION_CONCLUDED = 2;
 }
 
 // Hash is one integrity digest of a package: an algorithm label and its

--- a/sbom/mql_sbom.proto
+++ b/sbom/mql_sbom.proto
@@ -264,7 +264,28 @@ message Package {
   // SPDX license expression (or upstream-reported license string).
   // Empty when the backend has no source for it (e.g. Windows registry
   // — DisplayName carries no license field).
-  string license = 26;
+  //
+  // Deprecated: use 'licenses' (field 31) instead. One string cannot say
+  // whether a license was declared by the package or concluded from the files
+  // it ships, and those two disagreeing is the case a compliance document
+  // exists to surface. It cannot carry more than one license, a confidence, or
+  // the file a conclusion was read from either.
+  //
+  // Still read, and still the only source for most producers. Every renderer
+  // falls back to this field when 'licenses' is empty, so a producer that has
+  // not adopted the list renders exactly as it did before and nothing breaks on
+  // the version that introduces this marker.
+  //
+  // Note what is NOT enforced: nothing populates this field from 'licenses'. A
+  // producer that adopts the list is responsible for continuing to set this
+  // scalar to its first declared entry, or consumers still reading the scalar
+  // will silently see an empty license where one was determined. That is a
+  // convention, not a guarantee the model makes.
+  //
+  // The deprecation says which field new code should read, not that this one
+  // has stopped working. It will not be removed while unmigrated producers
+  // remain.
+  string license = 26 [deprecated = true];
   // Time the package was installed on this asset, RFC3339 format
   // (e.g. "2024-03-15T00:00:00Z"). Empty when the backend doesn't
   // surface install time (dpkg without log parsing, apk, pacman,
@@ -295,8 +316,10 @@ message Package {
   // is the case a compliance document must not flatten, and the scalar has no
   // room for both values.
   //
-  // The scalar stays populated with the first declared entry so consumers can
-  // migrate without a flag day.
+  // The scalar is deprecated in favour of this field. A producer adopting this
+  // list should keep the scalar set to its first declared entry so consumers
+  // can migrate without a flag day — the renderers fall back to the scalar, but
+  // nothing populates it from here.
   repeated License licenses = 31;
   // 'copyright' holds the copyright statements found in the package's license
   // and notice files. Attribution output needs these: no amount of license

--- a/sbom/mql_sbom_vtproto.pb.go
+++ b/sbom/mql_sbom_vtproto.pb.go
@@ -5,10 +5,12 @@
 package sbom
 
 import (
+	binary "encoding/binary"
 	fmt "fmt"
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	io "io"
+	math "math"
 )
 
 const (
@@ -523,6 +525,40 @@ func (m *Package) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.Supplier) > 0 {
+		i -= len(m.Supplier)
+		copy(dAtA[i:], m.Supplier)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Supplier)))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0x8a
+	}
+	if len(m.Copyright) > 0 {
+		for iNdEx := len(m.Copyright) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Copyright[iNdEx])
+			copy(dAtA[i:], m.Copyright[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Copyright[iNdEx])))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0x82
+		}
+	}
+	if len(m.Licenses) > 0 {
+		for iNdEx := len(m.Licenses) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Licenses[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0xfa
+		}
+	}
 	if len(m.Hashes) > 0 {
 		for iNdEx := len(m.Hashes) - 1; iNdEx >= 0; iNdEx-- {
 			size, err := m.Hashes[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
@@ -680,6 +716,78 @@ func (m *Package) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.Name)
 		copy(dAtA[i:], m.Name)
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *License) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *License) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *License) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Location) > 0 {
+		i -= len(m.Location)
+		copy(dAtA[i:], m.Location)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Location)))
+		i--
+		dAtA[i] = 0x32
+	}
+	if m.Confidence != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Confidence))))
+		i--
+		dAtA[i] = 0x29
+	}
+	if m.Acquisition != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Acquisition))
+		i--
+		dAtA[i] = 0x20
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Expression) > 0 {
+		i -= len(m.Expression)
+		copy(dAtA[i:], m.Expression)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Expression)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.SpdxId) > 0 {
+		i -= len(m.SpdxId)
+		copy(dAtA[i:], m.SpdxId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.SpdxId)))
 		i--
 		dAtA[i] = 0xa
 	}
@@ -1120,6 +1228,54 @@ func (m *Package) SizeVT() (n int) {
 			l = e.SizeVT()
 			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	if len(m.Licenses) > 0 {
+		for _, e := range m.Licenses {
+			l = e.SizeVT()
+			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if len(m.Copyright) > 0 {
+		for _, s := range m.Copyright {
+			l = len(s)
+			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	l = len(m.Supplier)
+	if l > 0 {
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *License) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.SpdxId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Expression)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Acquisition != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.Acquisition))
+	}
+	if m.Confidence != 0 {
+		n += 9
+	}
+	l = len(m.Location)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -3239,6 +3395,313 @@ func (m *Package) UnmarshalVT(dAtA []byte) error {
 			if err := m.Hashes[len(m.Hashes)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 31:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Licenses", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Licenses = append(m.Licenses, &License{})
+			if err := m.Licenses[len(m.Licenses)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 32:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Copyright", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Copyright = append(m.Copyright, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 33:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Supplier", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Supplier = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *License) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: License: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: License: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SpdxId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SpdxId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Expression", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Expression = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Acquisition", wireType)
+			}
+			m.Acquisition = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Acquisition |= LicenseAcquisition(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 5:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Confidence", wireType)
+			}
+			var v uint64
+			if (iNdEx + 8) > l {
+				return io.ErrUnexpectedEOF
+			}
+			v = uint64(binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+			iNdEx += 8
+			m.Confidence = float64(math.Float64frombits(v))
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Location", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Location = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/sbom/spdx.go
+++ b/sbom/spdx.go
@@ -121,21 +121,29 @@ func (s *Spdx) convertToSpdx(bom *Sbom) *spdx.Document {
 		// The SPDX specification requires NOASSERTION rather than an empty value
 		// for the license and copyright fields. An empty string is not valid
 		// SPDX, and a strict consumer may reject the whole document over it.
-		declared := spdxNoAssertion(pkg.License)
+		//
+		// SPDX draws exactly the distinction the license model does: *declared*
+		// is what the package says about itself, *concluded* is what this
+		// document asserts after looking. They differ precisely when it matters
+		// — a package declaring MIT while shipping AGPL-3.0-only — so where a
+		// concluded license was determined it is emitted as itself rather than
+		// echoing the declared one.
+		declared := spdxNoAssertion(spdxLicense(declaredLicenses(pkg), pkg.License))
+		concluded := spdxNoAssertion(spdxLicense(concludedLicenses(pkg), ""))
+		if concluded == spdxNoAssertionValue {
+			// Nothing was concluded. Echoing the declared value is the honest
+			// reading: it is what the document has to go on, and asserting more
+			// than was determined is what NOASSERTION exists to avoid.
+			concluded = declared
+		}
 		doc.Packages = append(doc.Packages, &spdx.Package{
-			PackageSPDXIdentifier:  id,
-			PackageName:            pkg.Name,
-			PackageVersion:         pkg.Version,
-			PackageLicenseDeclared: declared,
-			// Concluded is the license this document asserts the package is
-			// under. With only a declared value to go on, the honest concluded
-			// value is the same one — asserting more than was determined is what
-			// NOASSERTION exists to avoid.
-			PackageLicenseConcluded: declared,
-			// The model carries no copyright field yet, so this states
-			// NOASSERTION rather than omitting a spec-required field. When
-			// Package gains one, this is the single line that changes.
-			PackageCopyrightText:      spdxNoAssertionValue,
+			PackageSPDXIdentifier:     id,
+			PackageName:               pkg.Name,
+			PackageVersion:            pkg.Version,
+			PackageLicenseDeclared:    declared,
+			PackageLicenseConcluded:   concluded,
+			PackageCopyrightText:      spdxNoAssertion(strings.Join(pkg.Copyright, "\n")),
+			PackageSupplier:           spdxSupplier(pkg.Supplier),
 			PackageDescription:        pkg.Description,
 			PackageExternalReferences: refs,
 			PackageFileName:           pkg.Location,
@@ -144,7 +152,8 @@ func (s *Spdx) convertToSpdx(bom *Sbom) *spdx.Document {
 		// A LicenseRef-* identifier is not on the SPDX license list, so the
 		// specification requires the document to define it before it may be
 		// referenced.
-		extractedLicenses.add(pkg.License)
+		extractedLicenses.add(declared)
+		extractedLicenses.add(concluded)
 	}
 
 	doc.OtherLicenses = extractedLicenses.render()
@@ -407,4 +416,51 @@ func (s extractedLicenseSet) render() []*spdx.OtherLicense {
 		})
 	}
 	return out
+}
+
+// spdxLicense renders license entries as the single value an SPDX field holds,
+// falling back to a legacy scalar when the structured list is empty.
+//
+// SPDX carries one expression per field, so several entries are joined with
+// AND: a package under two licenses is under both, and OR would grant a choice
+// the producer never reported.
+func spdxLicense(licenses []*License, fallback string) string {
+	parts := make([]string, 0, len(licenses))
+	for _, l := range licenses {
+		v := strings.TrimSpace(l.GetExpression())
+		if v == "" {
+			v = strings.TrimSpace(l.GetSpdxId())
+		}
+		if v == "" {
+			v = strings.TrimSpace(l.GetName())
+		}
+		if v == "" {
+			continue
+		}
+		if len(licenses) > 1 && isSPDXExpression(v) {
+			// Parenthesize so joining cannot reassociate an operand: "A OR B"
+			// AND "C" is not "A OR (B AND C)".
+			v = "(" + v + ")"
+		}
+		parts = append(parts, v)
+	}
+	if len(parts) == 0 {
+		return strings.TrimSpace(fallback)
+	}
+	return strings.Join(parts, " AND ")
+}
+
+// spdxSupplier renders a supplier as the spec's Originator/Supplier shape, or
+// NOASSERTION when none is known.
+//
+// SPDX requires the value to be typed — "Organization: name" or "Person: name".
+// An unqualified name is not valid, and this package has no way to tell which a
+// supplier is, so it reports the type SPDX itself uses for a supplier of
+// software: an organization.
+func spdxSupplier(supplier string) *common.Supplier {
+	supplier = strings.TrimSpace(supplier)
+	if supplier == "" {
+		return &common.Supplier{Supplier: spdxNoAssertionValue}
+	}
+	return &common.Supplier{Supplier: supplier, SupplierType: "Organization"}
 }

--- a/sbom/spdx.go
+++ b/sbom/spdx.go
@@ -128,8 +128,8 @@ func (s *Spdx) convertToSpdx(bom *Sbom) *spdx.Document {
 		// — a package declaring MIT while shipping AGPL-3.0-only — so where a
 		// concluded license was determined it is emitted as itself rather than
 		// echoing the declared one.
-		declared := spdxNoAssertion(spdxLicense(declaredLicenses(pkg), pkg.License))
-		concluded := spdxNoAssertion(spdxLicense(concludedLicenses(pkg), ""))
+		declared := spdxNoAssertion(spdxLicense(declaredLicenses(pkg), pkg.License, extractedLicenses))
+		concluded := spdxNoAssertion(spdxLicense(concludedLicenses(pkg), "", extractedLicenses))
 		if concluded == spdxNoAssertionValue {
 			// Nothing was concluded. Echoing the declared value is the honest
 			// reading: it is what the document has to go on, and asserting more
@@ -380,16 +380,38 @@ const licenseRefPrefix = "LicenseRef-"
 // extractedLicenseSet collects the LicenseRef-* identifiers a document
 // references, so each can be declared in hasExtractedLicensingInfos as the
 // specification requires.
-type extractedLicenseSet map[string]struct{}
+//
+// The value is the human-readable name the identifier stands for, which matters
+// for a reference synthesized from a free-form license string: "see LICENSE" is
+// not a legal identifier, so it becomes LicenseRef-see-LICENSE, and the original
+// text is the only place the reader learns what that means. Empty means the
+// identifier is all that is known and names itself.
+type extractedLicenseSet map[string]string
 
+// add registers every LicenseRef-* identifier appearing in a rendered license
+// expression. It never overwrites a name already recorded for an identifier, so
+// a reference synthesized by addNamed keeps its original text when the rendered
+// expression it landed in is scanned again.
 func (s extractedLicenseSet) add(license string) {
 	for _, tok := range strings.FieldsFunc(license, func(r rune) bool {
 		return r == ' ' || r == '\t' || r == '(' || r == ')'
 	}) {
-		if strings.HasPrefix(tok, licenseRefPrefix) {
-			s[tok] = struct{}{}
+		if !strings.HasPrefix(tok, licenseRefPrefix) {
+			continue
+		}
+		if _, ok := s[tok]; !ok {
+			s[tok] = ""
 		}
 	}
+}
+
+// addNamed registers an identifier together with the text it was synthesized
+// from.
+func (s extractedLicenseSet) addNamed(id, name string) {
+	if existing, ok := s[id]; ok && existing != "" {
+		return
+	}
+	s[id] = name
 }
 
 // render returns the collected identifiers as SPDX other-license entries, sorted
@@ -406,13 +428,17 @@ func (s extractedLicenseSet) render() []*spdx.OtherLicense {
 
 	out := make([]*spdx.OtherLicense, 0, len(ids))
 	for _, id := range ids {
+		name := s[id]
+		if name == "" {
+			name = id
+		}
 		out = append(out, &spdx.OtherLicense{
 			LicenseIdentifier: id,
 			// The text is not available here — the extractors carry an
 			// identifier, not a license body — so the field states that rather
 			// than inventing one.
 			ExtractedText: spdxNoAssertionValue,
-			LicenseName:   id,
+			LicenseName:   name,
 		})
 	}
 	return out
@@ -424,30 +450,91 @@ func (s extractedLicenseSet) render() []*spdx.OtherLicense {
 // SPDX carries one expression per field, so several entries are joined with
 // AND: a package under two licenses is under both, and OR would grant a choice
 // the producer never reported.
-func spdxLicense(licenses []*License, fallback string) string {
+//
+// The field must hold a license *expression*, which constrains what each operand
+// may be, so the three License shapes do not all reach it the same way. Refs
+// synthesized for a free-form name are registered in extracted so the document
+// declares them before referencing them.
+//
+// The fallback scalar is passed through unchanged. It has rendered verbatim for
+// as long as the field has existed and producers set it to whatever their
+// package manager reported; re-encoding it here would rewrite what every
+// existing document says about a large share of OS packages, which is a
+// migration to make deliberately rather than as a side effect of adding a list.
+func spdxLicense(licenses []*License, fallback string, extracted extractedLicenseSet) string {
 	parts := make([]string, 0, len(licenses))
 	for _, l := range licenses {
-		v := strings.TrimSpace(l.GetExpression())
-		if v == "" {
-			v = strings.TrimSpace(l.GetSpdxId())
-		}
-		if v == "" {
-			v = strings.TrimSpace(l.GetName())
-		}
-		if v == "" {
+		if v := strings.TrimSpace(l.GetExpression()); v != "" {
+			parts = append(parts, v)
 			continue
 		}
-		if len(licenses) > 1 && isSPDXExpression(v) {
-			// Parenthesize so joining cannot reassociate an operand: "A OR B"
-			// AND "C" is not "A OR (B AND C)".
-			v = "(" + v + ")"
+		if v := strings.TrimSpace(l.GetSpdxId()); v != "" {
+			parts = append(parts, v)
+			continue
 		}
-		parts = append(parts, v)
+		// A free-form name is not a legal operand: "see LICENSE" has a space in
+		// it, so emitting it raw makes the field unparseable and joining it with
+		// AND produces "MIT AND see LICENSE", which reads as an expression and
+		// is not one. SPDX's encoding for a license that is not on its list is a
+		// LicenseRef-* identifier defined in hasExtractedLicensingInfos, so that
+		// is what the text becomes — the name survives, in the field that can
+		// hold it.
+		if v := strings.TrimSpace(l.GetName()); v != "" {
+			ref := spdxLicenseRef(v)
+			if ref == "" {
+				// Nothing in the name survives sanitization, so there is no
+				// identifier to reference and no way to say this in SPDX.
+				continue
+			}
+			extracted.addNamed(ref, v)
+			parts = append(parts, ref)
+		}
 	}
 	if len(parts) == 0 {
 		return strings.TrimSpace(fallback)
 	}
+	if len(parts) == 1 {
+		return parts[0]
+	}
+	for i, p := range parts {
+		if isSPDXExpression(p) {
+			// Parenthesize so joining cannot reassociate an operand: "A OR B"
+			// AND "C" is not "A OR (B AND C)". Decided on the rendered operands
+			// rather than the input count, so an entry that carried no value
+			// cannot add parentheses around the one that did.
+			parts[i] = "(" + p + ")"
+		}
+	}
 	return strings.Join(parts, " AND ")
+}
+
+// spdxLicenseRef builds the LicenseRef-* identifier that stands for a free-form
+// license name.
+//
+// SPDX restricts the part after the prefix to letters, digits, "." and "-", so
+// every other run of characters collapses to a single dash. Returns "" when the
+// name has nothing an identifier can be built from, which is the caller's signal
+// that there is no way to reference it.
+func spdxLicenseRef(name string) string {
+	var b strings.Builder
+	dash := false
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '-':
+			if dash && b.Len() > 0 {
+				b.WriteByte('-')
+			}
+			dash = false
+			b.WriteRune(r)
+		default:
+			dash = true
+		}
+	}
+	id := strings.Trim(b.String(), "-.")
+	if id == "" {
+		return ""
+	}
+	return licenseRefPrefix + id
 }
 
 // spdxSupplier renders a supplier as the spec's Originator/Supplier shape, or


### PR DESCRIPTION
## The problem

`sbom.Package` holds one license string, so a document cannot say the thing that matters most about a package's licensing: **what a package's manifest declares is not always what its shipped files say.** A package declaring MIT while shipping an AGPL-3.0-only license file is exactly the case a compliance document must not flatten, and the scalar has no room for both values.

Producers that read the shipped text had nowhere to put it, so the renderers echoed the declared license into the concluded field and emitted `NOASSERTION` for copyright — honest given the model, but not the picture the producer had.

## What this adds

`Package.licenses`, a repeated `License`:

- `spdx_id` / `expression` / `name` — which one is set says what kind of value it is. Not cosmetic: CycloneDX models the three mutually exclusively and rejects a document that puts an expression where an id belongs, so the producer says which it has rather than the renderer guessing.
- `acquisition` — `DECLARED` or `CONCLUDED`.
- `confidence` in (0,1] — a declared license is 1.0 because it is a statement, not a measurement; a license concluded by matching text carries the match's own score, so a consumer can tell a certainty from an inference.
- `location` — the file a concluded license was read from.

Plus `Package.copyright` and `Package.supplier`, both required by attribution output and both with a natural home in each renderer.

**No flag day.** The `license` scalar stays authoritative when `licenses` is empty, so a producer that has not adopted the list renders exactly as before.

## Renderers

**CycloneDX** — declared entries become `component.licenses`; concluded entries become `component.evidence.licenses`, which is what CycloneDX evidence is *for*: they were read out of a file rather than asserted by the package. Copyright renders both as `component.copyright` and as evidence. Supplier populated.

**SPDX** — `PackageLicenseConcluded` is now the concluded value where one was determined rather than an echo of declared. SPDX draws exactly this declared/concluded distinction; we were collapsing it. `PackageCopyrightText` and `PackageSupplier` carry real values, and `LicenseRef-*` identifiers from **either** field now reach `hasExtractedLicensingInfos`, which the spec requires before they may be referenced. Where nothing was concluded, echoing declared remains the honest reading, and `NOASSERTION` is emitted where nothing is known.

## Testing

`TestCycloneDXSeparatesDeclaredFromConcluded` and `TestSPDXConcludedIsNotAnEchoOfDeclared` cover the split end to end on a package that declares MIT and ships AGPL-3.0-only. `TestLegacyScalarStillRenders` pins the migration contract, and `TestSPDXConcludedFallsBackToDeclared` pins the NOASSERTION cases.

The absence of exactly these tests is why the renderers shipped emitting **no licenses at all** for as long as they existed — every SBOM test asserted on packages, none on licenses.

`go build ./sbom/`, `go vet ./sbom/` and `go test ./sbom/` green.

## On regeneration

Generated with protoc 33.6 — the release protobuf-go records as `v6.33.6`, matching the version the committed file already carried. Diffing the regenerated output against the file as committed before this PR shows **no change at all** outside the fields being added, and an earlier run with a v3.21.12 toolchain produced byte-identical descriptor bytes differing only in that version comment. The plugins are pinned via `go tool` and they are what determine the output.

## Review follow-up: a free-form name is not an SPDX expression

`License.name` exists to carry a value that is neither an identifier nor an
expression: "BSD-like, see LICENSE", "see LICENSE". An SPDX license field holds
a license *expression*, which constrains what may go in it to a listed
identifier, a `LicenseRef-*` the document defines, `NONE`, or `NOASSERTION`. The
renderer was passing a name straight through, so alone it produced an
unparseable field, and joined it produced something worse:

```
"licenseDeclared": "MIT AND see LICENSE"
```

That reads as an expression right up to the operand that is not one, so a
consumer either rejects the document or silently reads a license that does not
exist. The join is reachable only through the new list, so this is a defect in
the field being added rather than an existing one.

A name now becomes the `LicenseRef-*` identifier SPDX specifies for a license
that is not on its list, with the original text as that reference's name in
`hasExtractedLicensingInfos` — the reader learns what the reference means rather
than receiving one the document never defines. A name with nothing an identifier
can be built from is dropped rather than emitting a bare prefix.

Two smaller fixes alongside: grouping parentheses are decided on the operands
actually rendered rather than the input count, so a lone `MIT OR Apache-2.0` no
longer renders as `(MIT OR Apache-2.0)` because a sibling entry carried no
value; and `extractedLicenseSet` now carries the name an identifier stands for.

**The `license` scalar is deliberately unchanged.** Producers set it to whatever
their package manager reported, and a large share of OS packages report
something that is not an SPDX expression, so re-encoding it here would rewrite
what every existing document says about them. That is a migration to make on
purpose, not as a side effect of adding a list.
`TestSPDXLegacyScalarPassesThroughUnchanged` pins it.

## Known gaps (not addressed here)

- `License.confidence` and `License.location` are modelled but reach no
  renderer: CycloneDX 1.6 has no per-license confidence or location under
  `evidence.licenses`, and SPDX has no field for either. They are recorded in
  the native BOM and available to consumers of it, but a document does not carry
  them today.
- `evidence.licenses` and `evidence.copyright` are emitted regardless of
  `WithEvidence()`, unlike `evidence.occurrences`. Dropping concluded licensing
  when evidence is off would lose real license data rather than provenance
  detail, so it is emitted either way — flagging it because it is a divergence
  from how the rest of the evidence block behaves.
- `sbom/protobom.go` renders no licensing at all. Pre-existing.

## Verification

- `go build ./sbom/`, `go vet ./sbom/`, `go test ./sbom/...` green on current
  `main` (branch rebased onto `5ca5f0ffb`).
- Generated files: `go generate ./sbom` with protoc 33.6 — the version
  `.github/env` pins for CI (`protoc-version=33.x`) — reproduces both
  `mql_sbom.pb.go` and `mql_sbom_vtproto.pb.go` **byte-identically** to what is
  committed.
- The new tests were confirmed capable of failing: reverting the `LicenseRef`
  encoding turns `TestSPDXFreeFormNameBecomesLicenseRef` and
  `TestSPDXNameIsNotJoinedRawIntoAnExpression` red.
