### PR TITLE
🐛 os: run the SVR4 ps on Solaris so processes is not empty

### DIFF
--- a/providers/os/detector/parser_sol_test.go
+++ b/providers/os/detector/parser_sol_test.go
@@ -39,11 +39,11 @@ func TestSolaris11Release(t *testing.T) {
 	assert.Equal(t, "11", r.Release)
 }
 
+// Verbatim /etc/release from an Oracle Solaris 11.4.86 instance.
 func TestSolaris114Release(t *testing.T) {
-	input := `
-                             Oracle Solaris 11.4 X86
-  Copyright (c) 1983, 2018, Oracle and/or its affiliates.  All rights reserved.
-                            Assembled 16 August 2018
+	input := `                             Oracle Solaris 11.4 X86
+             Copyright (c) 1983, 2025, Oracle and/or its affiliates.
+                            Assembled 07 October 2025
 `
 
 	r, err := detector.ParseSolarisRelease(input)

--- a/providers/os/resources/cpu_test.go
+++ b/providers/os/resources/cpu_test.go
@@ -157,9 +157,57 @@ func TestGetCpuInfoSolaris(t *testing.T) {
 	assert.Equal(t, int64(8), info.Cores)
 }
 
-// psrinfo uses the singular "core" for a single-core socket, which is the
-// common shape for a small cloud VM.
-func TestGetCpuInfoSolarisSingleCore(t *testing.T) {
+// Verbatim psrinfo -pv from a 2 OCPU Oracle Solaris 11.4.86 instance. Note the
+// nested "The core has ..." lines, which must not be mistaken for the model.
+func TestGetCpuInfoSolaris114TwoCore(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"psrinfo -pv": {
+				Stdout: "The physical processor has 2 cores and 4 virtual processors (0-3)\n" +
+					"  The core has 2 virtual processors (0-1)\n" +
+					"  The core has 2 virtual processors (2-3)\n" +
+					"    x86 (AuthenticAMD A10F11 family 25 model 17 step 1 clock 2600 MHz)\n" +
+					"      AMD EPYC 9J14 96-Core Processor\n",
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	info, err := getCpuInfoSolaris(conn)
+	require.NoError(t, err)
+
+	assert.Equal(t, "AMD", info.Manufacturer)
+	assert.Equal(t, "AMD EPYC 9J14 96-Core Processor", info.Model)
+	assert.Equal(t, int64(1), info.ProcessorCount)
+	assert.Equal(t, int64(2), info.Cores)
+}
+
+// Verbatim psrinfo -pv from a 1 OCPU Oracle Solaris 11.4.86 instance. psrinfo
+// prints no core count at all for a single-core socket, which used to be read
+// as zero cores.
+func TestGetCpuInfoSolaris114SingleCore(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"psrinfo -pv": {
+				Stdout: "The physical processor has 2 virtual processors (0-1)\n" +
+					"  x86 (AuthenticAMD A10F11 family 25 model 17 step 1 clock 2600 MHz)\n" +
+					"\tAMD EPYC 9J14 96-Core Processor\n",
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	info, err := getCpuInfoSolaris(conn)
+	require.NoError(t, err)
+
+	assert.Equal(t, "AMD", info.Manufacturer)
+	assert.Equal(t, "AMD EPYC 9J14 96-Core Processor", info.Model)
+	assert.Equal(t, int64(1), info.ProcessorCount)
+	assert.Equal(t, int64(1), info.Cores)
+}
+
+// psrinfo uses the singular "core" for a single-core socket that reports one.
+func TestGetCpuInfoSolarisSingularCoreWording(t *testing.T) {
 	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
 		Commands: map[string]*mock.Command{
 			"psrinfo -pv": {
@@ -175,26 +223,6 @@ func TestGetCpuInfoSolarisSingleCore(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "Intel", info.Manufacturer)
-	assert.Equal(t, int64(1), info.ProcessorCount)
-	assert.Equal(t, int64(1), info.Cores)
-}
-
-// A socket with a single core and no threads prints no core count at all.
-func TestGetCpuInfoSolarisSingleVirtualProcessor(t *testing.T) {
-	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
-		Commands: map[string]*mock.Command{
-			"psrinfo -pv": {
-				Stdout: "The physical processor has 1 virtual processor (0)\n" +
-					"  x86 (GenuineIntel 50654 family 6 model 85 step 4 clock 2000 MHz)\n" +
-					"        Intel(r) Xeon(r) Gold 6138 CPU @ 2.00GHz\n",
-			},
-		},
-	}))
-	require.NoError(t, err)
-
-	info, err := getCpuInfoSolaris(conn)
-	require.NoError(t, err)
-
 	assert.Equal(t, int64(1), info.ProcessorCount)
 	assert.Equal(t, int64(1), info.Cores)
 }

--- a/providers/os/resources/processes/solarisps_test.go
+++ b/providers/os/resources/processes/solarisps_test.go
@@ -1,0 +1,73 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package processes_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+	"go.mondoo.com/mql/providers/os/resources/processes"
+)
+
+// Solaris 11.4 ships an /etc/os-release and so lands in the linux family, but
+// its SVR4 ps rejects the BSD-style "axo" cluster the linux branch uses:
+//
+//	ps: illegal option -- o
+//	usage: ps [ -aceglnrSuUvwx ] [ -t term ] ...
+//
+// Both fixtures below are verbatim from an Oracle Solaris 11.4.86 instance.
+func solarisMock(t *testing.T) *mock.Connection {
+	t.Helper()
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:   "solaris",
+			Family: []string{"linux", "unix", "os"},
+		},
+	}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"ps axo pid,pcpu,pmem,vsz,rss,tty,stat,stime,time,uid,command": {
+				Stderr:     "ps: illegal option -- o\nusage: ps [ -aceglnrSuUvwx ] [ -t term ] [ --scale[=item1,item2,...] ] [ num ]",
+				ExitStatus: 1,
+			},
+			"ps -eo pid,pcpu,pmem,vsz,rss,tty,s,time,uid,args": {
+				Stdout: "  PID %CPU %MEM   VSZ      RSS TT      S        TIME   UID COMMAND\n" +
+					"    0  0.2  0.0     0        0 ?       T       00:02     0 sched\n" +
+					"    1  0.0  0.1  4952     4008 ?       S       00:00     0 /usr/sbin/init\n" +
+					"    6  0.8  0.0     0        0 ?       S       00:03     0 zpool-rpool\n" +
+					"  892  0.0  0.2 12140     6788 ?       S       00:00    54 /usr/lib/ssh/sshd\n",
+			},
+		},
+	}))
+	require.NoError(t, err)
+	return conn
+}
+
+func TestSolarisProcessList(t *testing.T) {
+	pm, err := processes.ResolveManager(solarisMock(t))
+	require.NoError(t, err)
+	require.NotNil(t, pm)
+
+	list, err := pm.List()
+	require.NoError(t, err, "solaris must not fall through to the BSD ps syntax")
+	require.NotNil(t, list)
+	require.Len(t, list, 4, "a running solaris host reports its processes")
+
+	byPid := map[int64]*processes.OSProcess{}
+	for _, p := range list {
+		byPid[p.Pid] = p
+	}
+
+	init := byPid[1]
+	require.NotNil(t, init)
+	assert.Equal(t, "init", init.Executable)
+	assert.Equal(t, "/usr/sbin/init", init.Command)
+
+	sshd := byPid[892]
+	require.NotNil(t, sshd)
+	assert.Equal(t, "sshd", sshd.Executable)
+	assert.Equal(t, "/usr/lib/ssh/sshd", sshd.Command)
+}

--- a/providers/os/resources/processes/unixps.go
+++ b/providers/os/resources/processes/unixps.go
@@ -278,7 +278,8 @@ func (upm *UnixProcessManager) listLocked() ([]*OSProcess, error) {
 func (upm *UnixProcessManager) runPs(command string) (io.Reader, error) {
 	c, err := upm.conn.RunCommand(command)
 	if err != nil {
-		return nil, fmt.Errorf("processes> could not run command")
+		// wrapped so a caller can tell a dead connection from a ps that ran
+		return nil, fmt.Errorf("processes> could not run %q: %w", command, err)
 	}
 	if c.ExitStatus != 0 {
 		stderr, _ := io.ReadAll(c.Stderr)

--- a/providers/os/resources/processes/unixps.go
+++ b/providers/os/resources/processes/unixps.go
@@ -272,52 +272,83 @@ func (upm *UnixProcessManager) listLocked() ([]*OSProcess, error) {
 	return upm.processes, nil
 }
 
+// runPs runs a ps invocation and fails loudly when it does not succeed. ps
+// writes nothing to stdout when it rejects its arguments, which would otherwise
+// parse into an empty slice and report a running host as having no processes.
+func (upm *UnixProcessManager) runPs(command string) (io.Reader, error) {
+	c, err := upm.conn.RunCommand(command)
+	if err != nil {
+		return nil, fmt.Errorf("processes> could not run command")
+	}
+	if c.ExitStatus != 0 {
+		stderr, _ := io.ReadAll(c.Stderr)
+		return nil, fmt.Errorf("processes> %q failed with exit code %d: %s",
+			command, c.ExitStatus, strings.TrimSpace(string(stderr)))
+	}
+	return c.Stdout, nil
+}
+
 // runList runs the platform-appropriate `ps` command and parses its output.
 func (upm *UnixProcessManager) runList() ([]*OSProcess, error) {
 	var entries []*ProcessEntry
 	// NOTE: improve proc parser instead of supporting multiple ps commands
-	if upm.platform.IsFamily("linux") {
-		c, err := upm.conn.RunCommand("ps axo pid,pcpu,pmem,vsz,rss,tty,stat,stime,time,uid,command")
-		if err != nil {
-			return nil, fmt.Errorf("processes> could not run command")
-		}
-
-		entries, err = ParseLinuxPsResult(c.Stdout)
+	switch {
+	case upm.platform.Name == "solaris":
+		// Solaris ships an SVR4 ps that rejects the BSD-style "axo" cluster with
+		// "ps: illegal option -- o", and has no /usr/ucb/ps to fall back on. This
+		// has to be tested before the linux family, because Solaris 11.4 ships an
+		// /etc/os-release and is therefore reported as part of it.
+		stdout, err := upm.runPs("ps -eo pid,pcpu,pmem,vsz,rss,tty,s,time,uid,args")
 		if err != nil {
 			return nil, err
 		}
-	} else if upm.platform.IsFamily("darwin") {
+
+		entries, err = ParseUnixPsResult(stdout)
+		if err != nil {
+			return nil, err
+		}
+	case upm.platform.IsFamily("linux"):
+		stdout, err := upm.runPs("ps axo pid,pcpu,pmem,vsz,rss,tty,stat,stime,time,uid,command")
+		if err != nil {
+			return nil, err
+		}
+
+		entries, err = ParseLinuxPsResult(stdout)
+		if err != nil {
+			return nil, err
+		}
+	case upm.platform.IsFamily("darwin"):
 		// NOTE: special case on darwin is that the ps axo only shows processes for users with terminals
 		// TODO: the same applies to OpenBSD and may result in missing processes
-		c, err := upm.conn.RunCommand("ps Axo pid,pcpu,pmem,vsz,rss,tty,stat,stime,time,uid,command")
-		if err != nil {
-			return nil, fmt.Errorf("processes> could not run command")
-		}
-
-		entries, err = ParseLinuxPsResult(c.Stdout)
+		stdout, err := upm.runPs("ps Axo pid,pcpu,pmem,vsz,rss,tty,stat,stime,time,uid,command")
 		if err != nil {
 			return nil, err
 		}
-	} else if upm.platform.Name == "aix" {
+
+		entries, err = ParseLinuxPsResult(stdout)
+		if err != nil {
+			return nil, err
+		}
+	case upm.platform.Name == "aix":
 		// special case for aix since it does not understand x
-		c, err := upm.conn.RunCommand("ps -A -o pid,pcpu,pmem,vsz,tty,time,uid,args")
-		if err != nil {
-			return nil, fmt.Errorf("processes> could not run command")
-		}
-
-		entries, err = ParseAixPsResult(c.Stdout)
+		stdout, err := upm.runPs("ps -A -o pid,pcpu,pmem,vsz,tty,time,uid,args")
 		if err != nil {
 			return nil, err
 		}
-	} else {
+
+		entries, err = ParseAixPsResult(stdout)
+		if err != nil {
+			return nil, err
+		}
+	default:
 		// TODO: consider using different ps calls for different platforms to determine max information
 		// do not use stime since it is not available on FreeBSD
-		c, err := upm.conn.RunCommand("ps axo pid,pcpu,pmem,vsz,rss,tty,stat,time,uid,command")
+		stdout, err := upm.runPs("ps axo pid,pcpu,pmem,vsz,rss,tty,stat,time,uid,command")
 		if err != nil {
-			return nil, fmt.Errorf("processes> could not run command")
+			return nil, err
 		}
 
-		entries, err = ParseUnixPsResult(c.Stdout)
+		entries, err = ParseUnixPsResult(stdout)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/os/resources/services/solarissmf_test.go
+++ b/providers/os/resources/services/solarissmf_test.go
@@ -262,10 +262,44 @@ uninitialized  22:01:39        svc:/test/uninit:default
 	assert.Equal(t, ServiceStopped, svc.State)
 }
 
+// Verbatim `svcs -a` lines from an Oracle Solaris 11.4.86 instance. 11.4 prints
+// STIME as an ISO timestamp rather than the wall-clock time older releases used.
+func TestParseSolarisSmfServices114(t *testing.T) {
+	testOutput := `STATE          STIME               FMRI
+legacy_run     2026-08-27T07:02:19 lrc:/etc/rc2_d/S89PRESERVE
+disabled       2026-08-27T07:01:57 svc:/application/management/net-snmp:default
+online         2026-08-27T07:01:40 svc:/network/ssh:default
+offline*       2026-08-27T07:01:57 svc:/application/man-index:default
+incomplete     2026-08-27T07:01:33 svc:/system/early-manifest-import:default`
+
+	services := ParseSolarisSmfServices(strings.NewReader(testOutput))
+	require.Len(t, services, 5)
+
+	legacy := findServiceByName(services, "lrc:/etc/rc2_d/S89PRESERVE")
+	require.NotNil(t, legacy)
+	assert.True(t, legacy.Running, "legacy_run is running")
+
+	ssh := findServiceByName(services, "svc:/network/ssh:default")
+	require.NotNil(t, ssh)
+	assert.True(t, ssh.Running)
+	assert.True(t, ssh.Enabled)
+
+	// a transitioning state carries a trailing asterisk
+	manIndex := findServiceByName(services, "svc:/application/man-index:default")
+	require.NotNil(t, manIndex)
+	assert.False(t, manIndex.Running, "offline* is not yet running")
+	assert.True(t, manIndex.Enabled, "offline* is still enabled")
+
+	snmp := findServiceByName(services, "svc:/application/management/net-snmp:default")
+	require.NotNil(t, snmp)
+	assert.False(t, snmp.Running)
+	assert.False(t, snmp.Enabled)
+}
+
 // Headerless output must not lose its first service.
 func TestParseSolarisSmfServicesHeaderless(t *testing.T) {
-	testOutput := `online         22:01:55        svc:/network/ssh:default
-disabled       22:01:40        svc:/network/telnet:default`
+	testOutput := `online         2026-08-27T07:01:40 svc:/network/ssh:default
+disabled       2026-08-27T07:01:31 svc:/network/telnet:default`
 
 	services := ParseSolarisSmfServices(strings.NewReader(testOutput))
 	require.Len(t, services, 2)


### PR DESCRIPTION
`processes` returned an **empty list on every Solaris host**. Found and fixed against a live Oracle Solaris 11.4.86 instance, which also corrected two fixture details the previous PR had reconstructed from documentation rather than captured.

## The bug

Solaris 11.4 ships an `/etc/os-release`:

```
NAME="Oracle Solaris"
ID=solaris
VERSION_ID=11.4
CPE_NAME="cpe:/o:oracle:solaris:11:4"
```

The `linuxFamily` resolver reads that file and stops there, so a Solaris asset is reported as part of the **linux family**. `runList` therefore took the linux branch, which runs a BSD-style `ps axo ...`. Solaris ships an SVR4 `ps`, which rejects it:

```
ps: illegal option -- o
usage: ps [ -aceglnrSuUvwx ] [ -t term ] [ --scale[=item1,item2,...] ] [ num ]
```

There is no `/usr/ucb/ps` to fall back on either — it exits 127.

`ps` writes **nothing** to stdout when it rejects its arguments, and the exit status was never checked. The empty output parsed into an empty slice and returned `nil` error, so a running host reported no processes at all.

## The fix

Solaris now runs `ps -eo pid,pcpu,pmem,vsz,rss,tty,s,time,uid,args`, which produces the exact column layout `ParseUnixPsResult` already expects. It is matched **before** the linux family, because of the `/etc/os-release` classification above.

Every `ps` invocation now goes through a helper that fails loudly on a non-zero exit rather than reporting an empty process list. This is a deliberate behaviour change: a `ps` that fails now surfaces an error instead of silently claiming the host runs nothing.

## Verified live

Against Oracle Solaris 11.4.86 (`VM.Standard.E5.Flex`, OCI):

| Query | Before | After |
|---|---|---|
| `processes.list.length` | **0** | **55** |

55 matches `ps -eo` on the host exactly (56 lines, one of them the header).

## Fixtures re-grounded in real output

The Solaris fixtures in #10516 were reconstructed from documented formats. They are now verbatim captures from that instance, which corrected two things the reconstruction got wrong:

- **`psrinfo -pv` on a single-core socket** prints `The physical processor has 2 virtual processors (0-1)` — not `1 virtual processor (0)` as guessed. Same code path (no core count printed at all), but the real string is now what's tested. A multi-core socket also nests `The core has ...` lines, which must not be mistaken for the model line.
- **`svcs -a` on 11.4** prints STIME as an ISO timestamp (`2026-08-27T07:01:57`), not the wall-clock time (`22:01:55`) older releases used.

The 2-core reading was confirmed end-to-end too: `machine.cpu` returns `coreCount: 2, processorCount: 1, model: "AMD EPYC 9J14 96-Core Processor"` on the live host.

## Related, not in this PR

- **The linux-family misclassification is the root cause here and affects more than `processes`.** `ports.list.length` also returns **0** on Solaris, because the linux branch reads `/proc/net/tcp`, which Solaris does not have. `kernel.info` returns null for the same reason. Solaris `netstat -an` has a genuinely different format (`*.68` notation, `Unbound`/`Idle` states) and needs a real parser, so I did not rush one in here.
- `OSProcess.Uid` is parsed by all three ps parsers and then dropped by `ToOSProcess`. It is not surfaced in the schema, so this is dead code rather than a wrong answer — though the `processes` doc-comment does claim you can filter "by user", which you currently cannot.
