### PR TITLE
🐛 arista: map the SSH containment fields the parser already produces

### DIFF
--- a/providers/arista/resources/arista_eos_security.go
+++ b/providers/arista/resources/arista_eos_security.go
@@ -102,6 +102,34 @@ func (a *mqlAristaEosSshSettings) id() (string, error) {
 	return "arista.eos.sshSettings", nil
 }
 
+// sshSettingsArgs maps a parsed `management ssh` block onto the resource's
+// fields. It is a named function so a test can assert it covers every field
+// the schema declares: codegen accepts a declared field with no population
+// path, and the eight containment fields were declared and parsed for a
+// release without ever being mapped here.
+func sshSettingsArgs(s *eos.SshSettings) map[string]*llx.RawData {
+	return map[string]*llx.RawData{
+		"enabled":                llx.BoolData(s.Enabled),
+		"protocolVersion":        llx.StringData(s.ProtocolVersion),
+		"idleTimeout":            llx.IntData(int64(s.IdleTimeout)),
+		"serverPort":             llx.IntData(int64(s.ServerPort)),
+		"authenticationMode":     llx.StringData(s.AuthenticationMode),
+		"ciphers":                llx.ArrayData(stringSliceToAny(s.Ciphers), types.String),
+		"keyExchange":            llx.ArrayData(stringSliceToAny(s.KeyExchange), types.String),
+		"macs":                   llx.ArrayData(stringSliceToAny(s.Macs), types.String),
+		"hostkeyAlgorithms":      llx.ArrayData(stringSliceToAny(s.HostkeyAlgorithms), types.String),
+		"fipsRestrictions":       llx.BoolData(s.FipsRestrictions),
+		"vrfs":                   llx.ArrayData(stringSliceToAny(s.Vrfs), types.String),
+		"loginTimeout":           llx.IntData(int64(s.LoginTimeout)),
+		"connectionLimit":        llx.IntData(int64(s.ConnectionLimit)),
+		"connectionPerHostLimit": llx.IntData(int64(s.ConnectionPerHostLimit)),
+		"emptyPasswords":         llx.StringData(s.EmptyPasswords),
+		"logLevel":               llx.StringData(s.LogLevel),
+		"clientAliveInterval":    llx.IntData(int64(s.ClientAliveInterval)),
+		"clientAliveCountMax":    llx.IntData(int64(s.ClientAliveCountMax)),
+	}
+}
+
 func (a *mqlAristaEos) sshSettings() (*mqlAristaEosSshSettings, error) {
 	rc, err := fetchRunningConfig(a.MqlRuntime)
 	if err != nil {
@@ -109,18 +137,7 @@ func (a *mqlAristaEos) sshSettings() (*mqlAristaEosSshSettings, error) {
 	}
 	s := eos.ParseSshSettings(rc)
 
-	res, err := CreateResource(a.MqlRuntime, "arista.eos.sshSettings", map[string]*llx.RawData{
-		"enabled":            llx.BoolData(s.Enabled),
-		"protocolVersion":    llx.StringData(s.ProtocolVersion),
-		"idleTimeout":        llx.IntData(int64(s.IdleTimeout)),
-		"serverPort":         llx.IntData(int64(s.ServerPort)),
-		"authenticationMode": llx.StringData(s.AuthenticationMode),
-		"ciphers":            llx.ArrayData(stringSliceToAny(s.Ciphers), types.String),
-		"keyExchange":        llx.ArrayData(stringSliceToAny(s.KeyExchange), types.String),
-		"macs":               llx.ArrayData(stringSliceToAny(s.Macs), types.String),
-		"hostkeyAlgorithms":  llx.ArrayData(stringSliceToAny(s.HostkeyAlgorithms), types.String),
-		"fipsRestrictions":   llx.BoolData(s.FipsRestrictions),
-	})
+	res, err := CreateResource(a.MqlRuntime, "arista.eos.sshSettings", sshSettingsArgs(s))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/arista/resources/ssh_settings_fields_test.go
+++ b/providers/arista/resources/ssh_settings_fields_test.go
@@ -1,0 +1,84 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"unicode"
+
+	"go.mondoo.com/mql/providers/arista/resources/eos"
+)
+
+// schemaFields returns the resource field names the generated struct carries,
+// one per field declared in the .lr, in schema spelling.
+func schemaFields(resource any) []string {
+	t := reflect.TypeOf(resource).Elem()
+	res := []string{}
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if !f.IsExported() || !strings.HasPrefix(f.Type.String(), "plugin.TValue[") {
+			continue
+		}
+		r := []rune(f.Name)
+		r[0] = unicode.ToLower(r[0])
+		res = append(res, string(r))
+	}
+	return res
+}
+
+// TestSshSettingsArgsCoverEverySchemaField guards the whole class of bug rather
+// than the eight fields that hit it. Codegen accepts a field declared in the
+// .lr with no population path: the generated getter just hands back the zero
+// TValue, whose State is 0 — unset, not null — which crosses the plugin
+// boundary as a primitive with no type information and reads client-side as a
+// null with nothing pointing back at the provider. Nothing fails to build and
+// no test goes red, so a field added to the schema and the parser but not to
+// the creator ships silently empty.
+func TestSshSettingsArgsCoverEverySchemaField(t *testing.T) {
+	args := sshSettingsArgs(&eos.SshSettings{})
+
+	for _, field := range schemaFields(&mqlAristaEosSshSettings{}) {
+		if _, ok := args[field]; !ok {
+			t.Errorf("arista.eos.sshSettings.%s is declared in the schema but never populated", field)
+		}
+	}
+}
+
+// TestSshSettingsArgsCarryTheParsedValues pins the containment fields against
+// a block that sets each of them, so a mapping that is present but wired to
+// the wrong source value still fails.
+func TestSshSettingsArgsCarryTheParsedValues(t *testing.T) {
+	s := &eos.SshSettings{
+		Vrfs:                   []string{"MGMT"},
+		LoginTimeout:           30,
+		ConnectionLimit:        20,
+		ConnectionPerHostLimit: 5,
+		EmptyPasswords:         "deny",
+		LogLevel:               "verbose",
+		ClientAliveInterval:    60,
+		ClientAliveCountMax:    3,
+	}
+	args := sshSettingsArgs(s)
+
+	for field, want := range map[string]any{
+		"loginTimeout":           int64(30),
+		"connectionLimit":        int64(20),
+		"connectionPerHostLimit": int64(5),
+		"emptyPasswords":         "deny",
+		"logLevel":               "verbose",
+		"clientAliveInterval":    int64(60),
+		"clientAliveCountMax":    int64(3),
+	} {
+		if got := args[field].Value; got != want {
+			t.Errorf("%s = %v, want %v", field, got, want)
+		}
+	}
+
+	vrfs, ok := args["vrfs"].Value.([]any)
+	if !ok || len(vrfs) != 1 || vrfs[0] != "MGMT" {
+		t.Errorf("vrfs = %v, want [MGMT]", args["vrfs"].Value)
+	}
+}


### PR DESCRIPTION
## Problem

`arista.eos.sshSettings` declares 18 fields in `arista.lr`. The creator passed **10**. These eight were declared in the schema, fully populated by `eos.ParseSshSettings`, and then dropped on the floor:

`vrfs`, `loginTimeout`, `connectionLimit`, `connectionPerHostLimit`, `emptyPasswords`, `logLevel`, `clientAliveInterval`, `clientAliveCountMax`

The parser even seeds the documented EOS default (`EmptyPasswords: "auto"`) — none of it reached the resource.

They are plain (non-computed) fields, so the generated getter has no lazy-fetch fallback; it just hands back the zero `TValue`, whose `State` is `0` — **unset, not null**. That crosses the plugin boundary as an empty `DataRes` and surfaces client-side as `llx: encountered a primitive with no type information, coercing to null`, with nothing pointing back at the provider.

**Not yet user-visible.** All eight are `13.3.16` in `.lr.versions` while `config/config.go` is `Version: "13.3.15"`, so the min-provider-version gate hides them today. They would have shipped empty on the next release.

`vrfs` is the one that matters most — its own doc-comment says *"an entry for the instance carrying production traffic means SSH is reachable from the data plane."*

## Fix

Map all eight. Then guard the *class* rather than the instance: `sshSettingsArgs` is lifted into a named function so a test can reflect over the generated struct and assert every declared field has a mapping.

That guard is the point of the PR. Codegen accepts a field declared in the `.lr` with no population path — it builds, it lints, and no test goes red — so a field added to the schema and the parser but not to the creator ships silently empty. This is the only thing that catches it.

No version bump; the release flow handles that.

## Test plan

- `TestSshSettingsArgsCoverEverySchemaField` — reflects over `mqlAristaEosSshSettings` and asserts each `plugin.TValue` field has a matching key.
- `TestSshSettingsArgsCarryTheParsedValues` — pins the eight against a block that sets each, so a mapping wired to the wrong source value also fails.
- Verified the guard catches it: deleting the `vrfs` mapping fails with `arista.eos.sshSettings.vrfs is declared in the schema but never populated`.
- `go build ./...` and `go test ./...` green in `providers/arista/`.
