### PR TITLE
🐛 os: fix Solaris core counting, silent empty lists, and release detection

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -1733,16 +1733,18 @@ var solaris = &PlatformResolver{
 
 		// NOTE: we have only one solaris system here, since we only get here is the family is sunos, we pass
 
-		// try to read "/etc/release" for more details
+		// try to read "/etc/release" for more details. uname already confirmed
+		// SunOS, so a missing or unreadable release file only costs us the title
+		// and version - it must not retract the platform detection itself.
 		f, err := conn.FileSystem().Open("/etc/release")
 		if err != nil {
-			return false, nil
+			return true, nil
 		}
 		defer f.Close()
 
 		c, err := io.ReadAll(f)
 		if err != nil {
-			return false, nil
+			return true, nil
 		}
 
 		release, err := ParseSolarisRelease(string(c))

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -1193,6 +1193,17 @@ func TestSolaris11Detector(t *testing.T) {
 	assert.Equal(t, []string{"unix", "os"}, di.Family)
 }
 
+// uname already proves the host is SunOS, so an unreadable /etc/release must
+// still detect solaris - just without a title and version.
+func TestSolarisDetectorWithoutReleaseFile(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-solaris11-no-release.toml")
+	require.NoError(t, err, "platform is still detected without /etc/release")
+
+	assert.Equal(t, "solaris", di.Name, "os name should be identified")
+	assert.Equal(t, "i86pc", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"unix", "os"}, di.Family)
+}
+
 func TestAix72Detector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-aix72.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/parser_sol.go
+++ b/providers/os/detector/parser_sol.go
@@ -15,7 +15,9 @@ type SolarisRelease struct {
 	Release string
 }
 
-var solarisVersionRegex = regexp.MustCompile(`^\s+((?:[\w]\s*)*Solaris)\s([\w\d.]+)`)
+// (?m) so the release line is found even when /etc/release carries preceding
+// content, such as a site banner prepended ahead of the vendor line.
+var solarisVersionRegex = regexp.MustCompile(`(?m)^\s+((?:[\w]\s*)*Solaris)\s([\w\d.]+)`)
 
 func ParseSolarisRelease(content string) (*SolarisRelease, error) {
 	m := solarisVersionRegex.FindStringSubmatch(content)

--- a/providers/os/detector/parser_sol_test.go
+++ b/providers/os/detector/parser_sol_test.go
@@ -39,6 +39,37 @@ func TestSolaris11Release(t *testing.T) {
 	assert.Equal(t, "11", r.Release)
 }
 
+func TestSolaris114Release(t *testing.T) {
+	input := `
+                             Oracle Solaris 11.4 X86
+  Copyright (c) 1983, 2018, Oracle and/or its affiliates.  All rights reserved.
+                            Assembled 16 August 2018
+`
+
+	r, err := detector.ParseSolarisRelease(input)
+	require.NoError(t, err)
+
+	assert.Equal(t, "solaris", r.ID)
+	assert.Equal(t, "Oracle Solaris", r.Title)
+	assert.Equal(t, "11.4", r.Release)
+}
+
+// Some sites prepend a banner to /etc/release. The release line still has to be
+// found rather than only being matched when it happens to come first.
+func TestSolarisReleaseAfterPrecedingLine(t *testing.T) {
+	input := `Authorized use only. Activity may be monitored.
+                             Oracle Solaris 11.4 SPARC
+  Copyright (c) 1983, 2024, Oracle and/or its affiliates.
+`
+
+	r, err := detector.ParseSolarisRelease(input)
+	require.NoError(t, err)
+
+	assert.Equal(t, "solaris", r.ID)
+	assert.Equal(t, "Oracle Solaris", r.Title)
+	assert.Equal(t, "11.4", r.Release)
+}
+
 func TestSolaris10Release(t *testing.T) {
 	input := `
                         Solaris 10 5/08 s10x_u5wos_10 X86

--- a/providers/os/detector/testdata/detect-solaris11-no-release.toml
+++ b/providers/os/detector/testdata/detect-solaris11-no-release.toml
@@ -1,0 +1,8 @@
+[commands."uname -s"]
+stdout = "SunOS"
+
+[commands."uname -m"]
+stdout = "i86pc"
+
+[commands."uname -r"]
+stdout = "5.11"

--- a/providers/os/resources/cpu.go
+++ b/providers/os/resources/cpu.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -325,6 +326,30 @@ func getCpuInfoAIX(conn shared.Connection) (*cpuInfo, error) {
 	return info, nil
 }
 
+// psrinfo reports the core count only when the socket has more than one, and
+// uses the singular "core" for exactly one. A socket line without a core count
+// therefore describes a single-core package.
+//
+//	The physical processor has 4 cores and 8 virtual processors (0-7)
+//	The physical processor has 1 core and 2 virtual processors (0 1)
+//	The physical processor has 1 virtual processor (0)
+var solarisCoreCountRegex = regexp.MustCompile(`\bhas (\d+) cores?\b`)
+
+// solarisSocketCores returns the number of physical cores described by a single
+// "The physical processor has ..." line from psrinfo -pv.
+func solarisSocketCores(line string) int64 {
+	m := solarisCoreCountRegex.FindStringSubmatch(line)
+	if m == nil {
+		// no core count printed => the socket has a single core
+		return 1
+	}
+	n, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil {
+		return 1
+	}
+	return n
+}
+
 func getCpuInfoSolaris(conn shared.Connection) (*cpuInfo, error) {
 	// psrinfo -pv gives per-physical-processor details including model.
 	// Example output:
@@ -355,17 +380,7 @@ func getCpuInfoSolaris(conn shared.Connection) (*cpuInfo, error) {
 		// "The physical processor has N cores and M virtual processors (...)"
 		if strings.HasPrefix(trimmed, "The physical processor has") {
 			sockets++
-			// Extract core count
-			if idx := strings.Index(trimmed, " cores"); idx > 0 {
-				// Find the number before " cores"
-				prefix := trimmed[:idx]
-				parts := strings.Fields(prefix)
-				if len(parts) > 0 {
-					if n, err := strconv.ParseInt(parts[len(parts)-1], 10, 64); err == nil {
-						totalCores += n
-					}
-				}
-			}
+			totalCores += solarisSocketCores(trimmed)
 		}
 
 		// The indented model line (deepest indent, no parens) e.g.:

--- a/providers/os/resources/cpu_test.go
+++ b/providers/os/resources/cpu_test.go
@@ -157,6 +157,86 @@ func TestGetCpuInfoSolaris(t *testing.T) {
 	assert.Equal(t, int64(8), info.Cores)
 }
 
+// psrinfo uses the singular "core" for a single-core socket, which is the
+// common shape for a small cloud VM.
+func TestGetCpuInfoSolarisSingleCore(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"psrinfo -pv": {
+				Stdout: "The physical processor has 1 core and 2 virtual processors (0 1)\n" +
+					"  x86 (GenuineIntel 50654 family 6 model 85 step 4 clock 2000 MHz)\n" +
+					"        Intel(r) Xeon(r) Gold 6138 CPU @ 2.00GHz\n",
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	info, err := getCpuInfoSolaris(conn)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Intel", info.Manufacturer)
+	assert.Equal(t, int64(1), info.ProcessorCount)
+	assert.Equal(t, int64(1), info.Cores)
+}
+
+// A socket with a single core and no threads prints no core count at all.
+func TestGetCpuInfoSolarisSingleVirtualProcessor(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"psrinfo -pv": {
+				Stdout: "The physical processor has 1 virtual processor (0)\n" +
+					"  x86 (GenuineIntel 50654 family 6 model 85 step 4 clock 2000 MHz)\n" +
+					"        Intel(r) Xeon(r) Gold 6138 CPU @ 2.00GHz\n",
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	info, err := getCpuInfoSolaris(conn)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), info.ProcessorCount)
+	assert.Equal(t, int64(1), info.Cores)
+}
+
+// Mixed singular and plural sockets have to add up.
+func TestGetCpuInfoSolarisMixedSockets(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"psrinfo -pv": {
+				Stdout: "The physical processor has 1 core and 2 virtual processors (0 1)\n" +
+					"  x86 (GenuineIntel 50654 family 6 model 85 step 4 clock 2000 MHz)\n" +
+					"        Intel(r) Xeon(r) Gold 6138 CPU @ 2.00GHz\n" +
+					"The physical processor has 4 cores and 8 virtual processors (2-9)\n" +
+					"  x86 (GenuineIntel 50654 family 6 model 85 step 4 clock 2000 MHz)\n" +
+					"        Intel(r) Xeon(r) Gold 6138 CPU @ 2.00GHz\n",
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	info, err := getCpuInfoSolaris(conn)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2), info.ProcessorCount)
+	assert.Equal(t, int64(5), info.Cores)
+}
+
+func TestGetCpuInfoSolarisCommandFailure(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"psrinfo -pv": {
+				Stderr:     "bash: psrinfo: command not found",
+				ExitStatus: 127,
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	_, err = getCpuInfoSolaris(conn)
+	require.Error(t, err, "a failing psrinfo must not report a zero-core cpu")
+}
+
 func TestGetCpuInfoLinuxArmWithLscpu(t *testing.T) {
 	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
 		Files: map[string]*mock.MockFileData{

--- a/providers/os/resources/packages/solaris_packages.go
+++ b/providers/os/resources/packages/solaris_packages.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"strings"
 
 	"go.mondoo.com/mql/providers/os/connection/shared"
 )
@@ -95,6 +96,13 @@ func (s *SolarisPkgManager) List() ([]Package, error) {
 	cmd, err := s.conn.RunCommand("pkg list -Hv")
 	if err != nil {
 		return nil, fmt.Errorf("could not read solaris package list")
+	}
+	// without this an unavailable or failing pkg reports an empty package list
+	// as if the system genuinely had no packages installed
+	if cmd.ExitStatus != 0 {
+		stderr, _ := io.ReadAll(cmd.Stderr)
+		return nil, fmt.Errorf("pkg list failed with exit code %d: %s",
+			cmd.ExitStatus, strings.TrimSpace(string(stderr)))
 	}
 
 	return ParseSolarisPackages(cmd.Stdout), nil

--- a/providers/os/resources/packages/solaris_packages_test.go
+++ b/providers/os/resources/packages/solaris_packages_test.go
@@ -151,3 +151,21 @@ func TestSolaris114Manager(t *testing.T) {
 	}
 	assert.Contains(t, pkgList, p, "pkg detected")
 }
+
+// A failing or unavailable `pkg` must surface an error. Reporting an empty list
+// would read as "this system has no packages installed".
+func TestSolarisPkgManagerCommandFailure(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"pkg list -Hv": {
+				Stderr:     "bash: pkg: command not found",
+				ExitStatus: 127,
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	pkgs, err := (&SolarisPkgManager{conn: conn}).List()
+	require.Error(t, err)
+	assert.Empty(t, pkgs)
+}

--- a/providers/os/resources/services/solarissmf.go
+++ b/providers/os/resources/services/solarissmf.go
@@ -5,6 +5,7 @@ package services
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"strings"
 
@@ -25,6 +26,13 @@ func (s *SolarisSmfServiceManager) List() ([]*Service, error) {
 	cmd, err := s.conn.RunCommand("svcs -a")
 	if err != nil {
 		return nil, err
+	}
+	// without this an unavailable or failing svcs reports an empty service list
+	// as if the system genuinely ran no services
+	if cmd.ExitStatus != 0 {
+		stderr, _ := io.ReadAll(cmd.Stderr)
+		return nil, fmt.Errorf("svcs -a failed with exit code %d: %s",
+			cmd.ExitStatus, strings.TrimSpace(string(stderr)))
 	}
 
 	return ParseSolarisSmfServices(cmd.Stdout), nil
@@ -51,11 +59,20 @@ func ParseSolarisSmfServices(r io.Reader) []*Service {
 	var services []*Service
 	scanner := bufio.NewScanner(r)
 
-	// Skip header line: "STATE          STIME           FMRI"
-	_ = scanner.Scan()
-
+	first := true
 	for scanner.Scan() {
 		line := scanner.Text()
+
+		// Drop the header line ("STATE STIME FMRI") when it is present, but only
+		// then. Skipping unconditionally loses the first service on headerless
+		// output such as `svcs -aH`.
+		if first {
+			first = false
+			if fields := strings.Fields(line); len(fields) > 0 && fields[0] == "STATE" {
+				continue
+			}
+		}
+
 		entry := parseSmfLine(line)
 		if entry == nil {
 			continue

--- a/providers/os/resources/services/solarissmf_test.go
+++ b/providers/os/resources/services/solarissmf_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
 )
 
 func TestParseSolarisSmfServices(t *testing.T) {
@@ -258,6 +260,41 @@ uninitialized  22:01:39        svc:/test/uninit:default
 	assert.False(t, svc.Running, "uninitialized should not be running")
 	assert.False(t, svc.Enabled, "uninitialized should not be enabled")
 	assert.Equal(t, ServiceStopped, svc.State)
+}
+
+// Headerless output must not lose its first service.
+func TestParseSolarisSmfServicesHeaderless(t *testing.T) {
+	testOutput := `online         22:01:55        svc:/network/ssh:default
+disabled       22:01:40        svc:/network/telnet:default`
+
+	services := ParseSolarisSmfServices(strings.NewReader(testOutput))
+	require.Len(t, services, 2)
+
+	ssh := findServiceByName(services, "svc:/network/ssh:default")
+	require.NotNil(t, ssh, "the first service must not be swallowed as a header")
+	assert.True(t, ssh.Running)
+
+	telnet := findServiceByName(services, "svc:/network/telnet:default")
+	require.NotNil(t, telnet)
+	assert.False(t, telnet.Running)
+}
+
+// A failing or unavailable `svcs` must surface an error rather than reporting a
+// system with no services at all.
+func TestSolarisSmfManagerCommandFailure(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"svcs -a": {
+				Stderr:     "bash: svcs: command not found",
+				ExitStatus: 127,
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	svcs, err := (&SolarisSmfServiceManager{conn: conn}).List()
+	require.Error(t, err)
+	assert.Empty(t, svcs)
 }
 
 func findServiceByName(services []*Service, name string) *Service {


### PR DESCRIPTION
Five defects in the OS provider's Solaris code paths. They share a failure mode: each one reports a confident wrong answer instead of an error, so nothing downstream can tell the difference between "measured and found nothing" and "never read anything".

Found by auditing the Solaris surface and pinning each hypothesis with a probe against the current code before changing it.

## What was wrong

**`cpu.coreCount` reads 0 on single-core systems** — `resources/cpu.go`

`psrinfo -pv` prints the core count only when a socket has more than one core, and uses the singular for exactly one:

```
The physical processor has 4 cores and 8 virtual processors (0-7)
The physical processor has 1 core and 2 virtual processors (0 1)
The physical processor has 1 virtual processor (0)
```

The parser matched only `" cores"`, so both lower forms contributed zero. A single-socket, single-core VM — the ordinary small cloud shape — reported `coreCount = 0`. The existing test only covered a 2-socket/4-core-each machine, so the whole singular branch was untested.

**Silent empty package list** — `resources/packages/solaris_packages.go`

`pkg list -Hv` had its exit status ignored. An unavailable or failing `pkg` yields empty stdout, which parses to an empty slice and returns `nil` error — indistinguishable from a host with no packages installed. Every other modern manager here (dpkg, rpm, apk, nix, flatpak, snap, xbps, pacman, homebrew) already checks `ExitStatus`; Solaris was a straggler.

**Silent empty service list, and a dropped first service** — `resources/services/solarissmf.go`

Same missing exit-status check for `svcs -a`. Separately, the header line was discarded unconditionally, so any headerless output lost its first *real* service.

**An unreadable `/etc/release` retracted the platform entirely** — `detector/detector_all.go`

`uname` had already confirmed SunOS and `pf.Name` was already set to `solaris`, but a failed open of `/etc/release` returned `false` — "this is not Solaris". The asset then matched no resolver at all and came out with no platform, rather than solaris without a version. The surrounding comment already claimed the opposite of what the code did:

> `// NOTE: we have only one solaris system here, since we only get here is the family is sunos, we pass`

**A preceding line in `/etc/release` broke version detection** — `detector/parser_sol.go`

The release regex had no `(?m)` flag, so it could only match when the vendor line was first in the file. A site banner ahead of it — not unusual — dropped the title and version silently.

## Verification

Each defect was reproduced before the fix and confirmed after. Observed values, current code → this branch:

| Case | Before | After |
|---|---|---|
| `psrinfo` 1 core / 2 vcpu | `Cores=0` | `Cores=1` |
| `psrinfo` 1 vcpu, no core count | `Cores=0` | `Cores=1` |
| `pkg list -Hv` exit 127 | `0 pkgs, err=nil` | error surfaced |
| `svcs -a` exit 127 | `0 svcs, err=nil` | error surfaced |
| headerless `svcs` output, 2 services | 1 parsed | 2 parsed |
| `/etc/release` with a banner line | parse error | `Oracle Solaris 11.4` |
| SunOS host, no `/etc/release` | no platform detected | `solaris` |

New tests cover each, plus a mixed singular/plural socket sum (1 + 4 = 5 cores). Full `providers/os` suite passes; the two failures that remain (`device_manager_test.go` build, `TestLocalConnectionIdDetectors`) reproduce identically on pristine `main` and are unrelated.

## Follow-ups, not in this PR

- **Fixtures are reconstructed from documented formats, not captured from a live host.** A Solaris 11.4 instance is being provisioned to re-ground them in real output; I'll refresh them in a follow-up.
- **`processes` may return an empty list on Solaris.** The generic branch runs BSD-syntax `ps axo ...`, which SVR4 `ps` rejects, and there is no exit-status check. Holding until it can be confirmed against the live host rather than guessing at the fix.
- **illumos distros are misreported.** OmniOS, OpenIndiana, SmartOS and Tribblix all report `uname -s` = SunOS and reach this resolver, but their `/etc/release` contains no "Solaris", so they land as platform `solaris` with an **empty version**. Fixing that means new platform IDs and touching the `== "solaris"` dispatch in packages and services, which is a behaviour change rather than a bugfix.
- **Gaps where AIX has a branch and Solaris does not**: `ports` errors outright on Solaris, and `kernel`, `nfs`, `smbios` and `cpe` have no Solaris equivalent.
