### PR TITLE
🐛 mikrotik: don't let a TLS request silently become a cleartext session

### DIFF
--- a/providers/mikrotik/connection/connection.go
+++ b/providers/mikrotik/connection/connection.go
@@ -5,6 +5,7 @@ package connection
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"maps"
 	"net"
@@ -53,6 +54,24 @@ type MikrotikConnection struct {
 	cacheMu    sync.Mutex
 }
 
+// parseTLSOption reads the tls connection option.
+//
+// It deliberately rejects anything it does not recognize rather than treating
+// it as false. The option selects between the TLS API port and the plaintext
+// one, and the RouterOS API sends the password in its very first sentence, so
+// silently reading an unrecognized value as "no TLS" would put the device
+// password on the wire in the clear and still report a successful scan.
+func parseTLSOption(v string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "", "false", "0", "no", "off":
+		return false, nil
+	case "true", "1", "yes", "on":
+		return true, nil
+	default:
+		return false, fmt.Errorf("invalid value %q for the mikrotik tls option, use true or false", v)
+	}
+}
+
 func NewMikrotikConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*MikrotikConnection, error) {
 	host := conf.Host
 	if host == "" {
@@ -64,16 +83,29 @@ func NewMikrotikConnection(id uint32, asset *inventory.Asset, conf *inventory.Co
 
 	user := ""
 	password := ""
-	if cred, err := vault.GetPassword(conf.Credentials); err == nil && cred != nil {
-		user = cred.User
-		password = string(cred.Secret)
+	// A credential that was supplied but could not be resolved is an error, not
+	// a reason to fall back to the default account: retrying as admin turns a
+	// vault problem into "invalid user name or password" against a username the
+	// operator never configured.
+	if len(conf.Credentials) > 0 {
+		cred, err := vault.GetPassword(conf.Credentials)
+		if err != nil {
+			return nil, fmt.Errorf("could not resolve credentials for the mikrotik device at %s: %w", host, err)
+		}
+		if cred != nil {
+			user = cred.User
+			password = string(cred.Secret)
+		}
 	}
 	if user == "" {
 		// RouterOS ships with the "admin" account by default
 		user = "admin"
 	}
 
-	useTLS := conf.Options["tls"] == "true"
+	useTLS, err := parseTLSOption(conf.Options["tls"])
+	if err != nil {
+		return nil, err
+	}
 
 	port := conf.Options["port"]
 	if port == "" && conf.Port != 0 {
@@ -91,7 +123,6 @@ func NewMikrotikConnection(id uint32, asset *inventory.Asset, conf *inventory.Co
 	timeout := 10 * time.Second
 
 	var client *routeros.Client
-	var err error
 	if useTLS {
 		tlsConfig := &tls.Config{InsecureSkipVerify: conf.Insecure}
 		client, err = routeros.DialTLSTimeout(address, user, password, tlsConfig, timeout)
@@ -134,6 +165,9 @@ func (c *MikrotikConnection) Close() {
 func (c *MikrotikConnection) Run(sentences ...string) (*routeros.Reply, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.client == nil {
+		return nil, errors.New("the mikrotik connection is closed")
+	}
 	return c.client.Run(sentences...)
 }
 

--- a/providers/mikrotik/connection/connection_test.go
+++ b/providers/mikrotik/connection/connection_test.go
@@ -177,3 +177,47 @@ func TestPrintOneOptionalPropagatesRealErrors(t *testing.T) {
 	// which would report an unread setting as an absent subsystem
 	require.Error(t, err)
 }
+
+// TestParseTLSOption pins the spellings an inventory may carry. The option
+// picks between the TLS API port and the plaintext one, and the RouterOS API
+// sends the password in its first sentence, so reading an unrecognized value
+// as "no TLS" put the device password on the wire in the clear and still
+// reported a successful scan. Only a literal "true" used to enable it, so an
+// inventory written `tls: "yes"` silently downgraded.
+func TestParseTLSOption(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want bool
+	}{
+		{"true", true}, {"True", true}, {"TRUE", true},
+		{"yes", true}, {"Yes", true}, {"1", true}, {"on", true}, {" true ", true},
+		{"", false}, {"false", false}, {"no", false}, {"0", false}, {"off", false},
+	} {
+		t.Run("accepts "+tc.in, func(t *testing.T) {
+			got, err := parseTLSOption(tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestParseTLSOptionRejectsUnknown keeps an unrecognized value from silently
+// becoming plaintext. Failing the connection is the safe direction: the user
+// finds out, rather than getting a green scan over a cleartext session.
+func TestParseTLSOptionRejectsUnknown(t *testing.T) {
+	for _, in := range []string{"tls", "enabled", "ssl", "maybe"} {
+		_, err := parseTLSOption(in)
+		require.Error(t, err, "%q must not be read as false", in)
+		assert.Contains(t, err.Error(), "use true or false")
+	}
+}
+
+// TestRunAfterCloseDoesNotPanic covers the nil client. A panic in a provider
+// goroutine takes down the whole scan, not one query.
+func TestRunAfterCloseDoesNotPanic(t *testing.T) {
+	c := &MikrotikConnection{}
+	assert.NotPanics(t, func() {
+		_, err := c.Run("/system/resource/print")
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
Three connection-layer defects, found while validating this provider against a real MikroTik CHR 7.23.2 in EC2.

## 1. A TLS request can silently become a cleartext session

```go
useTLS := conf.Options["tls"] == "true"
```

A literal string match. The CLI normalizes its bool flag to exactly `"true"`, so `--tls` works — I confirmed it selects port 8729 on the live device. But `conf.Options` is free-form `map[string]string` populated straight from inventory YAML, and an inventory is how fleets are described. Written the natural way:

```yaml
options:
  tls: "yes"
```

`useTLS` is false, the connection falls through to the **plaintext default port 8728**, and the RouterOS API sends the password in its very first sentence, unconditionally, before any challenge negotiation:

```go
c.RunContext(ctx, "/login", "=name="+username, "=password="+password)
```

So the device password crosses the network in the clear — **and the scan succeeds**. The user gets a green result with no indication their TLS setting was ignored.

Now accepts the usual spellings, and **rejects** anything unrecognized rather than reading it as false. Failing the connection is the safe direction here: the alternative is a cleartext session the user believes is encrypted.

Worth noting what is *not* broken: `conf.Insecure` defaults to `false` and feeds `InsecureSkipVerify`, so certificate verification is on by default. That common default-insecure bug does not exist here.

## 2. An unresolvable credential silently retried as `admin`

```go
if cred, err := vault.GetPassword(conf.Credentials); err == nil && cred != nil {
```

The error was bound inside the `if` and dropped, so a vault that could not be reached or a rotated secret ID fell through to `user = "admin"`, `password = ""` and dialed anyway. The user then sees:

```
could not login: from RouterOS: invalid user name or password (6)
```

which points at the device's credentials, not the vault, and names an account they never configured. Now propagated, and only when credentials were actually supplied — a bare `mikrotik <host>` still defaults to `admin`, which is RouterOS's shipped account.

## 3. `Run` after `Close` panicked

`Close` sets `c.client = nil`; `Run` dereferenced it unguarded. `rosClient` is an interface, so this is a nil dereference — and a panic in a provider goroutine takes down the whole scan, not one query.

## Test plan

- `TestParseTLSOption` — every spelling an inventory may carry, including whitespace and case.
- `TestParseTLSOptionRejectsUnknown` — `"ssl"`, `"enabled"`, `"maybe"` must error rather than downgrade.
- `TestRunAfterCloseDoesNotPanic`.
- `go build`, `go test`, `gofmt`, `golangci-lint` clean.

## Deliberately not in this PR

`Run` has no read deadline. `DialTimeout` covers only the TCP dial, and `runArgsContextSync` in go-routeros takes no context and sets no deadline — so a device that completes the handshake and then stops answering wedges the scan behind `cacheMu` with no cancellation path. Fixing it properly means the connection holding its own `net.Conn` so it can set per-command deadlines, which is a larger change than belongs here.
