### PR TITLE
✨ aws: discover EC2 instances as API assets by default

### DIFF
--- a/providers/aws/resources/discovery.go
+++ b/providers/aws/resources/discovery.go
@@ -32,8 +32,8 @@ const (
 	DiscoveryResources                   = "resources"          // all the resources
 	DiscoveryECSContainersAPI            = "ecs-containers-api" // need dedup story
 	DiscoveryECRImageAPI                 = "ecr-image-api"      // need policy + dedup story
-	DiscoveryEC2InstanceAPI              = "ec2-instances-api"  // need policy + dedup story
-	DiscoverySSMInstanceAPI              = "ssm-instances-api"  // need policy + dedup story
+	DiscoveryEC2InstanceAPI              = "ec2-instances-api"
+	DiscoverySSMInstanceAPI              = "ssm-instances-api" // need policy + dedup story
 	DiscoveryS3Buckets                   = "s3-buckets"
 	DiscoveryEKSClusters                 = "eks-clusters"
 	DiscoveryCloudtrailTrails            = "cloudtrail-trails"
@@ -89,8 +89,15 @@ const (
 var AllAPIResources = []string{
 	// DiscoveryECSContainersAPI,
 	// DiscoveryECRImageAPI,
-	// DiscoveryEC2InstanceAPI,
 	// DiscoverySSMInstanceAPI,
+	// EC2 instances as API (configuration) assets. This is a second view of an
+	// instance, not a replacement for OS scanning: the API asset carries the
+	// AWS-side posture (platform aws-ec2-instance, so the internet-exposure
+	// checks gated on that platform can run at all), while an OS scan of the
+	// same instance stays its own asset. The two never collide: this asset is
+	// identified by the instance ARN plus MondooObjectID's ".../instance/<id>"
+	// form, an OS scan by awsec2.MondooInstanceID's ".../instances/<id>" form.
+	DiscoveryEC2InstanceAPI,
 	DiscoveryS3Buckets,
 	DiscoveryEKSClusters,
 	DiscoveryCloudtrailTrails,

--- a/providers/aws/resources/discovery_test.go
+++ b/providers/aws/resources/discovery_test.go
@@ -66,6 +66,7 @@ func TestAllResolvedResources(t *testing.T) {
 		DiscoveryDocumentDBInstances,
 		DiscoverySnsTopics,
 		DiscoverySqsQueues,
+		DiscoveryEC2InstanceAPI,
 		DiscoveryInstances,
 		DiscoverySSMInstances,
 		DiscoveryECR,
@@ -127,6 +128,7 @@ func TestAutoResolvedResources(t *testing.T) {
 		DiscoveryDocumentDBInstances,
 		DiscoverySnsTopics,
 		DiscoverySqsQueues,
+		DiscoveryEC2InstanceAPI,
 	}
 	require.ElementsMatch(t, expected, Auto)
 }


### PR DESCRIPTION
## Problem

The internet-exposure risk-factor checks for EC2 instances are gated on `asset.platform == "aws-ec2-instance"` — `aws-ec2-instance-public` today, plus `aws-ec2-instance-behind-public-lb` from mondoohq/server#18347. But nothing produces assets with that platform by default: the `ec2-instances-api` discovery target has a complete implementation and is wired as a CLI option, yet sits excluded from `AllAPIResources` with `// need policy + dedup story`.

The practical effect, observed while debugging a customer space: 747 EC2 instances all represented as OS assets (bottlerocket/windows/almalinux), zero `aws-ec2-instance` assets, so the instance-exposure checks never evaluate anywhere in the space — while the same estate flags 294 internet-facing ELBs. Exposure stops at the load balancer.

## Why the two blockers no longer hold

**Dedup story.** An API asset and an OS scan of the same instance never collide:

| view | platform IDs |
|---|---|
| API asset (`MqlObjectToAsset`) | `arn:aws:ec2:<region>:<acct>:instance/<id>` + `//platformid…/aws/ec2/v1/accounts/<acct>/regions/<region>/instance/<id>` |
| OS asset (`awsec2.MondooInstanceID`) | `//platformid…/aws/ec2/v1/accounts/<acct>/regions/<region>/instances/<id>` |

Singular `instance/` vs plural `instances/` — distinct identities by construction, no platform flapping. Two views of one instance is the shape the platform already lives with (ECR image assets vs container-image assets; k8s operator `machine` assets vs integration EC2 assets): configuration posture on the API asset, packages/CVEs on the OS asset.

**Policy story.** The risk-factors bundle carries `aws-ec2-instance`-gated checks, and mondoohq/server#18347 adds the `include_asset_risks` overlay so detected risk factors surface on assets without scored findings — these assets are no longer empty husks in the UI.

## Change

- `DiscoveryEC2InstanceAPI` joins `AllAPIResources`, so `resources`, `auto`, and `all` discovery include EC2 API assets. The serverless AWS integration passes `["resources", "accounts"]`, so integrations pick this up with the provider update, no per-customer configuration.
- The lister already applies connection discovery filters (same `GetInstances` the OS `instances` target uses), so `--filters` behave identically for both views.
- `ecs-containers-api`, `ecr-image-api`, and `ssm-instances-api` stay excluded — their stories are not resolved by this PR.

## For reviewers to weigh

- **Asset counts.** Every space using `resources`/`auto` discovery gains one API asset per EC2 instance (including stopped instances, same as the OS `instances` target lists them). For the motivating space that is +747 assets across 67 accounts.
- **Per-asset API fan-out.** The `exposure()` field on each instance asset resolves subnets, SGs, NACLs — and `internetFacingLoadBalancers` lists the account's load balancers + target groups per asset scan. Scans of large single accounts will feel this (each discovered asset is its own connection, so the ELB list is not shared across instance assets). If that's a blocker, the alternative is keeping this opt-in and wiring an integration toggle instead.

## Verification

- `go build ./...` and full `go test ./...` inside `providers/aws` pass; the `Auto`/`All` expansion tests are updated to pin the new membership.
- The discovery case handler itself is shipped code (`--discover ec2-instances-api` works on released providers); this PR only changes the default expansion.

Companion to mondoohq/server#18347 (the checks this makes reachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)