### PR TITLE
🐛 os: fix os.uptime on the 13 of 19 Linux images where it read null

### DIFF
--- a/providers/os/resources/uptime/proc_uptime_test.go
+++ b/providers/os/resources/uptime/proc_uptime_test.go
@@ -1,0 +1,86 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package uptime_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+	"go.mondoo.com/mql/providers/os/resources/uptime"
+)
+
+func TestParseProcUptime(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    time.Duration
+	}{
+		{"typical", "350735.47 234388.90\n", 350735470 * time.Millisecond},
+		{"freshly booted", "0.42 0.11\n", 420 * time.Millisecond},
+		{"no trailing newline", "1140.00 900.00", 19 * time.Minute},
+		// a single-CPU kernel prints one column on some very old builds
+		{"one column", "60.00\n", time.Minute},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := uptime.ParseProcUptime(tc.content)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestParseProcUptime_Rejected(t *testing.T) {
+	for _, content := range []string{"", "\n", "not-a-number 1.0\n", "-1.0 0.0\n"} {
+		_, err := uptime.ParseProcUptime(content)
+		assert.Error(t, err, "content %q", content)
+	}
+}
+
+// A minimal image does not ship procps, so `uptime` exits 127 with nothing on
+// stdout. That used to surface as `could not parse uptime: ` and os.uptime read
+// null. /proc/uptime is always there and needs no binary.
+func TestUptimeOnLinux_FallsBackToProcWhenCommandIsMissing(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{Name: "debian", Version: "13", Family: []string{"debian", "linux", "unix", "os"}},
+	}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"uptime": {Stderr: "sh: 1: uptime: not found\n", ExitStatus: 127},
+		},
+		Files: map[string]*mock.MockFileData{
+			"/proc/uptime": {Content: "1140.00 900.00\n"},
+		},
+	}))
+	require.NoError(t, err)
+
+	ut, err := uptime.New(conn)
+	require.NoError(t, err)
+
+	d, err := ut.Duration()
+	require.NoError(t, err)
+	assert.Equal(t, "19m0s", d.String())
+}
+
+// A host with neither reports both reasons rather than only the parse failure.
+func TestUptimeOnLinux_ReportsBothFailures(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{Name: "debian", Version: "13", Family: []string{"debian", "linux", "unix", "os"}},
+	}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"uptime": {Stderr: "sh: 1: uptime: not found\n", ExitStatus: 127},
+		},
+	}))
+	require.NoError(t, err)
+
+	ut, err := uptime.New(conn)
+	require.NoError(t, err)
+
+	_, err = ut.Duration()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "uptime exited 127")
+	assert.Contains(t, err.Error(), "/proc/uptime")
+}

--- a/providers/os/resources/uptime/proc_uptime_test.go
+++ b/providers/os/resources/uptime/proc_uptime_test.go
@@ -84,3 +84,40 @@ func TestUptimeOnLinux_ReportsBothFailures(t *testing.T) {
 	assert.Contains(t, err.Error(), "uptime exited 127")
 	assert.Contains(t, err.Error(), "/proc/uptime")
 }
+
+// openSUSE Leap installs GNU coreutils' `uptime`, not the procps one. It
+// prints the day count with no comma after it -- "up 1 day 10:51," where
+// procps prints "up 1 day, 10:53," -- which the parser rejected outright, so
+// os.uptime read null on every openSUSE Leap host even though the command was
+// right there and working.
+func TestParseUnixUptime_CoreutilsNoCommaAfterDays(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		line string
+		want time.Duration
+	}{
+		{
+			// coreutils 8.32, openSUSE Leap 15.6
+			name: "coreutils leap",
+			line: " 16:31:12  up 1 day 10:51,  0 users,  load average: 0.05, 0.10, 0.19",
+			want: 34*time.Hour + 51*time.Minute,
+		},
+		{
+			name: "coreutils several days",
+			line: " 09:02:11  up 12 days 3:07,  2 users,  load average: 0.00, 0.01, 0.05",
+			want: 12*24*time.Hour + 3*time.Hour + 7*time.Minute,
+		},
+		{
+			// procps-ng, ubuntu 24.04 -- unchanged
+			name: "procps",
+			line: " 16:32:48 up 1 day, 10:53,  0 user,  load average: 0.13, 0.11, 0.18",
+			want: 34*time.Hour + 53*time.Minute,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := uptime.ParseUnixUptime(tc.line)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, time.Duration(res.Duration))
+		})
+	}
+}

--- a/providers/os/resources/uptime/unix.go
+++ b/providers/os/resources/uptime/unix.go
@@ -24,7 +24,13 @@ import (
 // Solaris pluralizes with a parenthesized suffix instead of a bare "s",
 // printing "up 26 min(s)" and "up 5 day(s), 21:03", so each unit accepts
 // that spelling too.
-var UnixUptimeRegex = regexp.MustCompile(`^.*up[\s]*(?:\s*(\d+)\s(day(?:s|\(s\))?),)*(?:\s*(\d+)\s(hr(?:s|\(s\))?),)*(?:\s*(\d+)\s(min(?:s|\(s\))?),)*(?:\s+([\d:]+),\s)*\s*(?:(\d+)\suser[s]*,\s)*\s*load\s+average[s]*:\s+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)\s*$`)
+//
+// The separator after a unit is optional. GNU coreutils ships its own
+// `uptime`, which openSUSE Leap installs instead of the procps one, and it
+// prints "up 1 day 10:51," with no comma after the day count. Requiring the
+// comma made the whole line unparseable, so os.uptime read null on every
+// openSUSE Leap host.
+var UnixUptimeRegex = regexp.MustCompile(`^.*up[\s]*(?:\s*(\d+)\s(day(?:s|\(s\))?),?)*(?:\s*(\d+)\s(hr(?:s|\(s\))?),?)*(?:\s*(\d+)\s(min(?:s|\(s\))?),?)*(?:\s+([\d:]+),\s)*\s*(?:(\d+)\suser[s]*,\s)*\s*load\s+average[s]*:\s+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)\s*$`)
 
 type UnixUptimeResult struct {
 	Duration           int64

--- a/providers/os/resources/uptime/unix.go
+++ b/providers/os/resources/uptime/unix.go
@@ -158,10 +158,46 @@ func (s *Unix) Name() string {
 	return "Unix Uptime"
 }
 
+// procUptimePath is the kernel's own uptime interface on Linux: two
+// space-separated floats, seconds since boot and seconds spent idle.
+const procUptimePath = "/proc/uptime"
+
 func (s *Unix) Duration() (time.Duration, error) {
+	var cmdErr error
+	if s.conn.Capabilities().Has(shared.Capability_RunCommand) {
+		d, err := s.durationFromCommand()
+		if err == nil {
+			return d, nil
+		}
+		cmdErr = err
+		log.Debug().Err(err).Msg("mql[uptime]> could not read the uptime command, trying " + procUptimePath)
+	}
+
+	// The `uptime` command comes from procps, which plenty of minimal images
+	// and container base images do not ship, and its output carries the
+	// locale's load-average separator. /proc/uptime needs no binary on PATH,
+	// is readable by anyone, and is also there for a scan that cannot run
+	// commands at all.
+	d, procErr := s.durationFromProc()
+	if procErr == nil {
+		return d, nil
+	}
+
+	if cmdErr != nil {
+		return 0, fmt.Errorf("could not determine uptime: %w (%s: %v)", cmdErr, procUptimePath, procErr)
+	}
+	return 0, procErr
+}
+
+func (s *Unix) durationFromCommand() (time.Duration, error) {
 	cmd, err := s.conn.RunCommand("uptime")
 	if err != nil {
 		return 0, err
+	}
+	if cmd.ExitStatus != 0 {
+		// An `uptime` that is not installed exits 127 with nothing on stdout,
+		// which the parser could only report as "could not parse uptime: ".
+		return 0, fmt.Errorf("uptime exited %d", cmd.ExitStatus)
 	}
 
 	ut, err := s.parse(cmd.Stdout)
@@ -170,6 +206,41 @@ func (s *Unix) Duration() (time.Duration, error) {
 	}
 
 	return time.Duration(ut.Duration), nil
+}
+
+func (s *Unix) durationFromProc() (time.Duration, error) {
+	f, err := s.conn.FileSystem().Open(procUptimePath)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return 0, err
+	}
+
+	return ParseProcUptime(string(content))
+}
+
+// ParseProcUptime reads the seconds-since-boot value out of /proc/uptime. The
+// file holds two floats -- uptime and idle time -- and only the first matters
+// here. The value is always printed with a "." separator, whatever the locale.
+func ParseProcUptime(content string) (time.Duration, error) {
+	fields := strings.Fields(content)
+	if len(fields) == 0 {
+		return 0, fmt.Errorf("could not parse %s: %q", procUptimePath, content)
+	}
+
+	seconds, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return 0, fmt.Errorf("could not parse %s: %w", procUptimePath, err)
+	}
+	if seconds < 0 {
+		return 0, fmt.Errorf("could not parse %s: negative uptime %v", procUptimePath, seconds)
+	}
+
+	return time.Duration(seconds * float64(time.Second)), nil
 }
 
 func (s *Unix) parse(r io.Reader) (*UnixUptimeResult, error) {

--- a/providers/os/resources/uptime/unix.go
+++ b/providers/os/resources/uptime/unix.go
@@ -6,6 +6,7 @@ package uptime
 import (
 	"fmt"
 	"io"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -246,7 +247,9 @@ func ParseProcUptime(content string) (time.Duration, error) {
 		return 0, fmt.Errorf("could not parse %s: negative uptime %v", procUptimePath, seconds)
 	}
 
-	return time.Duration(seconds * float64(time.Second)), nil
+	// round rather than truncate: the float product of a long uptime and 1e9
+	// is not exact, so truncating drops a sub-nanosecond sliver
+	return time.Duration(math.Round(seconds * float64(time.Second))), nil
 }
 
 func (s *Unix) parse(r io.Reader) (*UnixUptimeResult, error) {

--- a/providers/os/resources/uptime/uptime.go
+++ b/providers/os/resources/uptime/uptime.go
@@ -25,6 +25,6 @@ func New(conn shared.Connection) (Uptime, error) {
 	case pf.IsFamily(inventory.FAMILY_WINDOWS):
 		return &Windows{conn: conn}, nil
 	default:
-		return nil, errors.New("your platform is not supported by reboot resource")
+		return nil, errors.New("your platform is not supported by the uptime resource")
 	}
 }


### PR DESCRIPTION
## What

Two independent reasons `os.uptime` returned null, both found by sweeping containers.

### 1. The `uptime` command is often not installed

`os.uptime` shells out to `uptime` and parses its output. That command comes from procps, which minimal images and container base images do not ship: it exits 127 with nothing on stdout, the exit status was never checked, and the empty string reached the parser, which could only report:

```
could not parse uptime:
```

Fall back to `/proc/uptime`, the kernel's own interface. It needs no binary on PATH, is readable by anyone, carries no locale in its decimal separator, and is there for a scan that cannot run commands at all. The `uptime` command still goes first, so nothing changes on a host that has it, and a host with neither now reports both reasons instead of only the parse failure.

The answer also gains the precision the command's minute-granularity output threw away: `/proc/uptime` reports `125155.80` where `uptime` said `1 day, 10:45`.

### 2. openSUSE Leap ships the coreutils `uptime`, which drops a comma

openSUSE Leap installs GNU coreutils' `uptime` rather than the procps one:

```
opensuse/leap:15.6   16:31:12  up 1 day 10:51,  0 users,  load average: 0.05, 0.10, 0.19    (coreutils 8.32)
ubuntu:24.04         16:32:48 up 1 day, 10:53,  0 user,   load average: 0.13, 0.11, 0.18    (procps)
```

No comma after the day count. The regex required it, so the line did not match at all and `os.uptime` read null on every openSUSE Leap host with the command sitting right there and working. The separator after the day, hour and minute units is now optional; the procps and Solaris forms already handled are unchanged.

Also fixes the resolver's error text, which named the reboot resource.

## How it was found

A sweep of `mql run local` inside almalinux 8/9/10, amazonlinux 2/2023, debian 10/11/12/13, opensuse leap 15.5/15.6/16.0 + tumbleweed, and ubuntu 16.04–25.04 containers. `os.uptime` read **null on 13 of 19** — every family except ubuntu, whose base image ships procps.

After, verified live:

```
opensuse/leap:15.5  -> 1 days 10 hours 55 minutes            (coreutils command path)
opensuse/leap:15.6  -> 1 days 10 hours 55 minutes            (coreutils command path)
opensuse/tumbleweed -> 1 days 10 hours 56 minutes 5 seconds  (/proc/uptime)
almalinux:9         -> 1 days 10 hours 56 minutes 37 seconds (/proc/uptime)
ubuntu:24.04        -> 1 days 10 hours 57 minutes            (procps command path)
```

`/proc/uptime` read `125155.80` against a reported `1 days 10 hours 45 minutes 56 seconds` — exact.

## Test plan

- `TestUptimeOnLinux_FallsBackToProcWhenCommandIsMissing` — `uptime` exits 127, `/proc/uptime` answers.
- `TestUptimeOnLinux_ReportsBothFailures` — neither available, both reasons surface.
- `TestParseProcUptime` / `_Rejected` — the format, a freshly booted host, no trailing newline, the one-column form; and the empty, non-numeric and negative inputs.
- `TestParseUnixUptime_CoreutilsNoCommaAfterDays` — the coreutils form for one and several days, plus the procps form to pin that it is unchanged.
- The existing `uptime` suite (linux, `LC_NUMERIC=de_DE`, macOS, Solaris, alpine) still passes.