### PR TITLE
🐛 os: stop one unreadable sysctl emptying kernel.parameters

### DIFF
--- a/providers/os/resources/kernel/manager.go
+++ b/providers/os/resources/kernel/manager.go
@@ -141,12 +141,14 @@ func walkProcSys(fs afero.Fs) (map[string]string, error) {
 			return nil
 		}
 
-		stat, err := fs.Stat(path)
-		if err != nil {
-			log.Debug().Err(err).Str("path", path).Msg("mql[kernel]> could not stat sysctl parameter")
-			return nil
-		}
-		details := shared.FileModeDetails{FileMode: stat.Mode()}
+		// A handful of knobs are write-only by design -- vm/drop_caches,
+		// vm/compact_memory and net/ipv4/route/flush are the whole set on a
+		// stock kernel. Root can open and read those anyway, so the mode is
+		// what keeps them out of a map of parameter values. The walk already
+		// stat'd this entry, so use what it handed us rather than paying
+		// another syscall per file across ~1000 of them, which on an SSH
+		// connection is ~1000 round trips.
+		details := shared.FileModeDetails{FileMode: f.Mode()}
 		if !details.UserReadable() {
 			return nil
 		}

--- a/providers/os/resources/kernel/manager.go
+++ b/providers/os/resources/kernel/manager.go
@@ -114,43 +114,67 @@ func (s *LinuxKernelManager) Parameters() (map[string]string, error) {
 	}
 
 	log.Debug().Msg("using /proc/sys walking to read kernel parameters")
-	fs := s.conn.FileSystem()
+	return walkProcSys(s.conn.FileSystem())
+}
+
+// walkProcSys reads every readable knob under /proc/sys.
+//
+// Plenty of them are not readable: some are mode 0600 and owned by root
+// (kernel.usermodehelper/bset among them), and some are write-only by design
+// (kernel.kexec_load_disabled, the drop_caches knobs). A scan that is not root
+// hits the first of those a few entries into the walk. Reporting that as the
+// result of the walk cost the caller every parameter, so kernel.parameters was
+// empty for any non-root scan; skip the ones we cannot read and return the
+// rest.
+func walkProcSys(fs afero.Fs) (map[string]string, error) {
 	fsUtil := afero.Afero{Fs: fs}
 	kernelParameters := make(map[string]string)
+
 	err := fsUtil.Walk(sysctlPath, func(path string, f os.FileInfo, err error) error {
-		if f != nil && !f.IsDir() {
-			stat, err := s.conn.FileSystem().Stat(path)
-			if err != nil {
-				log.Error().Err(err)
-				return nil
-			}
-			details := shared.FileModeDetails{
-				FileMode: stat.Mode(),
-			}
-			if !details.UserReadable() {
-				return nil
-			}
-
-			f, err := s.conn.FileSystem().Open(path)
-			if err != nil {
-				log.Error().Err(err)
-				return err
-			}
-
-			content, err := io.ReadAll(f)
-			if err != nil {
-				log.Error().Err(err).Msg("cannot read content")
-				return nil
-			}
-			// remove leading sysctl path
-			k := strings.ReplaceAll(path, sysctlPath, "")
-			k = strings.ReplaceAll(k, "/", ".")
-			kernelParameters[k] = strings.TrimSpace(string(content))
+		if err != nil {
+			// Walk could not even stat this entry. Skipping the directory here
+			// would drop everything after it, so keep going.
+			log.Debug().Err(err).Str("path", path).Msg("mql[kernel]> skipping unreadable sysctl entry")
+			return nil
 		}
+		if f == nil || f.IsDir() {
+			return nil
+		}
+
+		stat, err := fs.Stat(path)
+		if err != nil {
+			log.Debug().Err(err).Str("path", path).Msg("mql[kernel]> could not stat sysctl parameter")
+			return nil
+		}
+		details := shared.FileModeDetails{FileMode: stat.Mode()}
+		if !details.UserReadable() {
+			return nil
+		}
+
+		file, err := fs.Open(path)
+		if err != nil {
+			log.Debug().Err(err).Str("path", path).Msg("mql[kernel]> could not open sysctl parameter")
+			return nil
+		}
+		defer file.Close()
+
+		content, err := io.ReadAll(file)
+		if err != nil {
+			log.Debug().Err(err).Str("path", path).Msg("mql[kernel]> could not read sysctl parameter")
+			return nil
+		}
+
+		// remove leading sysctl path
+		k := strings.ReplaceAll(path, sysctlPath, "")
+		k = strings.ReplaceAll(k, "/", ".")
+		kernelParameters[k] = strings.TrimSpace(string(content))
 		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
 
-	return kernelParameters, err
+	return kernelParameters, nil
 }
 
 func (s *LinuxKernelManager) Modules() ([]*KernelModule, error) {

--- a/providers/os/resources/kernel/manager_procsys_test.go
+++ b/providers/os/resources/kernel/manager_procsys_test.go
@@ -1,0 +1,93 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package kernel
+
+import (
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// denyOpenFs refuses to open the named paths with EACCES, the way /proc/sys
+// refuses a reader that is not root on the knobs the kernel restricts.
+type denyOpenFs struct {
+	afero.Fs
+	deny map[string]bool
+}
+
+func (f *denyOpenFs) Open(name string) (afero.File, error) {
+	if f.deny[name] {
+		return nil, &os.PathError{Op: "open", Path: name, Err: syscall.EACCES}
+	}
+	return f.Fs.Open(name)
+}
+
+func procSysFs(t *testing.T) afero.Fs {
+	t.Helper()
+
+	fs := afero.NewMemMapFs()
+	for path, content := range map[string]string{
+		// sorts before the denied entry
+		"/proc/sys/fs/protected_hardlinks": "1\n",
+		"/proc/sys/fs/suid_dumpable":       "0\n",
+		// the denied entry itself, mode 0600 root-only on a real host
+		"/proc/sys/kernel/usermodehelper/bset": "4294967295\n",
+		// sorts after the denied entry
+		"/proc/sys/kernel/randomize_va_space": "2\n",
+		"/proc/sys/net/ipv4/ip_forward":       "0\n",
+		"/proc/sys/vm/mmap_min_addr":          "65536\n",
+	} {
+		require.NoError(t, afero.WriteFile(fs, path, []byte(content), 0o644))
+	}
+	return fs
+}
+
+func TestWalkProcSys_ReadsEveryParameter(t *testing.T) {
+	params, err := walkProcSys(procSysFs(t))
+	require.NoError(t, err)
+
+	assert.Equal(t, "2", params["kernel.randomize_va_space"])
+	assert.Equal(t, "0", params["net.ipv4.ip_forward"])
+	assert.Equal(t, "1", params["fs.protected_hardlinks"])
+	assert.Equal(t, "4294967295", params["kernel.usermodehelper.bset"])
+	assert.Len(t, params, 6)
+}
+
+// kernel.usermodehelper/bset is mode 0600 and owned by root, so any scan that
+// is not root gets EACCES on it. Before the fix that error ended the walk and
+// kernel.parameters reported no data at all, rather than the hundreds of knobs
+// sitting there world-readable -- randomize_va_space and ip_forward among them.
+func TestWalkProcSys_KeepsGoingPastAnUnreadableParameter(t *testing.T) {
+	fs := &denyOpenFs{
+		Fs:   procSysFs(t),
+		deny: map[string]bool{"/proc/sys/kernel/usermodehelper/bset": true},
+	}
+
+	params, err := walkProcSys(fs)
+	require.NoError(t, err)
+
+	// the readable knobs still arrive, including the ones that sort after the
+	// denied entry
+	assert.Equal(t, "2", params["kernel.randomize_va_space"])
+	assert.Equal(t, "0", params["net.ipv4.ip_forward"])
+	assert.Equal(t, "65536", params["vm.mmap_min_addr"])
+	assert.Equal(t, "1", params["fs.protected_hardlinks"])
+	assert.Equal(t, "0", params["fs.suid_dumpable"])
+
+	// the one we could not read is absent rather than reported as empty, so a
+	// check on it cannot pass on a value we never saw
+	assert.NotContains(t, params, "kernel.usermodehelper.bset")
+	assert.Len(t, params, 5)
+}
+
+// A host without /proc/sys at all reports an empty map, not an error.
+func TestWalkProcSys_NoProcSys(t *testing.T) {
+	params, err := walkProcSys(afero.NewMemMapFs())
+	require.NoError(t, err)
+	assert.Empty(t, params)
+}

--- a/providers/os/resources/kernel/manager_procsys_test.go
+++ b/providers/os/resources/kernel/manager_procsys_test.go
@@ -85,6 +85,26 @@ func TestWalkProcSys_KeepsGoingPastAnUnreadableParameter(t *testing.T) {
 	assert.Len(t, params, 5)
 }
 
+// The three write-only knobs a stock kernel exports (vm/drop_caches,
+// vm/compact_memory, net/ipv4/route/flush) are not parameter values, and root
+// can open and read them regardless, so the mode is what keeps them out.
+func TestWalkProcSys_SkipsWriteOnlyKnobs(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/proc/sys/vm/mmap_min_addr", []byte("65536\n"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/proc/sys/vm/drop_caches", []byte("0\n"), 0o200))
+	require.NoError(t, afero.WriteFile(fs, "/proc/sys/vm/compact_memory", []byte("0\n"), 0o200))
+	require.NoError(t, afero.WriteFile(fs, "/proc/sys/net/ipv4/route/flush", []byte("\n"), 0o200))
+
+	params, err := walkProcSys(fs)
+	require.NoError(t, err)
+
+	assert.Equal(t, "65536", params["vm.mmap_min_addr"])
+	assert.NotContains(t, params, "vm.drop_caches")
+	assert.NotContains(t, params, "vm.compact_memory")
+	assert.NotContains(t, params, "net.ipv4.route.flush")
+	assert.Len(t, params, 1)
+}
+
 // A host without /proc/sys at all reports an empty map, not an error.
 func TestWalkProcSys_NoProcSys(t *testing.T) {
 	params, err := walkProcSys(afero.NewMemMapFs())


### PR DESCRIPTION
## What

When `/sbin/sysctl` is not on the host, `kernel.parameters` walks `/proc/sys` instead. Some knobs there cannot be read: a few are mode 0600 and owned by root — `kernel/usermodehelper/bset` is the one everything trips over — and others are write-only by design.

The walk returned that `open` error, which ended the walk and lost every parameter, so `kernel.parameters` reported no data at all on any host where the fallback ran.

A knob that cannot be read is now skipped and the rest are kept, the way the mode check next to it already skipped the ones it knew about. An unreadable parameter stays **absent** rather than being reported as empty, so a check on it cannot pass on a value nothing ever saw.

Two of the error paths logged with `log.Error().Err(err)` and no terminating `Msg`, which zerolog never emits — so they wrote nothing at all. They now log at debug with the path, alongside a third for the stat.

## How it was found

A sweep of `mql run local` inside almalinux 8/9/10, amazonlinux 2/2023, debian 10/11/12/13, opensuse leap 15.5/15.6/16.0 + tumbleweed, and ubuntu 16.04–25.04 containers. `kernel.parameters` reported `no data available` on **10 of 19** — every image without `/sbin/sysctl` installed:

```
kernel.parameters.length: no data available
  open /proc/sys/kernel/usermodehelper/bset: permission denied
```

## Test plan

- `TestWalkProcSys_KeepsGoingPastAnUnreadableParameter` denies `/proc/sys/kernel/usermodehelper/bset` with `EACCES` and asserts the readable knobs still arrive, including the ones sorting after it (`net.ipv4.ip_forward`, `vm.mmap_min_addr`). It fails on the pre-fix code.
- `TestWalkProcSys_ReadsEveryParameter` pins the all-readable case.
- `TestWalkProcSys_NoProcSys` pins that a host with no `/proc/sys` reports an empty map, not an error.
- `go test ./providers/os/resources/kernel/` passes.