### PR TITLE
🐛 os: give fstab its default path and a per-file __id

### DIFF
--- a/providers/os/resources/fstab.go
+++ b/providers/os/resources/fstab.go
@@ -35,6 +35,13 @@ func initFstab(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[strin
 	return args, nil, nil
 }
 
+// id keys the resource on the file it reads. Without it every fstab shares
+// the empty cache key, so `fstab("/a")` and `fstab("/b")` resolve to whichever
+// one was built first.
+func (f *mqlFstab) id() (string, error) {
+	return "fstab:" + f.Path.Data, nil
+}
+
 func (f *mqlFstab) entries() ([]any, error) {
 	conn, ok := f.MqlRuntime.Connection.(shared.Connection)
 	if !ok {

--- a/providers/os/resources/fstab_id_test.go
+++ b/providers/os/resources/fstab_id_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 )
 
@@ -70,4 +71,35 @@ func TestFstabEntryIDIsStable(t *testing.T) {
 	assert.Equal(t, first, second, "__id must be stable across calls")
 	assert.Contains(t, first, "tmpfs")
 	assert.Contains(t, first, "/dev/shm")
+}
+
+// The fstab resource is selected by path, so its __id has to carry that path.
+// Without an id() every fstab shares the empty cache key and the second
+// fstab(...) in a query resolves to the first one's file.
+func TestFstabIDIsPerFile(t *testing.T) {
+	mk := func(path string) *mqlFstab {
+		return &mqlFstab{Path: plugin.TValue[string]{Data: path, State: plugin.StateIsSet}}
+	}
+
+	etc, err := mk("/etc/fstab").id()
+	assert.NoError(t, err)
+	alt, err := mk("/tmp/fstab.alt").id()
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, etc, alt,
+		"two fstab files must not share an __id, or one silently serves the other")
+	assert.Contains(t, etc, "/etc/fstab")
+
+	again, err := mk("/etc/fstab").id()
+	assert.NoError(t, err)
+	assert.Equal(t, etc, again, "__id must be stable across calls")
+}
+
+// initFstab is what supplies the default path. os.linux.fstab has to go
+// through it (NewResource), not around it (CreateResource).
+func TestInitFstabDefaultsToEtcFstab(t *testing.T) {
+	args, res, err := initFstab(nil, map[string]*llx.RawData{})
+	assert.NoError(t, err)
+	assert.Nil(t, res)
+	assert.Equal(t, "/etc/fstab", args["path"].Value)
 }

--- a/providers/os/resources/os.go
+++ b/providers/os/resources/os.go
@@ -730,7 +730,10 @@ func (s *mqlOsLinux) firewalld() (*mqlFirewalld, error) {
 }
 
 func (s *mqlOsLinux) fstab() (*mqlFstab, error) {
-	res, err := CreateResource(s.MqlRuntime, "fstab", map[string]*llx.RawData{})
+	// NewResource, not CreateResource: only NewResource runs initFstab, which
+	// supplies the default /etc/fstab path. Without it the resource is built
+	// with an empty path and every read fails with "file does not exist".
+	res, err := NewResource(s.MqlRuntime, "fstab", map[string]*llx.RawData{})
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -63874,7 +63874,12 @@ func createFstab(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("fstab", res.__id)


### PR DESCRIPTION
## What

Two bugs in the `fstab` resource, both reproduced on a live Debian 13 host.

### 1. `os.linux.fstab` never gets a path

`mqlOsLinux.fstab()` built the resource with `CreateResource`, which **skips `initFstab`** — the only place the default `/etc/fstab` path is supplied. The resource was created with an empty path, so every read failed:

```
$ mql run ssh root@debian -c 'os.linux.fstab { path entries.length }'
x provider returned no data and no error for a field; the field was never set
  on the resource (provider bug) field=path resource=fstab

os.linux.fstab: {
  path: null
  entries.length: file does not exist
}
```

…on a host where `/etc/fstab` exists and `file("/etc/fstab").exists` is `true`. The bare `fstab` resource reads the same host fine, because it goes through `NewResource`.

### 2. `fstab` has no `__id`, so two files collide

Without an `id()` every instance shares the empty cache key, and the second `fstab(...)` in a query silently serves the first one's contents:

```
$ mql run ssh root@debian -c 'fstab("/etc/fstab") { path entries.length }
fstab("/tmp/fstab.alt") { path entries.length }'

fstab: { path: "/tmp/fstab.alt"  entries.length: 2 }
fstab: { path: "/tmp/fstab.alt"  entries.length: 2 }    # asked for /etc/fstab
```

This is also what made bug 1 intermittent: whichever construction reached the cache first defined `fstab` for the whole run, so `os.linux.fstab` could appear to work when a bare `fstab` had already populated it.

`fstab.entry` already carries a composite id for the same collision reason; the parent resource was missed.

## Fix

- `os.linux.fstab` uses `NewResource` so `initFstab` runs and supplies the default path
- `fstab` gets an `id()` keyed on its path

`.lr` schema is unchanged, so there are no `.lr.versions` entries to add; the only generated delta is `createFstab` now calling the new `id()`.

## Test plan

- [x] `TestFstabIDIsPerFile` — two paths must not share an `__id`
- [x] `TestInitFstabDefaultsToEtcFstab` — pins the default that `os.linux.fstab` was bypassing
- [x] `go test ./resources/ -run 'TestFstab|TestInitFstab'` passes
- [x] Verified live on Debian 13 after the fix:
  - `os.linux.fstab { path entries.length }` → `path: "/etc/fstab"`, `entries.length: 3`
  - the two-file query returns 3 entries for `/etc/fstab` and 2 for `/tmp/fstab.alt`