### PR TITLE
🐛 arista: keep distinct SNMP, syslog and RADIUS records apart in the cache

### DIFF
--- a/providers/arista/resources/arista_eos_aaa.go
+++ b/providers/arista/resources/arista_eos_aaa.go
@@ -71,8 +71,15 @@ func (a *mqlAristaEosAaaRadiusServer) id() (string, error) {
 	if a.AuthPort.Error != nil {
 		return "", a.AuthPort.Error
 	}
+	if a.AcctPort.Error != nil {
+		return "", a.AcctPort.Error
+	}
+	// RADIUS splits authentication and accounting across two independently
+	// configurable ports, so one host can be defined twice differing only in
+	// the accounting port. Both belong in the key.
 	return "arista.eos.aaa.radiusServer/" + a.Vrf.Data + "/" + a.Host.Data + "/" +
-		strconv.FormatInt(a.AuthPort.Data, 10), nil
+		strconv.FormatInt(a.AuthPort.Data, 10) + "/" +
+		strconv.FormatInt(a.AcctPort.Data, 10), nil
 }
 
 func (a *mqlAristaEosAaa) radiusServerHosts() ([]any, error) {

--- a/providers/arista/resources/arista_eos_logging.go
+++ b/providers/arista/resources/arista_eos_logging.go
@@ -52,8 +52,11 @@ func (a *mqlAristaEos) logging() (*mqlAristaEosLogging, error) {
 // =====================================================================
 
 // id keys a collector on the tuple that makes it distinct on the device: the
-// same address can be configured twice in different VRFs, or twice in one VRF
-// on different ports.
+// same address can be configured twice in different VRFs, twice in one VRF on
+// different ports, or twice on one port over different transports. Protocol is
+// part of the key for that last case: a collector reached over TCP and one
+// reached over plaintext UDP are different egress paths, and collapsing them
+// hides whichever was parsed second behind the other's transport.
 func (a *mqlAristaEosLoggingHost) id() (string, error) {
 	if a.Host.Error != nil {
 		return "", a.Host.Error
@@ -64,8 +67,11 @@ func (a *mqlAristaEosLoggingHost) id() (string, error) {
 	if a.Port.Error != nil {
 		return "", a.Port.Error
 	}
+	if a.Protocol.Error != nil {
+		return "", a.Protocol.Error
+	}
 	return "arista.eos.logging.host/" + a.Vrf.Data + "/" + a.Host.Data + "/" +
-		strconv.FormatInt(a.Port.Data, 10), nil
+		strconv.FormatInt(a.Port.Data, 10) + "/" + a.Protocol.Data, nil
 }
 
 func (a *mqlAristaEosLogging) hosts() ([]any, error) {

--- a/providers/arista/resources/arista_eos_management.go
+++ b/providers/arista/resources/arista_eos_management.go
@@ -420,15 +420,19 @@ type mqlAristaEosSnmpHostInternal struct {
 func (a *mqlAristaEosSnmpHost) id() (string, error) {
 	for _, e := range []error{
 		a.Host.Error, a.Vrf.Error, a.Version.Error,
-		a.NotificationType.Error, a.Port.Error,
+		a.NotificationType.Error, a.Port.Error, a.SecurityLevel.Error,
 	} {
 		if e != nil {
 			return "", e
 		}
 	}
+	// A v3 destination repeats to one collector at each security level, so
+	// the level belongs in the key for the same reason it does on
+	// arista.eos.snmpGroup: without it a noauth destination hides behind an
+	// authPriv one, and the unauthenticated path is the one worth finding.
 	return "arista.eos.snmpHost/" + a.Vrf.Data + "/" + a.Host.Data + "/" +
 		strconv.FormatInt(a.Port.Data, 10) + "/" + a.Version.Data + "/" +
-		a.NotificationType.Data, nil
+		a.NotificationType.Data + "/" + a.SecurityLevel.Data, nil
 }
 
 func (a *mqlAristaEosSnmpSetting) hosts() ([]any, error) {

--- a/providers/arista/resources/arista_eos_security.go
+++ b/providers/arista/resources/arista_eos_security.go
@@ -136,7 +136,22 @@ type mqlAristaEosSnmpCommunityInternal struct {
 }
 
 func (a *mqlAristaEosSnmpCommunity) id() (string, error) {
-	return "arista.eos.snmpCommunity/" + a.Name.Data, a.Name.Error
+	if a.Name.Error != nil {
+		return "", a.Name.Error
+	}
+	if a.Ipv6.Error != nil {
+		return "", a.Ipv6.Error
+	}
+	// One community is commonly declared twice, once per address family, to
+	// bind an IPv4 access-list and an IPv6 one. Keying on the name alone
+	// collapses the pair onto whichever was parsed first, so the second
+	// line's access-list disappears and the surviving row resolves its
+	// typed ACL in the wrong namespace.
+	family := "ipv4"
+	if a.Ipv6.Data {
+		family = "ipv6"
+	}
+	return "arista.eos.snmpCommunity/" + family + "/" + a.Name.Data, nil
 }
 
 func (a *mqlAristaEos) snmpCommunities() ([]any, error) {

--- a/providers/arista/resources/resource_id_test.go
+++ b/providers/arista/resources/resource_id_test.go
@@ -1,0 +1,91 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+func idBool(v bool) plugin.TValue[bool] {
+	return plugin.TValue[bool]{Data: v, State: plugin.StateIsSet}
+}
+
+func idInt(v int64) plugin.TValue[int64] {
+	return plugin.TValue[int64]{Data: v, State: plugin.StateIsSet}
+}
+
+// distinct asserts that two records the device really can carry at once do not
+// share a cache key. A shared key is silent: CreateResource returns the first
+// instance for the second record, so the list has the right length and every
+// row reads plausibly, while one record's values have been replaced by the
+// other's.
+func distinct(t *testing.T, what string, a, b func() (string, error)) {
+	t.Helper()
+	x, err := a()
+	if err != nil {
+		t.Fatalf("%s: first id: %v", what, err)
+	}
+	y, err := b()
+	if err != nil {
+		t.Fatalf("%s: second id: %v", what, err)
+	}
+	if x == y {
+		t.Fatalf("%s: both records share the cache key %q, so one is dropped", what, x)
+	}
+}
+
+// TestSnmpCommunityIDSeparatesAddressFamilies covers the dual-stack form:
+// one community declared twice to bind an IPv4 access-list and an IPv6 one.
+func TestSnmpCommunityIDSeparatesAddressFamilies(t *testing.T) {
+	v4 := &mqlAristaEosSnmpCommunity{Name: str("ops"), Acl: str("IPV4-MGMT"), Ipv6: idBool(false)}
+	v6 := &mqlAristaEosSnmpCommunity{Name: str("ops"), Acl: str("IPV6-MGMT"), Ipv6: idBool(true)}
+	distinct(t, "snmpCommunity", v4.id, v6.id)
+
+	again := &mqlAristaEosSnmpCommunity{Name: str("ops"), Acl: str("IPV4-MGMT"), Ipv6: idBool(false)}
+	x, _ := v4.id()
+	y, _ := again.id()
+	if x != y {
+		t.Fatalf("the same community produced two keys: %q and %q", x, y)
+	}
+}
+
+// TestSnmpHostIDSeparatesSecurityLevels covers a v3 trap destination declared
+// at two security levels to the same collector. The noauth one is the finding.
+func TestSnmpHostIDSeparatesSecurityLevels(t *testing.T) {
+	priv := &mqlAristaEosSnmpHost{
+		Host: str("192.0.2.20"), Vrf: str(""), Version: str("v3"),
+		NotificationType: str("traps"), Port: idInt(162), SecurityLevel: str("priv"),
+	}
+	noauth := &mqlAristaEosSnmpHost{
+		Host: str("192.0.2.20"), Vrf: str(""), Version: str("v3"),
+		NotificationType: str("traps"), Port: idInt(162), SecurityLevel: str("noauth"),
+	}
+	distinct(t, "snmpHost", priv.id, noauth.id)
+}
+
+// TestLoggingHostIDSeparatesTransports covers one collector reached over both
+// TCP and plaintext UDP on the same port.
+func TestLoggingHostIDSeparatesTransports(t *testing.T) {
+	tcp := &mqlAristaEosLoggingHost{
+		Host: str("10.0.0.2"), Vrf: str(""), Port: idInt(514), Protocol: str("tcp"),
+	}
+	udp := &mqlAristaEosLoggingHost{
+		Host: str("10.0.0.2"), Vrf: str(""), Port: idInt(514), Protocol: str("udp"),
+	}
+	distinct(t, "loggingHost", tcp.id, udp.id)
+}
+
+// TestRadiusServerIDSeparatesAccountingPorts covers one RADIUS host defined
+// twice with a shared authentication port and different accounting ports.
+func TestRadiusServerIDSeparatesAccountingPorts(t *testing.T) {
+	a := &mqlAristaEosAaaRadiusServer{
+		Host: str("10.1.1.1"), Vrf: str(""), AuthPort: idInt(1812), AcctPort: idInt(1813),
+	}
+	b := &mqlAristaEosAaaRadiusServer{
+		Host: str("10.1.1.1"), Vrf: str(""), AuthPort: idInt(1812), AcctPort: idInt(1646),
+	}
+	distinct(t, "radiusServer", a.id, b.id)
+}


### PR DESCRIPTION
## Problem

The runtime caches a resource under `resourceName + "\x00" + __id`, and `CreateResource` returns the cached instance on a key hit. Four resources build a key that drops a dimension the device can really vary, so two distinct records collapse onto one.

**The failure is silent.** The list has the right length and every row reads plausibly — it's just that one record's values have been replaced by the other's. Nothing errors.

| resource | missing dimension | what collapses |
|---|---|---|
| `arista.eos.snmpCommunity` | address family | one community declared twice to bind an IPv4 ACL and an IPv6 one |
| `arista.eos.snmpHost` | `securityLevel` | a v3 destination declared at two security levels to one collector |
| `arista.eos.logging.host` | `protocol` | one collector reached over both TCP and plaintext UDP on the same port |
| `arista.eos.aaa.radiusServer` | `acctPort` | one host defined twice with a shared auth port, different accounting ports |

Two are directly security-relevant:

- **`snmpHost`** — `snmp-server host X version 3 priv NOC` plus `... version 3 noauth LEGACY` returns two rows that are the same object, so `hosts.all(securityLevel == "priv")` **passes** and the unauthenticated destination is invisible.
- **`snmpCommunity`** — the dual-stack pair collapses, and the surviving row keeps the first line's `ipv6: false` while a post-create write leaves it holding the *second* line's ACL name. `aclResource()` then resolves an IPv6 ACL name in the IPv4 namespace and returns null, so the row reports a non-null `acl` alongside a null `aclResource`, and "every community is ACL-bound" gives the wrong verdict on a config that is fine.

`arista.eos.snmpGroup` already carries exactly this treatment, with a regression test (`snmp_group_id_test.go`) explaining the hazard. These are the siblings that needed it too — `snmpHost`'s own doc comment even claims to key "on every dimension along which one repeats".

## Fix

Add the missing dimension to each key. `__id` is an internal cache key, not schema, so this is not a breaking change.

## Test plan

- `resource_id_test.go` — one test per resource, each constructing the two records a device can genuinely carry at once and asserting distinct keys. Follows the existing `snmp_group_id_test.go` shape.
- Verified the tests catch it: neutralizing the family dimension fails with `snmpCommunity: both records share the cache key "arista.eos.snmpCommunity/ipv4/ops", so one is dropped`.
- `go build ./...` and `go test ./...` green in `providers/arista/`.
