### PR TITLE
🐛 aws: stop dropping Condition blocks from IAM policy documents

### DIFF
--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -6,9 +6,7 @@ package resources
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -26,7 +24,6 @@ import (
 	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/providers/aws/connection"
 	"go.mondoo.com/mql/providers/aws/resources/awsiam"
-	"go.mondoo.com/mql/providers/aws/resources/awspolicy"
 	"go.mondoo.com/mql/types"
 )
 
@@ -1888,22 +1885,19 @@ func (a *mqlAwsIamPolicyversion) rawDocument() (string, error) {
 func (a *mqlAwsIamPolicyversion) document() (any, error) {
 	rawDoc, err := a.rawDocument()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	decodedValue, err := url.QueryUnescape(rawDoc)
+	// Decode to the document's own JSON rather than round-tripping through
+	// awspolicy.IamPolicyDocument. That struct has no Condition field, so
+	// re-marshalling it dropped every condition block, and its statementSection
+	// flattens a principal map to a list of quoted values, turning
+	// {"AWS": "*"} into ["\"*\""]. The schema calls this field the raw policy
+	// JSON, so hand back what IAM actually returned.
+	doc, err := parseIamPolicyDocument(rawDoc)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	policyDoc := awspolicy.IamPolicyDocument{}
-	err = json.Unmarshal([]byte(decodedValue), &policyDoc)
-	if err != nil {
-		return "", err
-	}
-	dict, err := convert.JsonToDict(policyDoc)
-	if err != nil {
-		return "", err
-	}
-	return dict, nil
+	return doc, nil
 }
 
 // isServiceLinkedRolePath reports whether an IAM role path marks the role as

--- a/providers/aws/resources/aws_iam_inline_policy.go
+++ b/providers/aws/resources/aws_iam_inline_policy.go
@@ -31,18 +31,30 @@ func decodeIamPolicyDocument(document *string) map[string]any {
 	if document == nil {
 		return nil
 	}
-	raw := *document
-	var parsed map[string]any
-	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-		decoded, decodeErr := url.QueryUnescape(raw)
-		if decodeErr != nil {
-			return nil
-		}
-		if err := json.Unmarshal([]byte(decoded), &parsed); err != nil {
-			return nil
-		}
+	parsed, err := parseIamPolicyDocument(*document)
+	if err != nil {
+		return nil
 	}
 	return parsed
+}
+
+// parseIamPolicyDocument decodes an IAM policy or trust document to its parsed
+// JSON form, reporting why a document could not be read. Callers that treat an
+// unreadable document the way the API treats a missing one use
+// decodeIamPolicyDocument instead.
+func parseIamPolicyDocument(raw string) (map[string]any, error) {
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(raw), &parsed); err == nil {
+		return parsed, nil
+	}
+	decoded, err := url.QueryUnescape(raw)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal([]byte(decoded), &parsed); err != nil {
+		return nil, err
+	}
+	return parsed, nil
 }
 
 // newInlinePolicyResource builds an aws.iam.inlinePolicy for one embedded

--- a/providers/aws/resources/aws_iam_policy_document_test.go
+++ b/providers/aws/resources/aws_iam_policy_document_test.go
@@ -1,0 +1,96 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The document IAM hands back for a policy scoped by a condition. This is the
+// shape that used to lose its Condition block on the way through
+// awspolicy.IamPolicyDocument, which has no Condition field.
+const conditionPolicyJSON = `{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "CondScoped",
+    "Effect": "Allow",
+    "Action": "s3:GetObject",
+    "Resource": "arn:aws:s3:::example-bucket/*",
+    "Condition": {"StringEquals": {"aws:PrincipalOrgID": "o-exampleorgid"}}
+  }]
+}`
+
+func TestParseIamPolicyDocumentKeepsConditions(t *testing.T) {
+	for _, tc := range []struct {
+		title string
+		input string
+	}{
+		{"raw json", conditionPolicyJSON},
+		{"url-encoded, as IAM returns it", url.QueryEscape(conditionPolicyJSON)},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			doc, err := parseIamPolicyDocument(tc.input)
+			require.NoError(t, err)
+
+			stmts, ok := doc["Statement"].([]any)
+			require.True(t, ok, "Statement should decode to a list")
+			require.Len(t, stmts, 1)
+			stmt, ok := stmts[0].(map[string]any)
+			require.True(t, ok)
+
+			// The regression: a policy that only grants access within an
+			// organization read as an unconditional grant.
+			cond, ok := stmt["Condition"].(map[string]any)
+			require.True(t, ok, "Condition must survive decoding")
+			eq, ok := cond["StringEquals"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, "o-exampleorgid", eq["aws:PrincipalOrgID"])
+		})
+	}
+}
+
+func TestParseIamPolicyDocumentKeepsPrincipalShape(t *testing.T) {
+	// statementSection flattened a principal map to a list of quoted values,
+	// so {"AWS": "*"} came back as ["\"*\""] with the key gone.
+	doc, err := parseIamPolicyDocument(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"s3:GetObject","Resource":"*"}]}`)
+	require.NoError(t, err)
+
+	stmt := doc["Statement"].([]any)[0].(map[string]any)
+	principal, ok := stmt["Principal"].(map[string]any)
+	require.True(t, ok, "Principal must stay a map, not become a list of quoted strings")
+	assert.Equal(t, "*", principal["AWS"])
+}
+
+func TestParseIamPolicyDocumentPreservesScalarAndArrayActions(t *testing.T) {
+	// Action is legally either a string or an array; the raw document keeps
+	// whichever IAM sent rather than normalizing both to a list.
+	scalar, err := parseIamPolicyDocument(`{"Statement":[{"Action":"s3:GetObject"}]}`)
+	require.NoError(t, err)
+	assert.Equal(t, "s3:GetObject", scalar["Statement"].([]any)[0].(map[string]any)["Action"])
+
+	array, err := parseIamPolicyDocument(`{"Statement":[{"Action":["s3:GetObject","s3:PutObject"]}]}`)
+	require.NoError(t, err)
+	assert.Equal(t, []any{"s3:GetObject", "s3:PutObject"},
+		array["Statement"].([]any)[0].(map[string]any)["Action"])
+}
+
+func TestParseIamPolicyDocumentReportsUnreadableDocuments(t *testing.T) {
+	_, err := parseIamPolicyDocument("not json and not url-encoded json {{{")
+	assert.Error(t, err, "an unreadable document must not decode to an empty policy")
+}
+
+func TestDecodeIamPolicyDocumentTreatsUnreadableAsMissing(t *testing.T) {
+	// The nil-returning wrapper keeps its existing contract for callers that
+	// treat an unreadable document the way the API treats a missing one.
+	assert.Nil(t, decodeIamPolicyDocument(nil))
+	bad := "not json {{{"
+	assert.Nil(t, decodeIamPolicyDocument(&bad))
+
+	good := conditionPolicyJSON
+	require.NotNil(t, decodeIamPolicyDocument(&good))
+}


### PR DESCRIPTION
`aws.iam.policyversion.document` decoded the policy into `awspolicy.IamPolicyDocument` and then re-marshalled **that struct**:

```go
policyDoc := awspolicy.IamPolicyDocument{}
err = json.Unmarshal([]byte(decodedValue), &policyDoc)
dict, err := convert.JsonToDict(policyDoc)   // marshals the struct, not the document
```

`IamPolicyStatement` has no `Condition` field, so every condition in a managed policy was silently discarded.

## Confirmed against a live account

A customer-managed policy whose only grant is fenced by `aws:PrincipalOrgID`:

```json
{"Sid":"CondScoped","Effect":"Allow","Action":"s3:GetObject",
 "Resource":"arn:aws:s3:::example-bucket/*",
 "Condition":{"StringEquals":{"aws:PrincipalOrgID":"o-exampleorgid"}}}
```

came back from `aws.iam.policies { defaultVersion.document }` as:

```
Statement: [ 0: { Action: ["s3:GetObject"], Effect: "Allow",
                  Resource: ["arn:aws:s3:::example-bucket/*"], Sid: "CondScoped" } ]
```

No `Condition`, no error.

An audit reading `document` to check that a wildcard grant is fenced by `aws:PrincipalOrgID` or `aws:SourceAccount` sees no conditions at all, so the policy reads as unconditional — the wrong direction for a security scan. A check that *requires* a condition fails on a policy that has one.

The same struct's `statementSection` also flattens a principal map, so `{"AWS": "*"}` decoded to `["\"*\""]` — key dropped, value double-quoted.

This was also a **cross-path inconsistency**: `statements()` on the same resource parses via `awspolicy.S3BucketPolicy`, which keeps `Condition` as a `json.RawMessage`. So `policy.statements[].conditions` was right while `policy.defaultVersion.document` was wrong, for the same document.

## The fix

The `.lr` describes this field as *"Raw policy JSON for this version. See statements for the parsed statement form."* — so it now decodes straight to the document's own JSON. The decode is shared with the role trust-document path (`decodeIamPolicyDocument`), which already did this correctly; that wrapper keeps its existing nil-on-unreadable contract, and the new error-returning `parseIamPolicyDocument` lets `document()` report a document it could not read instead of returning an empty policy.

After the fix, same policy, same account:

```
Statement: [ 0: { Action: "s3:GetObject"
                  Condition: { StringEquals: { aws:PrincipalOrgID: "o-exampleorgid" } }
                  Effect: "Allow", Resource: "arn:aws:s3:::example-bucket/*", Sid: "CondScoped" } ]
```

## Heads-up for consumers

Values IAM sends as scalars now stay scalars, where the old struct normalized them to lists — `"Action": "s3:GetObject"` rather than `["s3:GetObject"]`. Both are legal in IAM, and returning what IAM sent is what "raw" means, but this is a visible change to a shipped field's values. `statements()` is unaffected and remains the normalized view (`actions`, `resources`, `principals` are always lists there), so anything wanting a stable shape should use it.

## Tests

`aws_iam_policy_document_test.go` pins the regression directly: `Condition` survives both the raw and the URL-encoded input form, `Principal` stays a map rather than a list of quoted strings, scalar and array `Action` are both preserved as sent, an unreadable document reports an error rather than decoding to an empty policy, and the nil-returning wrapper keeps its contract.

## Follow-up (not in this PR)

With this change `awspolicy.IamPolicyDocument` has no non-test callers left. It is worth deleting — its `statementSection.UnmarshalJSON` does a bare `item.(string)` on decoded JSON, which would panic the whole scan on a non-string element, where the S3 sibling uses `fmt.Sprintf("%v", item)`. I left the removal out of this PR to keep the correctness fix reviewable on its own.

## Verification

Reproduced on `main` and confirmed fixed on this branch against a live AWS account, using a free customer-managed IAM policy carrying a `Condition` block.