### PR TITLE
🐛 os: fix macOS resources that reported the wrong security state

### DIFF
--- a/providers/os/id/hypervisor/darwin_h.go
+++ b/providers/os/id/hypervisor/darwin_h.go
@@ -40,10 +40,42 @@ func (h *hyper) detectDarwinIOReg() (string, bool) {
 }
 
 // detectDarwinModelIdentifier uses system_profiler to detect virtualization.
+//
+// Only the model fields are matched, never the whole hardware profile. The
+// profile of a physical Mac carries the vendor name in several unrelated
+// places ("Chip: Apple M4 Pro"), and matching against all of it made every
+// Apple Silicon Mac report the "apple" key and come back as Apple
+// Virtualization. A guest names its hypervisor in the model itself --
+// "Apple Virtual Machine 1", "VMware Virtual Platform", "VirtualBox" -- so
+// those two lines carry the whole signal.
 func (h *hyper) detectDarwinModelIdentifier() (string, bool) {
 	stdout, err := h.RunCommand("system_profiler SPHardwareDataType")
 	if err != nil {
 		return "", false
 	}
-	return mapHypervisor(stdout)
+	return mapHypervisor(darwinHardwareModel(stdout))
+}
+
+// darwinHardwareModelKeys are the SPHardwareDataType labels whose values name
+// the machine. A hypervisor announces itself in one of them or not at all.
+var darwinHardwareModelKeys = []string{"Model Name", "Model Identifier"}
+
+// darwinHardwareModel returns the model values from SPHardwareDataType output,
+// joined by a newline so a key cannot match across two of them.
+func darwinHardwareModel(stdout string) string {
+	var models []string
+	for _, line := range strings.Split(stdout, "\n") {
+		label, value, found := strings.Cut(line, ":")
+		if !found {
+			continue
+		}
+		label = strings.TrimSpace(label)
+		for _, key := range darwinHardwareModelKeys {
+			if label == key {
+				models = append(models, strings.TrimSpace(value))
+				break
+			}
+		}
+	}
+	return strings.Join(models, "\n")
 }

--- a/providers/os/id/hypervisor/darwin_h_test.go
+++ b/providers/os/id/hypervisor/darwin_h_test.go
@@ -1,0 +1,78 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package hypervisor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A physical Apple Silicon Mac names the vendor in fields that have nothing to
+// do with virtualization ("Chip: Apple M4 Pro"). Matching the whole hardware
+// profile picked up the "apple" key and reported every such Mac as running
+// under Apple Virtualization, which also made the asset kind "virtualmachine".
+const physicalAppleSiliconProfile = `Hardware:
+
+    Hardware Overview:
+
+      Model Name: MacBook Pro
+      Model Identifier: Mac16,8
+      Model Number: MX2J3LL/A
+      Chip: Apple M4 Pro
+      Total Number of Cores: 14 (10 Performance and 4 Efficiency)
+      Memory: 24 GB
+      System Firmware Version: 18000.121.3
+      OS Loader Version: 18000.121.3
+      Serial Number (system): DWKDWYVG4W
+      Hardware UUID: 33822EE1-9366-5120-A0B1-6CCC4D8031FA
+      Provisioning UDID: 00006040-000C31D03EF8801C
+      Activation Lock Status: Disabled
+`
+
+const appleVirtualMachineProfile = `Hardware:
+
+    Hardware Overview:
+
+      Model Name: Apple Virtual Machine 1
+      Model Identifier: VirtualMac2,1
+      Chip: Apple M4 Pro
+      Memory: 8 GB
+`
+
+const vmwareGuestProfile = `Hardware:
+
+    Hardware Overview:
+
+      Model Name: VMware Virtual Platform
+      Model Identifier: VMware7,1
+      Processor Name: Intel Core i7
+`
+
+func TestDarwinHardwareModelIgnoresNonModelFields(t *testing.T) {
+	assert.Equal(t, "MacBook Pro\nMac16,8", darwinHardwareModel(physicalAppleSiliconProfile))
+	assert.Equal(t, "Apple Virtual Machine 1\nVirtualMac2,1", darwinHardwareModel(appleVirtualMachineProfile))
+}
+
+func TestMapHypervisorPhysicalMacIsNotVirtual(t *testing.T) {
+	v, ok := mapHypervisor(darwinHardwareModel(physicalAppleSiliconProfile))
+	assert.False(t, ok, "a physical Mac must not be reported as virtualized, got %q", v)
+	assert.Empty(t, v)
+}
+
+func TestMapHypervisorDarwinGuests(t *testing.T) {
+	for name, tt := range map[string]struct {
+		profile string
+		want    string
+	}{
+		"apple virtualization": {appleVirtualMachineProfile, "Apple Virtualization"},
+		"vmware fusion":        {vmwareGuestProfile, "VMware"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			v, ok := mapHypervisor(darwinHardwareModel(tt.profile))
+			assert.True(t, ok, "guest must still be detected")
+			assert.Equal(t, tt.want, v)
+		})
+	}
+}

--- a/providers/os/resources/macos_alf.go
+++ b/providers/os/resources/macos_alf.go
@@ -14,9 +14,19 @@ import (
 	"go.mondoo.com/mql/types"
 )
 
+// alfPlistLocations holds the ALF preferences file, which is where the
+// firewall settings were stored through macOS 14.
+//
+// /usr/libexec/ApplicationFirewall/com.apple.alf.plist is deliberately NOT
+// listed. That file is the factory-default template the OS ships with, not
+// live state: it is owned by root inside a SIP-protected directory and always
+// reads globalstate 0 / stealthenabled 0. Recent macOS releases no longer
+// write /Library/Preferences/com.apple.alf.plist at all, so treating the
+// template as a fallback reported the firewall as disabled with stealth mode
+// off on every such machine, whatever the firewall was actually doing.
+// macos.firewall reads the live state from socketfilterfw instead.
 var alfPlistLocations = []string{
 	"/Library/Preferences/com.apple.alf.plist",
-	"/usr/libexec/ApplicationFirewall/com.apple.alf.plist",
 }
 
 func initMacosAlf(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/os/resources/macos_firewall.go
+++ b/providers/os/resources/macos_firewall.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
@@ -69,7 +68,12 @@ func (m *mqlMacosFirewall) fetchConfig() (plist.Data, error) {
 	}
 
 	if plistLocation == "" {
-		return nil, errors.New("ALF configuration not found")
+		// No preferences file. Modern macOS stops writing one; the live state
+		// is read from socketfilterfw instead. Cache the empty result so the
+		// lookup is not repeated per field.
+		m.fetched = true
+		m.config = nil
+		return nil, nil
 	}
 
 	f, err := fs.Open(plistLocation)
@@ -93,11 +97,18 @@ func (m *mqlMacosFirewall) globalState() (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	v, err := alfConfigFloat(config, "globalstate")
+	if v, err := alfConfigFloat(config, "globalstate"); err == nil {
+		return int64(v), nil
+	}
+
+	stdout, err := m.runSocketfilterfw("--getglobalstate")
 	if err != nil {
 		return 0, err
 	}
-	return int64(v), nil
+	if v, ok := parseGlobalState(stdout); ok {
+		return v, nil
+	}
+	return 0, errFirewallStateUnavailable
 }
 
 func (m *mqlMacosFirewall) enabled() (bool, error) {
@@ -121,11 +132,18 @@ func (m *mqlMacosFirewall) stealthEnabled() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	v, err := alfConfigFloat(config, "stealthenabled")
+	if v, err := alfConfigFloat(config, "stealthenabled"); err == nil {
+		return int64(v) != 0, nil
+	}
+
+	stdout, err := m.runSocketfilterfw("--getstealthmode")
 	if err != nil {
 		return false, err
 	}
-	return int64(v) != 0, nil
+	if v, ok := parseOnOff(stdout); ok {
+		return v, nil
+	}
+	return false, errFirewallStateUnavailable
 }
 
 func (m *mqlMacosFirewall) loggingEnabled() (bool, error) {
@@ -133,11 +151,18 @@ func (m *mqlMacosFirewall) loggingEnabled() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	v, err := alfConfigFloat(config, "loggingenabled")
+	if v, err := alfConfigFloat(config, "loggingenabled"); err == nil {
+		return int64(v) != 0, nil
+	}
+
+	stdout, err := m.runSocketfilterfw("--getloggingmode")
 	if err != nil {
 		return false, err
 	}
-	return int64(v) != 0, nil
+	if v, ok := parseOnOff(stdout); ok {
+		return v, nil
+	}
+	return false, errFirewallStateUnavailable
 }
 
 func (m *mqlMacosFirewall) loggingDetail() (string, error) {
@@ -164,27 +189,37 @@ func (m *mqlMacosFirewall) loggingDetail() (string, error) {
 }
 
 func (m *mqlMacosFirewall) allowSignedApps() (bool, error) {
-	config, err := m.fetchConfig()
-	if err != nil {
-		return false, err
-	}
-	v, err := alfConfigFloat(config, "allowsignedenabled")
-	if err != nil {
-		return false, err
-	}
-	return int64(v) != 0, nil
+	return m.signedAppsFlag("allowsignedenabled", false)
 }
 
 func (m *mqlMacosFirewall) allowDownloadSignedApps() (bool, error) {
+	return m.signedAppsFlag("allowdownloadsignedenabled", true)
+}
+
+// signedAppsFlag reads one of the two auto-allow toggles. socketfilterfw
+// reports both in a single --getallowsigned reply, so `downloaded` picks the
+// line rather than the command.
+func (m *mqlMacosFirewall) signedAppsFlag(plistKey string, downloaded bool) (bool, error) {
 	config, err := m.fetchConfig()
 	if err != nil {
 		return false, err
 	}
-	v, err := alfConfigFloat(config, "allowdownloadsignedenabled")
+	if v, err := alfConfigFloat(config, plistKey); err == nil {
+		return int64(v) != 0, nil
+	}
+
+	stdout, err := m.runSocketfilterfw("--getallowsigned")
 	if err != nil {
 		return false, err
 	}
-	return int64(v) != 0, nil
+	builtin, download, ok := parseAllowSigned(stdout)
+	if !ok {
+		return false, errFirewallStateUnavailable
+	}
+	if downloaded {
+		return download, nil
+	}
+	return builtin, nil
 }
 
 func (m *mqlMacosFirewall) version() (string, error) {

--- a/providers/os/resources/macos_firewall_live.go
+++ b/providers/os/resources/macos_firewall_live.go
@@ -1,0 +1,106 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"go.mondoo.com/mql/llx"
+)
+
+// socketfilterfw is Apple's command line front end for the application
+// firewall. Its read-only getters work without root, and unlike the
+// preference plist it reports the state the firewall is actually running
+// with rather than what was last written to disk.
+const socketfilterfwPath = "/usr/libexec/ApplicationFirewall/socketfilterfw"
+
+// globalStateRegex pulls the numeric state out of `socketfilterfw
+// --getglobalstate`, which prints e.g. "Firewall is enabled. (State = 1)".
+// The number is the same value the plist stores under "globalstate": 0 off,
+// 1 on, 2 blocking all incoming connections.
+var globalStateRegex = regexp.MustCompile(`\(State\s*=\s*(\d+)\)`)
+
+// errFirewallStateUnavailable reports that neither source could answer. It is
+// deliberately an error rather than a false: "the firewall is off" and "we
+// could not read the firewall" are different findings, and reporting the
+// second as the first is how a disabled firewall passes an audit.
+var errFirewallStateUnavailable = errors.New(
+	"cannot determine application firewall state: no ALF preferences file and socketfilterfw did not return a readable answer")
+
+// runSocketfilterfw runs one socketfilterfw getter and returns its stdout.
+func (m *mqlMacosFirewall) runSocketfilterfw(flag string) (string, error) {
+	res, err := NewResource(m.MqlRuntime, "command", map[string]*llx.RawData{
+		"command": llx.StringData(socketfilterfwPath + " " + flag),
+	})
+	if err != nil {
+		return "", err
+	}
+	cmd := res.(*mqlCommand)
+	if exit := cmd.GetExitcode(); exit.Data != 0 {
+		return "", fmt.Errorf("socketfilterfw %s failed: %s", flag, cmd.GetStderr().Data)
+	}
+	return cmd.GetStdout().Data, nil
+}
+
+// parseGlobalState reads the numeric state out of --getglobalstate output.
+func parseGlobalState(stdout string) (int64, bool) {
+	if m := globalStateRegex.FindStringSubmatch(stdout); m != nil {
+		v, err := strconv.ParseInt(m[1], 10, 64)
+		if err == nil {
+			return v, true
+		}
+	}
+	// Older releases print the sentence without the "(State = N)" suffix.
+	switch {
+	case strings.Contains(stdout, "Firewall is enabled"):
+		return 1, true
+	case strings.Contains(stdout, "Firewall is disabled"):
+		return 0, true
+	}
+	return 0, false
+}
+
+// parseOnOff reads a socketfilterfw toggle sentence. It returns ok=false for
+// anything it does not recognise -- notably the "settings cannot be modified
+// from command line on managed Mac computers" reply -- so an unreadable
+// setting surfaces as an error and never as a confident false.
+func parseOnOff(stdout string) (bool, bool) {
+	s := strings.ToLower(stdout)
+	switch {
+	case strings.Contains(s, "cannot be modified"):
+		return false, false
+	case strings.Contains(s, " is on"), strings.Contains(s, "set to enabled"), strings.Contains(s, "enabled."):
+		return true, true
+	case strings.Contains(s, " is off"), strings.Contains(s, "set to disabled"), strings.Contains(s, "disabled."):
+		return false, true
+	}
+	return false, false
+}
+
+// parseAllowSigned reads the two-line --getallowsigned reply:
+//
+//	Automatically allow built-in signed software ENABLED.
+//	Automatically allow downloaded signed software ENABLED.
+//
+// It returns the built-in and downloaded flags separately.
+func parseAllowSigned(stdout string) (builtin bool, downloaded bool, ok bool) {
+	var haveBuiltin, haveDownloaded bool
+	for _, line := range strings.Split(stdout, "\n") {
+		l := strings.ToLower(line)
+		if !strings.Contains(l, "signed software") {
+			continue
+		}
+		enabled := strings.Contains(l, "enabled")
+		if strings.Contains(l, "downloaded") {
+			downloaded, haveDownloaded = enabled, true
+		} else if strings.Contains(l, "built-in") {
+			builtin, haveBuiltin = enabled, true
+		}
+	}
+	return builtin, downloaded, haveBuiltin && haveDownloaded
+}

--- a/providers/os/resources/macos_firewall_live.go
+++ b/providers/os/resources/macos_firewall_live.go
@@ -65,18 +65,35 @@ func parseGlobalState(stdout string) (int64, bool) {
 	return 0, false
 }
 
+// toggleOnRegex and toggleOffRegex anchor on the two sentence shapes
+// socketfilterfw uses for a toggle:
+//
+//	"Firewall stealth mode is on"                     (--getstealthmode)
+//	"Log mode is off"                                 (--getloggingmode)
+//	"Firewall has block all state set to disabled."   (--getblockall)
+//
+// They deliberately do not match a bare "enabled."/"disabled." anywhere in the
+// line. That suffix appears in replies that are not toggles at all -- the
+// --getallowsigned lines end in "signed software ENABLED." -- so accepting it
+// would let one getter's answer be read as another's.
+var (
+	toggleOnRegex  = regexp.MustCompile(`\bis on\b|\bset to enabled\b`)
+	toggleOffRegex = regexp.MustCompile(`\bis off\b|\bset to disabled\b`)
+)
+
 // parseOnOff reads a socketfilterfw toggle sentence. It returns ok=false for
 // anything it does not recognise -- notably the "settings cannot be modified
 // from command line on managed Mac computers" reply -- so an unreadable
 // setting surfaces as an error and never as a confident false.
 func parseOnOff(stdout string) (bool, bool) {
 	s := strings.ToLower(stdout)
-	switch {
-	case strings.Contains(s, "cannot be modified"):
+	if strings.Contains(s, "cannot be modified") {
 		return false, false
-	case strings.Contains(s, " is on"), strings.Contains(s, "set to enabled"), strings.Contains(s, "enabled."):
+	}
+	switch {
+	case toggleOnRegex.MatchString(s):
 		return true, true
-	case strings.Contains(s, " is off"), strings.Contains(s, "set to disabled"), strings.Contains(s, "disabled."):
+	case toggleOffRegex.MatchString(s):
 		return false, true
 	}
 	return false, false

--- a/providers/os/resources/macos_firewall_live_test.go
+++ b/providers/os/resources/macos_firewall_live_test.go
@@ -47,6 +47,13 @@ func TestParseOnOff(t *testing.T) {
 		"managed mac":    {"Firewall settings cannot be modified from command line on managed Mac computers.\n", false, false},
 		"unrecognised":   {"something else entirely\n", false, false},
 		"empty is not a": {"", false, false},
+		// A bare "enabled."/"disabled." is not a toggle answer. The
+		// --getallowsigned reply ends that way, and a logging line can too, so
+		// matching the suffix would let one getter be read as another.
+		"logging detail line": {"Logging enabled. Detail level: brief\n", false, false},
+		"allowsigned line":    {"Automatically allow built-in signed software ENABLED.\n", false, false},
+		// "is on" must be a whole word, not a prefix of something else.
+		"is one": {"Firewall stealth mode is one of several settings\n", false, false},
 	} {
 		t.Run(name, func(t *testing.T) {
 			v, ok := parseOnOff(tt.stdout)

--- a/providers/os/resources/macos_firewall_live_test.go
+++ b/providers/os/resources/macos_firewall_live_test.go
@@ -1,0 +1,82 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseGlobalState(t *testing.T) {
+	for name, tt := range map[string]struct {
+		stdout string
+		want   int64
+		ok     bool
+	}{
+		"enabled":     {"Firewall is enabled. (State = 1)\n", 1, true},
+		"block all":   {"Firewall is enabled. (State = 2)\n", 2, true},
+		"disabled":    {"Firewall is disabled. (State = 0)\n", 0, true},
+		"no state no": {"Firewall is enabled.\n", 1, true},
+		"managed":     {"Firewall settings cannot be modified from command line on managed Mac computers.\n", 0, false},
+		"empty":       {"", 0, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			v, ok := parseGlobalState(tt.stdout)
+			assert.Equal(t, tt.ok, ok)
+			if tt.ok {
+				assert.Equal(t, tt.want, v)
+			}
+		})
+	}
+}
+
+// An unreadable setting must not collapse to false. "the firewall is off" and
+// "we could not read the firewall" are different findings.
+func TestParseOnOff(t *testing.T) {
+	for name, tt := range map[string]struct {
+		stdout string
+		want   bool
+		ok     bool
+	}{
+		"stealth on":     {"Firewall stealth mode is on\n", true, true},
+		"stealth off":    {"Firewall stealth mode is off\n", false, true},
+		"blockall on":    {"Firewall has block all state set to enabled.\n", true, true},
+		"blockall off":   {"Firewall has block all state set to disabled.\n", false, true},
+		"managed mac":    {"Firewall settings cannot be modified from command line on managed Mac computers.\n", false, false},
+		"unrecognised":   {"something else entirely\n", false, false},
+		"empty is not a": {"", false, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			v, ok := parseOnOff(tt.stdout)
+			assert.Equal(t, tt.ok, ok, "recognised")
+			if tt.ok {
+				assert.Equal(t, tt.want, v)
+			}
+		})
+	}
+}
+
+func TestParseAllowSigned(t *testing.T) {
+	builtin, downloaded, ok := parseAllowSigned(
+		"Automatically allow built-in signed software ENABLED. \n" +
+			"Automatically allow downloaded signed software ENABLED. \n")
+	assert.True(t, ok)
+	assert.True(t, builtin)
+	assert.True(t, downloaded)
+
+	builtin, downloaded, ok = parseAllowSigned(
+		"Automatically allow built-in signed software ENABLED. \n" +
+			"Automatically allow downloaded signed software DISABLED. \n")
+	assert.True(t, ok)
+	assert.True(t, builtin)
+	assert.False(t, downloaded)
+
+	// A partial reply must not be reported as two falses.
+	_, _, ok = parseAllowSigned("Automatically allow built-in signed software ENABLED. \n")
+	assert.False(t, ok)
+
+	_, _, ok = parseAllowSigned("Firewall settings cannot be modified from command line on managed Mac computers.\n")
+	assert.False(t, ok)
+}

--- a/providers/os/resources/macos_sharing.go
+++ b/providers/os/resources/macos_sharing.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"errors"
 	"strings"
 	"sync"
 
@@ -27,11 +28,14 @@ func (s *mqlMacosSharing) id() (string, error) {
 	return "macos.sharing", nil
 }
 
-// fetchState runs `system_profiler SPSharingDataType` once and
-// returns the parsed map of service name → enabled. Non-Darwin hosts
-// (or hosts where system_profiler is unreachable) get an empty map,
-// which surfaces as `false` on every accessor — fail-soft for
-// systems that simply don't have a Sharing panel.
+// fetchState runs `system_profiler SPSharingDataType` once and returns the
+// parsed map of service name → enabled.
+//
+// An empty map means the Sharing panel could not be read, not that every
+// service is off. macOS 26 dropped SPSharingDataType altogether -- the
+// command exits 0 and prints nothing -- so treating an empty result as
+// fail-soft reported every sharing service as disabled on those releases,
+// whatever was actually running. Callers turn the empty map into an error.
 func (s *mqlMacosSharing) fetchState() (map[string]bool, error) {
 	if s.fetched {
 		return s.state, nil
@@ -98,15 +102,26 @@ func parseSharingOutput(stdout string) map[string]bool {
 	return out
 }
 
-// sharingFlag returns the bool for one Sharing panel entry. Missing
-// entries (some macOS versions omit services that aren't installed,
-// e.g. DVD or CD Sharing on Apple Silicon) read as `false` — the
-// "service is not present" outcome is operationally equivalent to
-// "service is off" for audit purposes.
+// errSharingPanelUnavailable reports that the Sharing panel could not be read
+// at all. macOS 26 removed the SPSharingDataType reporter, and there is no
+// replacement in system_profiler, so this is the expected outcome there.
+var errSharingPanelUnavailable = errors.New(
+	"cannot read the Sharing panel: system_profiler has no SPSharingDataType reporter on this macOS release")
+
+// sharingFlag returns the bool for one Sharing panel entry.
+//
+// A panel that returned entries but not this one reads as `false`: some macOS
+// versions omit services that aren't installed (DVD or CD Sharing on Apple
+// Silicon), and "not present" is operationally the same as "off". A panel that
+// returned nothing at all is a different thing -- nothing was measured -- and
+// is reported as an error so it cannot be mistaken for "everything is off".
 func (s *mqlMacosSharing) sharingFlag(name string) (bool, error) {
 	state, err := s.fetchState()
 	if err != nil {
 		return false, err
+	}
+	if len(state) == 0 {
+		return false, errSharingPanelUnavailable
 	}
 	return state[name], nil
 }

--- a/providers/os/resources/macos_sharing_test.go
+++ b/providers/os/resources/macos_sharing_test.go
@@ -122,3 +122,13 @@ func TestParseSharingOutput_ExtraWhitespace(t *testing.T) {
 	_, ok := got["File Sharing"]
 	assert.False(t, ok, "missing colon-space separator means the line is not a key/value")
 }
+
+// macOS 26 removed the SPSharingDataType reporter: the command exits 0 and
+// prints nothing. That must not read as "every sharing service is off".
+func TestParseSharingOutputEmpty(t *testing.T) {
+	assert.Empty(t, parseSharingOutput(""))
+	assert.Empty(t, parseSharingOutput("\n\n"))
+	// A panel that did report keeps working, including entries it omits.
+	state := parseSharingOutput("Sharing:\n\n    Computer Name: My Mac\n    File Sharing: On\n    Screen Sharing: Off\n")
+	assert.Equal(t, map[string]bool{"File Sharing": true, "Screen Sharing": false}, state)
+}

--- a/providers/os/resources/macos_softwareupdate.go
+++ b/providers/os/resources/macos_softwareupdate.go
@@ -34,6 +34,7 @@ type mqlMacosSoftwareupdateInternal struct {
 
 type softwareupdateSettings struct {
 	autoCheckEnabled         bool
+	autoCheckKeyPresent      bool
 	autoDownloadEnabled      bool
 	autoInstallMacOSUpdates  bool
 	installSystemDataFiles   bool
@@ -108,6 +109,7 @@ func (s *mqlMacosSoftwareupdate) readSoftwareUpdatePlist() (softwareupdateSettin
 func parseSoftwareUpdateSettings(d map[string]any) softwareupdateSettings {
 	return softwareupdateSettings{
 		autoCheckEnabled:         boolFromPlist(d, "AutomaticCheckEnabled"),
+		autoCheckKeyPresent:      keyPresentInPlist(d, "AutomaticCheckEnabled"),
 		autoDownloadEnabled:      boolFromPlist(d, "AutomaticDownload"),
 		autoInstallMacOSUpdates:  boolFromPlist(d, "AutomaticallyInstallMacOSUpdates"),
 		installSystemDataFiles:   boolFromPlist(d, "ConfigDataInstall"),
@@ -116,9 +118,63 @@ func parseSoftwareUpdateSettings(d map[string]any) softwareupdateSettings {
 	}
 }
 
+// autoCheckEnabled reports whether macOS checks for updates on its own.
+//
+// The preference key is only written once someone changes the setting, and its
+// absence does not mean "off" -- automatic checking is on by default, so a Mac
+// that has never been touched reads as compliant while the plist says nothing.
+// When the key is missing, ask softwareupdate what the schedule actually is
+// rather than inferring a value from the silence.
 func (s *mqlMacosSoftwareupdate) autoCheckEnabled() (bool, error) {
 	v, err := s.fetchSettings()
-	return v.autoCheckEnabled, err
+	if err != nil {
+		return false, err
+	}
+	if v.autoCheckKeyPresent {
+		return v.autoCheckEnabled, nil
+	}
+	return s.scheduleEnabled()
+}
+
+// errUpdateScheduleUnavailable reports that neither source could answer.
+var errUpdateScheduleUnavailable = errors.New(
+	"cannot determine the software update schedule: AutomaticCheckEnabled is unset and `softwareupdate --schedule` did not return a readable answer")
+
+// scheduleEnabled parses `softwareupdate --schedule`, which prints
+// "Automatic checking for updates is turned on" or "... turned off".
+func (s *mqlMacosSoftwareupdate) scheduleEnabled() (bool, error) {
+	res, err := NewResource(s.MqlRuntime, "command", map[string]*llx.RawData{
+		"command": llx.StringData("softwareupdate --schedule"),
+	})
+	if err != nil {
+		return false, err
+	}
+	cmd := res.(*mqlCommand)
+	if exit := cmd.GetExitcode(); exit.Data != 0 {
+		return false, errUpdateScheduleUnavailable
+	}
+	v, ok := parseSoftwareUpdateSchedule(cmd.GetStdout().Data)
+	if !ok {
+		return false, errUpdateScheduleUnavailable
+	}
+	return v, nil
+}
+
+// parseSoftwareUpdateSchedule reads the `softwareupdate --schedule` sentence.
+// Anything it does not recognise returns ok=false, so an unreadable schedule
+// surfaces as an error and never as a confident "automatic checking is off".
+func parseSoftwareUpdateSchedule(stdout string) (bool, bool) {
+	l := strings.ToLower(stdout)
+	if !strings.Contains(l, "automatic checking") {
+		return false, false
+	}
+	switch {
+	case strings.Contains(l, "turned on"), strings.Contains(l, "is on"):
+		return true, true
+	case strings.Contains(l, "turned off"), strings.Contains(l, "is off"):
+		return false, true
+	}
+	return false, false
 }
 
 func (s *mqlMacosSoftwareupdate) autoDownloadEnabled() (bool, error) {
@@ -370,6 +426,14 @@ func parseSoftwareUpdateSize(raw string) int64 {
 // =============================================================================
 // shared plist helpers
 // =============================================================================
+
+// keyPresentInPlist reports whether the key was written at all. A missing key
+// is not the same as a false one: several SoftwareUpdate preferences default
+// to on and are only written once someone changes them.
+func keyPresentInPlist(d map[string]any, key string) bool {
+	v, ok := d[key]
+	return ok && v != nil
+}
 
 // boolFromPlist coerces a plist key to bool. Through the plist.Decode
 // helper, real plist booleans arrive as `bool`; integer 0/1 fallbacks

--- a/providers/os/resources/macos_softwareupdate.go
+++ b/providers/os/resources/macos_softwareupdate.go
@@ -427,9 +427,18 @@ func parseSoftwareUpdateSize(raw string) int64 {
 // shared plist helpers
 // =============================================================================
 
-// keyPresentInPlist reports whether the key was written at all. A missing key
-// is not the same as a false one: several SoftwareUpdate preferences default
-// to on and are only written once someone changes them.
+// keyPresentInPlist reports whether the key carries a value the caller can
+// read. A missing key is not the same as a false one: several SoftwareUpdate
+// preferences default to on and are only written once someone changes them, so
+// the caller has to tell "nobody set this" apart from "somebody set it off".
+//
+// A key present with a nil value counts as absent, because it answers the
+// question no better than a missing key does: boolFromPlist has no case for
+// nil and would hand back false, which is the wrong-by-default reading this
+// helper exists to prevent. Reporting it as absent routes the caller to the
+// live `softwareupdate --schedule` lookup instead. Note this is about a nil
+// decoded value, not a written `<false/>`, which is a real answer and is
+// reported as present.
 func keyPresentInPlist(d map[string]any, key string) bool {
 	v, ok := d[key]
 	return ok && v != nil

--- a/providers/os/resources/macos_softwareupdate_test.go
+++ b/providers/os/resources/macos_softwareupdate_test.go
@@ -271,3 +271,39 @@ func TestStripPrefix(t *testing.T) {
 	assert.False(t, ok)
 	assert.Equal(t, "", rest)
 }
+
+// AutomaticCheckEnabled is only written once someone changes the setting.
+// Its absence is not "off" -- automatic checking is on by default -- so the
+// key's presence has to be distinguished from its value.
+func TestKeyPresentInPlist(t *testing.T) {
+	d := map[string]any{
+		"AutomaticDownload": float64(1),
+		"ExplicitFalse":     false,
+		"ExplicitNil":       nil,
+	}
+	assert.True(t, keyPresentInPlist(d, "AutomaticDownload"))
+	assert.True(t, keyPresentInPlist(d, "ExplicitFalse"), "an explicit false is still a written key")
+	assert.False(t, keyPresentInPlist(d, "ExplicitNil"))
+	assert.False(t, keyPresentInPlist(d, "AutomaticCheckEnabled"))
+}
+
+func TestParseSoftwareUpdateSchedule(t *testing.T) {
+	for name, tt := range map[string]struct {
+		stdout string
+		want   bool
+		ok     bool
+	}{
+		"on":           {"Automatic checking for updates is turned on\n", true, true},
+		"off":          {"Automatic checking for updates is turned off\n", false, true},
+		"unrecognised": {"softwareupdate: unknown option\n", false, false},
+		"empty":        {"", false, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			v, ok := parseSoftwareUpdateSchedule(tt.stdout)
+			assert.Equal(t, tt.ok, ok)
+			if tt.ok {
+				assert.Equal(t, tt.want, v)
+			}
+		})
+	}
+}

--- a/providers/os/resources/port.go
+++ b/providers/os/resources/port.go
@@ -559,6 +559,22 @@ func (p *mqlPorts) parseWindowsPorts(r io.Reader, processes map[int64]*mqlProces
 
 // macOS Implementation
 
+// expandLsofWildcardAddress spells out the wildcard bind lsof writes as "*".
+// A socket bound there listens on every address on every interface, so it maps
+// to the unspecified address -- 0.0.0.0 for IPv4, :: for IPv6 -- which is how
+// the same bind reads on Linux. It is emphatically not loopback: mapping it to
+// 127.0.0.1 reports a listener reachable from the network as a local-only one,
+// and silently passes any check looking for exposed ports.
+func expandLsofWildcardAddress(address string, protocol string) string {
+	if !strings.HasPrefix(address, "*") {
+		return address
+	}
+	if strings.HasSuffix(protocol, "6") {
+		return strings.Replace(address, "*", "::", 1)
+	}
+	return strings.Replace(address, "*", "0.0.0.0", 1)
+}
+
 // listMacos reads the lsof information of all open files that are tcp sockets
 func (p *mqlPorts) listMacos() ([]any, error) {
 	users, err := p.users()
@@ -618,15 +634,7 @@ func (p *mqlPorts) listMacos() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
-			// lsof presents a process listening on any ipv6 address as listening on "*"
-			// change this to a more ipv6-friendly formatting
-			if strings.HasPrefix(localAddress, "*") {
-				if strings.HasSuffix(protocol, "6") {
-					localAddress = strings.Replace(localAddress, "*", "::1", 1)
-				} else {
-					localAddress = strings.Replace(localAddress, "*", "127.0.0.1", 1)
-				}
-			}
+			localAddress = expandLsofWildcardAddress(localAddress, protocol)
 
 			state, ok := TCP_STATES[fd.TcpState()]
 			if !ok {

--- a/providers/os/resources/port_test.go
+++ b/providers/os/resources/port_test.go
@@ -123,3 +123,28 @@ func TestAixPortStatesAreCanonical(t *testing.T) {
 			"AIX state %q maps to %q which is not in TCP_STATES", aix, mapped)
 	}
 }
+
+// A wildcard bind is reachable from the network. It used to be rewritten to
+// loopback, which reported every exposed listener as local-only and quietly
+// passed any check looking for internet-facing ports.
+func TestExpandLsofWildcardAddress(t *testing.T) {
+	for _, tt := range []struct {
+		address  string
+		protocol string
+		want     string
+	}{
+		{"*", "tcp4", "0.0.0.0"},
+		{"*", "udp4", "0.0.0.0"},
+		{"*", "tcp6", "::"},
+		{"*", "udp6", "::"},
+		// concrete binds are passed through untouched
+		{"127.0.0.1", "tcp4", "127.0.0.1"},
+		{"::1", "tcp6", "::1"},
+		{"172.16.1.129", "tcp4", "172.16.1.129"},
+		{"", "tcp4", ""},
+	} {
+		t.Run(tt.protocol+"/"+tt.address, func(t *testing.T) {
+			assert.Equal(t, tt.want, expandLsofWildcardAddress(tt.address, tt.protocol))
+		})
+	}
+}

--- a/providers/os/resources/services/launchd.go
+++ b/providers/os/resources/services/launchd.go
@@ -10,11 +10,14 @@ import (
 	"go.mondoo.com/mql/providers/os/connection/shared"
 )
 
-var LAUNCHD_REGEX = regexp.MustCompile(`(?m)^\s*([\d-]*)\s+(\d)\s+(.*)$`)
+// launchctl list prints three tab-separated columns: PID, the last exit
+// status, and the label. PID is a number or "-" when the job is not running.
+// The status is a signed integer: 0 for a clean exit, a positive exit code,
+// or a negative signal number (-9 for SIGKILL, -15 for SIGTERM). Matching it
+// as a single digit dropped every job that had ever been killed or exited
+// non-zero -- around 40% of the list on a normal macOS install.
+var LAUNCHD_REGEX = regexp.MustCompile(`(?m)^\s*(-|\d+)\s+(-?\d+)\s+(\S.*)$`)
 
-// PID: pid of process
-// Status: last know exit code
-// ^\s*([\d-]*)\s+(\d)\s+(.*)$
 func ParseServiceLaunchD(input io.Reader) ([]*Service, error) {
 	var services []*Service
 	content, err := io.ReadAll(input)

--- a/providers/os/resources/services/launchd_test.go
+++ b/providers/os/resources/services/launchd_test.go
@@ -4,9 +4,11 @@
 package services_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/providers/os/connection/mock"
 	"go.mondoo.com/mql/providers/os/resources/services"
@@ -35,4 +37,48 @@ func TestParseServiceLaunchD(t *testing.T) {
 	assert.Equal(t, false, m[0].Running, "service is running")
 	assert.Equal(t, true, m[0].Installed, "service is installed")
 	assert.Equal(t, "launchd", m[0].Type, "service type is added")
+}
+
+// launchctl reports the last exit status as a signed integer. Matching it as a
+// single digit dropped every job that had been killed (-9, -15) or exited with
+// a multi-digit code, which silently hid around 40% of the services on a
+// normal macOS install -- including third-party security agents.
+func TestParseServiceLaunchDNonZeroStatus(t *testing.T) {
+	input := strings.Join([]string{
+		"PID\tStatus\tLabel",
+		"28494\t-9\tcom.apple.accessibility.axassetsd",
+		"-\t-9\tcom.apple.AccessibilityVisualsAgent",
+		"-\t-15\tcom.apple.terminated.by.sigterm",
+		"1354\t0\tcom.crowdstrike.falcon.UserAgent",
+		"-\t0\tcom.apple.screensharing.agent",
+		"500\t78\tcom.example.multidigit",
+		"-\t127\tcom.example.exit127",
+	}, "\n")
+
+	list, err := services.ParseServiceLaunchD(strings.NewReader(input))
+	require.NoError(t, err)
+
+	byName := map[string]*services.Service{}
+	for _, s := range list {
+		byName[s.Name] = s
+	}
+
+	// the header line must not be picked up as a service
+	assert.NotContains(t, byName, "Label")
+	assert.Len(t, list, 7)
+
+	for _, name := range []string{
+		"com.apple.accessibility.axassetsd",
+		"com.apple.AccessibilityVisualsAgent",
+		"com.apple.terminated.by.sigterm",
+		"com.example.multidigit",
+		"com.example.exit127",
+	} {
+		assert.Contains(t, byName, name, "service with a non-zero exit status must still be listed")
+	}
+
+	// a PID means the job is running; "-" means it is not
+	assert.True(t, byName["com.apple.accessibility.axassetsd"].Running)
+	assert.False(t, byName["com.apple.AccessibilityVisualsAgent"].Running)
+	assert.True(t, byName["com.crowdstrike.falcon.UserAgent"].Running)
 }


### PR DESCRIPTION
Full verification of the os provider against a live macOS 26 host (MacBook Pro, Apple M4 Pro, arm64). Six resources answered confidently and wrongly; all six are fixed here and re-verified against the same host.

They share a failure shape: a missing or renamed data source is converted into a concrete "safe" value instead of an error. Nothing errors, nothing logs, and the wrong answer is the one that makes an audit pass.

## What was wrong

| Resource | Reported | Actual | Consequence |
|---|---|---|---|
| `ports.listening.address` | `127.0.0.1` for every wildcard bind | `0.0.0.0` / `::` | `where(address == '0.0.0.0')` matched **nothing** on macOS, always |
| `services` | 319 services | 528 | 40% of services silently missing |
| `macos.firewall.enabled` | `false` | firewall **on** | firewall reported off on every current Mac |
| `macos.firewall.stealthEnabled` | `false` | stealth **on** | same |
| `macos.sharing.*` | all `false` | unknown | every sharing toggle reported off on macOS 26 |
| `macos.softwareupdate.autoCheckEnabled` | `false` | **on** | compliant Mac reported non-compliant |
| `os.hypervisor` / `asset.kind` | `Apple Virtualization` / `virtualmachine` | bare metal | every physical Apple Silicon Mac misclassified |

## Root causes

**`ports`** — lsof writes a wildcard bind as `*`. The code rewrote it to `127.0.0.1` (`::1` for IPv6) under a comment about "ipv6-friendly formatting". A wildcard bind is reachable from the network; loopback is not. Now maps to `0.0.0.0` / `::`, matching Linux. On the test host, 9 of 17 listeners were misreported.

**`services`** — `launchctl list` prints the last exit status as a signed integer, but the regex matched it as `(\d)`, one digit. Every job killed (`-9`, `-15`) or exited with a multi-digit code was dropped.

**`macos.firewall` / `macos.alf`** — `/Library/Preferences/com.apple.alf.plist` no longer exists on current macOS, and the lookup fell through to `/usr/libexec/ApplicationFirewall/com.apple.alf.plist`. That is the factory-default template the OS ships (root-owned, SIP-protected, always `globalstate 0`), not live state. The template is dropped; live state comes from `socketfilterfw`, which needs no root. Settings neither source can answer now return an error rather than `false`.

**`macos.sharing`** — macOS 26 removed the `SPSharingDataType` reporter; `system_profiler` exits 0 and prints nothing. The code documented that as fail-soft "surfaces as false on every accessor". A panel returning *no entries at all* is now an error. A panel returning entries but omitting one still reads `false`, as before.

**`macos.softwareupdate`** — `AutomaticCheckEnabled` is only written once someone changes the setting, and the macOS default is on. Falls back to `softwareupdate --schedule` when the key is unset.

**`os.hypervisor`** — the Darwin fallback ran `mapHypervisor()` over the whole `SPHardwareDataType` output, which on any Apple Silicon Mac contains the vendor name in unrelated fields (`Chip: Apple M4 Pro`). It matched the bare `apple` key. Now only `Model Name` and `Model Identifier` are matched, where a guest actually names its hypervisor.

## Verified on the live host

```
ports    address distribution: {'0.0.0.0': 5, '::': 4, '127.0.0.1': 8}   (was: 17 loopback)
         lsof TCP wildcards: 5 IPv4, 4 IPv6; loopback 8   -- exact match
services 528                                              (launchctl: 528, exact match)
firewall enabled=true stealthEnabled=true blockAllIncoming=false
         socketfilterfw: "Firewall is enabled. (State = 1)", "stealth mode is on", "block all ... disabled"
sharing  honest error instead of silent all-false
update   autoCheckEnabled=true   (softwareupdate --schedule: "turned on")
asset    kind="baremetal", title="macOS, Bare metal system", os.hypervisor=null
```

Unaffected resources spot-checked against ground truth and correct: `macos.hardware`, `macos.systemExtensions`, `macos.sip`, `macos.gatekeeper`, `macos.mdm`, `macos.xprotect`, `macos.filevault`, `macos.systemsetup`, `homebrew`, `users`, `groups`, `processes`, `network`, `mount`.

## Tests

Pure-Go tests for every parser added or changed, each covering the unreadable case explicitly so an unparseable answer can never collapse back into a confident `false`:

- `expandLsofWildcardAddress` — wildcard and concrete binds, both families
- `ParseServiceLaunchD` — negative, multi-digit and zero statuses; header line rejected
- `parseGlobalState` / `parseOnOff` / `parseAllowSigned` — including the managed-Mac "cannot be modified" reply
- `parseSoftwareUpdateSchedule` / `keyPresentInPlist` — absent key vs explicit false
- `parseSharingOutput` — empty panel vs populated panel with an omitted entry
- `darwinHardwareModel` / `mapHypervisor` — physical Mac, Apple VM, VMware guest

`go test ./providers/os/...` passes. (`connection/device/linux` fails to build on main too — a mock that isn't checked in; unrelated.)

No schema changes, so no `.lr` / `.lr.versions` / generated-file churn.

## Known gaps not fixed here

- **`macos.sharing` values are unavailable on macOS 26.** `system_profiler` has no replacement reporter (`-listDataTypes` confirms). Rebuilding it means per-service detection I could not verify without enabling sharing services on the test host. This PR makes the failure honest; the values need a follow-up.
- **`user.enabled` is `false` for every user on macOS and Linux.** Only the Windows manager ever sets it; the dscl and /etc/passwd managers leave it at Go's zero value. I can verify the enabled case here but not the disabled one, so I did not ship a guess.
