### PR TITLE
🐛 arista: stop reading banner text as device configuration

### DIFF
--- a/providers/arista/resources/arista_eos.go
+++ b/providers/arista/resources/arista_eos.go
@@ -66,6 +66,30 @@ type mqlAristaEosRunningConfigInternal struct {
 	snmpParsed     atomic.Bool
 	snmpCache      *eos.SnmpConfig
 	snmpLock       sync.Mutex
+	strippedDone   atomic.Bool
+	strippedCache  string
+	strippedLock   sync.Mutex
+}
+
+// fetchStrippedContent returns the running-config with banner bodies blanked
+// out, which is what every command parser reads. Doing it here rather than in
+// each parser means a parser added later cannot forget it.
+func (a *mqlAristaEosRunningConfig) fetchStrippedContent() (string, error) {
+	if a.strippedDone.Load() {
+		return a.strippedCache, nil
+	}
+	a.strippedLock.Lock()
+	defer a.strippedLock.Unlock()
+	if a.strippedDone.Load() {
+		return a.strippedCache, nil
+	}
+	rc, err := a.fetchContent()
+	if err != nil {
+		return "", err
+	}
+	a.strippedCache = eos.StripBanners(rc)
+	a.strippedDone.Store(true)
+	return a.strippedCache, nil
 }
 
 // fetchSnmpConfig parses the SNMP configuration once per device. The users,

--- a/providers/arista/resources/arista_eos_logging.go
+++ b/providers/arista/resources/arista_eos_logging.go
@@ -102,7 +102,7 @@ func (a *mqlAristaEosLogging) hosts() ([]any, error) {
 // =====================================================================
 
 func (a *mqlAristaEos) loginBanner() (string, error) {
-	rc, err := fetchRunningConfig(a.MqlRuntime)
+	rc, err := fetchRawRunningConfig(a.MqlRuntime)
 	if err != nil {
 		return "", err
 	}
@@ -110,7 +110,7 @@ func (a *mqlAristaEos) loginBanner() (string, error) {
 }
 
 func (a *mqlAristaEos) motdBanner() (string, error) {
-	rc, err := fetchRunningConfig(a.MqlRuntime)
+	rc, err := fetchRawRunningConfig(a.MqlRuntime)
 	if err != nil {
 		return "", err
 	}

--- a/providers/arista/resources/arista_eos_persistence.go
+++ b/providers/arista/resources/arista_eos_persistence.go
@@ -198,7 +198,10 @@ func fetchStartupConfig(runtime *plugin.Runtime) (string, error) {
 // so once the comment header and blank lines are removed a saved device
 // compares equal.
 func (a *mqlAristaEos) configSavedToStartup() (bool, error) {
-	running, err := fetchRunningConfig(a.MqlRuntime)
+	// Compares two renderings of the whole config, so it reads the raw text:
+	// a stripped banner on one side and an intact one on the other would be
+	// reported as drift.
+	running, err := fetchRawRunningConfig(a.MqlRuntime)
 	if err != nil {
 		return false, err
 	}

--- a/providers/arista/resources/arista_eos_security.go
+++ b/providers/arista/resources/arista_eos_security.go
@@ -12,11 +12,25 @@ import (
 	"go.mondoo.com/mql/types"
 )
 
-// fetchRunningConfig returns the EOS running-config, preferring the cached
-// content on the existing arista.eos.runningConfig resource (which already
-// handles double-checked locking) so we don't issue redundant
-// `show running-config` calls when multiple security resources are queried.
+// fetchRunningConfig returns the device's running-config with banner bodies
+// blanked out. Banner text is operator-authored prose that routinely quotes
+// configuration, and every parser here scans the same namespace it sits in, so
+// command parsers must not see it. Use fetchRawRunningConfig for the banners
+// themselves and for anything that reports the config verbatim.
+//
+// Both go through the cached arista.eos.runningConfig resource, so the device
+// is asked for its configuration once however many resources are queried.
 func fetchRunningConfig(runtime *plugin.Runtime) (string, error) {
+	rc, err := runningConfigResource(runtime)
+	if err != nil {
+		return "", err
+	}
+	return rc.fetchStrippedContent()
+}
+
+// fetchRawRunningConfig returns the running-config exactly as the device
+// rendered it, banners included.
+func fetchRawRunningConfig(runtime *plugin.Runtime) (string, error) {
 	rc, err := runningConfigResource(runtime)
 	if err != nil {
 		return "", err

--- a/providers/arista/resources/eos/banner.go
+++ b/providers/arista/resources/eos/banner.go
@@ -73,3 +73,45 @@ func ParseBanners(runningConfig string) *Banners {
 
 	return b
 }
+
+// StripBanners replaces every banner body with blank lines, leaving the rest
+// of the running-config and its line numbering untouched.
+//
+// A banner body is arbitrary operator-authored text sitting at column 0 in the
+// same namespace every command parser scans, and operational banners routinely
+// quote configuration ("do not run: no aaa root"). Scanned as config it cuts
+// both ways: a quoted line can invent a setting the device does not have, and
+// because several parsers are last-write-wins, one appearing after the real
+// line can overwrite the device's true value. Neither shows up as an error.
+//
+// ParseBanners itself reads the raw text; everything else should read this.
+func StripBanners(runningConfig string) string {
+	var out strings.Builder
+
+	scanner := bufio.NewScanner(strings.NewReader(runningConfig))
+	for scanner.Scan() {
+		line := scanner.Text()
+		out.WriteString(line)
+		out.WriteByte('\n')
+
+		switch strings.TrimSpace(line) {
+		case "banner login", "banner motd":
+		default:
+			continue
+		}
+
+		// Blank out the body up to and including the EOF terminator, so the
+		// stripped config keeps the same number of lines as the original.
+		for scanner.Scan() {
+			body := scanner.Text()
+			if strings.TrimSpace(body) == "EOF" {
+				out.WriteString(body)
+				out.WriteByte('\n')
+				break
+			}
+			out.WriteByte('\n')
+		}
+	}
+
+	return out.String()
+}

--- a/providers/arista/resources/eos/strip_banners_test.go
+++ b/providers/arista/resources/eos/strip_banners_test.go
@@ -1,0 +1,100 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package eos
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStripBanners_SuppressionQuotedNegationHidesRealConfig is the dangerous
+// direction: a banner quoting a command overwrites what the device really
+// says. Here root is enabled with a secret, and an operational notice telling
+// people not to run "no aaa root" turns the answer into "root is disabled" --
+// a "root must be disabled" check passes on a device that fails it.
+func TestStripBanners_SuppressionQuotedNegationHidesRealConfig(t *testing.T) {
+	cfg := `aaa root secret sha512 $6$salt$hash
+banner login
+NOTICE: this device is managed. Do not run:
+no aaa root
+EOF
+`
+	assert.False(t, ParseRootAccount(cfg).Enabled, "precondition: the raw config is misread")
+
+	got := ParseRootAccount(StripBanners(cfg))
+	assert.True(t, got.Enabled, "root is enabled with a secret")
+	assert.Equal(t, "sha512", got.SecretFormat)
+}
+
+// TestStripBanners_FabricationQuotedCommandInventsConfig is the other
+// direction: a banner quoting a community string reports a read-write
+// plaintext community the device does not have, which is unfalsifiable from
+// the query output.
+func TestStripBanners_FabricationQuotedCommandInventsConfig(t *testing.T) {
+	cfg := `banner login
+Authorized use only. Reminder from netops:
+snmp-server community public rw
+is prohibited on this device.
+EOF
+snmp-server community realcomm ro MGMT-ACL
+`
+	require.Len(t, ParseSnmpCommunities(cfg), 2, "precondition: the raw config is misread")
+
+	got := ParseSnmpCommunities(StripBanners(cfg))
+	require.Len(t, got, 1)
+	assert.Equal(t, "realcomm", got[0].Name)
+	assert.Equal(t, "ro", got[0].Access)
+}
+
+// TestStripBanners_KeepsEverythingElseIntact guards against the strip eating
+// real configuration, including a line that merely mentions a banner.
+func TestStripBanners_KeepsEverythingElseIntact(t *testing.T) {
+	cfg := `hostname leaf1
+banner motd
+maintenance window Sunday
+EOF
+management ssh
+   idle-timeout 15
+!
+no banner login
+`
+	got := StripBanners(cfg)
+	assert.Contains(t, got, "hostname leaf1")
+	assert.Contains(t, got, "management ssh")
+	assert.Contains(t, got, "   idle-timeout 15")
+	assert.Contains(t, got, "no banner login")
+	assert.NotContains(t, got, "maintenance window Sunday")
+
+	// The header and terminator stay, so the shape of the config is
+	// unchanged and line numbering is preserved.
+	assert.Contains(t, got, "banner motd")
+	assert.Contains(t, got, "EOF")
+	assert.Equal(t, strings.Count(cfg, "\n"), strings.Count(got, "\n"))
+}
+
+// TestStripBanners_ParseBannersStillReadsTheBody keeps the banner resources
+// reading the real text: they take the raw config, not the stripped one.
+func TestStripBanners_ParseBannersStillReadsTheBody(t *testing.T) {
+	cfg := `banner login
+Authorized use only.
+EOF
+`
+	assert.Equal(t, "Authorized use only.", ParseBanners(cfg).Login)
+	assert.Empty(t, ParseBanners(StripBanners(cfg)).Login)
+}
+
+// TestStripBanners_TruncatedBannerDoesNotEatTheRest covers a config that ends
+// mid-banner: everything up to that point must survive.
+func TestStripBanners_TruncatedBannerDoesNotEatTheRest(t *testing.T) {
+	cfg := `hostname leaf1
+banner motd
+no terminator here
+`
+	got := StripBanners(cfg)
+	assert.Contains(t, got, "hostname leaf1")
+	assert.NotContains(t, got, "no terminator here")
+}


### PR DESCRIPTION
## Problem

A banner body is arbitrary operator-authored prose sitting at column 0 in the same namespace every command parser scans, and operational banners routinely quote configuration (change-control notices, "do not configure X" guidance). `ParseBanners` is the only function in the package that knows where a body starts and ends. Every other parser reads straight through one.

It cuts both ways, and neither surfaces as an error.

### Suppression — a real finding is erased

```
aaa root secret sha512 $6$salt$hash
banner login
NOTICE: this device is managed. Do not run:
no aaa root
EOF
```

`arista.eos.aaa.rootAccountEnabled` reads **false** on a device where root is enabled with a secret. A "root account must be disabled" check **passes on a device that fails it**.

Several parsers are last-write-wins, so this generalizes: a banner appearing *after* the real line silently overwrites the device true value. The AAA method lists work exactly that way.

### Fabrication — a finding is invented

```
banner login
Authorized use only. Reminder from netops:
snmp-server community public rw
is prohibited on this device.
EOF
snmp-server community realcomm ro MGMT-ACL
```

`arista.eos.snmpCommunities` reports a read-write plaintext community named `public` that **does not exist on the device** — a fabricated critical finding, unfalsifiable from the query output.

## Fix

Add `StripBanners`, which blanks banner bodies while preserving line count, and apply it **once** in `fetchRunningConfig`. Doing it there rather than in each of the ~45 parser call sites means a parser added later cannot forget it.

Two things keep reading the raw text via a new `fetchRawRunningConfig`:

- the banner resources themselves (`loginBanner`, `motdBanner`)
- `configSavedToStartup`, which compares two whole renderings and would otherwise read a stripped banner on one side as drift

`arista.eos.runningConfig.content` and `.section()` were already on `fetchContent()` and stay verbatim.

## Test plan

Both bug directions are pinned, and each test first asserts the **raw** config is misread — so the test is proof of the bug, not just of the fix:

- `..._SuppressionQuotedNegationHidesRealConfig`
- `..._FabricationQuotedCommandInventsConfig`
- `..._KeepsEverythingElseIntact` — real config survives, including a `no banner login` line; line count unchanged
- `..._ParseBannersStillReadsTheBody` — the banner resources still see the real text
- `..._TruncatedBannerDoesNotEatTheRest` — a config ending mid-banner

`go build ./...` and `go test ./...` green in `providers/arista/`.
