### PR TITLE
🐛 aws: report a real DynamoDB table identifier

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -13674,8 +13674,18 @@ private aws.dynamodb.table @defaults("name region") {
   name string
   // Region where the table exists
   region string
-  // Table ID
-  id string
+  // Table identifier
+  //
+  // Deprecated in favor of tableId. ListTables reports only table names, so
+  // this field was never populated from the listing and always read as empty.
+  id @maturity("deprecated") string
+  // Table identifier
+  //
+  // Unique identifier AWS assigns the table, for example
+  // 6c4ca0b9-bdde-43b7-b0fd-7c271c538b72. A table recreated under the same
+  // name gets a new identifier, so this distinguishes the current table from
+  // an earlier one that shared its name.
+  tableId() string
   // On-demand and system backups of the table
   //
   // Each entry carries BackupArn, BackupName, BackupCreationDateTime,

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -18563,6 +18563,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.dynamodb.table.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDynamodbTable).GetId()).ToDataRes(types.String)
 	},
+	"aws.dynamodb.table.tableId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsDynamodbTable).GetTableId()).ToDataRes(types.String)
+	},
 	"aws.dynamodb.table.backups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsDynamodbTable).GetBackups()).ToDataRes(types.Array(types.Dict))
 	},
@@ -56713,6 +56716,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.dynamodb.table.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsDynamodbTable).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.dynamodb.table.tableId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsDynamodbTable).TableId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.dynamodb.table.backups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -136965,6 +136972,7 @@ type mqlAwsDynamodbTable struct {
 	Name                       plugin.TValue[string]
 	Region                     plugin.TValue[string]
 	Id                         plugin.TValue[string]
+	TableId                    plugin.TValue[string]
 	Backups                    plugin.TValue[[]any]
 	SseDescription             plugin.TValue[any]
 	SseType                    plugin.TValue[string]
@@ -137053,6 +137061,12 @@ func (c *mqlAwsDynamodbTable) GetRegion() *plugin.TValue[string] {
 
 func (c *mqlAwsDynamodbTable) GetId() *plugin.TValue[string] {
 	return &c.Id
+}
+
+func (c *mqlAwsDynamodbTable) GetTableId() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.TableId, func() (string, error) {
+		return c.tableId()
+	})
 }
 
 func (c *mqlAwsDynamodbTable) GetBackups() *plugin.TValue[[]any] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3286,6 +3286,7 @@ aws.dynamodb.table.status 11.15.2
 aws.dynamodb.table.streamEnabled 11.16.1
 aws.dynamodb.table.streamViewType 11.16.1
 aws.dynamodb.table.tableClass 11.16.1
+aws.dynamodb.table.tableId 13.53.4
 aws.dynamodb.table.tags 11.15.2
 aws.dynamodb.table.ttlDescription 13.6.3
 aws.dynamodb.tables 11.15.2

--- a/providers/aws/resources/aws_dynamodb.go
+++ b/providers/aws/resources/aws_dynamodb.go
@@ -371,7 +371,7 @@ func initAwsDynamodbTable(runtime *plugin.Runtime, args map[string]*llx.RawData)
 				"arn":    llx.StringData(arnVal),
 				"name":   llx.StringData(tableName),
 				"region": llx.StringData(region),
-				"id":     llx.StringData(""),
+				"id":     llx.NilData,
 			})
 		if err != nil {
 			return nil, nil, err
@@ -619,7 +619,7 @@ func (a *mqlAwsDynamodb) getTables(conn *connection.AwsConnection) []*jobpool.Jo
 							"arn":    llx.StringData(fmt.Sprintf(dynamoTableArnPattern, region, conn.AccountId(), tableName)),
 							"name":   llx.StringData(tableName),
 							"region": llx.StringData(region),
-							"id":     llx.StringData(""),
+							"id":     llx.NilData,
 						})
 					if err != nil {
 						return nil, err
@@ -687,7 +687,7 @@ func (a *mqlAwsDynamodbTable) fetchDetail() error {
 	a.CreatedAt = plugin.TValue[*time.Time]{Data: table.Table.CreationDateTime, State: plugin.StateIsSet}
 	a.DeletionProtectionEnabled = plugin.TValue[bool]{Data: convert.ToValue(table.Table.DeletionProtectionEnabled), State: plugin.StateIsSet}
 	a.GlobalTableVersion = plugin.TValue[string]{Data: convert.ToValue(table.Table.GlobalTableVersion), State: plugin.StateIsSet}
-	a.Id = plugin.TValue[string]{Data: convert.ToValue(table.Table.TableId), State: plugin.StateIsSet}
+	a.TableId = plugin.TValue[string]{Data: convert.ToValue(table.Table.TableId), State: plugin.StateIsSet}
 	a.SizeBytes = plugin.TValue[int64]{Data: convert.ToValue(table.Table.TableSizeBytes), State: plugin.StateIsSet}
 	a.Status = plugin.TValue[string]{Data: string(table.Table.TableStatus), State: plugin.StateIsSet}
 	a.Items = plugin.TValue[int64]{Data: convert.ToValue(table.Table.ItemCount), State: plugin.StateIsSet}
@@ -1049,6 +1049,19 @@ func (a *mqlAwsDynamodbTable) pitrRecoveryPeriodInDays() (int64, error) {
 
 func (a *mqlAwsDynamodbGlobaltable) id() (string, error) {
 	return a.Arn.Data, nil
+}
+
+// tableId returns the identifier AWS assigns the table.
+//
+// ListTables reports only names, so the identifier costs a DescribeTable. The
+// old plain id field was set to "" at creation time and, because a plain field
+// is already StateIsSet, the runtime never called fetchDetail to replace it --
+// every table reported an empty identifier as though that were the value.
+func (a *mqlAwsDynamodbTable) tableId() (string, error) {
+	if err := a.fetchDetail(); err != nil {
+		return "", err
+	}
+	return a.TableId.Data, nil
 }
 
 func (a *mqlAwsDynamodbTable) id() (string, error) {


### PR DESCRIPTION
`aws.dynamodb.table.id` was pinned to the empty string in both creators — the listing path (`aws_dynamodb.go:622`) and the init path (`:374`):

```go
"id": llx.StringData(""),
```

`id` is a **plain** schema field, so `plugin.RawToTValue("")` stamps the empty string as a *resolved* value. `fetchDetail()` did assign the real `TableId` afterwards, but the runtime never called it — `GetOrCompute` short-circuits on a field that is already set. The assignment was dead code, and every table in every account reported an empty identifier as though that were the answer.

## Confirmed against a live account

A table whose real `TableId` is `6c4ca0b9-bdde-43b7-b0fd-7c271c538b72`:

```
aws.dynamodb.tables.where(name == "mondoo-audit-ddb") { name id }
→ id: ""

aws.dynamodb.tables.where(name == "mondoo-audit-ddb") { name status id }
→ id: ""     # even though resolving `status` runs fetchDetail
```

This is taxonomy class 0 — fabricated data that looks authoritative. The table identifier is what distinguishes a table from an earlier, deleted table that reused the same name, so an empty value quietly defeats exactly the comparison it exists for.

## Why `id` could not simply become computed

The obvious fix — declare `id() string` and back it with `fetchDetail()` — collides. `aws.dynamodb.table` already has a Go method:

```go
func (a *mqlAwsDynamodbTable) id() (string, error) { return a.Arn.Data, nil }
```

That method is the resource's **`__id` provider** (the generated constructor calls `id()` when `__id` is empty). A computed field named `id` would generate an accessor of the same name.

So this follows the deprecate-and-add rule in CLAUDE.md instead:

- `id` is marked `@maturity("deprecated")`, with the description leading `Deprecated in favor of tableId`.
- A computed `tableId()` carries the value, backed by the `DescribeTable` call `fetchDetail()` already makes — so it costs nothing extra for queries that already touch a detail field, and nothing at all for queries that do not ask for it.
- `.lr.versions` records `aws.dynamodb.table.tableId` at `13.53.4`, the next patch after the provider's current `13.53.3`. `aws.dynamodb.table.id` keeps its original `11.15.2` — deprecation does not bump the version.

## `""` → `null` on the deprecated field

The creators now pass `llx.NilData` rather than `""`. A table identifier costs a per-table `DescribeTable` that `ListTables` cannot supply, so on the listing path nothing has been read — and `null` says that, where `""` asserted a measured empty value.

After the fix, same table, same account:

```
{ name: "mondoo-audit-ddb", id: null, tableId: "6c4ca0b9-bdde-43b7-b0fd-7c271c538b72" }
```

## Tests

No unit test here: `tableId()` is a thin wrapper over the existing memoized `fetchDetail()`, which is one SDK call, so there is no pure-Go logic to assert that the API contract does not already assert. The behaviour is covered by the live verification above. The surrounding pure helpers this change touches nothing of (`tableClassFromSummary`, `streamEnabledFromSpec`, `billingModeFromSummary`) keep their existing coverage.

## Generated files

`aws.lr`, `aws.lr.go` and `aws.lr.versions` are regenerated. `aws.permissions.json` is unchanged (1038 permissions) — `DescribeTable` was already called.