### PR TITLE
🐛 os: stop the scp filesystem claiming an lstat it cannot do

### DIFF
--- a/providers/os/connection/ssh/scp/fs.go
+++ b/providers/os/connection/ssh/scp/fs.go
@@ -76,9 +76,10 @@ func (s Fs) Stat(path string) (os.FileInfo, error) {
 	return statutil.New(s.commandRunner).Stat(path)
 }
 
-func (s Fs) Lstat(p string) (os.FileInfo, error) {
-	return nil, errors.New("lstat not implemented")
-}
+// NOTE: deliberately no Lstat. Connection.FileInfo probes for an Lstat method
+// and uses it as the primary call, so declaring one that always errors makes
+// every stat fail instead of falling through to Stat above, which works. Symlink
+// detection on this filesystem is handled by statutil's compound command.
 
 func (s Fs) Chmod(name string, mode os.FileMode) error {
 	return errors.New("chmod not implemented")

--- a/providers/os/connection/ssh/scp/fs_test.go
+++ b/providers/os/connection/ssh/scp/fs_test.go
@@ -1,0 +1,31 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scp
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Connection.FileInfo probes for an Lstat method and, when it finds one, uses it
+// as the primary call with no fallback. This filesystem cannot lstat, so it must
+// not advertise the method: doing so made every stat fail with "lstat not
+// implemented" on any SSH target without an sftp subsystem - Oracle Solaris
+// 11.4 ships sshd with no Subsystem line at all - instead of falling through to
+// Stat, which works.
+func TestFsDoesNotAdvertiseLstat(t *testing.T) {
+	type lstater interface {
+		Lstat(string) (os.FileInfo, error)
+	}
+
+	var fs any = Fs{}
+	_, ok := fs.(lstater)
+	assert.False(t, ok, "scp Fs must not satisfy the lstat probe in Connection.FileInfo")
+
+	var pfs any = &Fs{}
+	_, ok = pfs.(lstater)
+	assert.False(t, ok, "*scp.Fs must not satisfy the lstat probe either")
+}


### PR DESCRIPTION
Every file resource failed with `lstat not implemented` on any SSH target without an sftp subsystem. This is a connection-layer bug, not a Solaris one — Solaris is just where it surfaced.

## What was wrong

`Connection.FileInfo` probes the filesystem for an `Lstat` method and, when it finds one, uses it as the primary call with **no fallback**:

```go
type lstater interface {
    Lstat(string) (os.FileInfo, error)
}
if ls, ok := fs.(lstater); ok {
    linfo, err := ls.Lstat(path)
    if err != nil {
        return shared.FileInfoDetails{}, err   // <- dead end
    }
    ...
}

// Fallback for filesystems without Lstat (cat, SCP).
// Symlink detection handled by statutil's compound command.
stat, err := afs.Stat(path)
```

The SCP filesystem declared an `Lstat` that unconditionally returned an error. So the probe succeeded, the call failed immediately, and the code **never reached its own `Stat`** — which works fine, via `statutil`.

The fallback that was meant for SCP is right there in `FileInfo`, and its comment names SCP explicitly. The stub is what made it unreachable. `cat` already omits the method and takes that path correctly.

## The fix

Remove the stub. `afero.Fs` does not require `Lstat`, so the probe now fails and SCP gets the `Stat` path the comment always intended for it. A test pins the property so the stub cannot come back.

## Why this matters beyond Solaris

Any SSH host whose sshd has no sftp subsystem falls back to the SCP filesystem, and every `file()`, `stat`, and file-backed resource on it was returning an error rather than data.

Oracle Solaris 11.4 is a concrete case: it ships sshd with an **empty** `# Configured Subsystems` section — no `Subsystem sftp` line at all — so every Solaris SSH scan hit this.

It also silently took `services` to zero. `ResolveManager` stats `/sbin/init` to detect a container with no init system; that stat failed, so `useNoopInit` became true and the noop service manager was selected — on a host running 202 services. `/sbin/init` exists on Solaris; the stat was the only thing that was broken.

## Verified live

Against Oracle Solaris 11.4.86 (`VM.Standard.E5.Flex`, OCI):

| Query | Before | After |
|---|---|---|
| `file("/etc/release")` | `lstat not implemented` | `exists: true, size: 176` |
| `services.list.length` | **0** | **202** |

176 bytes matches the file on the host exactly. 202 matches `svcs -a` (203 lines, one header), and the 139 reported running reconciles to 138 `online` + 1 `legacy_run` at query time.

## A note on scope

Restoring real `lstat` semantics — distinguishing a symlink from its target on this filesystem — would need a non-dereferencing variant of `statutil`'s compound command. That is worth doing separately; this change is limited to making stat work at all, which is what the fallback was already written to handle.
