### PR TITLE
🐛 os: parse the Solaris uptime pluralization

### DIFF
--- a/providers/os/resources/uptime/unix.go
+++ b/providers/os/resources/uptime/unix.go
@@ -20,7 +20,11 @@ import (
 // component is exactly zero — "up 11 days, 16 hrs" (macOS prints "N hrs"
 // instead of "N:00" for one minute every hour, so missing that form made
 // the uptime resource error once an hour).
-var UnixUptimeRegex = regexp.MustCompile(`^.*up[\s]*(?:\s*(\d+)\s(day[s]*),)*(?:\s*(\d+)\s(hr[s]*),)*(?:\s*(\d+)\s(min[s]*),)*(?:\s+([\d:]+),\s)*\s*(?:(\d+)\suser[s]*,\s)*\s*load\s+average[s]*:\s+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)\s*$`)
+//
+// Solaris pluralizes with a parenthesized suffix instead of a bare "s",
+// printing "up 26 min(s)" and "up 5 day(s), 21:03", so each unit accepts
+// that spelling too.
+var UnixUptimeRegex = regexp.MustCompile(`^.*up[\s]*(?:\s*(\d+)\s(day(?:s|\(s\))?),)*(?:\s*(\d+)\s(hr(?:s|\(s\))?),)*(?:\s*(\d+)\s(min(?:s|\(s\))?),)*(?:\s+([\d:]+),\s)*\s*(?:(\d+)\suser[s]*,\s)*\s*load\s+average[s]*:\s+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)\s*$`)
 
 type UnixUptimeResult struct {
 	Duration           int64
@@ -37,18 +41,16 @@ func unixDuration(date, measure string) (int64, error) {
 		return 0, err
 	}
 
+	// "days", "day(s)" and "day" all mean the same unit
+	measure = strings.TrimSuffix(measure, "(s)")
+	measure = strings.TrimSuffix(measure, "s")
+
 	switch measure {
 	case "day":
-		fallthrough
-	case "days":
 		duration = duration * 24 * int64(time.Hour)
 	case "hr":
-		fallthrough
-	case "hrs":
 		duration = duration * int64(time.Hour)
 	case "min":
-		fallthrough
-	case "mins":
 		duration = duration * int64(time.Minute)
 	}
 	return duration, nil

--- a/providers/os/resources/uptime/unix_test.go
+++ b/providers/os/resources/uptime/unix_test.go
@@ -204,3 +204,34 @@ func TestFreebsdUptime(t *testing.T) {
 	}, duration)
 	assert.Equal(t, "24m0s", time.Duration(duration.Duration).String())
 }
+
+// Solaris pluralizes with "(s)" rather than a bare "s". Verbatim output from an
+// Oracle Solaris 11.4.86 host.
+func TestSolarisUptimeMinutes(t *testing.T) {
+	data := "  7:28am  up 27 min(s),  0 users,  load average: 0.02, 0.01, 0.03"
+	duration, err := uptime.ParseUnixUptime(data)
+	assert.Nil(t, err)
+	assert.Equal(t, &uptime.UnixUptimeResult{
+		Duration:           int64(27 * time.Minute),
+		Users:              0,
+		LoadOneMinute:      float64(0.02),
+		LoadFiveMinutes:    float64(0.01),
+		LoadFifteenMinutes: float64(0.03),
+	}, duration)
+	assert.Equal(t, "27m0s", time.Duration(duration.Duration).String())
+}
+
+func TestSolarisUptimeDaysAndClock(t *testing.T) {
+	data := " 10:47am  up 5 day(s), 21:03,  1 user,  load average: 0.10, 0.20, 0.30"
+	duration, err := uptime.ParseUnixUptime(data)
+	assert.Nil(t, err)
+	assert.Equal(t, "141h3m0s", time.Duration(duration.Duration).String())
+	assert.Equal(t, 1, duration.Users)
+}
+
+func TestSolarisUptimeHours(t *testing.T) {
+	data := " 10:47am  up 2 hr(s), 15 min(s),  3 users,  load average: 0.10, 0.20, 0.30"
+	duration, err := uptime.ParseUnixUptime(data)
+	assert.Nil(t, err)
+	assert.Equal(t, "2h15m0s", time.Duration(duration.Duration).String())
+}


### PR DESCRIPTION
`os.uptime` errored on every Solaris host:

```
could not parse uptime:   7:28am  up 26 min(s),  0 users,  load average: 0.00, 0.00, 0.03
```

## What was wrong

Solaris pluralizes its units with a parenthesized suffix — `min(s)`, `hr(s)`, `day(s)` — where the regex only accepted a bare `s` (`min[s]*`, `day[s]*`). No unit alternative matched, the whole line failed, and the field surfaced an error instead of a duration.

## The fix

Each unit now also accepts the `(s)` spelling, and `unixDuration` normalizes the suffix rather than enumerating every variant — which also removes the `fallthrough` pairs it needed to keep `day`/`days` and `hr`/`hrs` in sync.

## Verified live

Against Oracle Solaris 11.4.86 (`VM.Standard.E5.Flex`, OCI):

| Query | Before | After |
|---|---|---|
| `os.uptime` | `could not parse uptime: ...` | `28 minutes` |

Test coverage added for the three Solaris shapes: minutes only (verbatim from the host), `5 day(s), 21:03`, and `2 hr(s), 15 min(s)`.

Every existing case — linux, alpine, busybox, debian, rhel, `LC_NUMERIC=de`, macOS and FreeBSD — still passes unchanged, including the macOS `N hrs` form the regex was previously extended for.
