### PR TITLE
🐛 os: stop systemd.units reporting an empty list when systemctl cannot answer

### DIFF
--- a/providers/os/resources/services/systemd_unit.go
+++ b/providers/os/resources/services/systemd_unit.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/coreos/go-systemd/unit"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"go.mondoo.com/mql/providers/os/connection/shared"
 )
@@ -104,10 +105,35 @@ type SystemdUnitManager struct {
 	conn shared.Connection
 }
 
+// fsFallback reads the unit files off disk. systemctl needs a running systemd
+// to answer, so it is not available in a container, a chroot, a rescue boot, or
+// on a host that keeps unit files around while another init runs. It reports
+// that by exiting non-zero with nothing on stdout, which parses into an empty
+// unit list -- indistinguishable from a host that genuinely runs no services,
+// and enough to make an assertion over systemd.units pass without ever having
+// read a unit.
+func (m *SystemdUnitManager) fsFallback() *SystemdFSUnitManager {
+	return &SystemdFSUnitManager{Fs: m.conn.FileSystem()}
+}
+
 func (m *SystemdUnitManager) List() ([]*SystemdUnit, error) {
+	units, err := m.listViaSystemctl()
+	if err == nil {
+		return units, nil
+	}
+
+	log.Debug().Err(err).
+		Msg("mql[systemd]> could not list units through systemctl, reading unit files instead")
+	return m.fsFallback().List()
+}
+
+func (m *SystemdUnitManager) listViaSystemctl() ([]*SystemdUnit, error) {
 	cmd, err := m.conn.RunCommand("systemctl list-unit-files --type service --all --no-legend")
 	if err != nil {
 		return nil, err
+	}
+	if cmd.ExitStatus != 0 {
+		return nil, systemctlError("systemctl list-unit-files", cmd)
 	}
 
 	names, err := parseSystemdUnitFileNames(cmd.Stdout)
@@ -127,6 +153,9 @@ func (m *SystemdUnitManager) List() ([]*SystemdUnit, error) {
 		if err != nil {
 			return nil, err
 		}
+		if showCmd.ExitStatus != 0 {
+			return nil, systemctlError("systemctl show", showCmd)
+		}
 
 		records, err := parseSystemdShowRecords(showCmd.Stdout)
 		if err != nil {
@@ -140,13 +169,42 @@ func (m *SystemdUnitManager) List() ([]*SystemdUnit, error) {
 		}
 	}
 
+	// systemctl named the units, so it knowing nothing about any of them is a
+	// failure to report rather than a host with nothing on it
+	if len(res) == 0 {
+		return nil, fmt.Errorf("systemctl show returned no properties for any of the %d service units", len(names))
+	}
+
 	return res, nil
+}
+
+// systemctlError turns a non-zero systemctl exit into an error carrying the
+// reason systemctl printed, which is the part that says what went wrong
+// ("System has not been booted with systemd as init system (PID 1)").
+func systemctlError(what string, cmd *shared.Command) error {
+	reason := ""
+	if cmd.Stderr != nil {
+		if out, err := io.ReadAll(cmd.Stderr); err == nil {
+			reason = strings.TrimSpace(string(out))
+		}
+	}
+	if reason == "" {
+		return fmt.Errorf("%s exited %d", what, cmd.ExitStatus)
+	}
+	return fmt.Errorf("%s exited %d: %s", what, cmd.ExitStatus, reason)
 }
 
 func (m *SystemdUnitManager) Get(name string) (*SystemdUnit, error) {
 	cmd, err := m.conn.RunCommand(buildSystemdUnitShowCommand([]string{name}))
 	if err != nil {
 		return nil, err
+	}
+	if cmd.ExitStatus != 0 {
+		// same reason as List: a systemctl that cannot answer must not read as
+		// "there is no such unit"
+		log.Debug().Err(systemctlError("systemctl show", cmd)).Str("unit", name).
+			Msg("mql[systemd]> could not read unit through systemctl, reading the unit file instead")
+		return m.fsFallback().Get(name)
 	}
 
 	records, err := parseSystemdShowRecords(cmd.Stdout)

--- a/providers/os/resources/services/systemd_unit_fallback_test.go
+++ b/providers/os/resources/services/systemd_unit_fallback_test.go
@@ -1,0 +1,185 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package services
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+	"go.mondoo.com/mql/providers/os/connection/shared"
+)
+
+// unitFileListing is what `systemctl list-unit-files` prints. It keeps working
+// when systemd is not running, because it only reads the unit files off disk.
+const unitFileListing = `sshd.service     enabled  enabled
+chronyd.service  enabled  enabled
+`
+
+// bootedElsewhere is what systemctl prints on stderr, exiting non-zero, when it
+// cannot reach the bus -- in a container, a chroot, a rescue boot, or on a host
+// running another init.
+const bootedElsewhere = "System has not been booted with systemd as init system (PID 1). Can't operate.\nFailed to connect to bus: Host is down\n"
+
+// fsConn is a mock connection whose filesystem is one we control, so the
+// unit-file fallback has something to read.
+type fsConn struct {
+	shared.Connection
+	fs afero.Fs
+}
+
+func (c *fsConn) FileSystem() afero.Fs { return c.fs }
+
+func unitFallbackConn(t *testing.T, cmds map[string]*mock.Command) shared.Connection {
+	t.Helper()
+
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:    "almalinux",
+			Version: "9.8",
+			Family:  []string{"redhat", "linux", "unix", "os"},
+		},
+	}, mock.WithData(&mock.TomlData{Commands: cmds}))
+	require.NoError(t, err)
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/usr/lib/systemd/system/sshd.service", []byte(`[Unit]
+Description=OpenSSH server daemon
+
+[Service]
+Type=notify
+ExecStart=/usr/sbin/sshd -D
+User=root
+NoNewPrivileges=no
+`), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/usr/lib/systemd/system/chronyd.service", []byte(`[Unit]
+Description=NTP client/server
+
+[Service]
+Type=forking
+ExecStart=/usr/sbin/chronyd
+User=chrony
+NoNewPrivileges=yes
+ProtectSystem=full
+`), 0o644))
+
+	return &fsConn{Connection: conn, fs: fs}
+}
+
+// systemctl can name the units without a running systemd, but cannot report
+// their properties: `systemctl show` exits non-zero with nothing on stdout.
+// That parses into zero records, so before the fix systemd.units reported an
+// empty list -- a host with no services at all -- and an assertion like
+// `systemd.units.where(noNewPrivileges == false)` passed without a unit ever
+// having been read.
+func TestSystemdUnitManager_FallsBackToUnitFilesWhenShowCannotRun(t *testing.T) {
+	conn := unitFallbackConn(t, map[string]*mock.Command{
+		"systemctl list-unit-files --type service --all --no-legend": {
+			Stdout: unitFileListing,
+		},
+		buildSystemdUnitShowCommand([]string{"sshd.service", "chronyd.service"}): {
+			Stderr:     bootedElsewhere,
+			ExitStatus: 1,
+		},
+	})
+
+	units, err := (&SystemdUnitManager{conn: conn}).List()
+	require.NoError(t, err)
+	require.Len(t, units, 2)
+
+	byName := map[string]*SystemdUnit{}
+	for _, u := range units {
+		byName[u.Name] = u
+	}
+
+	require.Contains(t, byName, "sshd.service")
+	assert.Equal(t, "OpenSSH server daemon", byName["sshd.service"].Description)
+	assert.Equal(t, "/usr/sbin/sshd -D", byName["sshd.service"].ExecStart)
+	assert.False(t, byName["sshd.service"].NoNewPrivileges)
+
+	require.Contains(t, byName, "chronyd.service")
+	assert.True(t, byName["chronyd.service"].NoNewPrivileges)
+	assert.Equal(t, "full", byName["chronyd.service"].ProtectSystem)
+}
+
+// The same for a host where systemctl cannot even list the unit files.
+func TestSystemdUnitManager_FallsBackWhenListCannotRun(t *testing.T) {
+	conn := unitFallbackConn(t, map[string]*mock.Command{
+		"systemctl list-unit-files --type service --all --no-legend": {
+			Stderr:     bootedElsewhere,
+			ExitStatus: 1,
+		},
+	})
+
+	units, err := (&SystemdUnitManager{conn: conn}).List()
+	require.NoError(t, err)
+	assert.Len(t, units, 2)
+}
+
+// A single unit lookup degrades the same way, so service("sshd.service") does
+// not report a unit that is sitting on disk as not found.
+func TestSystemdUnitManager_GetFallsBackWhenShowCannotRun(t *testing.T) {
+	conn := unitFallbackConn(t, map[string]*mock.Command{
+		buildSystemdUnitShowCommand([]string{"sshd.service"}): {
+			Stderr:     bootedElsewhere,
+			ExitStatus: 1,
+		},
+	})
+
+	unit, err := (&SystemdUnitManager{conn: conn}).Get("sshd.service")
+	require.NoError(t, err)
+	assert.Equal(t, "sshd.service", unit.Name)
+	assert.Equal(t, "/usr/sbin/sshd -D", unit.ExecStart)
+}
+
+// When systemctl answers, its values win -- they are the ones in effect after
+// drop-ins have been merged, which the unit file on its own does not show.
+func TestSystemdUnitManager_PrefersSystemctlWhenItAnswers(t *testing.T) {
+	conn := unitFallbackConn(t, map[string]*mock.Command{
+		"systemctl list-unit-files --type service --all --no-legend": {
+			Stdout: unitFileListing,
+		},
+		buildSystemdUnitShowCommand([]string{"sshd.service", "chronyd.service"}): {
+			Stdout: `Id=sshd.service
+Description=OpenSSH server daemon
+LoadState=loaded
+ActiveState=active
+NoNewPrivileges=yes
+
+Id=chronyd.service
+Description=NTP client/server
+LoadState=loaded
+ActiveState=active
+NoNewPrivileges=yes
+`,
+		},
+	})
+
+	units, err := (&SystemdUnitManager{conn: conn}).List()
+	require.NoError(t, err)
+	require.Len(t, units, 2)
+
+	// the drop-in merged value from systemctl, not the "no" in the unit file
+	assert.Equal(t, "sshd.service", units[0].Name)
+	assert.True(t, units[0].NoNewPrivileges)
+	assert.Equal(t, "active", units[0].ActiveState)
+}
+
+// A host that really runs no service units still reports an empty list rather
+// than an error.
+func TestSystemdUnitManager_NoUnitsAtAll(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{Name: "almalinux", Version: "9.8", Family: []string{"redhat", "linux", "unix", "os"}},
+	}, mock.WithData(&mock.TomlData{Commands: map[string]*mock.Command{
+		"systemctl list-unit-files --type service --all --no-legend": {Stdout: ""},
+	}}))
+	require.NoError(t, err)
+
+	units, err := (&SystemdUnitManager{conn: &fsConn{Connection: conn, fs: afero.NewMemMapFs()}}).List()
+	require.NoError(t, err)
+	assert.Empty(t, units)
+}


### PR DESCRIPTION
## What

`systemd.units` names the units with `systemctl list-unit-files`, which reads the unit files off disk and keeps working without a running systemd, then reads their settings with `systemctl show`, which needs the bus.

Where the bus is not reachable — a container, a chroot, a rescue boot, a host that keeps unit files around while another init runs — `show` exits non-zero and prints nothing on stdout:

```
$ systemctl show --property=Id,Description,... -- dbus-broker.service
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to bus: Host is down
```

Nothing checked the exit status. Empty stdout parses cleanly into zero records, so the resource reported an **empty list**: a host running no services at all. The schema's own doc-comment example —

```
systemd.units.where(user == "" && noNewPrivileges == false)
```

— therefore passed on a host whose units were never read. On `almalinux:9` that query returns **50** units once they are actually read.

## The fix

Check the exit status of both commands and fall back to `SystemdFSUnitManager`, which the package already has and which the filesystem-only path already uses. `systemctl` still wins whenever it answers, since its values are the ones in effect after drop-ins have been merged. A single lookup through `Get` degrades the same way, so `service(...)` no longer reports a unit sitting on disk as not found. systemctl naming units it then knows nothing about is reported rather than passed off as an empty host.

This is the same fix the `lsmod` fallback in `kernel/manager.go` already documents two files over.

## How it was found

A sweep of `mql run local` inside almalinux 8/9/10, amazonlinux 2/2023, debian 10/11/12/13, opensuse leap 15.5/15.6/16.0 + tumbleweed, and ubuntu 16.04–25.04 containers. `systemd.units.length` was **0 on all 19 images** — including the almalinux ones, where `services.length` was 62 and 321 `.service` files sat on disk, and where `systemd.targets`, `systemd.sockets` and `systemd.timers` all returned real data.

Before / after on `almalinux:9`:

| query | before | after |
|---|---|---|
| `systemd.units.length` | 0 | 62 |
| `systemd.units.where(noNewPrivileges == false).length` | 0 | 50 |

```
systemd.units.where(name == "dbus-broker.service") { ... }
  execStart: "/usr/bin/dbus-broker-launch --scope system --audit"
  description: "D-Bus System Message Bus"
  protectSystem: "full"
  noNewPrivileges: false
```

## Test plan

- `TestSystemdUnitManager_FallsBackToUnitFilesWhenShowCannotRun` — `list-unit-files` succeeds, `show` exits 1 with the real bus error on stderr; asserts both units come back with their real `execStart`, `noNewPrivileges` and `protectSystem`. Fails on the pre-fix code with `"[]" should have 2 item(s), but has 0`.
- `TestSystemdUnitManager_FallsBackWhenListCannotRun` — same for a systemctl that cannot even list.
- `TestSystemdUnitManager_GetFallsBackWhenShowCannotRun` — the single-unit path.
- `TestSystemdUnitManager_PrefersSystemctlWhenItAnswers` — the drop-in-merged value from systemctl still wins over the unit file.
- `TestSystemdUnitManager_NoUnitsAtAll` — a host that really runs nothing still reports an empty list, not an error.
- `go test ./providers/os/resources/services/` passes; verified live in `almalinux:9`.