### PR TITLE
🐛 gcp: give each GKE cluster its own network-policy cache key

### DIFF
--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -303,6 +303,11 @@ func (g *mqlGcpProjectGkeServiceClusterNodepoolConfig) bootDiskKmsKeyRef() (*mql
 	return newKmsCryptoKeyRef(g.MqlRuntime, &g.BootDiskKmsKeyRef, keyName.Data)
 }
 
+// gkeNetworkPolicyCacheKey scopes a cluster's network policy to that cluster.
+func gkeNetworkPolicyCacheKey(clusterId string) string {
+	return clusterId + "/networkPolicy"
+}
+
 func (g *mqlGcpProjectGkeServiceCluster) networkPolicy() (*mqlGcpProjectGkeServiceClusterNetworkPolicy, error) {
 	npConfig := g.cacheNetworkPolicyConfig
 	if npConfig == nil {
@@ -324,8 +329,15 @@ func (g *mqlGcpProjectGkeServiceCluster) networkPolicy() (*mqlGcpProjectGkeServi
 	}
 	clusterId := g.Id.Data
 
+	// The cache key has to be passed explicitly. This resource declares no
+	// id() method, so without an "__id" argument every cluster's network
+	// policy is stored under the same empty key, and CreateResource returns
+	// the first resource stored under a key -- so a cluster with network
+	// policy switched off reports the enabled neighbour's answer.
+	key := gkeNetworkPolicyCacheKey(clusterId)
 	res, err := CreateResource(g.MqlRuntime, "gcp.project.gkeService.cluster.networkPolicy", map[string]*llx.RawData{
-		"id":       llx.StringData(clusterId + "/networkPolicy"),
+		"__id":     llx.StringData(key),
+		"id":       llx.StringData(key),
 		"enabled":  llx.BoolData(enabled),
 		"provider": llx.StringData(provider),
 	})

--- a/providers/gcp/resources/gke_network_policy_test.go
+++ b/providers/gcp/resources/gke_network_policy_test.go
@@ -1,0 +1,77 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/utils/syncx"
+)
+
+// newNetworkPolicyTestCluster builds the minimum cluster resource
+// networkPolicy() reads: an id and the cached NetworkPolicy config the lister
+// stores on it.
+func newNetworkPolicyTestCluster(runtime *plugin.Runtime, clusterId string, enabled bool) *mqlGcpProjectGkeServiceCluster {
+	c := &mqlGcpProjectGkeServiceCluster{MqlRuntime: runtime}
+	c.Id = plugin.TValue[string]{Data: clusterId, State: plugin.StateIsSet}
+	c.cacheNetworkPolicyConfig = map[string]any{
+		"enabled":  enabled,
+		"provider": "CALICO",
+	}
+	return c
+}
+
+// TestGkeNetworkPolicyCacheKeyIsPerCluster pins the identity of a cluster's
+// network policy.
+//
+// gcp.project.gkeService.cluster.networkPolicy declares no id() method, so it
+// takes its cache key only from an explicit "__id" argument. Passing the value
+// as the public "id" field instead left __id empty for every cluster, and
+// CreateResource returns the FIRST resource stored under a key -- so on a
+// project with more than one cluster every cluster reported the first
+// cluster's network policy, and a cluster with network policy switched off
+// read as enabled.
+func TestGkeNetworkPolicyCacheKeyIsPerCluster(t *testing.T) {
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+
+	a := newNetworkPolicyTestCluster(runtime, "cluster-a", true)
+	b := newNetworkPolicyTestCluster(runtime, "cluster-b", false)
+
+	npA, err := a.networkPolicy()
+	require.NoError(t, err)
+	npB, err := b.networkPolicy()
+	require.NoError(t, err)
+
+	assert.NotEqual(t, npA.MqlID(), npB.MqlID(),
+		"two clusters must not share a network-policy cache key")
+	assert.Equal(t, "cluster-a/networkPolicy", npA.MqlID())
+	assert.Equal(t, "cluster-b/networkPolicy", npB.MqlID())
+
+	assert.True(t, npA.Enabled.Data, "cluster-a has network policy enabled")
+	assert.False(t, npB.Enabled.Data,
+		"cluster-b has network policy disabled and must not inherit cluster-a's answer")
+}
+
+// TestGkeNetworkPolicyNullWhenUnconfigured keeps the absent case distinguishable
+// from a disabled one: a cluster the API reports no NetworkPolicy for resolves
+// to null rather than to a fabricated "disabled" record.
+func TestGkeNetworkPolicyNullWhenUnconfigured(t *testing.T) {
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+
+	c := &mqlGcpProjectGkeServiceCluster{MqlRuntime: runtime}
+	c.Id = plugin.TValue[string]{Data: "cluster-c", State: plugin.StateIsSet}
+
+	np, err := c.networkPolicy()
+	require.NoError(t, err)
+	assert.Nil(t, np)
+	assert.Equal(t, plugin.StateIsNull|plugin.StateIsSet, c.NetworkPolicy.State)
+}
+
+func TestGkeNetworkPolicyCacheKey(t *testing.T) {
+	assert.Equal(t, "abc/networkPolicy", gkeNetworkPolicyCacheKey("abc"))
+}


### PR DESCRIPTION
## The bug

`gcp.project.gkeService.cluster.networkPolicy` declares no `id()` method, so it takes its cache key only from an explicit `"__id"` argument. `networkPolicy()` passed the parent-qualified value as the public **`id` field** instead, which sets the field and leaves `__id` empty.

The runtime keys its resource cache on `resourceName + "\x00" + __id`, and `CreateResource` returns the first resource already stored under a key. With `__id` empty for every cluster, **the first cluster's network policy was returned for all of them.** On a project with more than one GKE cluster, a cluster with network policy switched off reported the enabled neighbour's answer, with no error.

That is the dangerous direction for this field: a posture check for `networkPolicy.enabled` passes on a cluster that was never actually checked.

## Confirmed live

Two GKE clusters in one project, both with `--enable-network-policy` so the difference shows in the object identity:

**Before**

```
0: { name: "mql-np-a", id: "2106f24b…", networkPolicy: { id: "2106f24b…/networkPolicy" } }
1: { name: "mql-np-b", id: "ec3b7cd4…", networkPolicy: { id: "2106f24b…/networkPolicy" } }
```

`mql-np-b` is reporting `mql-np-a`'s object.

**After**

```
0: { name: "mql-np-a", id: "2106f24b…", networkPolicy: { id: "2106f24b…/networkPolicy" } }
1: { name: "mql-np-b", id: "ec3b7cd4…", networkPolicy: { id: "ec3b7cd4…/networkPolicy" } }
```

## Test

The regression test pins the consequence rather than the string: it drives `networkPolicy()` on two clusters with different settings and asserts the disabled one does not inherit the enabled one's value. Removing the `"__id"` argument makes it fail on exactly that assertion (`cluster-b has network policy disabled and must not inherit cluster-a's answer`).

A second test keeps the absent case distinguishable from a disabled one: a cluster the API reports no `NetworkPolicy` for still resolves to null, not to a fabricated "disabled" record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
