### PR TITLE
🐛 arista: never publish a password as its encoding format

### DIFF
--- a/providers/arista/resources/eos/aaa.go
+++ b/providers/arista/resources/eos/aaa.go
@@ -353,6 +353,12 @@ type RootAccountState struct {
 	SecretFormat string
 }
 
+// aaaRootSecretRe captures only the first token after `secret`, which is what
+// keeps the credential out of the result in both spellings of the line. With a
+// selector (`aaa root secret sha512 <hash>`) the hash sits in the next token
+// and is never captured at all; without one (`aaa root secret <password>`) the
+// password lands in the capture group and is discarded by the selector check
+// below rather than stored. Widening this regex would break that guarantee.
 var aaaRootSecretRe = regexp.MustCompile(`^aaa root secret\s+(\S+)`)
 
 // ParseRootAccount reports the state of the `aaa root` account.
@@ -377,8 +383,9 @@ func ParseRootAccount(runningConfig string) *RootAccountState {
 				state.NoPassword = false
 				// The selector is optional. Taking the first token
 				// positionally publishes the root password itself when the
-				// line is written without one, so anything that is not a
-				// known selector is the secret and the line is cleartext.
+				// line is written without one, so a token that is not a
+				// known selector is the secret: report the line as cleartext
+				// and let the captured value go.
 				if passwordSecretSelectors[m[1]] {
 					state.SecretFormat = m[1]
 				} else {

--- a/providers/arista/resources/eos/aaa.go
+++ b/providers/arista/resources/eos/aaa.go
@@ -347,7 +347,9 @@ type RootAccountState struct {
 	// of the three states.
 	NoPassword bool
 	// SecretFormat is the encoding selector on the secret, for example "5"
-	// or "sha512". Empty when root has no secret configured.
+	// or "sha512". Empty when root has no secret configured. A line written
+	// without a selector is cleartext, which EOS documents as equivalent to
+	// "0", and is reported as "0". The secret itself is never captured.
 	SecretFormat string
 }
 
@@ -373,7 +375,15 @@ func ParseRootAccount(runningConfig string) *RootAccountState {
 			if m := aaaRootSecretRe.FindStringSubmatch(line); m != nil {
 				state.Enabled = true
 				state.NoPassword = false
-				state.SecretFormat = m[1]
+				// The selector is optional. Taking the first token
+				// positionally publishes the root password itself when the
+				// line is written without one, so anything that is not a
+				// known selector is the secret and the line is cleartext.
+				if passwordSecretSelectors[m[1]] {
+					state.SecretFormat = m[1]
+				} else {
+					state.SecretFormat = "0"
+				}
 			}
 		}
 	}

--- a/providers/arista/resources/eos/aaa_test.go
+++ b/providers/arista/resources/eos/aaa_test.go
@@ -202,3 +202,44 @@ func TestParseAaaConfig_ConsoleAuthorizationAbsent(t *testing.T) {
 	assert.Empty(t, a.AuthorizationConsoleCommands)
 	assert.False(t, a.SerialConsoleAuthorization)
 }
+
+// TestParseRootAccount_BareFormIsCleartextAndHidesThePassword pins the closed
+// selector set. The selector is optional on `aaa root secret`, so reading the
+// first token positionally as the format published the root account's password
+// in arista.eos.aaa.rootSecretFormat, a field every consumer reads as safe
+// metadata. The sibling `enable secret` line has had this guard from the start.
+func TestParseRootAccount_BareFormIsCleartextAndHidesThePassword(t *testing.T) {
+	const password = "ExamplePassphraseValue"
+	got := ParseRootAccount("aaa root secret " + password + "\n")
+	assert.True(t, got.Enabled)
+	assert.False(t, got.NoPassword)
+	assert.Equal(t, "0", got.SecretFormat)
+	assert.NotContains(t, got.SecretFormat, password)
+}
+
+func TestParseRootAccount_NeverCarriesTheHash(t *testing.T) {
+	const hash = "$6$Zx1ExampleSalt$ExampleHashValueOnly"
+	got := ParseRootAccount("aaa root secret sha512 " + hash + "\n")
+	assert.True(t, got.Enabled)
+	assert.Equal(t, "sha512", got.SecretFormat)
+	assert.NotContains(t, got.SecretFormat, hash)
+}
+
+// TestPasswordSecretSelectors covers every selector EOS accepts on a password
+// secret. Type 7 was missing from the set, so a reversibly-obfuscated secret
+// and a genuinely cleartext one were both reported as "0" and a check for
+// "the enable password must not be stored in cleartext" failed on a device
+// that does not store it in cleartext.
+func TestPasswordSecretSelectors(t *testing.T) {
+	for _, selector := range []string{"0", "5", "7", "sha512"} {
+		t.Run("root "+selector, func(t *testing.T) {
+			got := ParseRootAccount("aaa root secret " + selector + " SecretValue\n")
+			assert.Equal(t, selector, got.SecretFormat)
+		})
+		t.Run("enable "+selector, func(t *testing.T) {
+			got := ParseEnableSecret("enable secret " + selector + " SecretValue\n")
+			assert.True(t, got.Configured)
+			assert.Equal(t, selector, got.Format)
+		})
+	}
+}

--- a/providers/arista/resources/eos/management_plane.go
+++ b/providers/arista/resources/eos/management_plane.go
@@ -134,12 +134,20 @@ type EnableSecretState struct {
 	Format string
 }
 
-// enableSecretFormats is the closed set of encoding selectors EOS accepts on
-// the enable password line. The selector is optional, so a token outside this
-// set is the password itself and must not be read as a format.
-var enableSecretFormats = map[string]bool{
+// passwordSecretSelectors is the closed set of encoding selectors EOS accepts
+// on a password secret, shared by the `enable secret` and `aaa root secret`
+// lines. The selector is optional on both, so a token outside this set is the
+// password itself and must never be read as a format: doing so publishes the
+// credential in a field every consumer treats as safe metadata.
+//
+// The set matches the one Arista's own eAPI library applies to the sibling
+// `username <name> secret <selector> <value>` line. It is deliberately not
+// keyEncryptionTypes: that covers the reversible encodings a shared secret
+// can use, and a TACACS+ key cannot be stored as a hash.
+var passwordSecretSelectors = map[string]bool{
 	"0":      true,
 	"5":      true,
+	"7":      true,
 	"sha512": true,
 }
 
@@ -188,7 +196,7 @@ func ParseEnableSecret(runningConfig string) *EnableSecretState {
 		}
 
 		state.Configured = true
-		if enableSecretFormats[fields[0]] {
+		if passwordSecretSelectors[fields[0]] {
 			state.Format = fields[0]
 		} else {
 			// No selector: the token is the password, and EOS documents the


### PR DESCRIPTION
## Problem

### 1. The root account's password is published as its "format"

`ParseRootAccount` took the first token after `aaa root secret` positionally as the encoding selector:

```go
if m := aaaRootSecretRe.FindStringSubmatch(line); m != nil {
    state.SecretFormat = m[1]   // no closed-set guard
}
```

The selector is optional. On a line written without one:

```
aaa root secret MyPlaintextPassword
```

`arista.eos.aaa.rootSecretFormat` reports **`MyPlaintextPassword`** — the root account's password, carried off the device into scan results and stored reports.

`ParseEnableSecret`, 200 lines away in the same package, already guards exactly this, with a comment saying *"Taking the first token positionally would publish the password itself as the format."* Two implementations of the same idea; one has the guard.

The package is otherwise deliberate about this — `aaa.go`: *"The shared secret itself is deliberately not captured"*; `management_plane.go`: *"The password itself is never kept"*; and there are two regression tests named `..._NeverCarriesTheHash` / `..._BareFormIsCleartextAndHidesThePassword`. The root path just never got them.

### 2. Type-7 secrets are reported as cleartext

`enableSecretFormats` was `{0, 5, sha512}` — no `7`. So `enable secret 7 042B0F1C0A` reported `format: "0"`. A reversibly-obfuscated secret and a genuinely cleartext one become indistinguishable, and a check for "the enable password must not be stored in cleartext" **fails on a device that does not store it in cleartext**.

## Fix

One shared `passwordSecretSelectors` set used by both `enable secret` and `aaa root secret`; anything outside it is the secret, and the line is reported as cleartext (`"0"`) without capturing the value.

The set is `{0, 5, 7, sha512}` — the same one Arista's own eAPI library applies to the sibling `username <name> secret <selector> <value>` line.

It is deliberately **not** merged with `keyEncryptionTypes` (`{0, 7, 8a}`). That set covers the reversible encodings a *shared secret* can use, and a TACACS+ key cannot be stored as a hash — the two sets are semantically different and unioning them would be wrong in both directions.

## Test plan

- `TestParseRootAccount_BareFormIsCleartextAndHidesThePassword` and `TestParseRootAccount_NeverCarriesTheHash` — mirrors of the two `enable secret` tests that already existed.
- `TestPasswordSecretSelectors` — every selector against both commands.
- Verified the leak test catches it: removing the guard fails with `expected: "0"` / `actual: "ExamplePassphraseValue"`.
- `go build ./...` and `go test ./...` green in `providers/arista/`.
