### PR TITLE
🐛 gcp: resolve serialPortEnabled the way Compute Engine resolves it

### DIFF
--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -4257,6 +4257,35 @@ func (g *mqlGcpProjectComputeServiceInstance) osLoginEnabled() (bool, error) {
 	if _, set := md.Data["enable-oslogin"]; set {
 		return metadataBoolFlag(md.Data, "enable-oslogin"), nil
 	}
+	return g.projectMetadataFlag("enable-oslogin")
+}
+
+// serialPortEnabled reports whether interactive serial console access is
+// enabled for this instance, which is what an audit of the control needs to
+// know.
+//
+// Compute Engine resolves the setting the same way it resolves OS Login: the
+// instance's own serial-port-enable metadata wins, and an instance that does
+// not set the key inherits the project's commonInstanceMetadata value. Reading
+// only the instance metadata therefore reported false for every VM in a
+// project that had switched serial console access on project-wide -- the exact
+// case the control exists to catch, and one where a false answer is
+// indistinguishable from a VM that genuinely has it off.
+func (g *mqlGcpProjectComputeServiceInstance) serialPortEnabled() (bool, error) {
+	md := g.GetMetadata()
+	if md.Error != nil {
+		return false, md.Error
+	}
+	if _, set := md.Data["serial-port-enable"]; set {
+		return metadataBoolFlag(md.Data, "serial-port-enable"), nil
+	}
+	return g.projectMetadataFlag("serial-port-enable")
+}
+
+// projectMetadataFlag reads a boolean key from the project's
+// commonInstanceMetadata, for the instance-level accessors whose setting falls
+// back to the project when the instance does not set it.
+func (g *mqlGcpProjectComputeServiceInstance) projectMetadataFlag(key string) (bool, error) {
 	if g.ProjectId.Error != nil {
 		return false, g.ProjectId.Error
 	}
@@ -4270,23 +4299,14 @@ func (g *mqlGcpProjectComputeServiceInstance) osLoginEnabled() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	proj := projRes.(*mqlGcpProject)
-	projMd := proj.GetCommonInstanceMetadata()
+	projMd := projRes.(*mqlGcpProject).GetCommonInstanceMetadata()
 	if projMd.Error != nil {
 		return false, projMd.Error
 	}
 	if projMd.Data == nil {
 		return false, nil
 	}
-	return metadataBoolFlag(projMd.Data, "enable-oslogin"), nil
-}
-
-func (g *mqlGcpProjectComputeServiceInstance) serialPortEnabled() (bool, error) {
-	md := g.GetMetadata()
-	if md.Error != nil {
-		return false, md.Error
-	}
-	return metadataBoolFlag(md.Data, "serial-port-enable"), nil
+	return metadataBoolFlag(projMd.Data, key), nil
 }
 
 func (g *mqlGcpProjectComputeService) projectMetadataFlag(key string) (bool, error) {

--- a/providers/gcp/resources/compute_metadata_flags_test.go
+++ b/providers/gcp/resources/compute_metadata_flags_test.go
@@ -1,0 +1,116 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+func TestMetadataBoolFlag(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		md   map[string]any
+		key  string
+		want bool
+	}{
+		{name: "absent key", md: map[string]any{}, key: "serial-port-enable"},
+		{name: "nil map", md: nil, key: "serial-port-enable"},
+		{name: "TRUE", md: map[string]any{"serial-port-enable": "TRUE"}, key: "serial-port-enable", want: true},
+		{name: "true", md: map[string]any{"serial-port-enable": "true"}, key: "serial-port-enable", want: true},
+		{name: "1", md: map[string]any{"serial-port-enable": "1"}, key: "serial-port-enable", want: true},
+		{name: "FALSE", md: map[string]any{"serial-port-enable": "FALSE"}, key: "serial-port-enable"},
+		{name: "0", md: map[string]any{"serial-port-enable": "0"}, key: "serial-port-enable"},
+		{name: "empty string", md: map[string]any{"serial-port-enable": ""}, key: "serial-port-enable"},
+		{name: "non-string value", md: map[string]any{"serial-port-enable": true}, key: "serial-port-enable"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, metadataBoolFlag(tc.md, tc.key))
+		})
+	}
+}
+
+// seedProjectMetadataEndpoints serves the two calls the project-metadata
+// fallback makes: initGcpProject's Cloud Resource Manager get, and the Compute
+// projects.get that carries commonInstanceMetadata.
+func seedProjectMetadataEndpoints(t *testing.T, env *testEnv, items string) {
+	t.Helper()
+	seedProjectEndpoint(t, env)
+	env.Mux.HandleFunc("/compute/v1/projects/"+testProjectId, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"name": %q, "commonInstanceMetadata": {"items": [%s]}}`, testProjectId, items)
+	})
+}
+
+func newMetadataTestInstance(env *testEnv, md map[string]any) *mqlGcpProjectComputeServiceInstance {
+	i := &mqlGcpProjectComputeServiceInstance{MqlRuntime: env.Runtime}
+	i.ProjectId = plugin.TValue[string]{Data: testProjectId, State: plugin.StateIsSet}
+	i.Metadata = plugin.TValue[map[string]any]{Data: md, State: plugin.StateIsSet}
+	return i
+}
+
+// TestSerialPortEnabledInheritsProjectMetadata pins how Compute Engine resolves
+// interactive serial console access: the instance's own serial-port-enable
+// metadata wins, and an instance that does not set the key inherits the
+// project's commonInstanceMetadata value.
+//
+// Reading only the instance metadata reported false for every VM in a project
+// that had switched serial console access on project-wide -- exactly the case
+// the control exists to catch, and a false there is indistinguishable from a
+// VM that genuinely has it off. Confirmed against a live project: with
+// serial-port-enable=TRUE set project-wide and no instance metadata, the VM
+// read false while gcp.project.compute.projectSerialPortEnabled read true.
+func TestSerialPortEnabledInheritsProjectMetadata(t *testing.T) {
+	t.Run("inherits the project value when the instance does not set it", func(t *testing.T) {
+		env := setupTestEnv(t, projectScopes())
+		seedProjectMetadataEndpoints(t, env, `{"key": "serial-port-enable", "value": "TRUE"}`)
+
+		got, err := newMetadataTestInstance(env, map[string]any{}).serialPortEnabled()
+		require.NoError(t, err)
+		assert.True(t, got, "the project enables serial console access for every VM that does not opt out")
+	})
+
+	t.Run("instance metadata overrides the project", func(t *testing.T) {
+		env := setupTestEnv(t, projectScopes())
+		seedProjectMetadataEndpoints(t, env, `{"key": "serial-port-enable", "value": "TRUE"}`)
+
+		md := map[string]any{"serial-port-enable": "FALSE"}
+		got, err := newMetadataTestInstance(env, md).serialPortEnabled()
+		require.NoError(t, err)
+		assert.False(t, got, "an explicit instance value wins over the project default")
+	})
+
+	t.Run("false when neither sets it", func(t *testing.T) {
+		env := setupTestEnv(t, projectScopes())
+		seedProjectMetadataEndpoints(t, env, "")
+
+		got, err := newMetadataTestInstance(env, map[string]any{}).serialPortEnabled()
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+}
+
+// TestOsLoginEnabledInheritsProjectMetadata keeps the sibling accessor pinned:
+// serialPortEnabled and osLoginEnabled now share projectMetadataFlag, so a
+// change to one must not silently change the other.
+func TestOsLoginEnabledInheritsProjectMetadata(t *testing.T) {
+	env := setupTestEnv(t, projectScopes())
+	seedProjectMetadataEndpoints(t, env, `{"key": "enable-oslogin", "value": "TRUE"}`)
+
+	got, err := newMetadataTestInstance(env, map[string]any{}).osLoginEnabled()
+	require.NoError(t, err)
+	assert.True(t, got)
+
+	env2 := setupTestEnv(t, projectScopes())
+	seedProjectMetadataEndpoints(t, env2, `{"key": "enable-oslogin", "value": "TRUE"}`)
+	got, err = newMetadataTestInstance(env2, map[string]any{"enable-oslogin": "FALSE"}).osLoginEnabled()
+	require.NoError(t, err)
+	assert.False(t, got)
+}

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1781,7 +1781,11 @@ gcp.project.computeService.instance @defaults("name id") {
   // raw `publicKey`, and any trailing `comment`. Empty when no
   // instance-level keys are set; these grant access outside OS Login.
   instanceSshKeys() []dict
-  // Whether instance metadata 'serial-port-enable' is set to true (interactive serial console)
+  // Whether interactive serial console access is enabled on this instance
+  //
+  // Reads the instance metadata `serial-port-enable`, falling back to the
+  // project `commonInstanceMetadata` value when the instance does not set it,
+  // which is how Compute Engine itself resolves the setting.
   serialPortEnabled() bool
   // Private IPv6 google access type for the VM
   privateIpv6GoogleAccess string


### PR DESCRIPTION
## The bug

Compute Engine resolves interactive serial console access from two places: the instance's own `serial-port-enable` metadata wins, and an instance that does not set the key **inherits the project's `commonInstanceMetadata` value**.

`serialPortEnabled` read only the instance metadata. Every VM in a project that had switched serial console access on project-wide therefore reported `false` — the exact case the control exists to catch, and a `false` there is indistinguishable from a VM that genuinely has it off.

`osLoginEnabled` already had the project fallback and documented it. The two accessors now share one `projectMetadataFlag` helper, so they cannot drift apart again.

## Confirmed live

A `e2-micro` with no instance metadata, in a project with `serial-port-enable=TRUE` set project-wide:

| | `serialPortEnabled` | `projectSerialPortEnabled` |
|---|---|---|
| before | `false` | `true` |
| after | `true` | `true` |

Then adding `serial-port-enable=FALSE` to the instance:

```
metadata: { serial-port-enable: "FALSE" }
serialPortEnabled: false
projectSerialPortEnabled: true
```

so the instance still overrides the project, which is the other half of the semantics.

## Scope of the change

This changes what a shipped field answers, from "does this instance set the key" to "is serial console access enabled on this instance". That is the question the field name asks and the one an audit needs; the previous answer was not usable for either. `gcp.project.computeService.projectSerialPortEnabled` is unchanged and still answers the project-only question for anyone who wants it. The field doc now states the resolution order.

## Tests

- `TestMetadataBoolFlag` — table test over `TRUE`/`true`/`1`/`FALSE`/`0`/empty/absent/non-string.
- `TestSerialPortEnabledInheritsProjectMetadata` — inherits, overrides, and neither-set, driven through the HTTP test harness.
- `TestOsLoginEnabledInheritsProjectMetadata` — pins the sibling, now that both share a code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
