### PR TITLE
🐛 os: fix os.rebootpending on rpm containers and add SUSE support

### DIFF
--- a/providers/os/resources/reboot/reboot.go
+++ b/providers/os/resources/reboot/reboot.go
@@ -23,6 +23,8 @@ func New(conn shared.Connection) (Reboot, error) {
 		return &DebianReboot{conn: conn}, nil
 	case pf.IsFamily("redhat") || pf.Name == "amazonlinux":
 		return &RpmNewestKernel{conn: conn}, nil
+	case pf.IsFamily("suse"):
+		return &ZypperNeedsRebooting{conn: conn}, nil
 	case pf.IsFamily(inventory.FAMILY_WINDOWS):
 		return &WinReboot{conn: conn}, nil
 	default:

--- a/providers/os/resources/reboot/rhel.go
+++ b/providers/os/resources/reboot/rhel.go
@@ -35,6 +35,15 @@ func (s *RpmNewestKernel) RebootPending() (bool, error) {
 		return false, err
 	}
 
+	// `rpm -q` exits non-zero and prints "package kernel is not installed" on
+	// stdout when there is no kernel package, which is the normal case in a
+	// container. Feeding that sentence to the package parser made it report a
+	// dropped package line, so every container scan warned that packages were
+	// missing from the inventory when nothing was.
+	if installedKernelCmd.ExitStatus != 0 {
+		return false, nil
+	}
+
 	var pf *inventory.Platform
 	if s.conn.Asset() != nil {
 		pf = s.conn.Asset().Platform

--- a/providers/os/resources/reboot/rhel_container_test.go
+++ b/providers/os/resources/reboot/rhel_container_test.go
@@ -1,0 +1,68 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reboot
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+)
+
+// captureLog swaps the global logger for one writing into a buffer, so a test
+// can assert on what a scan actually prints.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	previous := log.Logger
+	previousLevel := zerolog.GlobalLevel()
+	log.Logger = zerolog.New(buf)
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	t.Cleanup(func() {
+		log.Logger = previous
+		zerolog.SetGlobalLevel(previousLevel)
+	})
+	return buf
+}
+
+const rpmQueryKernel = "rpm -q kernel --queryformat '%{NAME} %{EPOCHNUM}:%{VERSION}-%{RELEASE} %{ARCH}__%{VENDOR}__%{SUMMARY}__%{LICENSE}__%{INSTALLTIME}\n'"
+
+// A container has no kernel package, so `rpm -q kernel` exits 1 and prints
+// "package kernel is not installed" on stdout. That sentence used to reach the
+// rpm package parser, which counted it as a package line it could not parse and
+// warned that packages were missing from the inventory -- on every scan of
+// every rpm-based container, with nothing actually missing.
+func TestRhelRebootWithoutKernelPackage(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:    "almalinux",
+			Version: "9.8",
+			Family:  []string{"redhat", "linux", "unix", "os"},
+		},
+	}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			rpmQueryKernel: {
+				Stdout:     "package kernel is not installed\n",
+				ExitStatus: 1,
+			},
+			"uname -r": {Stdout: "6.12.0-55.el9.aarch64\n"},
+		},
+	}))
+	require.NoError(t, err)
+
+	logs := captureLog(t)
+
+	pending, err := (&RpmNewestKernel{conn: conn}).RebootPending()
+	require.NoError(t, err)
+	assert.False(t, pending)
+
+	assert.NotContains(t, logs.String(), "packages are missing from the inventory",
+		"a container with no kernel package must not be reported as a short package inventory")
+}

--- a/providers/os/resources/reboot/suse.go
+++ b/providers/os/resources/reboot/suse.go
@@ -1,0 +1,65 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reboot
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"go.mondoo.com/mql/providers/os/connection/shared"
+)
+
+// zypperRebootNeededExit is what `zypper needs-rebooting` exits with when core
+// libraries or the kernel have been updated since the machine booted. zypper
+// documents it as ZYPPER_EXIT_INF_REBOOT_NEEDED; a clean check exits 0.
+const zypperRebootNeededExit = 103
+
+// ZypperNeedsRebooting asks zypper whether anything updated since boot needs
+// the machine restarted.
+//
+// The rpm-newest-kernel comparison the redhat family uses does not carry over:
+// SUSE names the kernel package for its flavour (kernel-default,
+// kernel-azure, ...), so `rpm -q kernel` reports nothing installed and the
+// comparison would answer "no reboot pending" on every SUSE host.
+type ZypperNeedsRebooting struct {
+	conn shared.Connection
+}
+
+func (s *ZypperNeedsRebooting) Name() string {
+	return "Zypper Needs Rebooting"
+}
+
+func (s *ZypperNeedsRebooting) RebootPending() (bool, error) {
+	// a static asset cannot be asked, and has not booted anything either
+	if !s.conn.Capabilities().Has(shared.Capability_RunCommand) {
+		return false, nil
+	}
+
+	cmd, err := s.conn.RunCommand("zypper --non-interactive needs-rebooting")
+	if err != nil {
+		return false, err
+	}
+
+	switch cmd.ExitStatus {
+	case 0:
+		return false, nil
+	case zypperRebootNeededExit:
+		return true, nil
+	default:
+		return false, fmt.Errorf("zypper needs-rebooting exited %d: %s",
+			cmd.ExitStatus, readTrimmed(cmd.Stderr))
+	}
+}
+
+func readTrimmed(r io.Reader) string {
+	if r == nil {
+		return ""
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/providers/os/resources/reboot/suse_test.go
+++ b/providers/os/resources/reboot/suse_test.go
@@ -1,0 +1,76 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package reboot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+)
+
+func suseConn(t *testing.T, cmd *mock.Command) *mock.Connection {
+	t.Helper()
+
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:    "opensuse-leap",
+			Version: "15.6",
+			Family:  []string{"suse", "linux", "unix", "os"},
+		},
+	}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"zypper --non-interactive needs-rebooting": cmd,
+		},
+	}))
+	require.NoError(t, err)
+	return conn
+}
+
+func TestSuseResolvesToZypper(t *testing.T) {
+	r, err := New(suseConn(t, &mock.Command{}))
+	require.NoError(t, err)
+
+	_, ok := r.(*ZypperNeedsRebooting)
+	assert.True(t, ok, "SUSE resolves to the zypper reboot check")
+}
+
+func TestZypperNoRebootNeeded(t *testing.T) {
+	conn := suseConn(t, &mock.Command{
+		Stdout: "No core libraries or services have been updated since the last system boot.\n" +
+			"Reboot is probably not necessary.\n",
+	})
+
+	pending, err := (&ZypperNeedsRebooting{conn: conn}).RebootPending()
+	require.NoError(t, err)
+	assert.False(t, pending)
+}
+
+func TestZypperRebootNeeded(t *testing.T) {
+	conn := suseConn(t, &mock.Command{
+		Stdout:     "Core libraries or services have been updated.\nReboot is required...\n",
+		ExitStatus: zypperRebootNeededExit,
+	})
+
+	pending, err := (&ZypperNeedsRebooting{conn: conn}).RebootPending()
+	require.NoError(t, err)
+	assert.True(t, pending)
+}
+
+// An exit code that is neither of the two documented ones is reported rather
+// than read as "no reboot pending" -- a zypper too old for the subcommand exits
+// 1, and answering "you are fine" there would be an answer nothing measured.
+func TestZypperUnknownExitIsReported(t *testing.T) {
+	conn := suseConn(t, &mock.Command{
+		Stderr:     "Unknown command 'needs-rebooting'\n",
+		ExitStatus: 1,
+	})
+
+	_, err := (&ZypperNeedsRebooting{conn: conn}).RebootPending()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exited 1")
+	assert.Contains(t, err.Error(), "Unknown command")
+}


### PR DESCRIPTION
## What

Two problems the container sweep turned up.

### 1. A false "packages are missing" warning on every rpm container

The redhat-family reboot check runs `rpm -q kernel`. With no kernel package installed — the normal case in a container — rpm exits 1 and prints `package kernel is not installed` **on stdout**. Nothing checked the exit status, so that sentence reached the rpm package parser, which counted it as a package line it could not parse:

```
DBG  mql[rpm]> could not parse package line line="package kernel is not installed"
!    mql[rpm]> some package lines could not be parsed, packages are missing from the inventory dropped=1 parsed=0
```

Nothing was missing. `packages.length` matched `rpm -qa | wc -l` exactly on all five rpm images swept (almalinux 8/9/10: 156/159/136; amazonlinux 2/2023: 107/106). The warning is the loudest thing in the scan output and points at a package inventory that is in fact complete. Check the exit status instead.

### 2. `os.rebootpending` was unsupported on SUSE

The resolver had no suse branch, so the resource errored on every openSUSE and SLES host:

```
* your platform is not supported by reboot resource
```

The redhat approach does not carry over: SUSE names the kernel package for its flavour (`kernel-default`, `kernel-azure`, …), so `rpm -q kernel` reports nothing installed and the newest-kernel comparison would answer "no reboot pending" on every SUSE host — worse than an error.

Ask `zypper needs-rebooting` instead, which exits `103` (`ZYPPER_EXIT_INF_REBOOT_NEEDED`) when core libraries or the kernel have been updated since boot, and `0` when they have not. Any other exit — a zypper too old for the subcommand exits 1 — is reported rather than read as "you are fine".

## How it was found

A sweep of `mql run local` inside almalinux 8/9/10, amazonlinux 2/2023, debian 10/11/12/13, opensuse leap 15.5/15.6/16.0 + tumbleweed, and ubuntu 16.04–25.04 containers. The false warning appeared on all 5 rpm images; the unsupported error on all 4 SUSE images.

## Test plan

- `TestRhelRebootWithoutKernelPackage` captures the log and asserts the "packages are missing from the inventory" warning is **not** emitted for a container whose `rpm -q kernel` exits 1 with that sentence on stdout. It fails on the pre-fix code, printing the warning it is asserting against.
- `TestSuseResolvesToZypper`, `TestZypperNoRebootNeeded`, `TestZypperRebootNeeded`, `TestZypperUnknownExitIsReported`.
- Verified live: opensuse/leap 15.5, 15.6, 16.0 and tumbleweed now answer `false` instead of erroring, and the warning is gone from almalinux and amazonlinux scans. The reboot-needed branch is covered by unit test only — a container cannot be made to need one.