### PR TITLE
🐛 os: name the right resource in the parse.* errors

### DIFF
--- a/providers/os/resources/parse.go
+++ b/providers/os/resources/parse.go
@@ -290,7 +290,7 @@ func initParseXml(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[st
 
 func (s *mqlParseXml) id() (string, error) {
 	if s.File.Data == nil {
-		return "", errors.New("no file provided for parse.json")
+		return "", errors.New("no file provided for parse.xml")
 	}
 
 	file := s.File.Data
@@ -428,7 +428,7 @@ func initParseCertificates(runtime *plugin.Runtime, args map[string]*llx.RawData
 		args["file"] = llx.ResourceData(f, "file")
 		args["path"] = llx.StringData(virtualPath)
 	} else {
-		return nil, nil, errors.New("missing 'path' or 'content' for parse.json initialization")
+		return nil, nil, errors.New("missing 'path' or 'content' for parse.certificates initialization")
 	}
 
 	return args, nil, nil
@@ -503,7 +503,7 @@ func initParseOpenpgp(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 		args["file"] = llx.ResourceData(f, "file")
 
 	} else {
-		return nil, nil, errors.New("missing 'path' or 'content' for parse.json initialization")
+		return nil, nil, errors.New("missing 'path' or 'content' for parse.openpgp initialization")
 	}
 
 	return args, nil, nil
@@ -512,6 +512,9 @@ func initParseOpenpgp(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 func (a *mqlParseOpenpgp) id() (string, error) {
 	if a.File.Error != nil {
 		return "", a.File.Error
+	}
+	if a.File.Data == nil {
+		return "", errors.New("no file provided for parse.openpgp")
 	}
 
 	return a.File.Data.Path.Data, nil


### PR DESCRIPTION
## What

Three `parse.*` resources reported their failure as `parse.json`, pointing the user at a resource they never wrote. Found sweeping the os provider against a live Debian 13 host:

```
$ mql run ssh root@debian -c 'parse { xml }'
xml: no file provided for parse.json          # the query was parse.xml
```

- `mqlParseXml.id()` — said `parse.json`
- `initParseCertificates` — said "missing 'path' or 'content' for **parse.json** initialization"
- `initParseOpenpgp` — same

The sibling resources (`parse.ini`, `parse.yaml`, `parse.plist`, `parse.json`) already name themselves correctly.

## Also fixed

`mqlParseOpenpgp.id()` checked `File.Error` but not `File.Data`, unlike every sibling. A bare `parse.openpgp` therefore dereferences nil and the field surfaces as an opaque `panic in provider GetData`. The new test panics on the unfixed code.

## Test plan

- `go build ./providers/os/...` and `go test ./providers/os/resources/` pass.
- Verified by hand against a live Debian 13 host: `parse { xml }` now reports `no file provided for parse.xml`, and a bare `parse.openpgp` reports the missing file instead of panicking in the provider.
