### PR TITLE
🐛 arista: derive MLAG and BGP admin state from the running-config

### DIFF
--- a/providers/arista/resources/arista_eos.go
+++ b/providers/arista/resources/arista_eos.go
@@ -912,12 +912,22 @@ func (a *mqlAristaEosBgp) fetchConfig() *module.BgpConfig {
 	return a.bgpConfig
 }
 
+// enabled reports whether the device is running BGP: a `router bgp` block
+// exists and is not administratively shut down.
+//
+// This reads the running-config the provider already holds rather than the
+// eAPI client's own view, which derives the state by looking for a literal
+// `no shutdown` line and treats its absence as shut down. Not being shut down
+// is the default, and EOS omits defaults from the running-config, so that view
+// reports every conventionally-configured device as having BGP disabled, while
+// the sibling `vrfs` field lists established sessions on the same resource.
 func (a *mqlAristaEosBgp) enabled() (bool, error) {
-	cfg := a.fetchConfig()
-	if cfg == nil {
-		return false, nil
+	rc, err := fetchRunningConfig(a.MqlRuntime)
+	if err != nil {
+		return false, err
 	}
-	return cfg.Shutdown() != "true", nil
+	state := eos.ParseBlockAdminState(rc, "router bgp ")
+	return state.Configured && !state.Shutdown, nil
 }
 
 func (a *mqlAristaEosBgp) asNumber() (string, error) {
@@ -1129,12 +1139,16 @@ func (a *mqlAristaEosMlag) peerLink() (string, error) {
 	return cfg.PeerLink(), nil
 }
 
+// shutdown reports whether MLAG is administratively down. See bgp.enabled for
+// why this reads the running-config rather than the eAPI client's derived
+// state: the same inverted default reported a healthy MLAG pair as shut down
+// while domainId, peerAddress and peerLink all described a working peering.
 func (a *mqlAristaEosMlag) shutdown() (bool, error) {
-	cfg := a.fetchConfig()
-	if cfg == nil {
-		return false, nil
+	rc, err := fetchRunningConfig(a.MqlRuntime)
+	if err != nil {
+		return false, err
 	}
-	return cfg.Shutdown() == "true", nil
+	return eos.ParseBlockAdminState(rc, "mlag configuration").Shutdown, nil
 }
 
 func (a *mqlAristaEos) mlag() (*mqlAristaEosMlag, error) {

--- a/providers/arista/resources/eos/admin_state.go
+++ b/providers/arista/resources/eos/admin_state.go
@@ -1,0 +1,51 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package eos
+
+import "strings"
+
+// AdminState is whether a top-level configuration block exists on the device
+// and whether it is administratively shut down.
+//
+// The two are separate questions and collapsing them loses the answer. A
+// feature that is not configured at all is not the same as one configured and
+// then shut down, and neither is the same as one that is up.
+type AdminState struct {
+	// Configured is true when the block is present in the running-config.
+	Configured bool
+	// Shutdown is true only when the block explicitly says so. Both the MLAG
+	// and BGP blocks default to running, and EOS omits a default from the
+	// running-config, so the absence of a shutdown line means the feature is
+	// up. Reading absence as "shut down" reports a healthy device as down.
+	Shutdown bool
+}
+
+// ParseBlockAdminState reports the admin state of the top-level block whose
+// header equals header, or begins with it when header ends in a space (which
+// is how `router bgp <asn>` is matched without knowing the AS number).
+func ParseBlockAdminState(runningConfig, header string) AdminState {
+	state := AdminState{}
+
+	EachTopLevelBlock(runningConfig, func(blockHeader, body string) {
+		if strings.HasSuffix(header, " ") {
+			if !strings.HasPrefix(blockHeader, header) {
+				return
+			}
+		} else if blockHeader != header {
+			return
+		}
+		state.Configured = true
+
+		for _, line := range strings.Split(body, "\n") {
+			switch strings.TrimSpace(line) {
+			case "shutdown":
+				state.Shutdown = true
+			case "no shutdown", "default shutdown":
+				state.Shutdown = false
+			}
+		}
+	})
+
+	return state
+}

--- a/providers/arista/resources/eos/admin_state_test.go
+++ b/providers/arista/resources/eos/admin_state_test.go
@@ -1,0 +1,96 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package eos
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseBlockAdminState_AbsentShutdownLineMeansRunning is the case that
+// matters. Both blocks default to running and EOS omits defaults from the
+// running-config, so a conventionally-configured device carries no shutdown
+// line at all. Reading that absence as "shut down" reports a healthy device
+// as down.
+func TestParseBlockAdminState_AbsentShutdownLineMeansRunning(t *testing.T) {
+	cfg := `mlag configuration
+   domain-id mlag1
+   local-interface Vlan4094
+   peer-address 10.0.0.2
+   peer-link Port-Channel1000
+!
+router bgp 65001
+   router-id 10.0.0.1
+   neighbor 10.1.1.2 remote-as 65002
+!
+`
+	mlag := ParseBlockAdminState(cfg, "mlag configuration")
+	assert.True(t, mlag.Configured)
+	assert.False(t, mlag.Shutdown, "a peering with no shutdown line is up")
+
+	bgp := ParseBlockAdminState(cfg, "router bgp ")
+	assert.True(t, bgp.Configured)
+	assert.False(t, bgp.Shutdown)
+}
+
+// TestParseBlockAdminState_RealDeviceCapture runs the assertion against the
+// running-config captured from an actual vEOS switch, which is where the
+// inverted default shows up in the repository itself.
+func TestParseBlockAdminState_RealDeviceCapture(t *testing.T) {
+	raw, err := os.ReadFile("testdata/mlag-config")
+	require.NoError(t, err)
+
+	got := ParseBlockAdminState(string(raw), "mlag configuration")
+	assert.True(t, got.Configured)
+	assert.False(t, got.Shutdown, "the captured device has a working MLAG peering")
+}
+
+func TestParseBlockAdminState_ExplicitShutdown(t *testing.T) {
+	cfg := `mlag configuration
+   domain-id mlag1
+   shutdown
+!
+`
+	got := ParseBlockAdminState(cfg, "mlag configuration")
+	assert.True(t, got.Configured)
+	assert.True(t, got.Shutdown)
+}
+
+// TestParseBlockAdminState_LastStatementWins covers a block that shuts down
+// and is then brought back up, and the "default shutdown" spelling.
+func TestParseBlockAdminState_LastStatementWins(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"no shutdown after shutdown", "   shutdown\n   no shutdown\n", false},
+		{"shutdown after no shutdown", "   no shutdown\n   shutdown\n", true},
+		{"default shutdown means running", "   default shutdown\n", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseBlockAdminState("mlag configuration\n"+tc.body+"!\n", "mlag configuration")
+			assert.True(t, got.Configured)
+			assert.Equal(t, tc.want, got.Shutdown)
+		})
+	}
+}
+
+// TestParseBlockAdminState_AbsentBlockIsNotConfigured keeps "not configured"
+// distinct from "configured and running", which a single boolean would lose.
+func TestParseBlockAdminState_AbsentBlockIsNotConfigured(t *testing.T) {
+	got := ParseBlockAdminState("hostname leaf1\n!\n", "mlag configuration")
+	assert.False(t, got.Configured)
+	assert.False(t, got.Shutdown)
+}
+
+// TestParseBlockAdminState_HeaderIsNotAPrefixMatch stops "router bgp" from
+// matching an unrelated block, while still matching any AS number.
+func TestParseBlockAdminState_HeaderIsNotAPrefixMatch(t *testing.T) {
+	assert.False(t, ParseBlockAdminState("mlag configuration extra\n   shutdown\n!\n", "mlag configuration").Configured)
+	assert.True(t, ParseBlockAdminState("router bgp 4200000000\n   shutdown\n!\n", "router bgp ").Shutdown)
+}


### PR DESCRIPTION
## Problem

`arista.eos.mlag.shutdown` and `arista.eos.bgp.enabled` took their answer from the eAPI client's derived state:

```go
func (m *MlagEntity) parseShutdown(config string) bool {
	matched, _ := regexp.MatchString(`(?m)no shutdown`, config)
	if matched { return false }
	return !matched          // absence of "no shutdown" => shutdown == TRUE
}
```

(`BGPEntity.parseShutdown` is byte-identical.) It decides admin state by looking for a literal `no shutdown` line and returns **shut down** when it finds none. But both blocks default to running, and EOS omits defaults from the running-config — and the block is fetched with a plain `show running-config`, not `... all` — so a conventionally-configured device carries no such line at all.

### MLAG: self-contradicting resource

The captured vEOS running-config already in this repo demonstrates it. `resources/eos/testdata/mlag-config` has a domain-id, a local interface, a peer address and a peer link — and **zero** shutdown lines:

```
mlag configuration
   domain-id mlag1
   local-interface Vlan4094
   peer-address 10.0.0.2
   peer-link Port-Channel1000
```

`shutdown` reports `true` while every other field on the same resource describes a working peering.

### BGP: a silent scope collapse

Worse, because it fails quietly in scope rather than loudly in value. A conventional block:

```
router bgp 65001
   router-id 10.0.0.1
   neighbor 10.1.1.2 remote-as 65002
```

reports `enabled: false`, so a policy shaped `if (arista.eos.bgp.enabled) { ...check peer authentication... }` **skips its checks entirely on every BGP-speaking device** — while `arista.eos.bgp.vrfs` lists `Established` peers from the operational view on the same resource.

## Fix

Read the running-config the provider already holds. `ParseBlockAdminState` keeps *not configured* and *configured and running* apart — one boolean cannot carry both — and treats an absent shutdown line as running, which is what the default actually is.

Also removes a dead `cfg == nil` branch: `MlagEntity.Get()` never returns nil, so the not-configured case was silently taking the "MLAG is up" path.

## Test plan

- `..._AbsentShutdownLineMeansRunning` — the conventional shape, both blocks.
- `..._RealDeviceCapture` — runs against `testdata/mlag-config`, the actual vEOS capture, which is where the inversion shows up in the repo itself.
- `..._ExplicitShutdown`, `..._LastStatementWins` (including the `default shutdown` spelling), `..._AbsentBlockIsNotConfigured`, `..._HeaderIsNotAPrefixMatch` (so `router bgp ` matches any AS number but not an unrelated block).

`go build ./...` and `go test ./...` green in `providers/arista/`.
