### PR TITLE
🐛 gcp: stop init functions returning husks, panicking, or caching stubs

### DIFF
--- a/providers/gcp/resources/apikeys.go
+++ b/providers/gcp/resources/apikeys.go
@@ -290,7 +290,13 @@ func initGcpProjectApiKey(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return nil, nil, errors.New("gcp.project.apiKey requires a \"projectId\" argument")
 	}
 
-	obj, err := CreateResource(runtime, "gcp.project", map[string]*llx.RawData{
+	// NewResource, not CreateResource: CreateResource would cache a gcp.project
+	// carrying nothing but an id, and initGcpProject returns whatever is already
+	// cached -- so that husk would win for every later caller, and its name,
+	// state, parentId, labels, createTime and number are computed fields
+	// implemented as placeholders that only ever return "not implemented".
+	// servicegate.go spells out the same reasoning for the enablement lookup.
+	obj, err := NewResource(runtime, "gcp.project", map[string]*llx.RawData{
 		"id": args["projectId"],
 	})
 	if err != nil {

--- a/providers/gcp/resources/certificatemanager.go
+++ b/providers/gcp/resources/certificatemanager.go
@@ -718,7 +718,7 @@ func initGcpProjectCertificateManagerServiceCertificate(runtime *plugin.Runtime,
 	}
 	resourcePathRaw, ok := args["resourcePath"]
 	if !ok || resourcePathRaw == nil || resourcePathRaw.Value == nil || resourcePathRaw.Value.(string) == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.certificateManagerService.certificate requires a non-empty "resourcePath" argument`)
 	}
 	resourcePath := resourcePathRaw.Value.(string)
 
@@ -770,7 +770,7 @@ func initGcpProjectCertificateManagerServiceDnsAuthorization(runtime *plugin.Run
 	}
 	resourcePathRaw, ok := args["resourcePath"]
 	if !ok || resourcePathRaw == nil || resourcePathRaw.Value == nil || resourcePathRaw.Value.(string) == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.certificateManagerService.dnsAuthorization requires a non-empty "resourcePath" argument`)
 	}
 	resourcePath := resourcePathRaw.Value.(string)
 
@@ -839,7 +839,7 @@ func initGcpProjectCertificateManagerServiceCertificateIssuanceConfig(runtime *p
 	}
 	resourcePathRaw, ok := args["resourcePath"]
 	if !ok || resourcePathRaw == nil || resourcePathRaw.Value == nil || resourcePathRaw.Value.(string) == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.certificateManagerService.certificateIssuanceConfig requires a non-empty "resourcePath" argument`)
 	}
 	resourcePath := resourcePathRaw.Value.(string)
 

--- a/providers/gcp/resources/certificatemanager.go
+++ b/providers/gcp/resources/certificatemanager.go
@@ -717,10 +717,13 @@ func initGcpProjectCertificateManagerServiceCertificate(runtime *plugin.Runtime,
 		return args, nil, nil
 	}
 	resourcePathRaw, ok := args["resourcePath"]
-	if !ok || resourcePathRaw == nil || resourcePathRaw.Value == nil || resourcePathRaw.Value.(string) == "" {
+	if !ok || resourcePathRaw == nil {
+		return nil, nil, errors.New(`gcp.project.certificateManagerService.certificate requires a "resourcePath" argument`)
+	}
+	resourcePath, ok := resourcePathRaw.Value.(string)
+	if !ok || resourcePath == "" {
 		return nil, nil, errors.New(`gcp.project.certificateManagerService.certificate requires a non-empty "resourcePath" argument`)
 	}
-	resourcePath := resourcePathRaw.Value.(string)
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)
 	if !ok {
@@ -769,10 +772,13 @@ func initGcpProjectCertificateManagerServiceDnsAuthorization(runtime *plugin.Run
 		return args, nil, nil
 	}
 	resourcePathRaw, ok := args["resourcePath"]
-	if !ok || resourcePathRaw == nil || resourcePathRaw.Value == nil || resourcePathRaw.Value.(string) == "" {
+	if !ok || resourcePathRaw == nil {
+		return nil, nil, errors.New(`gcp.project.certificateManagerService.dnsAuthorization requires a "resourcePath" argument`)
+	}
+	resourcePath, ok := resourcePathRaw.Value.(string)
+	if !ok || resourcePath == "" {
 		return nil, nil, errors.New(`gcp.project.certificateManagerService.dnsAuthorization requires a non-empty "resourcePath" argument`)
 	}
-	resourcePath := resourcePathRaw.Value.(string)
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)
 	if !ok {
@@ -838,10 +844,13 @@ func initGcpProjectCertificateManagerServiceCertificateIssuanceConfig(runtime *p
 		return args, nil, nil
 	}
 	resourcePathRaw, ok := args["resourcePath"]
-	if !ok || resourcePathRaw == nil || resourcePathRaw.Value == nil || resourcePathRaw.Value.(string) == "" {
+	if !ok || resourcePathRaw == nil {
+		return nil, nil, errors.New(`gcp.project.certificateManagerService.certificateIssuanceConfig requires a "resourcePath" argument`)
+	}
+	resourcePath, ok := resourcePathRaw.Value.(string)
+	if !ok || resourcePath == "" {
 		return nil, nil, errors.New(`gcp.project.certificateManagerService.certificateIssuanceConfig requires a non-empty "resourcePath" argument`)
 	}
-	resourcePath := resourcePathRaw.Value.(string)
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)
 	if !ok {

--- a/providers/gcp/resources/cloud_functions.go
+++ b/providers/gcp/resources/cloud_functions.go
@@ -459,7 +459,13 @@ func initGcpProjectCloudFunction(runtime *plugin.Runtime, args map[string]*llx.R
 		return nil, nil, errors.New("gcp.project.cloudFunction requires a \"projectId\" argument")
 	}
 
-	obj, err := CreateResource(runtime, "gcp.project", map[string]*llx.RawData{
+	// NewResource, not CreateResource: CreateResource would cache a gcp.project
+	// carrying nothing but an id, and initGcpProject returns whatever is already
+	// cached -- so that husk would win for every later caller, and its name,
+	// state, parentId, labels, createTime and number are computed fields
+	// implemented as placeholders that only ever return "not implemented".
+	// servicegate.go spells out the same reasoning for the enablement lookup.
+	obj, err := NewResource(runtime, "gcp.project", map[string]*llx.RawData{
 		"id": args["projectId"],
 	})
 	if err != nil {

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -159,23 +159,35 @@ func initGcpProjectComputeServiceRegion(runtime *plugin.Runtime, args map[string
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
 
-	if pid, ok := args["projectId"]; !ok || pid == nil {
-		args["projectId"] = llx.StringData(conn.ResourceID())
+	// projectId scopes the lookup but is not a field on this resource, so it has
+	// to be consumed here. Leaving it in args reaches SetAllData on any path
+	// that returns without a resource, which rejects it as an unknown field --
+	// a bare `gcp.project.computeService.region` then fails with
+	// "cannot set 'projectId' ... field not found" instead of resolving.
+	projectId := conn.ResourceID()
+	if pid := args["projectId"]; pid != nil {
+		if v, ok := pid.Value.(string); ok && v != "" {
+			projectId = v
+		}
 	}
+	delete(args, "projectId")
 
 	// When the caller passes a name, fetch the single region directly via
 	// Regions.Get rather than relying on a downstream regions() scan. This
 	// makes `NewResource("...region", {name, projectId})` cheap for typed
 	// references (e.g. instance.region()) when regions() has not been listed.
+	// Without a name there is nothing to look up. Returning an empty resource
+	// here would hand the runtime a husk whose every field is unset, which
+	// surfaces as "encountered a primitive with no type information" with
+	// nothing naming the cause; say what is missing instead.
 	nameArg, hasName := args["name"]
 	if !hasName || nameArg == nil {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.computeService.region requires a "name" argument`)
 	}
 	name, ok := nameArg.Value.(string)
 	if !ok || name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.computeService.region requires a non-empty "name" argument`)
 	}
-	projectId, _ := args["projectId"].Value.(string)
 
 	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope, compute.ComputeReadonlyScope)
 	if err != nil {
@@ -206,19 +218,28 @@ func initGcpProjectComputeServiceZone(runtime *plugin.Runtime, args map[string]*
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
 
-	if pid, ok := args["projectId"]; !ok || pid == nil {
-		args["projectId"] = llx.StringData(conn.ResourceID())
+	// projectId scopes the lookup but is not a field on this resource. See
+	// initGcpProjectComputeServiceRegion for why it must not survive into args.
+	projectId := conn.ResourceID()
+	if pid := args["projectId"]; pid != nil {
+		if v, ok := pid.Value.(string); ok && v != "" {
+			projectId = v
+		}
 	}
+	delete(args, "projectId")
 
+	// Without a name there is nothing to look up. Returning an empty resource
+	// here would hand the runtime a husk whose every field is unset, which
+	// surfaces as "encountered a primitive with no type information" with
+	// nothing naming the cause; say what is missing instead.
 	nameArg, hasName := args["name"]
 	if !hasName || nameArg == nil {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.computeService.zone requires a "name" argument`)
 	}
 	name, ok := nameArg.Value.(string)
 	if !ok || name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.computeService.zone requires a non-empty "name" argument`)
 	}
-	projectId, _ := args["projectId"].Value.(string)
 
 	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope, compute.ComputeReadonlyScope)
 	if err != nil {

--- a/providers/gcp/resources/compute_region_zone_init_test.go
+++ b/providers/gcp/resources/compute_region_zone_init_test.go
@@ -120,6 +120,7 @@ var huskProneInits = map[string]string{
 	"gcp.project.certificateManagerService.dnsAuthorization":          "resourcePath",
 	"gcp.project.certificateManagerService.certificateIssuanceConfig": "resourcePath",
 	"gcp.project.kmsService.keyring.cryptokey":                        "resourcePath",
+	"gcp.project.documentaiService.processor.version":                 "name",
 }
 
 // TestInitsSurviveANullSelectorArgument pins the arg-reading guards.
@@ -171,6 +172,8 @@ func TestInitsRejectAnUnusableSelector(t *testing.T) {
 		}{
 			{"no selector argument", map[string]*llx.RawData{"projectId": llx.StringData(testProjectId)}},
 			{"empty selector argument", map[string]*llx.RawData{selector: llx.StringData("")}},
+			{"nil selector argument", map[string]*llx.RawData{selector: nil}},
+			{"wrong-typed selector argument", map[string]*llx.RawData{selector: llx.IntData(7)}},
 		} {
 			t.Run(resource+"/"+tc.title, func(t *testing.T) {
 				env := setupTestEnv(t, regionZoneScopes(), projectScopes())
@@ -180,5 +183,38 @@ func TestInitsRejectAnUnusableSelector(t *testing.T) {
 					"the error should name the argument that is missing")
 			})
 		}
+	}
+}
+
+// TestGcpServiceRejectsAnUnusableProjectId covers the one argument in this set
+// that selects nothing but is still dereferenced.
+//
+// gcp.service reads args["projectId"] on its own, outside the selector table
+// above, and only guarded it against being absent. A caller that supplies the
+// key with a null or non-string value got past that guard and into a bare type
+// assertion, which panics the provider and takes the whole scan with it. Two
+// arguments also stay under the init's len(args) > 2 fast path, so this is
+// reachable from a plain query rather than only from an internal caller.
+func TestGcpServiceRejectsAnUnusableProjectId(t *testing.T) {
+	for _, tc := range []struct {
+		title     string
+		projectId *llx.RawData
+	}{
+		{"null projectId", &llx.RawData{Type: types.String}},
+		{"wrong-typed projectId", llx.IntData(7)},
+		{"empty projectId", llx.StringData("")},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			env := setupTestEnv(t, regionZoneScopes(), projectScopes())
+			var err error
+			assert.NotPanics(t, func() {
+				_, err = NewResource(env.Runtime, "gcp.service", map[string]*llx.RawData{
+					"name":      llx.StringData("compute.googleapis.com"),
+					"projectId": tc.projectId,
+				})
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "projectId")
+		})
 	}
 }

--- a/providers/gcp/resources/compute_region_zone_init_test.go
+++ b/providers/gcp/resources/compute_region_zone_init_test.go
@@ -97,6 +97,18 @@ func TestRegionInitDoesNotLeakProjectIdIntoArgs(t *testing.T) {
 // panics when the value is null rather than a string, and a panic in a provider
 // takes the whole scan down rather than one field. These inits now all use the
 // guarded form.
+//
+// The guarded form then has to report the unusable argument rather than hand
+// back partial args: the runtime builds the resource from those, leaving every
+// field unset, which surfaces as "encountered a primitive with no type
+// information" with nothing naming the cause. So an unusable name is an error,
+// not an empty resource.
+//
+// Both scope sets are registered because they are disjoint beyond the shared
+// cloudresourcemanager scope: the region and zone lookups need
+// compute.ComputeReadonlyScope, while the project-backed inits need
+// iam.CloudPlatformScope and compute.CloudPlatformScope. A resource whose scope
+// set is not registered cannot build its client.
 func TestInitsSurviveANullNameArgument(t *testing.T) {
 	for _, name := range []string{
 		"gcp.project.spannerService.instanceConfig",
@@ -106,13 +118,41 @@ func TestInitsSurviveANullNameArgument(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			env := setupTestEnv(t, regionZoneScopes(), projectScopes())
+			var err error
 			assert.NotPanics(t, func() {
-				// The lookup is expected to fail or come back empty; what is
-				// pinned here is that it does not panic on a null argument.
-				_, _ = NewResource(env.Runtime, name, map[string]*llx.RawData{
+				_, err = NewResource(env.Runtime, name, map[string]*llx.RawData{
 					"name": {Type: "\x07"},
 				})
 			})
+			assert.Error(t, err, "a null name must be reported, not resolved to a husk")
 		})
+	}
+}
+
+// TestInitsRejectAnUnusableName pins the same contract for the two other ways a
+// name can be unusable: absent entirely, and present but empty. Both used to
+// return (args, nil, nil), which the runtime turns into a resource with every
+// field unset.
+func TestInitsRejectAnUnusableName(t *testing.T) {
+	for _, resource := range []string{
+		"gcp.project.spannerService.instanceConfig",
+		"gcp.project.memcacheService.instance",
+		"gcp.service",
+	} {
+		for _, tc := range []struct {
+			title string
+			args  map[string]*llx.RawData
+		}{
+			{"no name argument", map[string]*llx.RawData{"projectId": llx.StringData(testProjectId)}},
+			{"empty name argument", map[string]*llx.RawData{"name": llx.StringData("")}},
+		} {
+			t.Run(resource+"/"+tc.title, func(t *testing.T) {
+				env := setupTestEnv(t, regionZoneScopes(), projectScopes())
+				_, err := NewResource(env.Runtime, resource, tc.args)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "name",
+					"the error should name the argument that is missing")
+			})
+		}
 	}
 }

--- a/providers/gcp/resources/compute_region_zone_init_test.go
+++ b/providers/gcp/resources/compute_region_zone_init_test.go
@@ -1,0 +1,118 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.mondoo.com/mql/llx"
+	"google.golang.org/api/cloudresourcemanager/v3"
+	"google.golang.org/api/compute/v1"
+)
+
+func regionZoneScopes() []string {
+	return []string{cloudresourcemanager.CloudPlatformReadOnlyScope, compute.ComputeReadonlyScope}
+}
+
+// TestRegionInitDoesNotLeakProjectIdIntoArgs pins the two ways a region or zone
+// lookup can end.
+//
+// projectId scopes the lookup but is not a field on either resource. The init
+// used to write it into args and then, on any path that returned without a
+// resource, hand those args to SetAllData -- which rejects an unknown field. A
+// bare `gcp.project.computeService.region` therefore failed with
+//
+//	[gcp] cannot set 'projectId' in resource
+//	'gcp.project.computeService.region', field not found
+//
+// which names an internal mechanism rather than the missing argument. Dropping
+// projectId from args without also reporting the missing name only traded that
+// for an empty husk whose every field is unset, which surfaces as "encountered
+// a primitive with no type information" with nothing naming the cause. Both
+// were verified against a live project.
+func TestRegionInitDoesNotLeakProjectIdIntoArgs(t *testing.T) {
+	t.Run("region without a name says so", func(t *testing.T) {
+		env := setupTestEnv(t, regionZoneScopes())
+		_, err := NewResource(env.Runtime, "gcp.project.computeService.region", map[string]*llx.RawData{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `requires a "name" argument`)
+		assert.NotContains(t, err.Error(), "field not found",
+			"the caller should learn which argument is missing, not that an internal setter rejected a key")
+	})
+
+	t.Run("zone without a name says so", func(t *testing.T) {
+		env := setupTestEnv(t, regionZoneScopes())
+		_, err := NewResource(env.Runtime, "gcp.project.computeService.zone", map[string]*llx.RawData{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `requires a "name" argument`)
+		assert.NotContains(t, err.Error(), "field not found")
+	})
+
+	t.Run("region with a name and a projectId resolves", func(t *testing.T) {
+		env := setupTestEnv(t, regionZoneScopes())
+		env.Mux.HandleFunc("/compute/v1/projects/"+testProjectId+"/regions/us-central1",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"id": "1000", "name": "us-central1", "status": "UP", "description": "us-central1"}`)
+			})
+
+		res, err := NewResource(env.Runtime, "gcp.project.computeService.region", map[string]*llx.RawData{
+			"name":      llx.StringData("us-central1"),
+			"projectId": llx.StringData(testProjectId),
+		})
+		require.NoError(t, err)
+		region := res.(*mqlGcpProjectComputeServiceRegion)
+		assert.Equal(t, "us-central1", region.Name.Data)
+		assert.Equal(t, "UP", region.Status.Data)
+	})
+
+	t.Run("zone with a name and a projectId resolves", func(t *testing.T) {
+		env := setupTestEnv(t, regionZoneScopes())
+		env.Mux.HandleFunc("/compute/v1/projects/"+testProjectId+"/zones/us-central1-a",
+			func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"id": "2000", "name": "us-central1-a", "status": "UP", "description": "us-central1-a"}`)
+			})
+
+		res, err := NewResource(env.Runtime, "gcp.project.computeService.zone", map[string]*llx.RawData{
+			"name":      llx.StringData("us-central1-a"),
+			"projectId": llx.StringData(testProjectId),
+		})
+		require.NoError(t, err)
+		zone := res.(*mqlGcpProjectComputeServiceZone)
+		assert.Equal(t, "us-central1-a", zone.Name.Data)
+		assert.Equal(t, "UP", zone.Status.Data)
+	})
+}
+
+// TestInitsSurviveANullNameArgument pins the arg-reading guards.
+//
+// An init that reads args["name"].Value.(string) without the comma-ok form
+// panics when the value is null rather than a string, and a panic in a provider
+// takes the whole scan down rather than one field. These inits now all use the
+// guarded form.
+func TestInitsSurviveANullNameArgument(t *testing.T) {
+	for _, name := range []string{
+		"gcp.project.spannerService.instanceConfig",
+		"gcp.project.memcacheService.instance",
+		"gcp.project.pubsubService.schema",
+		"gcp.service",
+	} {
+		t.Run(name, func(t *testing.T) {
+			env := setupTestEnv(t, regionZoneScopes(), projectScopes())
+			assert.NotPanics(t, func() {
+				// The lookup is expected to fail or come back empty; what is
+				// pinned here is that it does not panic on a null argument.
+				_, _ = NewResource(env.Runtime, name, map[string]*llx.RawData{
+					"name": {Type: "\x07"},
+				})
+			})
+		})
+	}
+}

--- a/providers/gcp/resources/compute_region_zone_init_test.go
+++ b/providers/gcp/resources/compute_region_zone_init_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/types"
 	"google.golang.org/api/cloudresourcemanager/v3"
 	"google.golang.org/api/compute/v1"
 )
@@ -91,66 +92,91 @@ func TestRegionInitDoesNotLeakProjectIdIntoArgs(t *testing.T) {
 	})
 }
 
-// TestInitsSurviveANullNameArgument pins the arg-reading guards.
+// huskProneInits are the per-object inits that resolve one named object, each
+// with the argument that selects it. Keeping them in one table is what stops
+// the guard from being fixed in the files someone happened to look at: the
+// resourcePath-selected resources below were missed exactly that way.
+//
+// The *Service inits are deliberately absent. A bare gcp.project.<svc> is a
+// legitimate empty state whose fields come from the connection rather than a
+// lookup, so returning args there is correct.
+var huskProneInits = map[string]string{
+	"gcp.project.vertexaiService.customJob":                           "name",
+	"gcp.project.vertexaiService.endpoint":                            "name",
+	"gcp.project.vertexaiService.pipelineJob":                         "name",
+	"gcp.project.vertexaiService.notebookRuntimeTemplate":             "name",
+	"gcp.project.vertexaiService.schedule":                            "name",
+	"gcp.project.memorystoreService.instance":                         "name",
+	"gcp.project.memorystoreService.backupCollection":                 "name",
+	"gcp.project.memcacheService.instance":                            "name",
+	"gcp.project.modelArmorService.template":                          "name",
+	"gcp.project.spannerService.instanceConfig":                       "name",
+	"gcp.project.datastreamService.connectionProfile":                 "name",
+	"gcp.project.datastreamService.privateConnection":                 "name",
+	"gcp.project.storageService.bucket":                               "name",
+	"gcp.project.pubsubService.schema":                                "name",
+	"gcp.service":                                                     "name",
+	"gcp.project.certificateManagerService.certificate":               "resourcePath",
+	"gcp.project.certificateManagerService.dnsAuthorization":          "resourcePath",
+	"gcp.project.certificateManagerService.certificateIssuanceConfig": "resourcePath",
+	"gcp.project.kmsService.keyring.cryptokey":                        "resourcePath",
+}
+
+// TestInitsSurviveANullSelectorArgument pins the arg-reading guards.
 //
 // An init that reads args["name"].Value.(string) without the comma-ok form
 // panics when the value is null rather than a string, and a panic in a provider
-// takes the whole scan down rather than one field. These inits now all use the
-// guarded form.
-//
-// The guarded form then has to report the unusable argument rather than hand
-// back partial args: the runtime builds the resource from those, leaving every
-// field unset, which surfaces as "encountered a primitive with no type
-// information" with nothing naming the cause. So an unusable name is an error,
-// not an empty resource.
-//
-// Both scope sets are registered because they are disjoint beyond the shared
-// cloudresourcemanager scope: the region and zone lookups need
-// compute.ComputeReadonlyScope, while the project-backed inits need
-// iam.CloudPlatformScope and compute.CloudPlatformScope. A resource whose scope
-// set is not registered cannot build its client.
-func TestInitsSurviveANullNameArgument(t *testing.T) {
-	for _, name := range []string{
-		"gcp.project.spannerService.instanceConfig",
-		"gcp.project.memcacheService.instance",
-		"gcp.project.pubsubService.schema",
-		"gcp.service",
-	} {
-		t.Run(name, func(t *testing.T) {
+// takes down the whole scan rather than one field. A null selector must be
+// reported, not resolved to a husk.
+func TestInitsSurviveANullSelectorArgument(t *testing.T) {
+	for resource, selector := range huskProneInits {
+		t.Run(resource, func(t *testing.T) {
 			env := setupTestEnv(t, regionZoneScopes(), projectScopes())
 			var err error
 			assert.NotPanics(t, func() {
-				_, err = NewResource(env.Runtime, name, map[string]*llx.RawData{
-					"name": {Type: "\x07"},
+				_, err = NewResource(env.Runtime, resource, map[string]*llx.RawData{
+					selector: {Type: types.String},
 				})
 			})
-			assert.Error(t, err, "a null name must be reported, not resolved to a husk")
+			assert.Error(t, err, "a null %s must be reported, not resolved to a husk", selector)
 		})
 	}
 }
 
-// TestInitsRejectAnUnusableName pins the same contract for the two other ways a
-// name can be unusable: absent entirely, and present but empty. Both used to
-// return (args, nil, nil), which the runtime turns into a resource with every
-// field unset.
-func TestInitsRejectAnUnusableName(t *testing.T) {
-	for _, resource := range []string{
-		"gcp.project.spannerService.instanceConfig",
-		"gcp.project.memcacheService.instance",
-		"gcp.service",
-	} {
+// TestInitsRejectAnUnusableSelector pins the same contract for the two other
+// ways a selector can be unusable: absent entirely, and present but empty.
+//
+// Both used to return (args, nil, nil), which the runtime turns into a resource
+// with every field UNSET -- not null, unset. Reading one then surfaces
+// client-side as
+//
+//	provider returned no data and no error for a field; the field was never
+//	set on the resource (provider bug)
+//	llx: encountered a primitive with no type information, coercing to null
+//
+// with nothing naming the cause, and the husk carries an empty __id so every
+// such resource also aliases in the runtime cache. Reproduced live against a
+// real project before the change for vertexai customJob, memorystore instance,
+// storage bucket, datastream connectionProfile, spanner instanceConfig and
+// gcp.service.
+//
+// Every internal caller of these resources already guards its selector against
+// "" before resolving, so erroring here changes nothing for them; it only makes
+// a direct query say what is missing.
+func TestInitsRejectAnUnusableSelector(t *testing.T) {
+	for resource, selector := range huskProneInits {
 		for _, tc := range []struct {
 			title string
 			args  map[string]*llx.RawData
 		}{
-			{"no name argument", map[string]*llx.RawData{"projectId": llx.StringData(testProjectId)}},
-			{"empty name argument", map[string]*llx.RawData{"name": llx.StringData("")}},
+			{"no selector argument", map[string]*llx.RawData{"projectId": llx.StringData(testProjectId)}},
+			{"empty selector argument", map[string]*llx.RawData{selector: llx.StringData("")}},
 		} {
 			t.Run(resource+"/"+tc.title, func(t *testing.T) {
 				env := setupTestEnv(t, regionZoneScopes(), projectScopes())
 				_, err := NewResource(env.Runtime, resource, tc.args)
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "name",
+				assert.Contains(t, err.Error(), selector,
 					"the error should name the argument that is missing")
 			})
 		}

--- a/providers/gcp/resources/datastream.go
+++ b/providers/gcp/resources/datastream.go
@@ -309,7 +309,10 @@ func initGcpProjectDatastreamServiceConnectionProfile(runtime *plugin.Runtime, a
 	if nameRaw == nil {
 		return args, nil, nil
 	}
-	name := nameRaw.Value.(string)
+	name, ok := nameRaw.Value.(string)
+	if !ok || name == "" {
+		return args, nil, nil
+	}
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)
 	if !ok {
@@ -535,7 +538,10 @@ func initGcpProjectDatastreamServicePrivateConnection(runtime *plugin.Runtime, a
 	if nameRaw == nil {
 		return args, nil, nil
 	}
-	name := nameRaw.Value.(string)
+	name, ok := nameRaw.Value.(string)
+	if !ok || name == "" {
+		return args, nil, nil
+	}
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)
 	if !ok {

--- a/providers/gcp/resources/datastream.go
+++ b/providers/gcp/resources/datastream.go
@@ -307,11 +307,11 @@ func initGcpProjectDatastreamServiceConnectionProfile(runtime *plugin.Runtime, a
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.datastreamService.connectionProfile requires a "name" argument`)
 	}
 	name, ok := nameRaw.Value.(string)
 	if !ok || name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.datastreamService.connectionProfile requires a non-empty "name" argument`)
 	}
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)
@@ -536,11 +536,11 @@ func initGcpProjectDatastreamServicePrivateConnection(runtime *plugin.Runtime, a
 	}
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.datastreamService.privateConnection requires a "name" argument`)
 	}
 	name, ok := nameRaw.Value.(string)
 	if !ok || name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.datastreamService.privateConnection requires a non-empty "name" argument`)
 	}
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)

--- a/providers/gcp/resources/documentai.go
+++ b/providers/gcp/resources/documentai.go
@@ -251,7 +251,7 @@ func initGcpProjectDocumentaiServiceProcessorVersion(runtime *plugin.Runtime, ar
 		return args, nil, nil
 	}
 	nameRaw, ok := args["name"]
-	if !ok {
+	if !ok || nameRaw == nil {
 		return nil, nil, errors.New("gcp.project.documentaiService.processor.version requires a name")
 	}
 	name, ok := nameRaw.Value.(string)

--- a/providers/gcp/resources/iam.go
+++ b/providers/gcp/resources/iam.go
@@ -177,7 +177,13 @@ func initGcpProjectIamServiceServiceAccount(runtime *plugin.Runtime, args map[st
 	// flag — constructing the iamService directly leaves the flag at its
 	// zero value, which short-circuits serviceAccounts() to nil and makes the
 	// SA lookup miss every typed-ref query.
-	projObj, err := CreateResource(runtime, "gcp.project", map[string]*llx.RawData{
+	// NewResource, not CreateResource: CreateResource would cache a gcp.project
+	// carrying nothing but an id, and initGcpProject returns whatever is already
+	// cached -- so that husk would win for every later caller, and its name,
+	// state, parentId, labels, createTime and number are computed fields
+	// implemented as placeholders that only ever return "not implemented".
+	// servicegate.go spells out the same reasoning for the enablement lookup.
+	projObj, err := NewResource(runtime, "gcp.project", map[string]*llx.RawData{
 		"id": args["projectId"],
 	})
 	if err != nil {

--- a/providers/gcp/resources/kms.go
+++ b/providers/gcp/resources/kms.go
@@ -174,7 +174,7 @@ func initGcpProjectKmsServiceKeyringCryptokey(runtime *plugin.Runtime, args map[
 
 	resourcePathRaw, ok := args["resourcePath"]
 	if !ok || resourcePathRaw.Value == nil || resourcePathRaw.Value.(string) == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.kmsService.keyring.cryptokey requires a non-empty "resourcePath" argument`)
 	}
 	resourcePath := resourcePathRaw.Value.(string)
 

--- a/providers/gcp/resources/kms.go
+++ b/providers/gcp/resources/kms.go
@@ -173,10 +173,13 @@ func initGcpProjectKmsServiceKeyringCryptokey(runtime *plugin.Runtime, args map[
 	}
 
 	resourcePathRaw, ok := args["resourcePath"]
-	if !ok || resourcePathRaw.Value == nil || resourcePathRaw.Value.(string) == "" {
+	if !ok || resourcePathRaw == nil {
+		return nil, nil, errors.New(`gcp.project.kmsService.keyring.cryptokey requires a "resourcePath" argument`)
+	}
+	resourcePath, ok := resourcePathRaw.Value.(string)
+	if !ok || resourcePath == "" {
 		return nil, nil, errors.New(`gcp.project.kmsService.keyring.cryptokey requires a non-empty "resourcePath" argument`)
 	}
-	resourcePath := resourcePathRaw.Value.(string)
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)
 	if !ok {

--- a/providers/gcp/resources/memcache.go
+++ b/providers/gcp/resources/memcache.go
@@ -82,7 +82,10 @@ func initGcpProjectMemcacheServiceInstance(runtime *plugin.Runtime, args map[str
 	if nameRaw == nil {
 		return args, nil, nil
 	}
-	name := nameRaw.Value.(string)
+	name, ok := nameRaw.Value.(string)
+	if !ok || name == "" {
+		return args, nil, nil
+	}
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)
 	if !ok {

--- a/providers/gcp/resources/memcache.go
+++ b/providers/gcp/resources/memcache.go
@@ -104,8 +104,9 @@ func initGcpProjectMemcacheServiceInstance(runtime *plugin.Runtime, args map[str
 		if locRaw == nil || projRaw == nil {
 			return nil, nil, errors.New("memcache instance init: projectId and location required when name is not a full resource path")
 		}
-		projectId = projRaw.Value.(string)
-		fullName = fmt.Sprintf("projects/%s/locations/%s/instances/%s", projectId, locRaw.Value.(string), name)
+		projectId, _ = projRaw.Value.(string)
+		location, _ := locRaw.Value.(string)
+		fullName = fmt.Sprintf("projects/%s/locations/%s/instances/%s", projectId, location, name)
 	}
 
 	// Ask whether the API is on before paying for a Get that cannot succeed

--- a/providers/gcp/resources/memcache.go
+++ b/providers/gcp/resources/memcache.go
@@ -80,11 +80,11 @@ func initGcpProjectMemcacheServiceInstance(runtime *plugin.Runtime, args map[str
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.memcacheService.instance requires a "name" argument`)
 	}
 	name, ok := nameRaw.Value.(string)
 	if !ok || name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.memcacheService.instance requires a non-empty "name" argument`)
 	}
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)

--- a/providers/gcp/resources/memorystore.go
+++ b/providers/gcp/resources/memorystore.go
@@ -295,7 +295,10 @@ func initGcpProjectMemorystoreServiceInstance(runtime *plugin.Runtime, args map[
 	if nameRaw == nil {
 		return args, nil, nil
 	}
-	name := nameRaw.Value.(string)
+	name, ok := nameRaw.Value.(string)
+	if !ok || name == "" {
+		return args, nil, nil
+	}
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)
 	if !ok {
@@ -639,7 +642,10 @@ func initGcpProjectMemorystoreServiceBackupCollection(runtime *plugin.Runtime, a
 	if nameRaw == nil {
 		return args, nil, nil
 	}
-	name := nameRaw.Value.(string)
+	name, ok := nameRaw.Value.(string)
+	if !ok || name == "" {
+		return args, nil, nil
+	}
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)
 	if !ok {

--- a/providers/gcp/resources/memorystore.go
+++ b/providers/gcp/resources/memorystore.go
@@ -293,11 +293,11 @@ func initGcpProjectMemorystoreServiceInstance(runtime *plugin.Runtime, args map[
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.memorystoreService.instance requires a "name" argument`)
 	}
 	name, ok := nameRaw.Value.(string)
 	if !ok || name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.memorystoreService.instance requires a non-empty "name" argument`)
 	}
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)
@@ -640,11 +640,11 @@ func initGcpProjectMemorystoreServiceBackupCollection(runtime *plugin.Runtime, a
 	}
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.memorystoreService.backupCollection requires a "name" argument`)
 	}
 	name, ok := nameRaw.Value.(string)
 	if !ok || name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.memorystoreService.backupCollection requires a non-empty "name" argument`)
 	}
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)

--- a/providers/gcp/resources/memorystore.go
+++ b/providers/gcp/resources/memorystore.go
@@ -327,8 +327,9 @@ func initGcpProjectMemorystoreServiceInstance(runtime *plugin.Runtime, args map[
 		if locRaw == nil || projRaw == nil {
 			return nil, nil, errors.New("memorystore instance init: projectId and location required when name is not a full resource path")
 		}
-		projectId = projRaw.Value.(string)
-		fullName = fmt.Sprintf("projects/%s/locations/%s/instances/%s", projectId, locRaw.Value.(string), name)
+		projectId, _ = projRaw.Value.(string)
+		location, _ := locRaw.Value.(string)
+		fullName = fmt.Sprintf("projects/%s/locations/%s/instances/%s", projectId, location, name)
 	}
 
 	// Ask whether the API is on before paying for a Get that cannot succeed

--- a/providers/gcp/resources/modelarmor.go
+++ b/providers/gcp/resources/modelarmor.go
@@ -174,11 +174,11 @@ func initGcpProjectModelArmorServiceTemplate(runtime *plugin.Runtime, args map[s
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.modelArmorService.template requires a "name" argument`)
 	}
 	name, ok := nameRaw.Value.(string)
 	if !ok || name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.modelArmorService.template requires a non-empty "name" argument`)
 	}
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)

--- a/providers/gcp/resources/modelarmor.go
+++ b/providers/gcp/resources/modelarmor.go
@@ -176,7 +176,10 @@ func initGcpProjectModelArmorServiceTemplate(runtime *plugin.Runtime, args map[s
 	if nameRaw == nil {
 		return args, nil, nil
 	}
-	name := nameRaw.Value.(string)
+	name, ok := nameRaw.Value.(string)
+	if !ok || name == "" {
+		return args, nil, nil
+	}
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)
 	if !ok {

--- a/providers/gcp/resources/pubsub.go
+++ b/providers/gcp/resources/pubsub.go
@@ -1013,7 +1013,10 @@ func initGcpProjectPubsubServiceSchema(runtime *plugin.Runtime, args map[string]
 	if !ok || nameArg == nil {
 		return nil, nil, errors.New("gcp.project.pubsubService.schema requires a name")
 	}
-	fullName := nameArg.Value.(string)
+	fullName, ok := nameArg.Value.(string)
+	if !ok || fullName == "" {
+		return nil, nil, errors.New("gcp.project.pubsubService.schema requires a name")
+	}
 
 	// Schema names are always projects/{project}/schemas/{schema}.
 	parts := strings.Split(fullName, "/")

--- a/providers/gcp/resources/recommendations.go
+++ b/providers/gcp/resources/recommendations.go
@@ -12,6 +12,7 @@ import (
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers/gcp/connection"
+	"go.mondoo.com/mql/types"
 
 	recommender "cloud.google.com/go/recommender/apiv1"
 	"cloud.google.com/go/recommender/apiv1/recommenderpb"
@@ -62,7 +63,7 @@ func newMqlRecommendation(runtime *plugin.Runtime, item *recommenderpb.Recommend
 		"name":             llx.StringData(item.Description),
 		"recommender":      llx.StringData(values[5]),
 		"primaryImpact":    llx.DictData(primaryImpact),
-		"additionalImpact": llx.DictData(additionalImpact),
+		"additionalImpact": llx.ArrayData(additionalImpact, types.Dict),
 		"content":          llx.DictData(content),
 		"category":         llx.StringData(category),
 		"priority":         llx.StringData(priority),

--- a/providers/gcp/resources/services.go
+++ b/providers/gcp/resources/services.go
@@ -166,11 +166,11 @@ func initGcpService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.service requires a "name" argument`)
 	}
 	name, ok := nameRaw.Value.(string)
 	if !ok || name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.service requires a non-empty "name" argument`)
 	}
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)

--- a/providers/gcp/resources/services.go
+++ b/providers/gcp/resources/services.go
@@ -168,7 +168,10 @@ func initGcpService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	if nameRaw == nil {
 		return args, nil, nil
 	}
-	name := nameRaw.Value.(string)
+	name, ok := nameRaw.Value.(string)
+	if !ok || name == "" {
+		return args, nil, nil
+	}
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)
 	if !ok {

--- a/providers/gcp/resources/services.go
+++ b/providers/gcp/resources/services.go
@@ -177,17 +177,19 @@ func initGcpService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	if !ok {
 		return nil, nil, errors.New("invalid connection provided, it is not a GCP connection")
 	}
-	credentials, err := conn.Credentials(serviceusage.DefaultAuthScopes()...)
-	if err != nil {
-		return nil, nil, err
-	}
-
+	// Check the arguments before building credentials, so an unusable one is
+	// reported as itself rather than as whatever the credential lookup says.
 	projectId := conn.ResourceID()
 	if projectIdRaw := args["projectId"]; projectIdRaw != nil {
 		projectId, ok = projectIdRaw.Value.(string)
 		if !ok || projectId == "" {
 			return nil, nil, errors.New(`gcp.service requires a non-empty "projectId" argument`)
 		}
+	}
+
+	credentials, err := conn.Credentials(serviceusage.DefaultAuthScopes()...)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	ctx := context.Background()

--- a/providers/gcp/resources/services.go
+++ b/providers/gcp/resources/services.go
@@ -182,12 +182,12 @@ func initGcpService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 		return nil, nil, err
 	}
 
-	var projectId string
-	projectIdRaw := args["projectId"]
-	if projectIdRaw != nil {
-		projectId = projectIdRaw.Value.(string)
-	} else {
-		projectId = conn.ResourceID()
+	projectId := conn.ResourceID()
+	if projectIdRaw := args["projectId"]; projectIdRaw != nil {
+		projectId, ok = projectIdRaw.Value.(string)
+		if !ok || projectId == "" {
+			return nil, nil, errors.New(`gcp.service requires a non-empty "projectId" argument`)
+		}
 	}
 
 	ctx := context.Background()

--- a/providers/gcp/resources/spanner.go
+++ b/providers/gcp/resources/spanner.go
@@ -748,13 +748,19 @@ func initGcpProjectSpannerServiceInstanceConfig(runtime *plugin.Runtime, args ma
 	if !ok {
 		return args, nil, nil
 	}
-	name := nameRaw.Value.(string)
+	name, ok := nameRaw.Value.(string)
+	if !ok || name == "" {
+		return args, nil, nil
+	}
 
 	projectIdRaw, ok := args["projectId"]
 	if !ok {
 		return args, nil, nil
 	}
-	projectId := projectIdRaw.Value.(string)
+	projectId, ok := projectIdRaw.Value.(string)
+	if !ok || projectId == "" {
+		return args, nil, nil
+	}
 
 	obj, err := CreateResource(runtime, "gcp.project.spannerService", map[string]*llx.RawData{
 		"projectId": llx.StringData(projectId),

--- a/providers/gcp/resources/spanner.go
+++ b/providers/gcp/resources/spanner.go
@@ -746,20 +746,20 @@ func initGcpProjectSpannerServiceInstanceConfig(runtime *plugin.Runtime, args ma
 
 	nameRaw, ok := args["name"]
 	if !ok {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.spannerService.instanceConfig requires a "name" argument`)
 	}
 	name, ok := nameRaw.Value.(string)
 	if !ok || name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.spannerService.instanceConfig requires a non-empty "name" argument`)
 	}
 
 	projectIdRaw, ok := args["projectId"]
 	if !ok {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.spannerService.instanceConfig requires a "projectId" argument`)
 	}
 	projectId, ok := projectIdRaw.Value.(string)
 	if !ok || projectId == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.spannerService.instanceConfig requires a non-empty "projectId" argument`)
 	}
 
 	obj, err := CreateResource(runtime, "gcp.project.spannerService", map[string]*llx.RawData{

--- a/providers/gcp/resources/spanner.go
+++ b/providers/gcp/resources/spanner.go
@@ -745,7 +745,7 @@ func initGcpProjectSpannerServiceInstanceConfig(runtime *plugin.Runtime, args ma
 	}
 
 	nameRaw, ok := args["name"]
-	if !ok {
+	if !ok || nameRaw == nil {
 		return nil, nil, errors.New(`gcp.project.spannerService.instanceConfig requires a "name" argument`)
 	}
 	name, ok := nameRaw.Value.(string)
@@ -754,7 +754,7 @@ func initGcpProjectSpannerServiceInstanceConfig(runtime *plugin.Runtime, args ma
 	}
 
 	projectIdRaw, ok := args["projectId"]
-	if !ok {
+	if !ok || projectIdRaw == nil {
 		return nil, nil, errors.New(`gcp.project.spannerService.instanceConfig requires a "projectId" argument`)
 	}
 	projectId, ok := projectIdRaw.Value.(string)

--- a/providers/gcp/resources/storage.go
+++ b/providers/gcp/resources/storage.go
@@ -517,11 +517,11 @@ func initGcpProjectStorageServiceBucket(runtime *plugin.Runtime, args map[string
 	// connection profile pointing at a GCS bucket).
 	nameRaw, ok := args["name"]
 	if !ok || nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.storageService.bucket requires a "name" argument`)
 	}
 	name, ok := nameRaw.Value.(string)
 	if !ok || name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.storageService.bucket requires a non-empty "name" argument`)
 	}
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)

--- a/providers/gcp/resources/vertexai.go
+++ b/providers/gcp/resources/vertexai.go
@@ -1162,7 +1162,10 @@ func initGcpProjectVertexaiServiceCustomJob(runtime *plugin.Runtime, args map[st
 	if nameRaw == nil {
 		return args, nil, nil
 	}
-	name := nameRaw.Value.(string)
+	name, ok := nameRaw.Value.(string)
+	if !ok || name == "" {
+		return args, nil, nil
+	}
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)
 	if !ok {
@@ -1246,7 +1249,10 @@ func initGcpProjectVertexaiServiceEndpoint(runtime *plugin.Runtime, args map[str
 	if nameRaw == nil {
 		return args, nil, nil
 	}
-	name := nameRaw.Value.(string)
+	name, ok := nameRaw.Value.(string)
+	if !ok || name == "" {
+		return args, nil, nil
+	}
 
 	region := vertexaiRegionFromName(name)
 	if region == "" {
@@ -1316,7 +1322,10 @@ func initGcpProjectVertexaiServicePipelineJob(runtime *plugin.Runtime, args map[
 	if nameRaw == nil {
 		return args, nil, nil
 	}
-	name := nameRaw.Value.(string)
+	name, ok := nameRaw.Value.(string)
+	if !ok || name == "" {
+		return args, nil, nil
+	}
 
 	region := vertexaiRegionFromName(name)
 	if region == "" {
@@ -1386,7 +1395,10 @@ func initGcpProjectVertexaiServiceNotebookRuntimeTemplate(runtime *plugin.Runtim
 	if nameRaw == nil {
 		return args, nil, nil
 	}
-	name := nameRaw.Value.(string)
+	name, ok := nameRaw.Value.(string)
+	if !ok || name == "" {
+		return args, nil, nil
+	}
 
 	region := vertexaiRegionFromName(name)
 	if region == "" {

--- a/providers/gcp/resources/vertexai.go
+++ b/providers/gcp/resources/vertexai.go
@@ -1160,11 +1160,11 @@ func initGcpProjectVertexaiServiceCustomJob(runtime *plugin.Runtime, args map[st
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.vertexaiService.customJob requires a "name" argument`)
 	}
 	name, ok := nameRaw.Value.(string)
 	if !ok || name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.vertexaiService.customJob requires a non-empty "name" argument`)
 	}
 
 	conn, ok := runtime.Connection.(*connection.GcpConnection)
@@ -1247,11 +1247,11 @@ func initGcpProjectVertexaiServiceEndpoint(runtime *plugin.Runtime, args map[str
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.vertexaiService.endpoint requires a "name" argument`)
 	}
 	name, ok := nameRaw.Value.(string)
 	if !ok || name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.vertexaiService.endpoint requires a non-empty "name" argument`)
 	}
 
 	region := vertexaiRegionFromName(name)
@@ -1320,11 +1320,11 @@ func initGcpProjectVertexaiServicePipelineJob(runtime *plugin.Runtime, args map[
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.vertexaiService.pipelineJob requires a "name" argument`)
 	}
 	name, ok := nameRaw.Value.(string)
 	if !ok || name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.vertexaiService.pipelineJob requires a non-empty "name" argument`)
 	}
 
 	region := vertexaiRegionFromName(name)
@@ -1393,11 +1393,11 @@ func initGcpProjectVertexaiServiceNotebookRuntimeTemplate(runtime *plugin.Runtim
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.vertexaiService.notebookRuntimeTemplate requires a "name" argument`)
 	}
 	name, ok := nameRaw.Value.(string)
 	if !ok || name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.vertexaiService.notebookRuntimeTemplate requires a non-empty "name" argument`)
 	}
 
 	region := vertexaiRegionFromName(name)
@@ -2658,11 +2658,11 @@ func initGcpProjectVertexaiServiceSchedule(runtime *plugin.Runtime, args map[str
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.vertexaiService.schedule requires a "name" argument`)
 	}
 	name, ok := nameRaw.Value.(string)
 	if !ok || name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New(`gcp.project.vertexaiService.schedule requires a non-empty "name" argument`)
 	}
 
 	region := vertexaiRegionFromName(name)

--- a/providers/gcp/resources/vertexai.go
+++ b/providers/gcp/resources/vertexai.go
@@ -1185,8 +1185,8 @@ func initGcpProjectVertexaiServiceCustomJob(runtime *plugin.Runtime, args map[st
 		if locRaw == nil || projRaw == nil {
 			return nil, nil, errors.New("vertexai custom job init: projectId and location required when name is not a full resource path")
 		}
-		region = locRaw.Value.(string)
-		projectId = projRaw.Value.(string)
+		region, _ = locRaw.Value.(string)
+		projectId, _ = projRaw.Value.(string)
 		fullName = fmt.Sprintf("projects/%s/locations/%s/customJobs/%s", projectId, region, name)
 	}
 


### PR DESCRIPTION
Three init defects that all surface as something other than what went wrong, plus one schema/constructor mismatch. Grouped because they are the same class — an init doing the wrong thing with its arguments — and because two of them touch the same functions.

## 1. A non-field argument reached `SetAllData`

`projectId` scopes the region and zone lookups but is **not a field** on either resource. The inits wrote it into `args`, so every path that returned without a resource handed it to `SetAllData`, which rejects an unknown field.

```
$ mql run gcp project … -c 'gcp.project.computeService.region'
[gcp] cannot set 'projectId' in resource 'gcp.project.computeService.region', field not found
```

That names an internal setter rather than the missing argument. Dropping `projectId` from `args` alone only traded it for an empty husk whose every field is unset — which surfaces as `llx: encountered a primitive with no type information` with nothing naming the cause. Both were reproduced live. Both inits now consume `projectId` and report what is actually missing:

```
gcp.project.computeService.region requires a "name" argument
```

`region(name: …)`, `zone(name: …)`, `compute.regions` and `compute.zones` are unaffected and were re-verified live.

## 2. Bare type assertions on argument values panicked

Eleven inits read `args["name"].Value.(string)` without the comma-ok form. A null value there is not a `string`, and the panic takes down the provider process — and with it the whole scan, not one field. All now use the guarded form.

Review then surfaced the half that a null check alone does not cover: a guard that tests `raw.Value == nil` and *then* asserts `raw.Value.(string)` bare still panics on a value that is neither nil nor a string, and a nil `*llx.RawData` stored under the key panics on the `.Value` read before any test runs. Reproduced on `kms.go`, three `certificatemanager.go` inits and `gcp.service` — the last reachable from a plain query, since it reads `projectId` outside the selector guard and two arguments stay under its `len(args) > 2` fast path.

Every guard now splits the key check from the type check, which covers absent key, nil `RawData`, null value, wrong type and empty string in one shape. Driving the two new cases through the table then exposed two more guards missing the `== nil` half (`spanner.go`, `documentai.go`). Three further sites in `memorystore`, `memcache` and `vertexai` were converted despite not being reachable — the fast path intercepts the three-argument call and the only route that reaches them builds all three arguments from `getAssetIdentifier` as strings — rather than leave the one unguarded shape in a file full of guarded ones. No bare type assertion on an argument value remains in the package.

`TestInitsSurviveANullNameArgument` drives four of them with a null name and fails on a panic. Restoring any one of the bare assertions makes it fail with the panic trace.

## 3. `gcp.project` was built with `CreateResource` in three inits

That caches a project carrying nothing but an id, and `initGcpProject` returns whatever is already cached — so the husk wins for every later caller. It never fills itself in either: `name`, `state`, `parentId`, `labels`, `createTime` and `number` are computed fields implemented as placeholders returning `"not implemented"`.

`servicegate.go` documents this exact hazard at length and uses `NewResource` for it. The service-account, api-key and cloud-function inits now do the same.

Honest caveat: which resolution lands first is a race, and I could not force it on a live scan — `gcp.project` happened to resolve first every time. The mechanism is confirmed (the cache short-circuit in `initGcpProject`, and the placeholders), so this is a latent failure rather than one reproduced on demand.

## 4. `gcp.recommendation.additionalImpact`

Declared `[]dict`, populated with `llx.DictData`. Now `llx.ArrayData(…, types.Dict)` like every other list-of-dict field. Harmless today — `RawToTValue` reads the Go value and ignores the type marker — but it is the wrong constructor and reads as correct.
