### PR TITLE
🐛 gcp: request the scope the IAM API accepts for federated pools

### DIFF
--- a/providers/gcp/resources/iam_scope_guard_test.go
+++ b/providers/gcp/resources/iam_scope_guard_test.go
@@ -1,0 +1,94 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestIamServiceUsesFullCloudPlatformScope pins the OAuth scope every
+// iam.googleapis.com call in this package is built with.
+//
+// Most Google APIs accept https://www.googleapis.com/auth/cloud-platform.read-only,
+// and this provider reaches for it by default because it is a read-only tool.
+// The IAM API does not: its reference lists cloud-platform as the ONLY accepted
+// scope for the workload-identity and workforce pool methods, and a read-only
+// token is rejected with
+//
+//	Error 403: Request had insufficient authentication scopes.
+//	reason = ACCESS_TOKEN_SCOPE_INSUFFICIENT
+//
+// The rejection happens in the token check, before any IAM permission is
+// consulted, so granting roles does not fix it and the failure looks like a
+// permission gap. Verified against a live project: the same list call returns
+// the pools under cloud-platform and 403s under cloud-platform.read-only.
+//
+// gcp.project.iamService.workloadIdentityPools (and its providers) and
+// gcp.organization.workforcePools (and its providers) all failed this way on
+// every scan authenticated with a service-account key -- the entire federated
+// trust surface, which is exactly the data a "who can assume an identity in
+// this project from outside it" audit reads.
+func TestIamServiceUsesFullCloudPlatformScope(t *testing.T) {
+	paths, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob package sources: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	checked := 0
+
+	for _, path := range paths {
+		if strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, ".lr.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			fn, ok := n.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				return true
+			}
+			body := render(fset, fn.Body)
+			if !strings.Contains(body, "iam.NewService(") {
+				return true
+			}
+			checked++
+			for _, line := range strings.Split(body, "\n") {
+				if !strings.Contains(line, "conn.Client(") {
+					continue
+				}
+				if strings.Contains(line, "CloudPlatformScope") {
+					continue
+				}
+				t.Errorf("%s: %s builds an iam.googleapis.com service from %s\n"+
+					"the IAM API accepts only cloud-platform; a read-only token is rejected with "+
+					"ACCESS_TOKEN_SCOPE_INSUFFICIENT before permissions are checked",
+					fset.Position(fn.Pos()), fn.Name.Name, strings.TrimSpace(line))
+			}
+			return true
+		})
+	}
+
+	if checked == 0 {
+		t.Fatal("no iam.NewService call sites found; this guard has stopped guarding anything")
+	}
+}
+
+func render(fset *token.FileSet, n ast.Node) string {
+	var b bytes.Buffer
+	if err := printer.Fprint(&b, fset, n); err != nil {
+		return ""
+	}
+	return b.String()
+}

--- a/providers/gcp/resources/iam_scope_guard_test.go
+++ b/providers/gcp/resources/iam_scope_guard_test.go
@@ -10,8 +10,13 @@ import (
 	"go/printer"
 	"go/token"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/cloudresourcemanager/v3"
+	"google.golang.org/api/iam/v1"
 )
 
 // TestIamServiceUsesFullCloudPlatformScope pins the OAuth scope every
@@ -36,6 +41,47 @@ import (
 // every scan authenticated with a service-account key -- the entire federated
 // trust surface, which is exactly the data a "who can assume an identity in
 // this project from outside it" audit reads.
+// fullScopeConstant matches a package-qualified reference to the SDK's
+// CloudPlatformScope constant.
+//
+// The trailing boundary is what makes this a token match rather than a
+// substring one: `CloudPlatformReadOnlyScope` never matched, but a constant
+// named `CloudPlatformScopeReadOnly` would have satisfied a plain
+// strings.Contains and been accepted as the full scope. No such constant
+// exists in google.golang.org/api today; this keeps the guard honest if one
+// ever appears.
+//
+// The package qualifier is deliberately left open. Every generated package
+// spells this constant identically and gives it the same value, and the
+// provider legitimately reaches for whichever one is already imported --
+// iam.CloudPlatformScope, compute.CloudPlatformScope,
+// sqladmin.CloudPlatformScope. Requiring `iam.` specifically would reject
+// call sites that are already correct. TestCloudPlatformScopeConstants pins
+// the values, which is the property the match actually stands in for.
+var fullScopeConstant = regexp.MustCompile(`\.CloudPlatformScope\b`)
+
+// TestCloudPlatformScopeConstants pins the two constant values the guard above
+// reasons about.
+//
+// That guard matches on a NAME, which is only meaningful while the name still
+// carries the value it does today. If the SDK renamed these, or gave
+// CloudPlatformScope the read-only URL, the guard would keep passing while
+// checking nothing -- the vacuous-pass failure mode. Assert the values.
+func TestCloudPlatformScopeConstants(t *testing.T) {
+	assert.Equal(t, "https://www.googleapis.com/auth/cloud-platform", iam.CloudPlatformScope,
+		"the guard treats CloudPlatformScope as the full cloud-platform scope")
+	assert.Equal(t, "https://www.googleapis.com/auth/cloud-platform", cloudresourcemanager.CloudPlatformScope,
+		"every generated package spells the full scope the same way, which is why the guard does not pin a package")
+	assert.NotEqual(t, iam.CloudPlatformScope, cloudresourcemanager.CloudPlatformReadOnlyScope,
+		"the read-only scope must stay distinguishable from the one the IAM API accepts")
+	assert.False(t, fullScopeConstant.MatchString("cloudresourcemanager.CloudPlatformReadOnlyScope"),
+		"the read-only constant must not satisfy the guard")
+	assert.False(t, fullScopeConstant.MatchString("iam.CloudPlatformScopeReadOnly"),
+		"a suffixed constant must not satisfy the guard by substring")
+	assert.True(t, fullScopeConstant.MatchString("iam.CloudPlatformScope"))
+	assert.True(t, fullScopeConstant.MatchString("sqladmin.CloudPlatformScope, iam.CloudPlatformScope"))
+}
+
 func TestIamServiceUsesFullCloudPlatformScope(t *testing.T) {
 	paths, err := filepath.Glob("*.go")
 	if err != nil {
@@ -68,7 +114,7 @@ func TestIamServiceUsesFullCloudPlatformScope(t *testing.T) {
 				if !strings.Contains(line, "conn.Client(") {
 					continue
 				}
-				if strings.Contains(line, "CloudPlatformScope") {
+				if fullScopeConstant.MatchString(line) {
 					continue
 				}
 				t.Errorf("%s: %s builds an iam.googleapis.com service from %s\n"+

--- a/providers/gcp/resources/iam_workforce.go
+++ b/providers/gcp/resources/iam_workforce.go
@@ -13,7 +13,6 @@ import (
 	"go.mondoo.com/mql/providers/gcp/connection"
 	"go.mondoo.com/mql/types"
 
-	"google.golang.org/api/cloudresourcemanager/v3"
 	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/option"
 )
@@ -25,7 +24,12 @@ func (g *mqlGcpOrganization) workforcePools() ([]any, error) {
 		return nil, err
 	}
 
-	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope)
+	// iam.CloudPlatformScope, not the cloud-platform.read-only variant the rest
+	// of this provider defaults to: the IAM API lists cloud-platform as the only
+	// accepted scope for the workload-identity and workforce pool methods, and a
+	// read-only token is rejected with ACCESS_TOKEN_SCOPE_INSUFFICIENT before
+	// any IAM permission is consulted -- so no amount of role granting fixes it.
+	client, err := conn.Client(iam.CloudPlatformScope)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +106,12 @@ func (g *mqlGcpOrganizationWorkforcePool) providers() ([]any, error) {
 	}
 
 	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
-	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope)
+	// iam.CloudPlatformScope, not the cloud-platform.read-only variant the rest
+	// of this provider defaults to: the IAM API lists cloud-platform as the only
+	// accepted scope for the workload-identity and workforce pool methods, and a
+	// read-only token is rejected with ACCESS_TOKEN_SCOPE_INSUFFICIENT before
+	// any IAM permission is consulted -- so no amount of role granting fixes it.
+	client, err := conn.Client(iam.CloudPlatformScope)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/iam_workload_identity.go
+++ b/providers/gcp/resources/iam_workload_identity.go
@@ -16,7 +16,6 @@ import (
 	"go.mondoo.com/mql/providers/gcp/connection"
 	"go.mondoo.com/mql/types"
 
-	"google.golang.org/api/cloudresourcemanager/v3"
 	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/option"
 )
@@ -44,7 +43,12 @@ func (g *mqlGcpProjectIamService) workloadIdentityPools() ([]any, error) {
 	projectId := g.ProjectId.Data
 
 	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
-	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope)
+	// iam.CloudPlatformScope, not the cloud-platform.read-only variant the rest
+	// of this provider defaults to: the IAM API lists cloud-platform as the only
+	// accepted scope for the workload-identity and workforce pool methods, and a
+	// read-only token is rejected with ACCESS_TOKEN_SCOPE_INSUFFICIENT before
+	// any IAM permission is consulted -- so no amount of role granting fixes it.
+	client, err := conn.Client(iam.CloudPlatformScope)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +201,12 @@ func (g *mqlGcpProjectIamServiceWorkloadIdentityPool) providers() ([]any, error)
 	poolId := g.PoolId.Data
 
 	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
-	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope)
+	// iam.CloudPlatformScope, not the cloud-platform.read-only variant the rest
+	// of this provider defaults to: the IAM API lists cloud-platform as the only
+	// accepted scope for the workload-identity and workforce pool methods, and a
+	// read-only token is rejected with ACCESS_TOKEN_SCOPE_INSUFFICIENT before
+	// any IAM permission is consulted -- so no amount of role granting fixes it.
+	client, err := conn.Client(iam.CloudPlatformScope)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## The bug

Every workload-identity and workforce pool listing built its IAM client from `cloud-platform.read-only`:

```go
client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope)
...
iamSvc, err := iam.NewService(ctx, option.WithHTTPClient(client))
```

The IAM API does not accept that scope. Its reference lists `cloud-platform` as the **only** accepted scope for these methods, and a read-only token is rejected in the token check — before any IAM permission is consulted:

```
Error 403: Request had insufficient authentication scopes.
reason = ACCESS_TOKEN_SCOPE_INSUFFICIENT
method = google.iam.v1.WorkloadIdentityPools.ListWorkloadIdentityPools
```

So all four collections failed on **every** scan authenticated with a service-account key:

- `gcp.project.iamService.workloadIdentityPools`
- `gcp.project.iamService.workloadIdentityPool.providers`
- `gcp.organization.workforcePools`
- `gcp.organization.workforcePool.providers`

That is the entire federated trust surface — exactly what a "who can assume an identity in this project from outside it" audit reads. Granting roles does not help, and because the failure is a 403 it reads as a permission gap rather than pointing at the scope.

## Confirmed live

The same list call against a live project under each scope:

```
scope=…/auth/cloud-platform.read-only   FAIL 403 ACCESS_TOKEN_SCOPE_INSUFFICIENT
scope=…/auth/cloud-platform             OK   pools=1
```

Before the fix, `gcp.project.iam.workloadIdentityPools` returned the 403. After:

```
gcp.project.iam.workloadIdentityPools: [
  0: { poolId: "tim-learning-project.svc.id.goog", state: "ACTIVE", disabled: false }
]
```

## Why this went unnoticed

Google ADC user credentials carry a fixed scope set that already includes `cloud-platform`, so the requested scope is effectively ignored on that path. The failure only appears under the documented production path — `--credentials-path <SERVICE-ACCT>`.

## Test

`TestIamServiceUsesFullCloudPlatformScope` walks the package and fails any function that builds an `iam.googleapis.com` service from a client that did not request `CloudPlatformScope`, so a new IAM call site cannot reintroduce it. It also fails if the call sites disappear, rather than passing vacuously.
