### PR TITLE
🐛 os: stop crontab/limits/logrotate entries panicking without a file

### DIFF
--- a/providers/os/resources/crontab.go
+++ b/providers/os/resources/crontab.go
@@ -233,6 +233,9 @@ func (e *mqlCrontabEntry) id() (string, error) {
 	if file.Error != nil {
 		return "", file.Error
 	}
+	if file.Data == nil {
+		return "", errors.New("cannot determine crontab entry ID (missing file)")
+	}
 
 	path := file.Data.GetPath()
 	if path.Error != nil {

--- a/providers/os/resources/entry_id_internal_test.go
+++ b/providers/os/resources/entry_id_internal_test.go
@@ -1,0 +1,76 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// Entry sub-resources are reachable through their singular accessor
+// (`limits.entry`, `logrotate.entry`, `crontab.entry`) with no arguments. The
+// runtime then builds the resource with `file` unset, so id() runs against a
+// nil *mqlFile. It must report that, not dereference it.
+func TestEntryID_MissingFile(t *testing.T) {
+	t.Run("limits.entry", func(t *testing.T) {
+		id, err := (&mqlLimitsEntry{}).id()
+		require.Error(t, err)
+		assert.Empty(t, id)
+		assert.Contains(t, err.Error(), "missing file")
+	})
+
+	t.Run("logrotate.entry", func(t *testing.T) {
+		id, err := (&mqlLogrotateEntry{}).id()
+		require.Error(t, err)
+		assert.Empty(t, id)
+		assert.Contains(t, err.Error(), "missing file")
+	})
+
+	t.Run("crontab.entry", func(t *testing.T) {
+		e := &mqlCrontabEntry{}
+		// GetFile short-circuits on an already-resolved field, so mark it set
+		// with a nil value -- the shape the runtime produces for a bare entry.
+		e.File.State = plugin.StateIsSet | plugin.StateIsNull
+		id, err := e.id()
+		require.Error(t, err)
+		assert.Empty(t, id)
+		assert.Contains(t, err.Error(), "missing file")
+	})
+}
+
+// A populated entry still produces the composite id it always did.
+func TestEntryID_WithFile(t *testing.T) {
+	f := &mqlFile{}
+	f.Path.Data = "/etc/security/limits.conf"
+	f.Path.State = plugin.StateIsSet
+
+	le := &mqlLimitsEntry{}
+	le.File.Data = f
+	le.File.State = plugin.StateIsSet
+	le.LineNumber.Data = 42
+	le.LineNumber.State = plugin.StateIsSet
+
+	id, err := le.id()
+	require.NoError(t, err)
+	assert.Equal(t, "/etc/security/limits.conf:42", id)
+
+	lf := &mqlFile{}
+	lf.Path.Data = "/etc/logrotate.conf"
+	lf.Path.State = plugin.StateIsSet
+
+	lge := &mqlLogrotateEntry{}
+	lge.File.Data = lf
+	lge.File.State = plugin.StateIsSet
+	lge.LineNumber.Data = 7
+	lge.LineNumber.State = plugin.StateIsSet
+	lge.Path.Data = "/var/log/syslog"
+	lge.Path.State = plugin.StateIsSet
+
+	id, err = lge.id()
+	require.NoError(t, err)
+	assert.Equal(t, "/etc/logrotate.conf:7:/var/log/syslog", id)
+}

--- a/providers/os/resources/limits.go
+++ b/providers/os/resources/limits.go
@@ -31,6 +31,10 @@ func (l *mqlLimits) id() (string, error) {
 
 func (le *mqlLimitsEntry) id() (string, error) {
 	file := le.File.Data
+	if file == nil {
+		return "", errors.New("cannot determine limits entry ID (missing file)")
+	}
+
 	lineNum := strconv.FormatInt(le.LineNumber.Data, 10)
 
 	// Create unique ID from file path and line number

--- a/providers/os/resources/logrotate.go
+++ b/providers/os/resources/logrotate.go
@@ -32,6 +32,10 @@ func (l *mqlLogrotate) id() (string, error) {
 
 func (le *mqlLogrotateEntry) id() (string, error) {
 	file := le.File.Data
+	if file == nil {
+		return "", errors.New("cannot determine logrotate entry ID (missing file)")
+	}
+
 	lineNum := strconv.FormatInt(le.LineNumber.Data, 10)
 
 	return file.Path.Data + ":" + lineNum + ":" + le.Path.Data, nil


### PR DESCRIPTION
## What

`crontab.entry`, `limits.entry` and `logrotate.entry` are reachable through their singular accessor with no arguments. The runtime then builds the resource with `file` unset, and all three `id()` functions dereferenced that nil `*mqlFile` immediately.

Found sweeping every reachable `os` resource against a live Debian 13 host.

```
$ mql run ssh root@debian -c 'limits { entry }'
x recovered panic in provider method=GetData
  panic="invalid memory address or nil pointer dereference"
  go.mondoo.com/mql/providers/os/resources.(*mqlLimitsEntry).id(...)
      providers/os/resources/limits.go:37

limits: {
  limits.entry: rpc error: code = Internal desc = panic in provider GetData: runtime error: invalid memory address or nil pointer dereference
}
```

Same shape for `crontab { entry }` (`crontab.go:237`, via `file.Data.GetPath()`) and `logrotate { entry }` (`logrotate.go:37`).

The SDK recovers the panic so the scan survives, but the field surfaces as an opaque `panic in provider GetData` rather than saying what was missing, and the surrounding fields on the same resource still resolve — so it reads as a partial success.

## Fix

Guard the nil file and return an error naming it, matching what `authorizedkeys.entry` already does for exactly this case.

## Test plan

- [x] `TestEntryID_MissingFile` covers all three; it **panics** on the unfixed code (verified by stashing the fix)
- [x] `TestEntryID_WithFile` pins the composite id a populated entry produces, so the guard cannot regress the happy path
- [x] `go test ./resources/ -run TestEntryID` passes
- [x] Reproduced and re-verified against Debian 13 (trixie) over SSH — 13 crontab entries / 5 limits entries / 25 logrotate entries still read correctly