### PR TITLE
🐛 arista: read ACL binding direction and routing instance correctly

### DIFF
--- a/providers/arista/resources/arista.lr
+++ b/providers/arista/resources/arista.lr
@@ -1220,6 +1220,13 @@ private arista.eos.aclBinding @defaults("target targetName direction aclName") {
   family string
   // Name of the applied access-list
   aclName string
+  // Routing instance the binding is scoped to
+  //
+  // Empty when the line names no instance, in which case the binding
+  // applies device-wide. A management service can be bound per instance, so
+  // a list scoped to the management instance leaves the service unrestricted
+  // in every other instance, including the one carrying production traffic.
+  vrf string
   // The applied access-list, resolved from aclName
   //
   // Null when the binding names a list that is not defined on the device,

--- a/providers/arista/resources/arista.lr.go
+++ b/providers/arista/resources/arista.lr.go
@@ -1249,6 +1249,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"arista.eos.aclBinding.aclName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAristaEosAclBinding).GetAclName()).ToDataRes(types.String)
 	},
+	"arista.eos.aclBinding.vrf": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAristaEosAclBinding).GetVrf()).ToDataRes(types.String)
+	},
 	"arista.eos.aclBinding.acl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAristaEosAclBinding).GetAcl()).ToDataRes(types.Resource("arista.eos.acl"))
 	},
@@ -3183,6 +3186,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"arista.eos.aclBinding.aclName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAristaEosAclBinding).AclName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"arista.eos.aclBinding.vrf": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAristaEosAclBinding).Vrf, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"arista.eos.aclBinding.acl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7846,6 +7853,7 @@ type mqlAristaEosAclBinding struct {
 	Direction  plugin.TValue[string]
 	Family     plugin.TValue[string]
 	AclName    plugin.TValue[string]
+	Vrf        plugin.TValue[string]
 	Acl        plugin.TValue[*mqlAristaEosAcl]
 }
 
@@ -7904,6 +7912,10 @@ func (c *mqlAristaEosAclBinding) GetFamily() *plugin.TValue[string] {
 
 func (c *mqlAristaEosAclBinding) GetAclName() *plugin.TValue[string] {
 	return &c.AclName
+}
+
+func (c *mqlAristaEosAclBinding) GetVrf() *plugin.TValue[string] {
+	return &c.Vrf
 }
 
 func (c *mqlAristaEosAclBinding) GetAcl() *plugin.TValue[*mqlAristaEosAcl] {

--- a/providers/arista/resources/arista.lr.versions
+++ b/providers/arista/resources/arista.lr.versions
@@ -71,6 +71,7 @@ arista.eos.aclBinding.direction 13.3.15
 arista.eos.aclBinding.family 13.3.15
 arista.eos.aclBinding.target 13.3.15
 arista.eos.aclBinding.targetName 13.3.15
+arista.eos.aclBinding.vrf 13.3.16
 arista.eos.aclBindings 13.3.15
 arista.eos.acls 13.0.1
 arista.eos.arpInspection 13.3.15

--- a/providers/arista/resources/arista_eos_aclbinding.go
+++ b/providers/arista/resources/arista_eos_aclbinding.go
@@ -61,14 +61,17 @@ func resolveAcl(runtime *plugin.Runtime, name, family string) (*mqlAristaEosAcl,
 func (a *mqlAristaEosAclBinding) id() (string, error) {
 	for _, f := range []struct{ err error }{
 		{a.Target.Error}, {a.TargetName.Error}, {a.Family.Error},
-		{a.Direction.Error}, {a.AclName.Error},
+		{a.Direction.Error}, {a.AclName.Error}, {a.Vrf.Error},
 	} {
 		if f.err != nil {
 			return "", f.err
 		}
 	}
+	// The same list can be bound to one target per routing instance, so the
+	// instance is part of what makes a binding distinct.
 	return "arista.eos.aclBinding/" + a.Target.Data + "/" + a.TargetName.Data + "/" +
-		a.Family.Data + "/" + a.Direction.Data + "/" + a.AclName.Data, nil
+		a.Family.Data + "/" + a.Direction.Data + "/" + a.AclName.Data + "/" +
+		a.Vrf.Data, nil
 }
 
 func (a *mqlAristaEos) aclBindings() ([]any, error) {
@@ -86,6 +89,7 @@ func (a *mqlAristaEos) aclBindings() ([]any, error) {
 			"direction":  llx.StringData(b.Direction),
 			"family":     llx.StringData(b.Family),
 			"aclName":    llx.StringData(b.AclName),
+			"vrf":        llx.StringData(b.VRF),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/arista/resources/eos/acl_binding.go
+++ b/providers/arista/resources/eos/acl_binding.go
@@ -35,6 +35,12 @@ type AclBinding struct {
 	Family string
 	// AclName is the name of the applied access-list.
 	AclName string
+	// VRF is the routing instance the binding is scoped to, empty when the
+	// line names none. A management service can be bound per instance, so a
+	// list applied only in the management instance leaves the service
+	// unrestricted everywhere else, and dropping the qualifier would report
+	// that as a device-wide restriction.
+	VRF string
 }
 
 // aclBindingTargets maps a top-level configuration header to the binding
@@ -98,8 +104,19 @@ func ParseAclBindings(runningConfig string) []AclBinding {
 				// EOS applies an access-group inbound unless told otherwise.
 				Direction: "in",
 			}
-			if len(fields) > 1 && (fields[1] == "in" || fields[1] == "out") {
-				binding.Direction = fields[1]
+			// The direction is the last thing on the line, but it is not
+			// always the token straight after the list name: a management
+			// service takes `ip access-group <acl> vrf <name> in`. Reading a
+			// fixed position reported such a binding as inbound whatever it
+			// said, so scan the qualifiers instead.
+			for i := 1; i < len(fields); i++ {
+				switch {
+				case fields[i] == "in" || fields[i] == "out":
+					binding.Direction = fields[i]
+				case fields[i] == "vrf" && i+1 < len(fields):
+					binding.VRF = fields[i+1]
+					i++
+				}
 			}
 			res = append(res, binding)
 		}

--- a/providers/arista/resources/eos/acl_config_test.go
+++ b/providers/arista/resources/eos/acl_config_test.go
@@ -278,3 +278,50 @@ func TestParseAclBindings_NegatedLineIsNotABinding(t *testing.T) {
 func TestParseAclBindings_None(t *testing.T) {
 	assert.Empty(t, ParseAclBindings("interface Ethernet1\n   description X\n"))
 }
+
+// TestParseAclBindings_DirectionIsNotPositional covers the management-service
+// form, where the direction is not the token straight after the list name.
+// Reading a fixed position reported an outbound binding as inbound, which
+// inverts what the ACL is understood to protect.
+func TestParseAclBindings_DirectionIsNotPositional(t *testing.T) {
+	bindings := ParseAclBindings(`management ssh
+   ip access-group MGMT-ACL vrf MGMT out
+!
+`)
+	require.Len(t, bindings, 1)
+	assert.Equal(t, "out", bindings[0].Direction)
+	assert.Equal(t, "MGMT", bindings[0].VRF)
+	assert.Equal(t, "MGMT-ACL", bindings[0].AclName)
+}
+
+// TestParseAclBindings_VrfIsCaptured pins the instance qualifier. A list bound
+// only in the management instance leaves the service unrestricted in every
+// other instance, including the one carrying production traffic; dropping the
+// qualifier reported that as a device-wide restriction.
+func TestParseAclBindings_VrfIsCaptured(t *testing.T) {
+	bindings := ParseAclBindings(`management ssh
+   ip access-group MGMT-ACL vrf MGMT in
+!
+`)
+	require.Len(t, bindings, 1)
+	assert.Equal(t, "MGMT", bindings[0].VRF)
+	assert.Equal(t, "in", bindings[0].Direction)
+}
+
+// TestParseAclBindings_UnqualifiedBindingHasNoVrf keeps the ordinary interface
+// form reporting no instance rather than a made-up one.
+func TestParseAclBindings_UnqualifiedBindingHasNoVrf(t *testing.T) {
+	bindings := ParseAclBindings(`interface Ethernet1
+   ip access-group EDGE-IN in
+   ip access-group EDGE-OUT out
+!
+`)
+	require.Len(t, bindings, 2)
+	for _, b := range bindings {
+		assert.Empty(t, b.VRF)
+		assert.Equal(t, "interface", b.Target)
+		assert.Equal(t, "Ethernet1", b.TargetName)
+	}
+	assert.Equal(t, "in", bindings[0].Direction)
+	assert.Equal(t, "out", bindings[1].Direction)
+}


### PR DESCRIPTION
## Problem

`arista.eos.aclBindings` is the resource that answers *"is this ACL actually applied, and to what?"* — so a wrong answer here inverts a security conclusion rather than degrading it.

### 1. Direction was read from a fixed position

```go
if len(fields) > 1 && (fields[1] == "in" || fields[1] == "out") {
    binding.Direction = fields[1]
}
```

`fields[1]` is the direction on an interface (`ip access-group EDGE-IN in`), but not on a management service, which takes:

```
management ssh
   ip access-group MGMT-ACL vrf MGMT out
```

There `fields[1]` is `vrf`, so the direction fell back to its `"in"` default and **an outbound binding was reported as inbound**. The parser couldn't distinguish "no direction written" from "direction written, just not where I looked".

### 2. The routing instance was dropped entirely

`AclBinding` had no VRF field and neither did `arista.eos.aclBinding`. A list bound only in the management instance leaves the service unrestricted in *every other* instance — including the one carrying production traffic — and that was reported as a plain, unqualified restriction. An auditor reading it concludes management access is locked down device-wide when the default instance is wide open.

## Fix

- Scan the qualifiers for the direction instead of indexing a fixed position.
- Capture `vrf <name>` into `AclBinding.VRF` and expose it as `arista.eos.aclBinding.vrf` (additive; `.lr.versions` auto-assigned `13.3.16`).
- Add the instance to the cache key — one list can be bound to one target once per instance, so without it those bindings would collapse.

## Test plan

- `..._DirectionIsNotPositional` — the `vrf MGMT out` form.
- `..._VrfIsCaptured` — the instance qualifier survives.
- `..._UnqualifiedBindingHasNoVrf` — the ordinary interface form still reports no instance rather than a made-up one, and in/out still resolve.
- Verified the tests catch it: restoring the `fields[1]` read fails with `expected: "out" / actual: "in"` and `expected: "MGMT" / actual: ""`.
- `go build ./...` and `go test ./...` green in `providers/arista/`.

## Not covered here

The audit that found this also flagged `mac access-group` and `ip access-class` under `line vty` as unrecognized binding forms, which read as "this ACL protects nothing" the same way. Left for a separate PR — both need confirmation against a live device first.
