### PR TITLE
🐛 aws: give flow logs and RDS parameter groups a real identity

### DIFF
--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -2924,11 +2924,11 @@ func init() {
 			Create: createAwsRdsRecommendationAction,
 		},
 		"aws.rds.clusterParameterGroup": {
-			// to override args, implement: initAwsRdsClusterParameterGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsRdsClusterParameterGroup,
 			Create: createAwsRdsClusterParameterGroup,
 		},
 		"aws.rds.parameterGroup": {
-			// to override args, implement: initAwsRdsParameterGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsRdsParameterGroup,
 			Create: createAwsRdsParameterGroup,
 		},
 		"aws.rds.parameterGroup.parameter": {

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -306,6 +306,113 @@ func newMqlAwsParameterGroup(runtime *plugin.Runtime, region string, parameterGr
 	return mqlParameterGroup, nil
 }
 
+// rdsGetParent returns the aws.rds resource the parameter-group lists hang off.
+func rdsGetParent(runtime *plugin.Runtime) (*mqlAwsRds, error) {
+	obj, err := CreateResource(runtime, "aws.rds", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	return obj.(*mqlAwsRds), nil
+}
+
+// rdsParameterGroupMatches reports whether a parameter group reached by name or
+// arn is the one the caller asked for. Callers pass whichever of the two the
+// query supplied; an empty wanted value never matches, so a query carrying only
+// a name cannot be satisfied by a group whose arn happens to be empty.
+func rdsParameterGroupMatches(gotArn, gotName, wantArn, wantName string) bool {
+	if wantArn != "" {
+		return gotArn == wantArn
+	}
+	return wantName != "" && gotName == wantName
+}
+
+// initAwsRdsParameterGroup resolves a DB parameter group by name or arn.
+//
+// Without an init, NewResource fell straight through to the generated
+// constructor, which builds the resource from the two args the query supplied
+// and leaves arn, family, description and region unset -- surfacing as
+// "primitive with no type information". Worse, the resource has no id()
+// method, so every such husk keyed on the empty string and the second lookup
+// in a session returned the first group's data: asking for
+// default.postgres16 answered with default.mysql8.0, with no error.
+func initAwsRdsParameterGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	wantArn, wantName := rdsParameterGroupArgs(args)
+	if wantArn == "" && wantName == "" {
+		return nil, nil, errors.New("name or arn required to fetch rds parameter group")
+	}
+	r, err := rdsGetParent(runtime)
+	if err != nil {
+		return nil, nil, err
+	}
+	groups := r.GetParameterGroups()
+	if groups.Error != nil {
+		return nil, nil, groups.Error
+	}
+	for _, raw := range groups.Data {
+		pg, ok := raw.(*mqlAwsRdsParameterGroup)
+		if !ok {
+			continue
+		}
+		if rdsParameterGroupMatches(pg.Arn.Data, pg.Name.Data, wantArn, wantName) {
+			return args, pg, nil
+		}
+	}
+	return nil, nil, fmt.Errorf("aws.rds.parameterGroup with %s not found", rdsParameterGroupWanted(wantArn, wantName))
+}
+
+// initAwsRdsClusterParameterGroup is initAwsRdsParameterGroup for cluster
+// parameter groups; see that function for why the fall-through was wrong.
+func initAwsRdsClusterParameterGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	wantArn, wantName := rdsParameterGroupArgs(args)
+	if wantArn == "" && wantName == "" {
+		return nil, nil, errors.New("name or arn required to fetch rds cluster parameter group")
+	}
+	r, err := rdsGetParent(runtime)
+	if err != nil {
+		return nil, nil, err
+	}
+	groups := r.GetClusterParameterGroups()
+	if groups.Error != nil {
+		return nil, nil, groups.Error
+	}
+	for _, raw := range groups.Data {
+		pg, ok := raw.(*mqlAwsRdsClusterParameterGroup)
+		if !ok {
+			continue
+		}
+		if rdsParameterGroupMatches(pg.Arn.Data, pg.Name.Data, wantArn, wantName) {
+			return args, pg, nil
+		}
+	}
+	return nil, nil, fmt.Errorf("aws.rds.clusterParameterGroup with %s not found", rdsParameterGroupWanted(wantArn, wantName))
+}
+
+// rdsParameterGroupArgs reads the arn and name a parameter-group lookup
+// supplied, tolerating either being absent or of an unexpected type.
+func rdsParameterGroupArgs(args map[string]*llx.RawData) (arn string, name string) {
+	if raw, ok := args["arn"]; ok && raw != nil {
+		arn, _ = raw.Value.(string)
+	}
+	if raw, ok := args["name"]; ok && raw != nil {
+		name, _ = raw.Value.(string)
+	}
+	return arn, name
+}
+
+// rdsParameterGroupWanted renders the lookup key for a not-found error.
+func rdsParameterGroupWanted(arn, name string) string {
+	if arn != "" {
+		return fmt.Sprintf("arn %q", arn)
+	}
+	return fmt.Sprintf("name %q", name)
+}
+
 func (a *mqlAwsRdsClusterParameterGroup) parameters() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	res := []any{}

--- a/providers/aws/resources/aws_resource_identity_test.go
+++ b/providers/aws/resources/aws_resource_identity_test.go
@@ -1,0 +1,80 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVpcFlowLogCacheKey(t *testing.T) {
+	t.Run("two flow logs on one vpc get distinct keys", func(t *testing.T) {
+		// The bug this guards: both creators omitted "__id", so every flow log
+		// keyed on "" and a VPC logging ALL and a VPC logging REJECT reported
+		// identical rows.
+		all := vpcFlowLogCacheKey("us-west-2", "fl-05570b926e84de4a6")
+		reject := vpcFlowLogCacheKey("us-west-2", "fl-0ff770bdab6b32b86")
+		assert.NotEqual(t, all, reject)
+		assert.NotEmpty(t, all)
+		assert.NotEmpty(t, reject)
+	})
+
+	t.Run("same flow log from vpc and subnet paths agrees", func(t *testing.T) {
+		// vpc.flowLogs() and subnet.flowLogs() must produce the same key so the
+		// runtime cache dedupes rather than building two instances.
+		assert.Equal(t,
+			vpcFlowLogCacheKey("eu-west-1", "fl-abc123"),
+			vpcFlowLogCacheKey("eu-west-1", "fl-abc123"),
+		)
+	})
+
+	t.Run("region qualifies the key", func(t *testing.T) {
+		assert.NotEqual(t,
+			vpcFlowLogCacheKey("us-west-2", "fl-abc123"),
+			vpcFlowLogCacheKey("us-east-1", "fl-abc123"),
+		)
+	})
+
+	t.Run("an empty flow log id still yields a region-scoped key", func(t *testing.T) {
+		assert.Equal(t, "us-west-2/", vpcFlowLogCacheKey("us-west-2", ""))
+	})
+}
+
+func TestRdsParameterGroupMatches(t *testing.T) {
+	const (
+		arn  = "arn:aws:rds:us-west-2:123456789012:pg:default.mysql8.0"
+		name = "default.mysql8.0"
+	)
+
+	for _, tc := range []struct {
+		title             string
+		gotArn, gotName   string
+		wantArn, wantName string
+		expected          bool
+	}{
+		{"arn matches", arn, name, arn, "", true},
+		{"arn mismatch", arn, name, "arn:aws:rds:us-west-2:123456789012:pg:other", "", false},
+		{"name matches", arn, name, "", name, true},
+		{"name mismatch", arn, name, "", "default.postgres16", false},
+		// The live bug: asking for default.postgres16 returned default.mysql8.0.
+		// A name-only lookup must never be satisfied by a different group.
+		{"name-only lookup ignores a matching arn field", arn, name, "", "default.postgres16", false},
+		// An arn was supplied, so the name is not consulted -- otherwise a stale
+		// arn would silently fall back to a name match.
+		{"arn takes precedence over name", arn, name, "arn:aws:rds:us-west-2:123456789012:pg:other", name, false},
+		{"empty wanted values never match", arn, name, "", "", false},
+		{"empty wanted values never match an empty group", "", "", "", "", false},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			assert.Equal(t, tc.expected,
+				rdsParameterGroupMatches(tc.gotArn, tc.gotName, tc.wantArn, tc.wantName))
+		})
+	}
+}
+
+func TestRdsParameterGroupWanted(t *testing.T) {
+	assert.Equal(t, `arn "arn:aws:rds:us-west-2:1:pg:x"`, rdsParameterGroupWanted("arn:aws:rds:us-west-2:1:pg:x", "x"))
+	assert.Equal(t, `name "default.mysql8.0"`, rdsParameterGroupWanted("", "default.mysql8.0"))
+}

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -913,6 +913,7 @@ func (a *mqlAwsVpc) flowLogs() ([]any, error) {
 		for _, flowLog := range flowLogsRes.FlowLogs {
 			mqlFlowLog, err := CreateResource(a.MqlRuntime, ResourceAwsVpcFlowlog,
 				map[string]*llx.RawData{
+					"__id":                   llx.StringData(vpcFlowLogCacheKey(a.Region.Data, convert.ToValue(flowLog.FlowLogId))),
 					"createdAt":              llx.TimeDataPtr(flowLog.CreationTime),
 					"destination":            llx.StringDataPtr(flowLog.LogDestination),
 					"destinationType":        llx.StringData(string(flowLog.LogDestinationType)),
@@ -2177,6 +2178,20 @@ type mqlAwsVpcFlowlogInternal struct {
 	region                        string
 }
 
+// vpcFlowLogCacheKey builds the cache key for an aws.vpc.flowlog.
+//
+// The resource has no id() method, so without an explicit "__id" every flow
+// log in the account keys on the empty string and CreateResource hands back
+// whichever one was built first. A VPC logging ALL traffic and a VPC logging
+// REJECT then report identical rows, and a check asking whether rejected
+// traffic is captured reads an unrelated flow log's trafficType.
+//
+// Flow log ids are unique per account; the region keeps the key aligned with
+// the rest of the provider and with the ARN the arn() accessor builds.
+func vpcFlowLogCacheKey(region, flowLogID string) string {
+	return region + "/" + flowLogID
+}
+
 func (a *mqlAwsVpcFlowlog) arn() (string, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	return fmt.Sprintf(vpcFlowLogArnPattern, a.Region.Data, conn.AccountId(), a.Id.Data), nil
@@ -2314,6 +2329,7 @@ func (a *mqlAwsVpcSubnet) flowLogs() ([]any, error) {
 		for _, flowLog := range resp.FlowLogs {
 			mqlFlowLog, err := CreateResource(a.MqlRuntime, ResourceAwsVpcFlowlog,
 				map[string]*llx.RawData{
+					"__id":                   llx.StringData(vpcFlowLogCacheKey(a.Region.Data, convert.ToValue(flowLog.FlowLogId))),
 					"createdAt":              llx.TimeDataPtr(flowLog.CreationTime),
 					"destination":            llx.StringDataPtr(flowLog.LogDestination),
 					"destinationType":        llx.StringData(string(flowLog.LogDestinationType)),


### PR DESCRIPTION
Two AWS resources had no usable cache key, so distinct AWS objects aliased onto whichever one the scan built first. Both were found by a static review of the provider and then **confirmed against a live AWS account**.

## `aws.vpc.flowlog` — every flow log aliases to the first one

The resource has no `id()` method, and neither creator (`vpc.flowLogs()` at `aws_vpc.go:914`, `subnet.flowLogs()` at `:2315`) passed `"__id"`. `SetAllData` leaves `res.__id` empty, so every flow log keys on `"aws.vpc.flowlog\x00"` and `CreateResource` returns the first one for every subsequent call. Setting the public `id` field does not help — `id` and `__id` are separate fields.

Live, on a VPC with one flow log capturing `ALL` and another capturing `REJECT`:

```
flowLogs: [
  { id: "fl-05570b926e84de4a6", trafficType: "ALL" }
  { id: "fl-05570b926e84de4a6", trafficType: "ALL" }   # fl-0ff770… / REJECT is invisible
]
```

The row count is right and the contents are wrong, with no error. A check asking whether a VPC captures rejected traffic reads an unrelated flow log's `trafficType`.

After the fix, same account, same two flow logs:

```
flowLogs: [
  { id: "fl-05570b926e84de4a6", trafficType: "ALL" }
  { id: "fl-0ff770bdab6b32b86", trafficType: "REJECT" }
]
```

## `aws.rds.parameterGroup` / `clusterParameterGroup` — husk plus cross-group aliasing

Neither resource has an `init`, though both `.lr` doc-comments advertise the selection form:

> The `name` field selects the group, for example `aws.rds.parameterGroup(name: "default.mysql8.0")`.

`NewResource` therefore fell through to the generated constructor, which builds the resource from the single supplied arg and leaves `arn`, `family`, `description` and `region` **unset** — not null, unset. The runtime says so itself:

```
x provider returned no data and no error for a field; the field was never set
  on the resource (provider bug) field=arn id= provider=aws resource=aws.rds.parameterGroup
x llx: encountered a primitive with no type information, coercing to null
```

Note `id=` — the cache key is empty, so the husk is cached and the *second* lookup in a session returns the first group's data:

```mql
a = aws.rds.parameterGroup(name: "default.mysql8.0")
b = aws.rds.parameterGroup(name: "default.postgres16")
→ first: "default.mysql8.0"   second: "default.mysql8.0"
```

Asked for postgres16, got mysql8.0, no error. Separately, the husk's `parameters()` reads `region == ""`, which `regionalClient` silently substitutes with the caller's default region — so it returned 553 real-looking parameters from the wrong region.

Both inits now resolve by `name` or `arn` against the parent's list and return a not-found error on a miss, matching `initAwsDocumentdbClusterParameterGroup`, which already does this correctly.

After the fix:

```
first: "default.mysql8.0"    second: "default.postgres16"
firstArn: "arn:aws:rds:us-west-2:…:pg:default.mysql8.0"
firstFamily: "mysql8.0"      firstRegion: "us-west-2"
```

## Verification

Against a live AWS account, using only free artifacts (two VPC flow logs delivering to S3; the default RDS parameter groups that exist in every account). Both bugs reproduced on `main` and both are gone on this branch.

## Tests

`aws_resource_identity_test.go` covers the two new pure-Go helpers: the flow-log cache key (distinct per flow log, stable across the vpc and subnet paths, region-qualified) and the parameter-group matcher — including the name-only lookup that must never be satisfied by a different group, which is the exact live failure above.

## Notes

No schema change: `aws.lr`, `aws.lr.versions`, `aws.resources.json` and `aws.permissions.json` are all unchanged. `aws.lr.go` changes only to register the two new inits, which the generator detects from the Go source.