### PR TITLE
📄 arista: document how to stand up a real test device in AWS

### DIFF
--- a/providers/arista/TESTING.MD
+++ b/providers/arista/TESTING.MD
@@ -6,8 +6,218 @@ This document covers how to set up a vEOS lab device for mql provider developmen
 
 ## Prerequisites
 
-- Access to a vEOS instance — available via the [AWS Marketplace](https://aws.amazon.com/marketplace/search/results?searchTerms=arista+veos)
+- Access to a CloudEOS/vEOS instance — see [Spinning up a test device in AWS](#spinning-up-a-test-device-in-aws)
 - SSH or console access
+
+---
+
+## Spinning up a test device in AWS
+
+A full run — launch, configure, sweep every resource, tear down — takes about
+40 minutes and costs well under a dollar. The traps below are all ones that
+have actually bitten; read them before starting rather than after.
+
+### 1. Subscribe, and get the AMI id from the console
+
+Arista publishes CloudEOS under **two separate Marketplace listings** with
+different product codes:
+
+| Listing | Product code | Notes |
+|---|---|---|
+| CloudEOS Router (BYOL) | `3gruvlcso4s66wfg2mdzxg8z6` | needs a licence from Arista sales; the AMI *is* publicly listed |
+| CloudEOS Router (PAYG) | `8xzz74jx7agumduhohu7zful3` | hourly software charge, no licence needed |
+
+**The PAYG AMI is not discoverable from the CLI.** `describe-images` returns
+only the BYOL image, in every region, even when you are subscribed to PAYG:
+
+```bash
+aws ec2 describe-images --owners aws-marketplace \
+  --filters "Name=name,Values=*CloudEOS*" --region us-west-2 \
+  --query 'Images[].[ImageId,Name,ProductCodes[0].ProductCodeId]' --output text
+```
+
+Launching the BYOL image while subscribed to PAYG fails with `OptInRequired`,
+which reads like "you are not subscribed" but actually means "not to *that*
+listing". Get the PAYG AMI id from the console instead:
+
+> Marketplace → Manage subscriptions → *Arista CloudEOS Router (PAYG)* →
+> **Launch new instance** → the AMI id is shown per region.
+
+Confirm it is launchable before writing any Terraform:
+
+```bash
+aws ec2 run-instances --dry-run --region us-west-2 \
+  --image-id <ami-id> --instance-type c5.xlarge --subnet-id <subnet>
+# want: DryRunOperation ("Request would have succeeded")
+```
+
+To check which listing an account holds:
+
+```bash
+aws license-manager list-received-licenses --region us-west-2 \
+  --query 'Licenses[].ProductName' --output text | tr '\t' '\n' | grep -i arista
+```
+
+### 2. Launch with a *minimal* startup-config
+
+CloudEOS reads a startup-config from EC2 user-data, wrapped in markers:
+
+```
+%EOS-STARTUP-CONFIG-START%
+...config...
+%EOS-STARTUP-CONFIG-END%
+```
+
+**Do not paste a complete lab config here.** What you supply *replaces* the
+image's AWS bootstrap config, which is what puts the management interface on
+DHCP. Omit that stanza and EOS comes up with no management address: the
+instance passes both EC2 status checks, the console shows a healthy EOS with
+your hostname and banner, and **both 22 and 443 are closed** with no
+indication why.
+
+Keep the bootstrap minimal, and always include the management interface:
+
+```
+%EOS-STARTUP-CONFIG-START%
+hostname arista-test-lab
+!
+interface Management1
+   ip address dhcp
+   no shutdown
+!
+interface Ethernet1
+   no switchport
+   ip address dhcp
+   no shutdown
+!
+username netadmin privilege 15 role network-admin secret 0 <password>
+!
+management api http-commands
+   protocol https
+   no shutdown
+!
+management ssh
+   no shutdown
+!
+end
+%EOS-STARTUP-CONFIG-END%
+```
+
+Both interface names are listed on purpose: a single-ENI CloudEOS presents
+eth0 as `Management1`, but configuring `Ethernet1` too costs nothing and
+removes the guess.
+
+eAPI takes roughly **2.5 minutes** to come up after `terraform apply` returns.
+
+### 3. Push the lab config over eAPI
+
+Apply everything else afterwards, over eAPI, where a mistake cannot lock you
+out and you can iterate:
+
+```bash
+curl -sk -u "netadmin:$PW" "https://$IP/command-api" \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"runCmds","params":{"version":1,
+       "cmds":["enable","configure","hostname lab"],"format":"json"},"id":1}'
+```
+
+Points that cost time:
+
+- **`enable` must be the first command**, or every config command fails with
+  `Invalid input (privileged mode required)`.
+- **eAPI aborts the whole batch on the first bad command** and tells you which
+  one: `CLI command N of M '<cmd>' failed`. Parse that, drop the command, and
+  retry in a loop — otherwise you fix them one round trip at a time.
+- **Banners need the `input` field**, not a plain command string:
+  `{"cmd": "banner login", "input": "line one\nline two\nEOF\n"}`.
+- **Never bind a deny-all ACL to the management interface.** An
+  `ip access-group ... in` whose list ends in `deny ip any any` will lock you
+  out exactly like the missing DHCP stanza does. Bind interface ACLs to a
+  Port-Channel or a non-management interface instead.
+- Setting `enable secret` can change what eAPI needs to authenticate — apply
+  it last, after everything else is verified.
+
+### 4. Point mql at it
+
+```bash
+export PROVIDERS_PATH="$HOME/.config/mondoo/providers"
+mql run arista "netadmin@$IP" --password "$PW" --auto-update=false \
+  -c 'arista.eos { hostname version }'
+```
+
+`--auto-update=false` matters: without it mql can replace your locally-built
+provider with the released one mid-run, and you end up validating code you did
+not build.
+
+### 5. Unreleased fields are hidden until the version bumps
+
+Fields carry a `.lr.versions` entry, and one newer than `config/config.go`'s
+`Version` is invisible — queries fail with `cannot find field`, not with
+anything that points at the version gate. Check before concluding a field is
+broken:
+
+```bash
+grep -n 'Version:' providers/arista/config/config.go
+grep '13.3.16' providers/arista/resources/arista.lr.versions | wc -l
+```
+
+Bump `config.go` **locally and uncommitted** to validate them, and revert
+before committing — the release flow owns that bump.
+
+### 6. Query private resources through their parent
+
+Most of this provider's resources are `private`, and reaching one by its
+dotted path returns a husk — every field null, with
+`provider returned no data and no error for a field`:
+
+```bash
+mql run arista ... -c 'arista.eos.aaa { rootAccountEnabled }'      # null
+mql run arista ... -c 'arista.eos { aaa { rootAccountEnabled } }'  # true
+```
+
+Always go through the parent accessor when validating.
+
+### 7. Tear down, and verify per service
+
+Tag everything through Terraform `default_tags` so a crashed run is still
+findable, then confirm deletion against the owning service — the Resource
+Groups Tagging API lags by hours and will keep listing resources that are
+already gone:
+
+```bash
+aws ec2 describe-instances --region us-west-2 \
+  --filters "Name=tag:mondoo-run-id,Values=$RUN_ID" \
+            "Name=instance-state-name,Values=running,pending,stopping,stopped" \
+  --query 'length(Reservations[].Instances[])' --output text
+```
+
+---
+
+## CloudEOS limitations and EOS 4.34 syntax changes
+
+Captured from CloudEOS 4.34.2F. Commands in this document that a current
+device rejects:
+
+| Command | Result on CloudEOS 4.34.2F |
+|---|---|
+| `ip domain-name <name>` | deprecated — use `dns domain <name>` |
+| `sflow ...` (all forms) | not supported on this hardware platform |
+| `monitor session X destination Cpu` | not supported on this hardware platform |
+| `show system environment power` | fails — no emulated PSUs, so `arista.eos.hardware.powerSupplies` cannot be exercised on a virtual device |
+| `logging host ... protocol tls` | incomplete command; `tcp` and `udp` work |
+| `snmp-server community <c> ro ipv6 <acl>` | the ACL must be a **standard** IPv6 list |
+| `neighbor <x> password 7 <string>` | rejected unless the string is genuinely type-7 encrypted; use `password 0 <plaintext>` |
+| `username <u> ssh-key ssh-rsa AAAA...` | rejected unless the key is real and well-formed |
+
+Two shapes a real device will not produce, so they can only be tested by unit
+test rather than against hardware:
+
+- **Two SNMP destinations to the same collector at different security levels**,
+  and **the same community declared per address family** — EOS replaces rather
+  than stacks these.
+- **One syslog collector on one port over two transports** — same reason.
+- **A secret written with no encoding selector** (`aaa root secret <plaintext>`)
+  — EOS hashes on load and always renders a selector.
 
 ---
 
@@ -19,7 +229,8 @@ configure terminal
 
 ! Hostname and domain
 hostname arista-test-lab
-ip domain-name lab.mondoo.com
+! 4.34+ deprecates `ip domain-name` in favor of `dns domain`
+dns domain lab.mondoo.com
 
 ! DNS
 ip name-server 8.8.8.8


### PR DESCRIPTION
`TESTING.MD` assumed you already had a vEOS instance and started from the first `configure terminal`. Everything before that was undocumented — and all of it is where the time goes.

Written from an end-to-end run against CloudEOS 4.34.2F on EC2, so every trap below is one that actually bit rather than one I anticipated.

## What's new

**Getting a launchable AMI.** Arista publishes CloudEOS under two Marketplace listings with different product codes, and the PAYG AMI is **not discoverable from the CLI** — `describe-images` returns only the BYOL image, in every region, even while subscribed to PAYG. Launching it then fails with `OptInRequired`, which reads as "you are not subscribed" but means "not to *that* listing". Documents where to get the id and how to check which listing an account holds.

**The lockout.** CloudEOS takes a startup-config via user-data, and what you supply *replaces* the image's AWS bootstrap config — including the stanza that puts the management interface on DHCP. Omit it and the instance passes both EC2 status checks, the console shows a healthy EOS with your hostname and banner, and **both 22 and 443 are closed** with nothing explaining why. Same outcome if you bind a deny-all ACL to the management interface. The doc now recommends a minimal bootstrap plus pushing the lab config over eAPI, where a mistake is recoverable.

**eAPI mechanics:** `enable` must lead or every config command fails on privilege; the batch aborts on the first bad command and names it, so a drop-and-retry loop beats one round trip per fix; banners need the `input` field.

**The version gate.** A `.lr.versions` entry newer than `config.go`'s `Version` makes a field invisible, and the error says `cannot find field` — nothing about versions. 70 fields are in that state right now.

**Private resources.** Reaching one by its dotted path returns a husk with every field null; you have to go through the parent accessor. Worth knowing before concluding a field is broken.

## Corrections to the existing content

`ip domain-name` is deprecated in EOS 4.34 (→ `dns domain`), so the System Basics block no longer applies cleanly — fixed in place.

New table of what a current CloudEOS rejects: sFlow and `show system environment power` are absent on virtual hardware, so anything reading power supplies needs a physical device. Plus three shapes EOS will not render at all — two SNMP destinations to one collector at different security levels, one syslog collector on one port over two transports, and a secret with no encoding selector — which are unit-test-only cases, worth knowing before trying to reproduce them on hardware.

## Test plan

Docs only. `typos` clean locally; en-US spelling checked against this repo's convention.
