### PR TITLE
🐛 arista: surface config fetch failures instead of an empty device

### DIFF
--- a/providers/arista/resources/arista.lr.go
+++ b/providers/arista/resources/arista.lr.go
@@ -5118,7 +5118,7 @@ func (c *mqlAristaEosRunningConfig) GetContent() *plugin.TValue[string] {
 type mqlAristaEosRunningConfigSection struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	mqlAristaEosRunningConfigSectionInternal
+	// optional: if you define mqlAristaEosRunningConfigSectionInternal it will be used here
 	Name    plugin.TValue[string]
 	Content plugin.TValue[string]
 }

--- a/providers/arista/resources/arista_eos.go
+++ b/providers/arista/resources/arista_eos.go
@@ -51,6 +51,7 @@ func (v *mqlAristaEosRunningConfig) id() (string, error) {
 type mqlAristaEosRunningConfigInternal struct {
 	contentFetched bool
 	contentCache   string
+	contentErr     error
 	lock           sync.Mutex
 
 	// Parsers that several resources share memoize their result here. The
@@ -70,74 +71,91 @@ type mqlAristaEosRunningConfigInternal struct {
 // fetchSnmpConfig parses the SNMP configuration once per device. The users,
 // groups, views, and notification destinations are separate collections that
 // all come out of the same walk of the running-config.
-func (a *mqlAristaEosRunningConfig) fetchSnmpConfig() *eos.SnmpConfig {
+func (a *mqlAristaEosRunningConfig) fetchSnmpConfig() (*eos.SnmpConfig, error) {
 	if a.snmpParsed.Load() {
-		return a.snmpCache
+		return a.snmpCache, nil
 	}
 	a.snmpLock.Lock()
 	defer a.snmpLock.Unlock()
 	if a.snmpParsed.Load() {
-		return a.snmpCache
+		return a.snmpCache, nil
 	}
-	a.snmpCache = eos.ParseSnmpConfig(a.fetchContent())
+	rc, err := a.fetchContent()
+	if err != nil {
+		return nil, err
+	}
+	a.snmpCache = eos.ParseSnmpConfig(rc)
 	a.snmpParsed.Store(true)
-	return a.snmpCache
+	return a.snmpCache, nil
 }
 
 // fetchSflowConfig parses the sFlow configuration once per device.
-func (a *mqlAristaEosRunningConfig) fetchSflowConfig() *eos.SflowConfig {
+func (a *mqlAristaEosRunningConfig) fetchSflowConfig() (*eos.SflowConfig, error) {
 	if a.sflowParsed.Load() {
-		return a.sflowCache
+		return a.sflowCache, nil
 	}
 	a.sflowLock.Lock()
 	defer a.sflowLock.Unlock()
 	if a.sflowParsed.Load() {
-		return a.sflowCache
+		return a.sflowCache, nil
 	}
-	a.sflowCache = eos.ParseSflowConfig(a.fetchContent())
+	rc, err := a.fetchContent()
+	if err != nil {
+		return nil, err
+	}
+	a.sflowCache = eos.ParseSflowConfig(rc)
 	a.sflowParsed.Store(true)
-	return a.sflowCache
+	return a.sflowCache, nil
 }
 
 // fetchInterfaceHardening parses the Layer 3 posture of every interface once
 // per device and keys it by interface name, so a query reading several
 // hardening fields across many interfaces still walks the config only once.
-func (a *mqlAristaEosRunningConfig) fetchInterfaceHardening() map[string]eos.InterfaceHardening {
+func (a *mqlAristaEosRunningConfig) fetchInterfaceHardening() (map[string]eos.InterfaceHardening, error) {
 	if a.hardeningDone.Load() {
-		return a.hardeningCache
+		return a.hardeningCache, nil
 	}
 	a.hardeningLock.Lock()
 	defer a.hardeningLock.Unlock()
 	if a.hardeningDone.Load() {
-		return a.hardeningCache
+		return a.hardeningCache, nil
 	}
-	parsed := eos.ParseInterfaceHardening(a.fetchContent())
+	rc, err := a.fetchContent()
+	if err != nil {
+		return nil, err
+	}
+	parsed := eos.ParseInterfaceHardening(rc)
 	cache := make(map[string]eos.InterfaceHardening, len(parsed))
 	for _, h := range parsed {
 		cache[h.Interface] = h
 	}
 	a.hardeningCache = cache
 	a.hardeningDone.Store(true)
-	return a.hardeningCache
+	return a.hardeningCache, nil
 }
 
-func (a *mqlAristaEosRunningConfig) fetchContent() string {
+// fetchContent reads the running-config once per device and remembers the
+// outcome, failure included. A failed read must not be cached as an empty
+// configuration: every parser here is a pure function of this string, and an
+// empty one parses into a device with no AAA servers, no syslog collectors and
+// no ACL bindings, which reads as a clean posture rather than as an error.
+func (a *mqlAristaEosRunningConfig) fetchContent() (string, error) {
 	if a.contentFetched {
-		return a.contentCache
+		return a.contentCache, a.contentErr
 	}
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	if a.contentFetched {
-		return a.contentCache
+		return a.contentCache, a.contentErr
 	}
 	eosClient := aristaClient(a.MqlRuntime)
-	a.contentCache = eosClient.RunningConfig()
+	a.contentCache, a.contentErr = eosClient.RunningConfig()
 	a.contentFetched = true
-	return a.contentCache
+	return a.contentCache, a.contentErr
 }
 
 func (a *mqlAristaEosRunningConfig) content() (string, error) {
-	return a.fetchContent(), nil
+	return a.fetchContent()
 }
 
 func (a *mqlAristaEosRunningConfigSection) id() (string, error) {
@@ -147,21 +165,15 @@ func (a *mqlAristaEosRunningConfigSection) id() (string, error) {
 	return "arista.eos.runningConfig.section " + a.Name.Data, nil
 }
 
-type mqlAristaEosRunningConfigSectionInternal struct {
-	runningConfig string
-}
-
 func (a *mqlAristaEosRunningConfigSection) content() (string, error) {
 	if a.Name.Error != nil {
 		return "", a.Name.Error
 	}
 	name := a.Name.Data
 
-	// Use cached running config passed from parent, or fetch directly
-	content := a.runningConfig
-	if content == "" {
-		eosClient := aristaClient(a.MqlRuntime)
-		content = eosClient.RunningConfig()
+	content, err := fetchRunningConfig(a.MqlRuntime)
+	if err != nil {
+		return "", err
 	}
 
 	return eos.GetSection(strings.NewReader(content), name), nil
@@ -1153,14 +1165,9 @@ func (a *mqlAristaEosMlag) interfaces() ([]any, error) {
 		return []any{}, nil
 	}
 
-	// Use the cached running config from the runningConfig resource if available,
-	// otherwise fetch directly
-	var runningConfig string
-	rcRes, err := CreateResource(a.MqlRuntime, "arista.eos.runningConfig", map[string]*llx.RawData{})
-	if err == nil {
-		runningConfig = rcRes.(*mqlAristaEosRunningConfig).fetchContent()
-	} else {
-		runningConfig = eosClient.RunningConfig()
+	runningConfig, err := fetchRunningConfig(a.MqlRuntime)
+	if err != nil {
+		return nil, err
 	}
 	mlagInterfaces := eos.ParseMlagInterfaces(runningConfig)
 

--- a/providers/arista/resources/arista_eos_management.go
+++ b/providers/arista/resources/arista_eos_management.go
@@ -173,7 +173,7 @@ func snmpConfig(runtime *plugin.Runtime) (*eos.SnmpConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	return rc.fetchSnmpConfig(), nil
+	return rc.fetchSnmpConfig()
 }
 
 // id keys a user on the group as well as the name, since the same security

--- a/providers/arista/resources/arista_eos_persistence.go
+++ b/providers/arista/resources/arista_eos_persistence.go
@@ -150,28 +150,29 @@ func (a *mqlAristaEosStartupConfig) id() (string, error) {
 type mqlAristaEosStartupConfigInternal struct {
 	contentFetched atomic.Bool
 	contentCache   string
+	contentErr     error
 	lock           sync.Mutex
 }
 
 // fetchContent caches the startup-config so the drift comparison and a direct
 // read of `content` share one fetch.
-func (a *mqlAristaEosStartupConfig) fetchContent() string {
+func (a *mqlAristaEosStartupConfig) fetchContent() (string, error) {
 	if a.contentFetched.Load() {
-		return a.contentCache
+		return a.contentCache, a.contentErr
 	}
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	if a.contentFetched.Load() {
-		return a.contentCache
+		return a.contentCache, a.contentErr
 	}
 	eosClient := aristaClient(a.MqlRuntime)
-	a.contentCache = eosClient.StartupConfig()
+	a.contentCache, a.contentErr = eosClient.StartupConfig()
 	a.contentFetched.Store(true)
-	return a.contentCache
+	return a.contentCache, a.contentErr
 }
 
 func (a *mqlAristaEosStartupConfig) content() (string, error) {
-	return a.fetchContent(), nil
+	return a.fetchContent()
 }
 
 func (a *mqlAristaEos) startupConfig() (*mqlAristaEosStartupConfig, error) {
@@ -189,7 +190,7 @@ func fetchStartupConfig(runtime *plugin.Runtime) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return sc.(*mqlAristaEosStartupConfig).fetchContent(), nil
+	return sc.(*mqlAristaEosStartupConfig).fetchContent()
 }
 
 // configSavedToStartup reports whether a reload would bring the device back in

--- a/providers/arista/resources/arista_eos_security.go
+++ b/providers/arista/resources/arista_eos_security.go
@@ -21,7 +21,7 @@ func fetchRunningConfig(runtime *plugin.Runtime) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return rc.fetchContent(), nil
+	return rc.fetchContent()
 }
 
 // runningConfigResource returns the device's running-config resource, which the

--- a/providers/arista/resources/arista_eos_traffic.go
+++ b/providers/arista/resources/arista_eos_traffic.go
@@ -83,7 +83,10 @@ func (a *mqlAristaEos) sflow() (*mqlAristaEosSflow, error) {
 	if err != nil {
 		return nil, err
 	}
-	cfg := rc.fetchSflowConfig()
+	cfg, err := rc.fetchSflowConfig()
+	if err != nil {
+		return nil, err
+	}
 
 	res, err := CreateResource(a.MqlRuntime, "arista.eos.sflow", map[string]*llx.RawData{
 		"enabled":         llx.BoolData(cfg.Enabled),
@@ -113,7 +116,10 @@ func (a *mqlAristaEosSflow) destinations() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	cfg := rc.fetchSflowConfig()
+	cfg, err := rc.fetchSflowConfig()
+	if err != nil {
+		return nil, err
+	}
 
 	res := make([]any, 0, len(cfg.Destinations))
 	for _, d := range cfg.Destinations {
@@ -150,7 +156,11 @@ func (a *mqlAristaEosInterface) interfaceHardening() (eos.InterfaceHardening, er
 	if err != nil {
 		return fallback, err
 	}
-	if h, ok := rc.fetchInterfaceHardening()[a.Name.Data]; ok {
+	hardening, err := rc.fetchInterfaceHardening()
+	if err != nil {
+		return eos.InterfaceHardening{}, err
+	}
+	if h, ok := hardening[a.Name.Data]; ok {
 		return h, nil
 	}
 	return fallback, nil

--- a/providers/arista/resources/eos/arista.go
+++ b/providers/arista/resources/eos/arista.go
@@ -6,6 +6,7 @@ package eos
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/aristanetworks/goeapi"
 	"github.com/aristanetworks/goeapi/module"
@@ -19,8 +20,42 @@ type Eos struct {
 	node *goeapi.Node
 }
 
-func (eos *Eos) RunningConfig() string {
-	return eos.node.RunningConfig()
+// RunningConfig returns the device's running-config, with every default
+// rendered explicitly.
+//
+// It deliberately does not use the eAPI client's own RunningConfig(), which
+// returns a bare string and discards the error: a permission gap or a timeout
+// there yields "", and an empty running-config parses cleanly into "no TACACS
+// servers, no syslog collectors, no ACL bindings, dot1x disabled" — a
+// confident pass for every hardening check, with nothing to attribute it to.
+func (eos *Eos) RunningConfig() (string, error) {
+	return configText(eos.node, goeapi.RunningConfig, "all")
+}
+
+// configText fetches a configuration as text and fails loudly rather than
+// returning a partial or empty result. An EOS device never renders an empty
+// configuration, so an empty body is a failed read, not a bare device.
+func configText(node *goeapi.Node, config, params string) (string, error) {
+	res, err := node.GetConfig(config, params, "text")
+	if err != nil {
+		return "", fmt.Errorf("could not read %s: %w", config, err)
+	}
+	return configTextFromResponse(res, config)
+}
+
+// configTextFromResponse extracts the configuration body from a successful
+// response, rejecting the two shapes that would otherwise become an empty
+// string: a response carrying no text output, and one carrying an empty body.
+func configTextFromResponse(res map[string]any, config string) (string, error) {
+	out, ok := res["output"].(string)
+	if !ok {
+		return "", fmt.Errorf("could not read %s: response carried no text output", config)
+	}
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return "", fmt.Errorf("could not read %s: device returned an empty configuration", config)
+	}
+	return out, nil
 }
 
 func (eos *Eos) SystemConfig() map[string]string {

--- a/providers/arista/resources/eos/config_text_test.go
+++ b/providers/arista/resources/eos/config_text_test.go
@@ -1,0 +1,52 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package eos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfigTextFromResponse covers the shapes that used to become an empty
+// string. Every running-config parser in this provider is a pure function of
+// that string, and an empty one parses into a device with no AAA servers, no
+// syslog collectors and no ACL bindings: a clean posture asserted from data
+// that was never read. These have to be errors, not empty results.
+func TestConfigTextFromResponse(t *testing.T) {
+	t.Run("a body is returned as-is", func(t *testing.T) {
+		got, err := configTextFromResponse(map[string]any{"output": "hostname leaf1\n"}, "running-config")
+		require.NoError(t, err)
+		assert.Equal(t, "hostname leaf1", got)
+	})
+
+	t.Run("no output key is an error", func(t *testing.T) {
+		_, err := configTextFromResponse(map[string]any{}, "running-config")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no text output")
+	})
+
+	t.Run("a non-string output is an error, not a panic", func(t *testing.T) {
+		_, err := configTextFromResponse(map[string]any{"output": 42}, "running-config")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no text output")
+	})
+
+	t.Run("an empty body is an error", func(t *testing.T) {
+		// An EOS device never renders an empty configuration, so this is a
+		// failed read rather than a bare device.
+		for _, body := range []string{"", "   ", "\n\n"} {
+			_, err := configTextFromResponse(map[string]any{"output": body}, "startup-config")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "empty configuration")
+		}
+	})
+
+	t.Run("the error names which configuration failed", func(t *testing.T) {
+		_, err := configTextFromResponse(map[string]any{}, "startup-config")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "startup-config")
+	})
+}

--- a/providers/arista/resources/eos/integrity.go
+++ b/providers/arista/resources/eos/integrity.go
@@ -3,6 +3,8 @@
 
 package eos
 
+import "github.com/aristanetworks/goeapi"
+
 // Extension is one installed EOS extension.
 //
 // Extensions are RPM packages installed onto the switch, which is how
@@ -88,6 +90,8 @@ func (eos *Eos) BootConfig() (*showBootConfig, error) {
 }
 
 // StartupConfig returns the saved configuration the device loads on boot.
-func (eos *Eos) StartupConfig() string {
-	return eos.node.StartupConfig()
+// StartupConfig returns the configuration the device would come back with
+// after a reload. See RunningConfig for why the error is not discarded.
+func (eos *Eos) StartupConfig() (string, error) {
+	return configText(eos.node, goeapi.StartupConfig, "")
 }


### PR DESCRIPTION
## Problem

The eAPI client discards the error:

```go
func (n *Node) RunningConfig() string {
	if n.runningConfig != "" { return n.runningConfig }
	n.runningConfig, _ = n.getConfigText(RunningConfig, "all")   // error dropped
	return n.runningConfig
}
```

And nothing downstream had anywhere to put a failure either — `Eos.RunningConfig()` returned only a string, `fetchContent()` returned only a string, and `fetchRunningConfig`'s error return was structurally unreachable. So a permission gap on `show running-config`, an eAPI timeout, or an under-scoped account produced `""` with **no error**, and `contentFetched` then latched that empty answer for the rest of the scan.

**Every running-config-derived resource in this provider is a pure function of that string.** An empty one parses cleanly into:

| query | reports |
|---|---|
| `aaa.tacacsServerHosts` | `[]` |
| `logging.hosts` | `[]` |
| `aclBindings` | `[]` |
| `snmpCommunities` | `[]` |
| `eventHandlers` | `[]` |
| `dot1x.enabled` | `false` |
| `dhcpSnooping.enabled` | `false` |
| `telnetService.enabled` | `false` |
| `aaa.rootAccountEnabled` | `false` |

These are **explicit values, not nulls**, so a `{ !telnetService.enabled && aaa.rootAccountEnabled == false }` assertion *passes* on a device nothing was read from — and an explicit `false` reads as a measured fact, which is worse than a null. This is the widest-blast-radius defect in the provider: it degrades every parser-backed resource at once, with nothing to attribute the result to.

## Fix

- `Eos.RunningConfig()` / `StartupConfig()` return `(string, error)`, fetching through the client call that has an error return.
- Thread it through `fetchContent` and the memoized parsers (`fetchSnmpConfig`, `fetchSflowConfig`, `fetchInterfaceHardening`).
- **Cache the failure alongside the text**, so a failed read is not remembered as an empty configuration.
- **Reject an empty body outright.** An EOS device never renders an empty configuration, so an empty body is a failed read, not a bare device.
- Guard the response extraction with comma-ok rather than a bare assertion.

Two unreachable fallbacks this exposed are dropped: `mqlAristaEosRunningConfigSectionInternal.runningConfig` was never assigned anywhere, so the branch reading it always re-fetched the whole config; and the `mlag.interfaces` fallback duplicated the same call. (Removing the Internal struct needs the second `mqlr generate` pass — done, hence the one-line `.lr.go` diff.)

## Test plan

The change is mostly signature threading, verified by build and the existing suite. The new pure logic is the response guard, factored into `configTextFromResponse` and covered by `TestConfigTextFromResponse`:

- a body returned as-is
- no `output` key → error
- a non-string `output` → error, not a panic
- an empty or whitespace-only body → error naming "empty configuration"
- the error names which configuration failed

`go build ./...`, `go vet ./...` and `go test ./...` green in `providers/arista/`.

## Note

`configSavedToStartup` compares `show running-config all` against `show startup-config` — two different renderings — so it reports "not saved" on a correctly-saved device. Before this PR, if *both* fetches failed it compared `"" == ""` and returned **true**. That second half is fixed here (both now error); the command asymmetry is a separate PR.
