### PR TITLE
🐛 arista: report power-supply sensors and fans instead of erroring

### DIFF
--- a/providers/arista/resources/arista_eos.go
+++ b/providers/arista/resources/arista_eos.go
@@ -1349,6 +1349,36 @@ func (a *mqlAristaEos) hardware() (*mqlAristaEosHardware, error) {
 	return res.(*mqlAristaEosHardware), nil
 }
 
+// powerSupplyTempSensors renders a power supply's temperature sensors as dict
+// rows. Every numeric leaf is widened to int64: llx only accepts JSON-native
+// types inside a dict, and a Go int makes the conversion of the whole array
+// fail, so a single un-widened value takes the field down rather than one row.
+func powerSupplyTempSensors(ps eos.PowerSupply) []any {
+	res := make([]any, 0, len(ps.TempSensors))
+	for name, sensor := range ps.TempSensors {
+		res = append(res, map[string]any{
+			"name":        name,
+			"status":      sensor.Status,
+			"temperature": int64(sensor.Temperature),
+		})
+	}
+	return res
+}
+
+// powerSupplyFans renders a power supply's fans as dict rows. See
+// powerSupplyTempSensors for why speed is widened.
+func powerSupplyFans(ps eos.PowerSupply) []any {
+	res := make([]any, 0, len(ps.Fans))
+	for name, fan := range ps.Fans {
+		res = append(res, map[string]any{
+			"name":   name,
+			"status": fan.Status,
+			"speed":  int64(fan.Speed),
+		})
+	}
+	return res
+}
+
 func (a *mqlAristaEosHardware) powerSupplies() ([]any, error) {
 	eosClient := aristaClient(a.MqlRuntime)
 
@@ -1359,25 +1389,8 @@ func (a *mqlAristaEosHardware) powerSupplies() ([]any, error) {
 
 	res := make([]any, 0, len(envPower.PowerSupplies))
 	for name, ps := range envPower.PowerSupplies {
-		// Build temp sensor dicts
-		tempSensors := make([]any, 0, len(ps.TempSensors))
-		for sensorName, sensor := range ps.TempSensors {
-			tempSensors = append(tempSensors, map[string]any{
-				"name":        sensorName,
-				"status":      sensor.Status,
-				"temperature": sensor.Temperature,
-			})
-		}
-
-		// Build fan dicts
-		fans := make([]any, 0, len(ps.Fans))
-		for fanName, fan := range ps.Fans {
-			fans = append(fans, map[string]any{
-				"name":   fanName,
-				"status": fan.Status,
-				"speed":  fan.Speed,
-			})
-		}
+		tempSensors := powerSupplyTempSensors(ps)
+		fans := powerSupplyFans(ps)
 
 		mqlPSU, err := CreateResource(a.MqlRuntime, "arista.eos.hardware.powerSupply", map[string]*llx.RawData{
 			"name":          llx.StringData(name),

--- a/providers/arista/resources/hardware_dict_test.go
+++ b/providers/arista/resources/hardware_dict_test.go
@@ -1,0 +1,47 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers/arista/resources/eos"
+	"go.mondoo.com/mql/types"
+)
+
+// TestPowerSupplyDictsSerialize pins the leaf types of the power-supply dict
+// rows. llx converts a dict only from JSON-native leaves, and array conversion
+// aborts on the first element that fails, so one Go int in a sensor row makes
+// the whole tempSensors (or fans) field error out for every power supply. The
+// list itself still resolves, so the failure reads as a bad query rather than
+// a provider bug.
+func TestPowerSupplyDictsSerialize(t *testing.T) {
+	ps := eos.PowerSupply{State: "ok", ModelName: "PWR-500AC"}
+	ps.TempSensors = map[string]struct {
+		Status      string `json:"status"`
+		Temperature int    `json:"temperature"`
+	}{
+		"TempSensor1": {Status: "ok", Temperature: 32},
+	}
+	ps.Fans = map[string]struct {
+		Status string `json:"status"`
+		Speed  int    `json:"speed"`
+	}{
+		"PS1/1": {Status: "ok", Speed: 33},
+	}
+
+	for _, tc := range []struct {
+		field string
+		rows  []any
+	}{
+		{"tempSensors", powerSupplyTempSensors(ps)},
+		{"fans", powerSupplyFans(ps)},
+	} {
+		res := llx.ArrayData(tc.rows, types.Dict).Result()
+		if res.Error != "" {
+			t.Errorf("%s does not serialize: %s", tc.field, res.Error)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`arista.eos.hardware.powerSupply.tempSensors` and `.fans` are declared `[]dict` and built as raw `map[string]any` rows whose numeric leaf comes straight from the eos structs, where `Temperature` and `Speed` are Go `int`.

`llx` converts a dict only from JSON-native leaves — `dict2primitive` handles `int64` but not `int` — and `array2result` aborts the whole array on the first element that fails. So one un-widened value doesn't degrade a single row, it takes the entire field down for every power supply:

```
failed to convert dict to primitive, unsupported child type: int
```

The power-supply list itself still resolves, so the failure reads as a bad query rather than a provider bug, and any policy asserting on PSU temperature never evaluates.

The repo's own fixture has these values: `eos/testdata/environment-power.json` carries `"temperature": 32` and `"speed": 33`, asserted in `eos/hardware_test.go`. The sibling `arista.eos.hardware.fan` creator immediately below already does the right thing with `llx.IntData(int64(fan.Speed))`.

## Fix

Widen both leaves to `int64`, and lift the two row builders out into `powerSupplyTempSensors` / `powerSupplyFans` so the leaf types are pinned by a test rather than re-derived by eye.

## Test plan

- `TestPowerSupplyDictsSerialize` runs both builders through `llx.ArrayData(..., types.Dict).Result()` and asserts no conversion error.
- Verified the test actually catches it: reverting `int64(sensor.Temperature)` to `sensor.Temperature` fails with `tempSensors does not serialize: failed to convert dict to primitive, unsupported child type: int`.
- `go build ./...` and `go test ./...` green in `providers/arista/`.
