### PR TITLE
🐛 azure: report a refused Key Vault read as null, not an empty vault

### DIFF
--- a/providers/azure/resources/keyvault.go
+++ b/providers/azure/resources/keyvault.go
@@ -383,11 +383,7 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) keys() ([]any, error) {
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			if isAzureNotConfigured(err) {
-				log.Warn().Err(err).Msg("could not list azure keys, returning partial results")
-				return res, nil
-			}
-			return nil, err
+			return keyVaultPageFault(&a.Keys, res, "azure key vault keys", err)
 		}
 
 		for _, entry := range page.Value {
@@ -457,15 +453,11 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) autorotation() ([]any, error)
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			// The same data-plane listing keys() walks, so it degrades the same
-			// way: a caller holding the vault's control-plane read but not the
-			// keys data action gets 403 here, and that should not fail the whole
-			// vault list.
-			if isAzureNotConfigured(err) {
-				log.Warn().Err(err).Msg("could not list azure keys for rotation policies, returning partial results")
-				return res, nil
-			}
-			return nil, err
+			// The same data-plane listing keys() walks, so it degrades the
+			// same way: a caller holding the vault's control-plane read but
+			// not the keys data action gets 403 here, which reports null
+			// rather than failing the whole vault list.
+			return keyVaultPageFault(&a.Autorotation, res, "azure key vault key rotation policies", err)
 		}
 
 		// Resolve auto-rotation status concurrently. Azure Key Vault has no
@@ -546,11 +538,7 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) secrets() ([]any, error) {
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			if isAzureNotConfigured(err) {
-				log.Warn().Err(err).Msg("could not list azure secrets, returning partial results")
-				return res, nil
-			}
-			return nil, err
+			return keyVaultPageFault(&a.Secrets, res, "azure key vault secrets", err)
 		}
 
 		for _, entry := range page.Value {
@@ -602,11 +590,7 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) certificates() ([]any, error)
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			if isAzureNotConfigured(err) {
-				log.Warn().Err(err).Msg("could not list azure certificates, returning partial results")
-				return res, nil
-			}
-			return nil, err
+			return keyVaultPageFault(&a.Certificates, res, "azure key vault certificates", err)
 		}
 
 		for _, entry := range page.Value {
@@ -1186,11 +1170,7 @@ func (a *mqlAzureSubscriptionKeyVaultServiceKey) versions() ([]any, error) {
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			if isAzureNotConfigured(err) {
-				log.Warn().Err(err).Msg("could not list azure versions, returning partial results")
-				return res, nil
-			}
-			return nil, err
+			return keyVaultPageFault(&a.Versions, res, "azure key vault key versions", err)
 		}
 		for _, entry := range page.Value {
 			if entry == nil {
@@ -1356,11 +1336,7 @@ func (a *mqlAzureSubscriptionKeyVaultServiceCertificate) versions() ([]any, erro
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			if isAzureNotConfigured(err) {
-				log.Warn().Err(err).Msg("could not list azure versions, returning partial results")
-				return res, nil
-			}
-			return nil, err
+			return keyVaultPageFault(&a.Versions, res, "azure key vault certificate versions", err)
 		}
 		for _, entry := range page.Value {
 			if entry == nil {
@@ -1736,11 +1712,7 @@ func (a *mqlAzureSubscriptionKeyVaultServiceSecret) versions() ([]any, error) {
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			if isAzureNotConfigured(err) {
-				log.Warn().Err(err).Msg("could not list azure versions, returning partial results")
-				return res, nil
-			}
-			return nil, err
+			return keyVaultPageFault(&a.Versions, res, "azure key vault secret versions", err)
 		}
 		for _, entry := range page.Value {
 			if entry == nil {
@@ -1930,12 +1902,7 @@ func (a *mqlAzureSubscriptionKeyVaultServiceManagedHsm) keys() ([]any, error) {
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			var respErr *azcore.ResponseError
-			if errors.As(err, &respErr) && (respErr.StatusCode == http.StatusUnauthorized || respErr.StatusCode == http.StatusForbidden) {
-				log.Warn().Err(err).Str("hsm", hsmUri.Data).Msg("azure> no data-plane access to list managed HSM keys, returning partial results")
-				return res, nil
-			}
-			return nil, err
+			return keyVaultPageFault(&a.Keys, res, "managed HSM keys", err)
 		}
 
 		for _, entry := range page.Value {
@@ -2190,4 +2157,62 @@ func (a *mqlAzureSubscriptionKeyVaultServiceManagedHsm) privateEndpointConnectio
 	}
 
 	return res, nil
+}
+
+// isKeyVaultReadRefused reports whether a Key Vault data-plane call was refused
+// for this identity.
+//
+// Key Vault splits its permissions in two: the control plane lists the vaults,
+// the data plane reads what is inside them, and they are granted separately. A
+// Reader on the subscription therefore sees every vault and none of its
+// contents, which is the most common credential shape there is. Key Vault
+// answers 403 when the caller holds no data action for the contents, and 401
+// when the token carries no data-plane access at all. Both mean the contents
+// were not read.
+func isKeyVaultReadRefused(err error) bool {
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		return false
+	}
+	return respErr.StatusCode == http.StatusUnauthorized || respErr.StatusCode == http.StatusForbidden
+}
+
+// keyVaultPageFault decides what a Key Vault data-plane page walk reports when
+// a page fails, and is the only place that decision is made.
+//
+// A refused read reports null rather than an empty collection. The two are not
+// the same answer and must not look alike: an empty list is a claim that the
+// vault holds nothing, and a policy written as `keys.none(...)` or
+// `secrets.all(...)` passes on it. Reported for contents nobody was allowed to
+// look at, that is a silent pass on unexamined key material -- which is the
+// most dangerous way for a secrets audit to fail, because it fails as success.
+//
+// A 404, or one of the not-applicable codes, is a real absence and keeps the
+// empty list. Anything else -- a throttle, a 5xx, a transport failure -- proves
+// nothing about the contents and stays an error.
+//
+// collected is what the walk had already read. Once any row has been read, a
+// fault can only be reported as an error: returning the rows so far would
+// present a truncated collection as a complete one, and nothing downstream can
+// tell the difference. This mirrors listPaged, which makes the same call for
+// the ARM pagers.
+func keyVaultPageFault(field *plugin.TValue[[]any], collected []any, what string, err error) ([]any, error) {
+	if len(collected) > 0 {
+		return nil, errors.New("could not read all " + what + ": " + err.Error())
+	}
+
+	if isKeyVaultReadRefused(err) {
+		log.Warn().Err(err).Str("collection", what).
+			Msg("azure> not permitted to read, reporting null")
+		field.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	if isAzureFeatureUnavailable(err) {
+		log.Debug().Err(err).Str("collection", what).
+			Msg("azure> not available, reporting an empty list")
+		return []any{}, nil
+	}
+
+	return nil, err
 }

--- a/providers/azure/resources/keyvault_denied_test.go
+++ b/providers/azure/resources/keyvault_denied_test.go
@@ -1,0 +1,103 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+func TestIsKeyVaultReadRefused(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		// The vault lists fine on the control plane and refuses its contents
+		// on the data plane. This is the shape a subscription Reader hits on
+		// every vault in the subscription.
+		{"403 is refused", armError(http.StatusForbidden, ""), true},
+		// A token carrying no data-plane access at all.
+		{"401 is refused", armError(http.StatusUnauthorized, ""), true},
+		// An absence, not a refusal: the empty list is the honest answer.
+		{"404 is not a refusal", armError(http.StatusNotFound, ""), false},
+		// Neither of these proves anything about the contents.
+		{"429 is not a refusal", armError(http.StatusTooManyRequests, ""), false},
+		{"500 is not a refusal", armError(http.StatusInternalServerError, ""), false},
+		{"a transport failure is not a refusal", errors.New("dial tcp: i/o timeout"), false},
+		{"nil is not a refusal", nil, false},
+		{
+			"a wrapped response error is still classified",
+			errors.Join(errors.New("listing keys"), armError(http.StatusForbidden, "")),
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isKeyVaultReadRefused(tt.err))
+		})
+	}
+}
+
+// A refused read must report null, not an empty list. An empty list is a claim
+// that the vault holds nothing, and `keys.none(...)` passes on it -- so
+// reporting one for contents nobody was allowed to read is a silent pass on
+// unexamined key material.
+func TestKeyVaultPageFaultRefusedReportsNullNotEmpty(t *testing.T) {
+	for _, status := range []int{http.StatusForbidden, http.StatusUnauthorized} {
+		var field plugin.TValue[[]any]
+
+		res, err := keyVaultPageFault(&field, nil, "azure key vault keys", armError(status, ""))
+
+		require.NoError(t, err)
+		assert.Nil(t, res)
+		assert.True(t, field.State&plugin.StateIsNull != 0, "status %d must report null", status)
+		assert.True(t, field.State&plugin.StateIsSet != 0, "status %d must mark the field resolved", status)
+	}
+}
+
+// A 404 means the resource provider genuinely has nothing here, so the empty
+// list is correct and a null would understate what is known.
+func TestKeyVaultPageFaultAbsentReportsEmptyList(t *testing.T) {
+	var field plugin.TValue[[]any]
+
+	res, err := keyVaultPageFault(&field, nil, "azure key vault keys", armError(http.StatusNotFound, ""))
+
+	require.NoError(t, err)
+	assert.Equal(t, []any{}, res)
+	assert.Zero(t, field.State, "an absence must not mark the field null")
+}
+
+// A throttle or a server error says nothing about the contents. Degrading
+// either one would report an authoritative answer derived from no data.
+func TestKeyVaultPageFaultFatalStaysAnError(t *testing.T) {
+	for _, status := range []int{http.StatusTooManyRequests, http.StatusInternalServerError} {
+		var field plugin.TValue[[]any]
+
+		_, err := keyVaultPageFault(&field, nil, "azure key vault keys", armError(status, ""))
+
+		require.Error(t, err, "status %d must surface", status)
+		assert.Zero(t, field.State, "status %d must not mark the field null", status)
+	}
+}
+
+// Once any row has been read, a fault can only be an error: returning the rows
+// collected so far would present a truncated collection as a complete one, and
+// nothing downstream can tell the difference.
+func TestKeyVaultPageFaultPartialWalkIsAnError(t *testing.T) {
+	var field plugin.TValue[[]any]
+	collected := []any{"key-one"}
+
+	res, err := keyVaultPageFault(&field, collected, "azure key vault keys", armError(http.StatusForbidden, ""))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not read all azure key vault keys")
+	assert.Nil(t, res)
+	assert.Zero(t, field.State, "a truncated walk must not be reported as null")
+}


### PR DESCRIPTION
## What

Eight Key Vault data-plane collection accessors reported a **refused** read as an **empty collection**.

Key Vault grants control-plane and data-plane access separately. An identity that can list every vault in a subscription commonly cannot read what is inside them — that is what a plain subscription `Reader` looks like. Key Vault answers 401/403 for those reads.

All eight classified that refusal with `isAzureNotConfigured`, which [deliberately folds 403 in with 404](https://github.com/mondoohq/mql/blob/main/providers/azure/resources/shared.go), and then returned the rows collected so far — an empty list. So a vault whose contents could not be read reported as a vault with **no keys, no secrets and no certificates**, with no error anywhere.

## Why it matters

This is a silent *pass*, not a silent failure. `keys.none(...)` and `secrets.all(...)` both pass on an empty list, so a policy over key material passes precisely on the vaults nobody was able to look at — the most dangerous way for a secrets audit to fail, because it fails as success.

## The fix

`isAzureNotConfigured` is right for a *scalar* optional, where 403 and 404 both mean "the feature is not there". It is wrong for a *collection that is itself the security finding* — which is why `shared.go` already carries the narrower `isAzureAccessDenied`, and `lister.go` already makes exactly this distinction for the ARM pagers.

This wires the same taxonomy into the Key Vault data-plane walks, in one place:

| ARM answer | reported as |
|---|---|
| 401 / 403 | **null** — the read was refused |
| 404, not-applicable 400 | empty list — there is genuinely nothing there |
| 429 / 5xx / transport | error — the call proves nothing |

A fault partway through a walk is now an error too. Returning the rows read so far presented a truncated collection as a complete one, and nothing downstream could tell the difference. (Same call `listPaged` makes.)

Accessors changed: `vault.keys`, `vault.secrets`, `vault.certificates`, `vault.autorotation`, `key.versions`, `certificate.versions`, `secret.versions`, `managedHsm.keys`.

No schema change — no `.lr`, `.lr.versions` or permissions diff.

## Verification

Against a live subscription, using a service principal holding subscription-wide `*/read` and **no** Key Vault access policy, on a vault containing one key and one secret. Key Vault returned a genuine 403 for the data-plane list while the management-plane read succeeded.

| build | identity | `keys` | `secrets` |
|---|---|---|---|
| main | authorized | 1 | 1 |
| main | refused | `[]` ← **the bug** | `[]` |
| this PR | refused | `null` | `null` |
| this PR | authorized | `[probekey]` | `[probesecret]` |

## Tests

New `keyvault_denied_test.go` covers the classifier and all four branches of the fault handler: refusal → null, absence → empty list, throttle/5xx → error, and partial-walk → error. Full `providers/azure` suite passes.
