### PR TITLE
🐛 os: list running instances of systemd template units

### DIFF
--- a/providers/os/resources/services/systemd.go
+++ b/providers/os/resources/services/systemd.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/coreos/go-systemd/unit"
@@ -277,7 +278,10 @@ func (s *SystemDServiceManager) List() ([]*Service, error) {
 	// Step 3: Merge - update services from step 1 with running state from step 2.
 	// Services in list-unit-files but not in list-units are unloaded/templates;
 	// Running=false is correct for them (already the default).
+	known := make(map[string]struct{}, len(services))
 	for _, service := range services {
+		known[service.Name] = struct{}{}
+
 		unitState, ok := unitStates[service.Name]
 		if !ok {
 			continue
@@ -289,7 +293,71 @@ func (s *SystemDServiceManager) List() ([]*Service, error) {
 		}
 	}
 
-	return services, nil
+	// Step 4: Add loaded units that have no unit file of their own. An
+	// instantiated template unit (getty@tty1) is only ever reported by
+	// list-units -- list-unit-files carries the template (getty@) instead --
+	// so without this the running instance is invisible and the template
+	// reads running=false while an instance of it is up.
+	return append(services, s.instanceUnits(unitStates, known)...), nil
+}
+
+// instanceUnits builds services for loaded units that list-unit-files did not
+// report. Their unit-file state is read with a batched "systemctl show" over
+// the instances themselves: that call is unreliable for *template* units
+// (name@.service yields no record), which is why List does not use it for the
+// full set, but concrete instances return a record each. An instance's
+// enablement cannot be inherited from its template -- nut-driver@ can be
+// "indirect" while nut-driver@apc is "enabled" -- so it has to be asked for.
+func (s *SystemDServiceManager) instanceUnits(unitStates map[string]*Service, known map[string]struct{}) []*Service {
+	names := make([]string, 0, len(unitStates))
+	for name, state := range unitStates {
+		if _, ok := known[name]; ok {
+			continue
+		}
+		// list-units --all also names units that do not exist, because some
+		// other unit references them in After=/Conflicts=. They load as
+		// not-found and are not services on this host.
+		if !state.Installed {
+			continue
+		}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	sort.Strings(names)
+
+	units := make([]string, len(names))
+	for i, name := range names {
+		units[i] = ensureSystemdServiceUnit(name)
+	}
+
+	// A failure here costs the unit-file state, not the unit: report the
+	// service with what list-units already told us rather than dropping it.
+	shown := map[string]*Service{}
+	if cmd, err := s.conn.RunCommand(buildSystemdShowCommand(units)); err == nil {
+		if parsed, err := ParseServiceSystemDShow(cmd.Stdout); err == nil {
+			shown = parsed
+		}
+	}
+
+	instances := make([]*Service, 0, len(names))
+	for _, name := range names {
+		if service, ok := shown[name]; ok {
+			instances = append(instances, service)
+			continue
+		}
+		state := unitStates[name]
+		instances = append(instances, &Service{
+			Name:        name,
+			Description: state.Description,
+			Running:     state.Running,
+			Installed:   state.Installed,
+			Type:        "systemd",
+		})
+	}
+
+	return instances
 }
 
 type SystemdFSServiceManager struct {

--- a/providers/os/resources/services/systemd_instances_test.go
+++ b/providers/os/resources/services/systemd_instances_test.go
@@ -1,0 +1,128 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package services
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+)
+
+const (
+	unitFilesCmd = "systemctl list-unit-files --type service --all"
+	listUnitsCmd = "systemctl list-units --type service --all"
+)
+
+// Shape taken from a live Debian 13 host: the template units carry the unit
+// file, the running instances only ever appear in list-units.
+func instanceMock(t *testing.T, extra map[string]*mock.Command) *recordingConnection {
+	t.Helper()
+
+	commands := map[string]*mock.Command{
+		unitFilesCmd: {Stdout: strings.Join([]string{
+			"UNIT FILE                 STATE     PRESET",
+			"getty@.service            enabled   enabled",
+			"nut-driver@.service       indirect  enabled",
+			"ssh.service               enabled   enabled",
+			"",
+			"3 unit files listed.",
+			"",
+		}, "\n")},
+		listUnitsCmd: {Stdout: strings.Join([]string{
+			"  UNIT                     LOAD   ACTIVE SUB     DESCRIPTION",
+			"  getty@tty1.service       loaded active running Getty on tty1",
+			"  nut-driver@apc.service   loaded active running NUT device 'apc'",
+			"  ssh.service              loaded active running OpenBSD Secure Shell server",
+			"  firewalld.service        not-found inactive dead firewalld.service",
+			"",
+		}, "\n")},
+	}
+	for k, v := range extra {
+		commands[k] = v
+	}
+
+	mockConn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{Name: "debian", Family: []string{"debian", "linux"}},
+	}, mock.WithData(&mock.TomlData{Commands: commands}))
+	require.NoError(t, err)
+
+	return &recordingConnection{Connection: mockConn}
+}
+
+func servicesByName(services []*Service) map[string]*Service {
+	byName := map[string]*Service{}
+	for _, s := range services {
+		byName[s.Name] = s
+	}
+	return byName
+}
+
+// A running instance of a template unit has to appear in the list. Before this,
+// only the template (getty@, nut-driver@) was listed, with running=false, so a
+// policy asking whether a getty is running got the wrong answer.
+func TestSystemDServiceManagerListIncludesTemplateInstances(t *testing.T) {
+	const showCmd = "systemctl show --property=Id,LoadState,ActiveState,UnitFileState,Description getty@tty1.service nut-driver@apc.service"
+
+	conn := instanceMock(t, map[string]*mock.Command{
+		showCmd: {Stdout: strings.Join([]string{
+			"Id=getty@tty1.service",
+			"Description=Getty on tty1",
+			"LoadState=loaded",
+			"ActiveState=active",
+			"UnitFileState=enabled",
+			"",
+			"Id=nut-driver@apc.service",
+			"Description=NUT device 'apc'",
+			"LoadState=loaded",
+			"ActiveState=active",
+			"UnitFileState=enabled",
+			"",
+		}, "\n")},
+	})
+
+	services, err := (&SystemDServiceManager{conn: conn}).List()
+	require.NoError(t, err)
+
+	byName := servicesByName(services)
+
+	require.Contains(t, byName, "getty@tty1", "running template instance must be listed")
+	assert.True(t, byName["getty@tty1"].Running)
+	assert.True(t, byName["getty@tty1"].Enabled)
+
+	require.Contains(t, byName, "nut-driver@apc")
+	assert.True(t, byName["nut-driver@apc"].Running)
+	// the instance is enabled even though its template reports "indirect",
+	// so the state must come from the instance, not be inherited
+	assert.True(t, byName["nut-driver@apc"].Enabled)
+	assert.False(t, byName["nut-driver@"].Enabled)
+
+	// the templates themselves stay, and stay not-running
+	assert.False(t, byName["getty@"].Running)
+	assert.False(t, byName["nut-driver@"].Running)
+
+	// ordinary units are untouched
+	assert.True(t, byName["ssh"].Running)
+	assert.True(t, byName["ssh"].Enabled)
+
+	// list-units --all also names units that do not exist on the host,
+	// because something references them; they are not services here
+	assert.NotContains(t, byName, "firewalld")
+}
+
+// A failed "systemctl show" costs the unit-file state, not the whole unit.
+func TestSystemDServiceManagerListKeepsInstancesWhenShowFails(t *testing.T) {
+	conn := instanceMock(t, nil) // no show command registered -> the call fails
+
+	services, err := (&SystemDServiceManager{conn: conn}).List()
+	require.NoError(t, err)
+
+	byName := servicesByName(services)
+	require.Contains(t, byName, "getty@tty1")
+	assert.True(t, byName["getty@tty1"].Running)
+	assert.True(t, byName["getty@tty1"].Installed)
+}


### PR DESCRIPTION
## What

`services` enumerated `systemctl list-unit-files` and used `list-units` only to stamp running state onto entries that were *already* there. An instantiated template unit (`getty@tty1`) has no unit file of its own — `list-unit-files` carries the template (`getty@`) instead — so every running instance was silently dropped, and the template was reported in its place as not running.

Found sweeping the os provider against a live Debian 13 host:

```
$ mql run ssh root@debian -c 'services.where(name == /getty|nut-driver/).list { name running enabled }'
getty@        running: false     # getty@tty1 is loaded active running
nut-driver@   running: false     # nut-driver@apc and @eaton are loaded active running
```

while systemd says:

```
getty@tty1.service      loaded active running  Getty on tty1
nut-driver@apc.service  loaded active running  NUT device 'apc'
```

The singular lookup was already right — `service("nut-driver@apc").running` returns `true` — so the list and the lookup disagreed about the same host. Any policy of the form "is service X running" silently missed every templated service: `getty@`, `user@`, `nut-driver@`, `modprobe@`, `systemd-fsck@`, and so on.

## Fix

Append loaded units that `list-unit-files` did not report, and read their unit-file state with one batched `systemctl show` over the instances.

The existing comment on `List()` is right that batched `show` is unreliable for **template** units (`name@.service` yields no record, the blank-line separators desync and adjacent records merge) — that is why `List` does not use it for the full set. Concrete instances return a record each, verified live. The state has to be asked for rather than inherited from the template, because a template can be `indirect` while its instance is `enabled`:

```
$ systemctl list-unit-files | grep nut-driver@
nut-driver@.service   indirect   enabled
$ systemctl is-enabled nut-driver@apc.service
enabled
```

Units that load as `not-found` are skipped — `list-units --all` also names units that do not exist on the host, because something references them in `After=`/`Conflicts=` (on this host: `NetworkManager`, `firewalld`, `iscsi`, `wsdd`, ~30 more). Without that filter they would be added as phantom `installed=false` services.

If the `show` call fails, the instance is still listed with what `list-units` reported; the failure costs the unit-file state, not the unit.

## Test plan

- [x] `TestSystemDServiceManagerListIncludesTemplateInstances` — instances listed, template state *not* inherited, templates still present and not running, ordinary units untouched, `not-found` units excluded
- [x] `TestSystemDServiceManagerListKeepsInstancesWhenShowFails` — degraded path still lists the unit
- [x] Both **fail** on the unfixed code (`does not contain "getty@tty1"`); whole `services` package passes with it
- [x] Verified live on Debian 13: adds exactly the 11 real instances (`getty@tty1`, `nut-driver@apc`, `nut-driver@eaton`, `user@0`, `user-runtime-dir@0`, five `modprobe@*`, `sshd@sshd-keygen`) and removes nothing