### PR TITLE
🐛 os: keep the readable SMBIOS attributes when a serial is root-only

### DIFF
--- a/providers/os/resources/smbios/linux.go
+++ b/providers/os/resources/smbios/linux.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"go.mondoo.com/mql/providers/os/connection/shared"
 )
@@ -22,16 +23,30 @@ func (s *LinuxSmbiosManager) Name() string {
 }
 
 func (s *LinuxSmbiosManager) Info() (*SmBiosInfo, error) {
-	smInfo := SmBiosInfo{}
+	return readLinuxSmbios(s.provider.FileSystem())
+}
 
-	fs := s.provider.FileSystem()
+// dmiRoot is the sysfs directory the kernel exports the SMBIOS tables through.
+const dmiRoot = "/sys/class/dmi/id/"
+
+func readLinuxSmbios(fs afero.Fs) (*SmBiosInfo, error) {
+	smInfo := &SmBiosInfo{}
 	afs := &afero.Afero{Fs: fs}
-	root := "/sys/class/dmi/id/"
+	root := dmiRoot
 
 	wErr := afs.Walk(root, func(path string, info os.FileInfo, fErr error) error {
 		if fErr != nil {
-			// we skip files that we cannot access
-			return filepath.SkipDir
+			// The directory itself may not exist at all, on a platform with no
+			// DMI tables or a scan that cannot reach sysfs. That is not an
+			// error: it just means there is nothing to report.
+			if path == root {
+				return filepath.SkipDir
+			}
+			// A single entry we cannot even stat is skipped on its own. Walk
+			// reads SkipDir from a file as "skip the rest of this directory",
+			// which would drop every attribute alphabetically after it.
+			log.Debug().Err(fErr).Str("path", path).Msg("skipping unreadable dmi entry")
+			return nil
 		}
 
 		if info.IsDir() && path != root {
@@ -83,16 +98,15 @@ func (s *LinuxSmbiosManager) Info() (*SmBiosInfo, error) {
 		}
 
 		if dst != nil {
-			f, err := fs.Open(path)
-			if err != nil {
-				return err
+			// product_serial, board_serial, chassis_serial and product_uuid are
+			// mode 0400 root-only on every Linux host, so a scan that is not
+			// root cannot read them. Losing one of those must not cost us the
+			// world-readable attributes next to it -- bios vendor and version,
+			// the product name, the chassis type -- which is what firmware
+			// audits actually ask for.
+			if err := readDmiAttribute(fs, path, dst); err != nil {
+				log.Debug().Err(err).Str("path", path).Msg("could not read dmi attribute")
 			}
-			defer f.Close()
-			data, err := io.ReadAll(f)
-			if err != nil {
-				return err
-			}
-			*dst = strings.TrimSpace(string(data))
 		}
 
 		return nil
@@ -103,5 +117,23 @@ func (s *LinuxSmbiosManager) Info() (*SmBiosInfo, error) {
 		return nil, wErr
 	}
 
-	return &smInfo, nil
+	return smInfo, nil
+}
+
+// readDmiAttribute reads one sysfs DMI attribute into dst, leaving dst
+// untouched when the file cannot be read.
+func readDmiAttribute(fs afero.Fs, path string, dst *string) error {
+	f, err := fs.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
+	*dst = strings.TrimSpace(string(data))
+	return nil
 }

--- a/providers/os/resources/smbios/linux_test.go
+++ b/providers/os/resources/smbios/linux_test.go
@@ -1,0 +1,127 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package smbios
+
+import (
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// denyFs refuses to open the named paths with EACCES, the way sysfs refuses a
+// non-root reader on the DMI attributes the kernel marks root-only.
+type denyFs struct {
+	afero.Fs
+	deny map[string]bool
+}
+
+func (f *denyFs) Open(name string) (afero.File, error) {
+	if f.deny[name] {
+		return nil, &os.PathError{Op: "open", Path: name, Err: syscall.EACCES}
+	}
+	return f.Fs.Open(name)
+}
+
+// dmiFs builds a /sys/class/dmi/id tree with the attribute set a real host
+// exports.
+func dmiFs(t *testing.T) afero.Fs {
+	t.Helper()
+
+	fs := afero.NewMemMapFs()
+	for name, content := range map[string]string{
+		"bios_date":         "04/01/2014\n",
+		"bios_vendor":       "SeaBIOS\n",
+		"bios_version":      "1.16.3-2.fc39\n",
+		"board_asset_tag":   "board-tag\n",
+		"board_name":        "board-name\n",
+		"board_serial":      "board-secret\n",
+		"board_vendor":      "board-vendor\n",
+		"board_version":     "board-version\n",
+		"chassis_asset_tag": "chassis-tag\n",
+		"chassis_serial":    "chassis-secret\n",
+		"chassis_type":      "1\n",
+		"chassis_vendor":    "QEMU\n",
+		"chassis_version":   "pc-q35\n",
+		"product_family":    "Unknown\n",
+		"product_name":      "Standard PC (Q35 + ICH9, 2009)\n",
+		"product_serial":    "product-secret\n",
+		"product_sku":       "sku-1\n",
+		"product_uuid":      "1a2b3c4d-0000-0000-0000-000000000000\n",
+		"product_version":   "pc-q35-8.1\n",
+		"sys_vendor":        "QEMU\n",
+	} {
+		require.NoError(t, afero.WriteFile(fs, dmiRoot+name, []byte(content), 0o444))
+	}
+	return fs
+}
+
+func TestLinuxSmbios_AllAttributesReadable(t *testing.T) {
+	info, err := readLinuxSmbios(dmiFs(t))
+	require.NoError(t, err)
+
+	assert.Equal(t, "SeaBIOS", info.BIOS.Vendor)
+	assert.Equal(t, "1.16.3-2.fc39", info.BIOS.Version)
+	assert.Equal(t, "04/01/2014", info.BIOS.ReleaseDate)
+	assert.Equal(t, "QEMU", info.SysInfo.Vendor)
+	assert.Equal(t, "Standard PC (Q35 + ICH9, 2009)", info.SysInfo.Model)
+	assert.Equal(t, "product-secret", info.SysInfo.SerialNumber)
+	assert.Equal(t, "1a2b3c4d-0000-0000-0000-000000000000", info.SysInfo.UUID)
+	assert.Equal(t, "board-secret", info.BaseBoardInfo.SerialNumber)
+	assert.Equal(t, "chassis-secret", info.ChassisInfo.SerialNumber)
+	assert.Equal(t, "1", info.ChassisInfo.Type)
+}
+
+// The kernel marks product_serial, board_serial, chassis_serial and
+// product_uuid as root-only (mode 0400), so every scan that does not run as
+// root gets EACCES on those four and on nothing else. Before the fix the walk
+// returned that error, so the whole SMBIOS read failed and machine.bios,
+// machine.system, machine.baseboard and machine.chassis all reported no data.
+func TestLinuxSmbios_KeepsReadableAttributesWhenSerialsAreRootOnly(t *testing.T) {
+	fs := &denyFs{
+		Fs: dmiFs(t),
+		deny: map[string]bool{
+			dmiRoot + "product_serial": true,
+			dmiRoot + "board_serial":   true,
+			dmiRoot + "chassis_serial": true,
+			dmiRoot + "product_uuid":   true,
+		},
+	}
+
+	info, err := readLinuxSmbios(fs)
+	require.NoError(t, err)
+
+	// the readable attributes still arrive, including the ones that sort
+	// after the denied entries
+	assert.Equal(t, "SeaBIOS", info.BIOS.Vendor)
+	assert.Equal(t, "1.16.3-2.fc39", info.BIOS.Version)
+	assert.Equal(t, "04/01/2014", info.BIOS.ReleaseDate)
+	assert.Equal(t, "board-name", info.BaseBoardInfo.Model)
+	assert.Equal(t, "board-vendor", info.BaseBoardInfo.Vendor)
+	assert.Equal(t, "chassis-tag", info.ChassisInfo.AssetTag)
+	assert.Equal(t, "1", info.ChassisInfo.Type)
+	assert.Equal(t, "QEMU", info.ChassisInfo.Vendor)
+	assert.Equal(t, "Standard PC (Q35 + ICH9, 2009)", info.SysInfo.Model)
+	assert.Equal(t, "sku-1", info.SysInfo.SKU)
+	assert.Equal(t, "pc-q35-8.1", info.SysInfo.Version)
+	assert.Equal(t, "QEMU", info.SysInfo.Vendor)
+
+	// the four we could not read stay empty rather than carrying a value we
+	// never saw
+	assert.Empty(t, info.SysInfo.SerialNumber)
+	assert.Empty(t, info.SysInfo.UUID)
+	assert.Empty(t, info.BaseBoardInfo.SerialNumber)
+	assert.Empty(t, info.ChassisInfo.SerialNumber)
+}
+
+// A host with no DMI tables at all reports an empty struct, not an error.
+func TestLinuxSmbios_NoDmiDirectory(t *testing.T) {
+	info, err := readLinuxSmbios(afero.NewMemMapFs())
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Empty(t, info.BIOS.Vendor)
+}


### PR DESCRIPTION
## What

`/sys/class/dmi/id` exports four attributes the kernel marks root-only (mode 0400): `product_serial`, `board_serial`, `chassis_serial` and `product_uuid`. The other sixteen are world-readable.

The walk that reads them returned the first `open` error, which aborted the whole walk, so `Info()` returned no data at all. A scan that is not root therefore lost `machine.bios`, `machine.system`, `machine.baseboard` and `machine.chassis` **entirely** — including the BIOS vendor, version and release date that firmware audits ask for and that were sitting there readable. `chassis_serial` sorts fifth of twenty, so almost nothing was read before the walk gave up.

Each attribute is now read on its own: a failure logs at debug and leaves that one field empty, and the rest still arrive. A single entry that cannot be stat'ed is skipped the same way — returning `SkipDir` for a *file* tells `Walk` to drop every remaining entry in the directory, which silently truncated the attribute list by alphabetical accident.

## How it was found

A sweep of `mql run local` inside almalinux 8/9/10, amazonlinux 2/2023, debian 10/11/12/13, opensuse leap 15.5/15.6/16.0 + tumbleweed, and ubuntu 16.04/18.04/20.04/22.04/24.04/25.04 containers. All four `machine.*` sub-resources reported `no data available` on **all 19 images**.

The permission split is the same on every Linux host:

```
-r--r--r--. bios_vendor        OK
-r--r--r--. bios_version       OK
-r--------. chassis_serial     DENY
-r--r--r--. product_name       OK
-r--------. product_serial     DENY
-r--------. product_uuid       DENY
```

## Test plan

- `TestLinuxSmbios_KeepsReadableAttributesWhenSerialsAreRootOnly` denies exactly those four paths with `EACCES` and asserts the other sixteen still arrive, including the ones that sort *after* the denied entries. It fails on the pre-fix code with `open /sys/class/dmi/id/board_serial: permission denied`.
- `TestLinuxSmbios_AllAttributesReadable` pins the root case.
- `TestLinuxSmbios_NoDmiDirectory` pins that a host with no DMI tables still reports an empty struct rather than an error.
- `go test ./providers/os/resources/smbios/` passes.