### PR TITLE
🐛 arista: fold BGP peer-group settings into member sessions

### DIFF
--- a/providers/arista/resources/arista.lr
+++ b/providers/arista/resources/arista.lr
@@ -973,6 +973,14 @@ private arista.eos.bgp.peer @defaults("peerAddress") {
   ebgpMultihop int
   // Peer description
   description string
+  // Peer group the session takes its settings from
+  //
+  // Empty when the session is configured on its own. A fabric is normally
+  // built by configuring the session controls once on a group and pointing
+  // every session at it, so a session with a group name here is protected by
+  // whatever that group sets even though its own lines say nothing. The
+  // controls above already report the inherited values.
+  peerGroup string
 }
 
 // Arista EOS route-map

--- a/providers/arista/resources/arista.lr.go
+++ b/providers/arista/resources/arista.lr.go
@@ -1084,6 +1084,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"arista.eos.bgp.peer.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAristaEosBgpPeer).GetDescription()).ToDataRes(types.String)
 	},
+	"arista.eos.bgp.peer.peerGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAristaEosBgpPeer).GetPeerGroup()).ToDataRes(types.String)
+	},
 	"arista.eos.routeMap.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAristaEosRouteMap).GetName()).ToDataRes(types.String)
 	},
@@ -2927,6 +2930,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"arista.eos.bgp.peer.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAristaEosBgpPeer).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"arista.eos.bgp.peer.peerGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAristaEosBgpPeer).PeerGroup, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"arista.eos.routeMap.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7033,6 +7040,7 @@ type mqlAristaEosBgpPeer struct {
 	UpdateSource           plugin.TValue[string]
 	EbgpMultihop           plugin.TValue[int64]
 	Description            plugin.TValue[string]
+	PeerGroup              plugin.TValue[string]
 }
 
 // createAristaEosBgpPeer creates a new instance of this resource
@@ -7162,6 +7170,10 @@ func (c *mqlAristaEosBgpPeer) GetEbgpMultihop() *plugin.TValue[int64] {
 
 func (c *mqlAristaEosBgpPeer) GetDescription() *plugin.TValue[string] {
 	return &c.Description
+}
+
+func (c *mqlAristaEosBgpPeer) GetPeerGroup() *plugin.TValue[string] {
+	return &c.PeerGroup
 }
 
 // mqlAristaEosRouteMap for the arista.eos.routeMap resource

--- a/providers/arista/resources/arista.lr.versions
+++ b/providers/arista/resources/arista.lr.versions
@@ -90,6 +90,7 @@ arista.eos.bgp.peer.outboundPolicy 13.3.15
 arista.eos.bgp.peer.passwordConfigured 13.3.15
 arista.eos.bgp.peer.passwordEncryptionType 13.3.15
 arista.eos.bgp.peer.peerAddress 13.0.1
+arista.eos.bgp.peer.peerGroup 13.3.16
 arista.eos.bgp.peer.prefixesAccepted 13.0.1
 arista.eos.bgp.peer.prefixesReceived 13.0.1
 arista.eos.bgp.peer.remoteAs 13.0.1

--- a/providers/arista/resources/arista_eos.go
+++ b/providers/arista/resources/arista_eos.go
@@ -1008,6 +1008,9 @@ func (a *mqlAristaEosBgp) vrfs() ([]any, error) {
 			// A peer present operationally but absent from the config we
 			// parsed keeps the zero values, which read as "no protection
 			// configured" — the same conclusion an empty setting warrants.
+			// A peer that takes its settings from a peer group is not that
+			// case: ParseBgpConfig has already folded the group's settings
+			// into the member, so conf carries what is actually in effect.
 			conf := configuredPeers[vrfName+"/"+peerAddr]
 			// The config is the better source for the policy names: it holds
 			// them even for a session that never came up.
@@ -1034,6 +1037,7 @@ func (a *mqlAristaEosBgp) vrfs() ([]any, error) {
 				"shutdown":               llx.BoolData(conf.Shutdown),
 				"updateSource":           llx.StringData(conf.UpdateSource),
 				"ebgpMultihop":           llx.IntData(int64(conf.EbgpMultihop)),
+				"peerGroup":              llx.StringData(conf.PeerGroup),
 			})
 			if err != nil {
 				return nil, err

--- a/providers/arista/resources/eos/bgp_config.go
+++ b/providers/arista/resources/eos/bgp_config.go
@@ -52,6 +52,15 @@ type BgpNeighborConfig struct {
 	// routes received from and advertised to the peer.
 	InboundRouteMap  string
 	OutboundRouteMap string
+	// PeerGroup is the peer group the session takes its settings from, empty
+	// when the session is configured on its own. A fabric is normally built
+	// by configuring the controls once on a group and pointing every session
+	// at it, so reading only the session's own lines reports every member as
+	// unprotected.
+	PeerGroup string
+	// IsPeerGroup marks an entry that defines a group rather than a session.
+	// It carries the group's settings and is not itself a peer.
+	IsPeerGroup bool
 }
 
 // BgpGlobalConfig is the configured BGP state, keyed by neighbor.
@@ -138,9 +147,50 @@ func ParseBgpConfig(runningConfig string) *BgpGlobalConfig {
 	}
 
 	for _, key := range order {
-		cfg.Neighbors = append(cfg.Neighbors, *byKey[key])
+		n := byKey[key]
+		if n.PeerGroup != "" {
+			if group, ok := byKey[n.VRF+"/"+n.PeerGroup]; ok {
+				inheritBgpGroupSettings(n, group)
+			}
+		}
+		if n.IsPeerGroup {
+			continue
+		}
+		cfg.Neighbors = append(cfg.Neighbors, *n)
 	}
 	return cfg
+}
+
+// inheritBgpGroupSettings folds a peer group's settings into one of its
+// members. A setting written on the session itself wins; everything the
+// session does not set comes from the group, which is where a fabric
+// normally configures the controls exactly once.
+func inheritBgpGroupSettings(n, group *BgpNeighborConfig) {
+	if !n.PasswordConfigured && group.PasswordConfigured {
+		n.PasswordConfigured = true
+		n.PasswordEncryptionType = group.PasswordEncryptionType
+	}
+	if n.TtlMaximumHops == 0 {
+		n.TtlMaximumHops = group.TtlMaximumHops
+	}
+	if n.MaximumRoutes == 0 {
+		n.MaximumRoutes = group.MaximumRoutes
+	}
+	if n.EbgpMultihop == 0 {
+		n.EbgpMultihop = group.EbgpMultihop
+	}
+	if n.UpdateSource == "" {
+		n.UpdateSource = group.UpdateSource
+	}
+	if n.InboundRouteMap == "" {
+		n.InboundRouteMap = group.InboundRouteMap
+	}
+	if n.OutboundRouteMap == "" {
+		n.OutboundRouteMap = group.OutboundRouteMap
+	}
+	if !n.Shutdown && group.Shutdown {
+		n.Shutdown = true
+	}
 }
 
 // applyBgpNeighborSetting folds one `neighbor <peer> ...` line into the
@@ -174,6 +224,22 @@ func applyBgpNeighborSetting(n *BgpNeighborConfig, fields []string) {
 		if len(fields) > 2 && fields[1] == "maximum-hops" {
 			n.TtlMaximumHops = atoiOrZero(fields[2])
 		}
+
+	case "peer", "peer-group":
+		// `neighbor <name> peer group` (or `peer-group`) defines a group;
+		// `neighbor <addr> peer group <name>` puts a session in one.
+		rest := fields[1:]
+		if fields[0] == "peer" {
+			if len(rest) == 0 || rest[0] != "group" {
+				return
+			}
+			rest = rest[1:]
+		}
+		if len(rest) == 0 {
+			n.IsPeerGroup = true
+			return
+		}
+		n.PeerGroup = rest[0]
 
 	case "route-map":
 		// `neighbor <peer> route-map <name> in|out`

--- a/providers/arista/resources/eos/bgp_config.go
+++ b/providers/arista/resources/eos/bgp_config.go
@@ -43,6 +43,8 @@ type BgpNeighborConfig struct {
 	// meaning no limit).
 	MaximumRoutes int
 	// Shutdown reports a neighbor configured but administratively down.
+	// Only the positive form is read, so this cannot distinguish a session
+	// that says nothing from one explicitly brought up with `no shutdown`.
 	Shutdown bool
 	// UpdateSource is the interface sourcing the session.
 	UpdateSource string
@@ -188,6 +190,15 @@ func inheritBgpGroupSettings(n, group *BgpNeighborConfig) {
 	if n.OutboundRouteMap == "" {
 		n.OutboundRouteMap = group.OutboundRouteMap
 	}
+	// Shutdown inherits one way only. `applyBgpNeighborSetting` recognizes
+	// `shutdown` but not `no shutdown` — the parser skips `no ` lines
+	// wholesale — so there is no value a member could carry that means
+	// "explicitly up", and a member that re-enables itself under a
+	// shut-down group is reported as down. That is a false "neighbor
+	// administratively down", not a missed control, so it is the safe
+	// direction to be wrong in. Teaching the parser `no ` prefixes would
+	// make Shutdown tri-state, and this branch has to become "the member
+	// said nothing" rather than "the member is not shut down".
 	if !n.Shutdown && group.Shutdown {
 		n.Shutdown = true
 	}

--- a/providers/arista/resources/eos/bgp_config_test.go
+++ b/providers/arista/resources/eos/bgp_config_test.go
@@ -1,0 +1,119 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package eos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func neighborByAddr(t *testing.T, cfg *BgpGlobalConfig, vrf, addr string) BgpNeighborConfig {
+	t.Helper()
+	for _, n := range cfg.Neighbors {
+		if n.VRF == vrf && n.PeerAddress == addr {
+			return n
+		}
+	}
+	t.Fatalf("no neighbor %s in vrf %s; got %+v", addr, vrf, cfg.Neighbors)
+	return BgpNeighborConfig{}
+}
+
+// TestParseBgpConfig_PeerGroupSettingsReachMembers is the case a leaf/spine
+// fabric is actually built with: the session controls are configured once on
+// the group and every session points at it. Reading only a session's own lines
+// reports every member as unauthenticated with no route ceiling, so
+// `peers.where(passwordConfigured == false)` flags the whole fabric.
+func TestParseBgpConfig_PeerGroupSettingsReachMembers(t *testing.T) {
+	cfg := ParseBgpConfig(`router bgp 65001
+   neighbor SPINE peer group
+   neighbor SPINE password 7 abcdef
+   neighbor SPINE maximum-routes 12000
+   neighbor SPINE ttl maximum-hops 2
+   neighbor SPINE route-map IMPORT in
+   neighbor 10.1.1.2 peer group SPINE
+   neighbor 10.1.1.2 remote-as 65002
+   neighbor 10.1.1.3 peer group SPINE
+!
+`)
+
+	// The group definition is not itself a peer.
+	for _, n := range cfg.Neighbors {
+		assert.NotEqual(t, "SPINE", n.PeerAddress, "the group definition leaked into the neighbor list")
+	}
+	require.Len(t, cfg.Neighbors, 2)
+
+	for _, addr := range []string{"10.1.1.2", "10.1.1.3"} {
+		n := neighborByAddr(t, cfg, "default", addr)
+		assert.True(t, n.PasswordConfigured, "%s: session is authenticated by its group", addr)
+		assert.Equal(t, "7", n.PasswordEncryptionType, addr)
+		assert.Equal(t, 12000, n.MaximumRoutes, addr)
+		assert.Equal(t, 2, n.TtlMaximumHops, addr)
+		assert.Equal(t, "IMPORT", n.InboundRouteMap, addr)
+		assert.Equal(t, "SPINE", n.PeerGroup, addr)
+	}
+}
+
+// TestParseBgpConfig_MemberSettingWinsOverGroup pins the precedence: a control
+// written on the session itself is the one in effect.
+func TestParseBgpConfig_MemberSettingWinsOverGroup(t *testing.T) {
+	cfg := ParseBgpConfig(`router bgp 65001
+   neighbor EDGE peer group
+   neighbor EDGE maximum-routes 12000
+   neighbor 10.1.1.2 peer group EDGE
+   neighbor 10.1.1.2 maximum-routes 100
+!
+`)
+	n := neighborByAddr(t, cfg, "default", "10.1.1.2")
+	assert.Equal(t, 100, n.MaximumRoutes)
+}
+
+// TestParseBgpConfig_HyphenatedPeerGroupSpelling covers the `peer-group`
+// rendering alongside `peer group`.
+func TestParseBgpConfig_HyphenatedPeerGroupSpelling(t *testing.T) {
+	cfg := ParseBgpConfig(`router bgp 65001
+   neighbor SPINE peer-group
+   neighbor SPINE password 7 abcdef
+   neighbor 10.1.1.2 peer-group SPINE
+!
+`)
+	require.Len(t, cfg.Neighbors, 1)
+	n := neighborByAddr(t, cfg, "default", "10.1.1.2")
+	assert.True(t, n.PasswordConfigured)
+	assert.Equal(t, "SPINE", n.PeerGroup)
+}
+
+// TestParseBgpConfig_GroupsAreScopedToTheirVrf keeps a group in one routing
+// instance from lending its settings to a same-named group in another.
+func TestParseBgpConfig_GroupsAreScopedToTheirVrf(t *testing.T) {
+	cfg := ParseBgpConfig(`router bgp 65001
+   neighbor SHARED peer group
+   neighbor SHARED password 7 abcdef
+   vrf PROD
+      neighbor SHARED peer group
+      neighbor 10.100.1.2 peer group SHARED
+!
+`)
+	n := neighborByAddr(t, cfg, "PROD", "10.100.1.2")
+	assert.False(t, n.PasswordConfigured, "the default-instance group must not protect a PROD session")
+}
+
+// TestParseBgpConfig_StandaloneSessionIsUnchanged keeps the no-group path
+// reporting exactly what the session's own lines say.
+func TestParseBgpConfig_StandaloneSessionIsUnchanged(t *testing.T) {
+	cfg := ParseBgpConfig(`router bgp 65001
+   neighbor 10.1.1.2 remote-as 65002
+   neighbor 10.1.1.2 password 0 plain
+   neighbor 10.1.1.3 remote-as 65003
+!
+`)
+	protected := neighborByAddr(t, cfg, "default", "10.1.1.2")
+	assert.True(t, protected.PasswordConfigured)
+	assert.Empty(t, protected.PeerGroup)
+
+	bare := neighborByAddr(t, cfg, "default", "10.1.1.3")
+	assert.False(t, bare.PasswordConfigured)
+	assert.Zero(t, bare.MaximumRoutes)
+}


### PR DESCRIPTION
## Problem

`ParseBgpConfig` keys every `neighbor <token> ...` line on the literal token, and never resolves `neighbor <addr> peer group <NAME>` back to the group's settings.

Peer groups are how a leaf/spine fabric is normally configured — the session controls are set **once** on the group and every session points at it:

```
router bgp 65001
   neighbor SPINE peer group
   neighbor SPINE password 7 abcdef
   neighbor SPINE maximum-routes 12000
   neighbor SPINE ttl maximum-hops 2
   neighbor 10.1.1.2 peer group SPINE
   neighbor 10.1.1.3 peer group SPINE
```

Before this PR every member reports:

```
10.1.1.2  passwordConfigured=false  maximumRoutes=0  ttlMaximumHops=0
10.1.1.3  passwordConfigured=false  maximumRoutes=0  ttlMaximumHops=0
```

So `arista.eos.bgp.vrfs { peers.where(passwordConfigured == false) }` — the natural "find unauthenticated BGP sessions" query — **flags every authenticated session in the fabric**, and a check counting protected neighbors can pass on the phantom `SPINE` entry instead of a real one.

The consumer's zero-value fallback is correctly reasoned for its own case:

> *A peer present operationally but absent from the config we parsed keeps the zero values, which read as "no protection configured" — the same conclusion an empty setting warrants.*

But a peer-group member is not that case. The setting is not empty; it is inherited.

## Fix

- Parse `neighbor <name> peer group` / `peer-group` as a group definition and `neighbor <addr> peer group <NAME>` as membership (both spellings).
- Fold the group's settings into each member, with a setting written on the session itself winning.
- Scope the lookup to the group's own VRF, so a group in the default instance can't lend settings to a same-named group under `vrf PROD`.
- Keep group definitions out of `Neighbors` — a group is not a peer.
- Expose `peerGroup` on `arista.eos.bgp.peer` so the inheritance is visible rather than implied. Additive; `.lr.versions` entry auto-assigned `13.3.16`.

## Test plan

`bgp_config.go` had **no test file at all** — 189 lines of block-boundary and VRF state machine with nothing pinning it, which is why this survived. This adds one:

- `..._PeerGroupSettingsReachMembers` — the fabric case above; asserts every control reaches both members and the group definition doesn't leak into the peer list.
- `..._MemberSettingWinsOverGroup` — precedence.
- `..._HyphenatedPeerGroupSpelling` — the `peer-group` rendering.
- `..._GroupsAreScopedToTheirVrf` — a default-instance group must not protect a `vrf PROD` session.
- `..._StandaloneSessionIsUnchanged` — the no-group path still reports exactly what the session's own lines say.

`go build ./...` and `go test ./...` green in `providers/arista/`.
