### PR TITLE
🐛 arista: report locked user accounts correctly

### DIFF
--- a/providers/arista/resources/arista.lr
+++ b/providers/arista/resources/arista.lr
@@ -180,7 +180,11 @@ arista.eos.user @defaults("name privilege") {
   privilege string
   // User's assigned role
   role string
-  // Set to "nopassword" when the account has no password configured, empty otherwise
+  // Whether the account is configured with `nopassword`
+  //
+  // One of "true" or "false". An account written with the `nopassword`
+  // keyword has no password at all, so the only credential it can present
+  // is an SSH key.
   nopassword string
   // Specifies how the secret is encoded
   format string

--- a/providers/arista/resources/arista_eos.go
+++ b/providers/arista/resources/arista_eos.go
@@ -215,7 +215,8 @@ func (a *mqlAristaEosUser) locked() (bool, error) {
 		return false, a.Sshkey.Error
 	}
 
-	hasNoPassword := a.Nopassword.Data == "nopassword"
+	// The field carries the string "true" or "false", not the keyword itself.
+	hasNoPassword := a.Nopassword.Data == "true"
 	hasSecret := a.Secret.Data != ""
 	hasSSHKey := a.Sshkey.Data != ""
 

--- a/providers/arista/resources/user_locked_test.go
+++ b/providers/arista/resources/user_locked_test.go
@@ -1,0 +1,50 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+func tstr(v string) plugin.TValue[string] {
+	return plugin.TValue[string]{Data: v, State: plugin.StateIsSet}
+}
+
+// TestUserLocked pins the predicate against the values `nopassword` actually
+// carries. It is the string "true" or "false"; comparing it against the
+// keyword "nopassword" is a comparison that can never hold, so locked() read
+// false for every account on every device and an audit hunting credential-less
+// accounts reported "none found" as a fact.
+func TestUserLocked(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		nopassword string
+		secret     string
+		sshkey     string
+		want       bool
+	}{
+		{"nopassword and no key is locked", "true", "", "", true},
+		{"nopassword but an ssh key still authenticates", "true", "", "ssh-rsa AAAA", false},
+		{"a secret means the account can log in", "false", "$6$salt$hash", "", false},
+		{"a password-protected account is not locked", "false", "$6$salt$hash", "ssh-rsa AAAA", false},
+		{"no password and no key, keyword absent", "false", "", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			u := &mqlAristaEosUser{
+				Nopassword: tstr(tc.nopassword),
+				Secret:     tstr(tc.secret),
+				Sshkey:     tstr(tc.sshkey),
+			}
+			got, err := u.locked()
+			if err != nil {
+				t.Fatalf("locked: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("locked = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`arista.eos.user.locked` computes:

```go
hasNoPassword := a.Nopassword.Data == "nopassword"
```

but the `nopassword` field never holds that keyword. The value is rendered as the string `"true"` or `"false"`, so the comparison can never hold and **`locked` returned `false` for every account on every device**.

The dangerous direction is the vacuous one. A switch carrying:

```
username backup privilege 15 nopassword
```

has a privilege-15 account reachable with no credential at all, and `arista.eos.users.where(locked)` returns the empty set — an audit hunting credential-less or disabled accounts reports "none found" as a fact.

The field's own doc-comment described the same wrong contract:

```
// Set to "nopassword" when the account has no password configured, empty otherwise
```

So the documented query `where(nopassword == "nopassword")` matched nothing, while the natural `where(nopassword != "")` matched *every* account — password-protected ones included, because they carry the literal `"false"`.

## Fix

Compare against the value the field actually carries, and correct the doc-comment to state the real contract.

Scoped deliberately to the correctness bug. A `nopassword string` carrying `"true"`/`"false"` is poor schema, but the field is shipped, so replacing it with a bool is a deprecate-and-add change and belongs in its own PR.

## Test plan

- `TestUserLocked` — table test over the five combinations of `nopassword` / `secret` / `sshkey`.
- Verified the test catches it: restoring `== "nopassword"` fails with `locked = false, want true` on the `nopassword and no key is locked` case.
- `./mqlr generate` run; no diff to generated output beyond the doc string (`*.resources.json` is gitignored).
- `go build ./...` and `go test ./...` green in `providers/arista/`.
