### PR TITLE
🐛 os: fill in systemd.sockets and systemd.timers when systemctl cannot answer

### DIFF
--- a/providers/os/resources/services/systemd_socket.go
+++ b/providers/os/resources/services/systemd_socket.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/providers/os/connection/shared"
 )
 
@@ -31,11 +32,31 @@ func NewSystemdSocketManager(conn shared.Connection) *SystemdSocketManager {
 	return &SystemdSocketManager{conn: conn}
 }
 
+// fsFallback reads the socket unit files off disk, for the same reason
+// SystemdTimerManager.fsFallback does.
+func (m *SystemdSocketManager) fsFallback() *SystemdFSSocketManager {
+	return &SystemdFSSocketManager{Fs: m.conn.FileSystem()}
+}
+
 func (m *SystemdSocketManager) List() ([]*SystemdSocket, error) {
+	sockets, err := m.listViaSystemctl()
+	if err == nil {
+		return sockets, nil
+	}
+
+	log.Debug().Err(err).
+		Msg("mql[systemd]> could not list sockets through systemctl, reading unit files instead")
+	return m.fsFallback().List()
+}
+
+func (m *SystemdSocketManager) listViaSystemctl() ([]*SystemdSocket, error) {
 	// Step 1: Get all socket unit files (provides Enabled/Masked/Static/Installed)
 	cmdList, err := m.conn.RunCommand("systemctl list-unit-files --type socket --all")
 	if err != nil {
 		return nil, err
+	}
+	if cmdList.ExitStatus != 0 {
+		return nil, systemctlError("systemctl list-unit-files --type socket", cmdList)
 	}
 
 	sockets, err := ParseSystemdSocketUnitFiles(cmdList.Stdout)
@@ -47,6 +68,9 @@ func (m *SystemdSocketManager) List() ([]*SystemdSocket, error) {
 	cmdUnits, err := m.conn.RunCommand("systemctl list-units --type socket --all")
 	if err != nil {
 		return nil, err
+	}
+	if cmdUnits.ExitStatus != 0 {
+		return nil, systemctlError("systemctl list-units --type socket", cmdUnits)
 	}
 
 	unitStates, err := ParseSystemdSocketListUnits(cmdUnits.Stdout)
@@ -75,6 +99,13 @@ func (m *SystemdSocketManager) Get(name string) (*SystemdSocket, error) {
 	cmd, err := m.conn.RunCommand(buildSystemdShowCommand([]string{unit}))
 	if err != nil {
 		return nil, err
+	}
+	if cmd.ExitStatus != 0 {
+		// same reason as List: a systemctl that cannot answer must not read as
+		// "there is no such socket"
+		log.Debug().Err(systemctlError("systemctl show", cmd)).Str("unit", unit).
+			Msg("mql[systemd]> could not read socket through systemctl, reading the unit file instead")
+		return m.fsFallback().Get(name)
 	}
 
 	props, err := parseShowProperties(cmd.Stdout)
@@ -105,6 +136,11 @@ func (m *SystemdSocketManager) ShowSocketProperties(name string) (map[string]str
 	cmd, err := m.conn.RunCommand(buildShowPropertyCommand("Triggers,Accept,Listen", unit))
 	if err != nil {
 		return nil, err
+	}
+	if cmd.ExitStatus != 0 {
+		log.Debug().Err(systemctlError("systemctl show", cmd)).Str("unit", unit).
+			Msg("mql[systemd]> could not read socket properties through systemctl, reading the unit file instead")
+		return m.fsFallback().ShowSocketProperties(name)
 	}
 
 	return parseShowProperties(cmd.Stdout)

--- a/providers/os/resources/services/systemd_socket_timer_fallback_test.go
+++ b/providers/os/resources/services/systemd_socket_timer_fallback_test.go
@@ -1,0 +1,183 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package services
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+	"go.mondoo.com/mql/providers/os/connection/shared"
+)
+
+// unitFileList is what `systemctl list-unit-files` prints. It reads the unit
+// files off disk, so it keeps working with no systemd running -- unlike
+// `list-units` and `show`, which need the bus.
+const (
+	timerUnitFileList = `UNIT FILE            STATE    PRESET
+dnf-makecache.timer  enabled  enabled
+
+1 unit files listed.
+`
+	socketUnitFileList = `UNIT FILE    STATE    PRESET
+dbus.socket  enabled  enabled
+
+1 unit files listed.
+`
+)
+
+func systemdFallbackConn(t *testing.T, cmds map[string]*mock.Command) shared.Connection {
+	t.Helper()
+
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:    "almalinux",
+			Version: "9.8",
+			Family:  []string{"redhat", "linux", "unix", "os"},
+		},
+	}, mock.WithData(&mock.TomlData{Commands: cmds}))
+	require.NoError(t, err)
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/usr/lib/systemd/system/dnf-makecache.timer", []byte(`[Unit]
+Description=dnf makecache --timer
+
+[Timer]
+OnBootSec=10min
+OnUnitInactiveSec=1h
+Unit=dnf-makecache.service
+
+[Install]
+WantedBy=timers.target
+`), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/usr/lib/systemd/system/dbus.socket", []byte(`[Unit]
+Description=D-Bus System Message Bus Socket
+
+[Socket]
+ListenStream=/run/dbus/system_bus_socket
+
+[Install]
+WantedBy=sockets.target
+`), 0o644))
+
+	return &fsConn{Connection: conn, fs: fs}
+}
+
+// `systemctl list-unit-files` names the timers without a running systemd, but
+// `list-units` needs the bus and exits non-zero with nothing on stdout. That
+// parses into "no running state", so the merge left every timer with a blank
+// description, and `systemctl show` failing the same way left onCalendar blank
+// too. dnf-makecache.timer reported description "" against a unit file that
+// says "dnf makecache --timer".
+func TestSystemdTimerManager_FallsBackToUnitFilesWhenListUnitsCannotRun(t *testing.T) {
+	conn := systemdFallbackConn(t, map[string]*mock.Command{
+		"systemctl list-unit-files --type timer --all": {Stdout: timerUnitFileList},
+		"systemctl list-units --type timer --all": {
+			Stderr:     bootedElsewhere,
+			ExitStatus: 1,
+		},
+	})
+
+	timers, err := NewSystemdTimerManager(conn).List()
+	require.NoError(t, err)
+	require.Len(t, timers, 1)
+
+	assert.Equal(t, "dnf-makecache", timers[0].Name)
+	assert.Equal(t, "dnf makecache --timer", timers[0].Description)
+	assert.True(t, timers[0].Installed)
+}
+
+func TestSystemdTimerManager_ShowPropertiesFallsBack(t *testing.T) {
+	conn := systemdFallbackConn(t, map[string]*mock.Command{
+		buildShowPropertyCommand("Unit,OnCalendar,Persistent", "dnf-makecache.timer"): {
+			Stderr:     bootedElsewhere,
+			ExitStatus: 1,
+		},
+	})
+
+	props, err := NewSystemdTimerManager(conn).ShowTimerProperties("dnf-makecache")
+	require.NoError(t, err)
+	assert.Equal(t, "dnf-makecache.service", props["Unit"])
+}
+
+func TestSystemdSocketManager_FallsBackToUnitFilesWhenListUnitsCannotRun(t *testing.T) {
+	conn := systemdFallbackConn(t, map[string]*mock.Command{
+		"systemctl list-unit-files --type socket --all": {Stdout: socketUnitFileList},
+		"systemctl list-units --type socket --all": {
+			Stderr:     bootedElsewhere,
+			ExitStatus: 1,
+		},
+	})
+
+	sockets, err := NewSystemdSocketManager(conn).List()
+	require.NoError(t, err)
+	require.Len(t, sockets, 1)
+
+	assert.Equal(t, "dbus", sockets[0].Name)
+	assert.Equal(t, "D-Bus System Message Bus Socket", sockets[0].Description)
+}
+
+// The listen addresses are what an exposure audit reads, and they came back
+// empty on every host systemctl could not answer for.
+func TestSystemdSocketManager_ShowPropertiesFallsBack(t *testing.T) {
+	conn := systemdFallbackConn(t, map[string]*mock.Command{
+		buildShowPropertyCommand("Triggers,Accept,Listen", "dbus.socket"): {
+			Stderr:     bootedElsewhere,
+			ExitStatus: 1,
+		},
+	})
+
+	props, err := NewSystemdSocketManager(conn).ShowSocketProperties("dbus")
+	require.NoError(t, err)
+	assert.Contains(t, props["Listen"], "/run/dbus/system_bus_socket")
+}
+
+// A single lookup does not report a timer sitting on disk as not found.
+func TestSystemdTimerManager_GetFallsBack(t *testing.T) {
+	conn := systemdFallbackConn(t, map[string]*mock.Command{
+		buildSystemdShowCommand([]string{"dnf-makecache.timer"}): {
+			Stderr:     bootedElsewhere,
+			ExitStatus: 1,
+		},
+	})
+
+	timer, err := NewSystemdTimerManager(conn).Get("dnf-makecache")
+	require.NoError(t, err)
+	assert.Equal(t, "dnf-makecache", timer.Name)
+	assert.Equal(t, "dnf makecache --timer", timer.Description)
+}
+
+func TestSystemdSocketManager_GetFallsBack(t *testing.T) {
+	conn := systemdFallbackConn(t, map[string]*mock.Command{
+		buildSystemdShowCommand([]string{"dbus.socket"}): {
+			Stderr:     bootedElsewhere,
+			ExitStatus: 1,
+		},
+	})
+
+	socket, err := NewSystemdSocketManager(conn).Get("dbus")
+	require.NoError(t, err)
+	assert.Equal(t, "dbus", socket.Name)
+	assert.Equal(t, "D-Bus System Message Bus Socket", socket.Description)
+}
+
+// When systemctl answers, its values still win.
+func TestSystemdTimerManager_PrefersSystemctlWhenItAnswers(t *testing.T) {
+	conn := systemdFallbackConn(t, map[string]*mock.Command{
+		"systemctl list-unit-files --type timer --all": {Stdout: timerUnitFileList},
+		"systemctl list-units --type timer --all": {Stdout: `UNIT                 LOAD   ACTIVE SUB     DESCRIPTION
+dnf-makecache.timer  loaded active waiting dnf makecache --timer
+
+1 loaded units listed.
+`},
+	})
+
+	timers, err := NewSystemdTimerManager(conn).List()
+	require.NoError(t, err)
+	require.Len(t, timers, 1)
+	assert.True(t, timers[0].Running)
+}

--- a/providers/os/resources/services/systemd_timer.go
+++ b/providers/os/resources/services/systemd_timer.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/providers/os/connection/shared"
 )
 
@@ -31,11 +32,35 @@ func NewSystemdTimerManager(conn shared.Connection) *SystemdTimerManager {
 	return &SystemdTimerManager{conn: conn}
 }
 
+// fsFallback reads the timer unit files off disk. `systemctl list-units` and
+// `systemctl show` need a running systemd to answer, so they are not available
+// in a container, a chroot, a rescue boot, or on a host that keeps unit files
+// around while another init runs. They report that by exiting non-zero with
+// nothing on stdout, which parses into "no properties" rather than a failure,
+// and every timer then reads back with a blank description and no schedule.
+func (m *SystemdTimerManager) fsFallback() *SystemdFSTimerManager {
+	return &SystemdFSTimerManager{Fs: m.conn.FileSystem()}
+}
+
 func (m *SystemdTimerManager) List() ([]*SystemdTimer, error) {
+	timers, err := m.listViaSystemctl()
+	if err == nil {
+		return timers, nil
+	}
+
+	log.Debug().Err(err).
+		Msg("mql[systemd]> could not list timers through systemctl, reading unit files instead")
+	return m.fsFallback().List()
+}
+
+func (m *SystemdTimerManager) listViaSystemctl() ([]*SystemdTimer, error) {
 	// Step 1: Get all timer unit files (provides Enabled/Masked/Static/Installed)
 	cmdList, err := m.conn.RunCommand("systemctl list-unit-files --type timer --all")
 	if err != nil {
 		return nil, err
+	}
+	if cmdList.ExitStatus != 0 {
+		return nil, systemctlError("systemctl list-unit-files --type timer", cmdList)
 	}
 
 	timers, err := ParseSystemdTimerUnitFiles(cmdList.Stdout)
@@ -47,6 +72,9 @@ func (m *SystemdTimerManager) List() ([]*SystemdTimer, error) {
 	cmdUnits, err := m.conn.RunCommand("systemctl list-units --type timer --all")
 	if err != nil {
 		return nil, err
+	}
+	if cmdUnits.ExitStatus != 0 {
+		return nil, systemctlError("systemctl list-units --type timer", cmdUnits)
 	}
 
 	unitStates, err := ParseSystemdTimerListUnits(cmdUnits.Stdout)
@@ -76,6 +104,13 @@ func (m *SystemdTimerManager) Get(name string) (*SystemdTimer, error) {
 	if err != nil {
 		return nil, err
 	}
+	if cmd.ExitStatus != 0 {
+		// same reason as List: a systemctl that cannot answer must not read as
+		// "there is no such timer"
+		log.Debug().Err(systemctlError("systemctl show", cmd)).Str("unit", unit).
+			Msg("mql[systemd]> could not read timer through systemctl, reading the unit file instead")
+		return m.fsFallback().Get(name)
+	}
 
 	props, err := parseShowProperties(cmd.Stdout)
 	if err != nil {
@@ -104,6 +139,11 @@ func (m *SystemdTimerManager) ShowTimerProperties(name string) (map[string]strin
 	cmd, err := m.conn.RunCommand(buildShowPropertyCommand("Unit,OnCalendar,Persistent", unit))
 	if err != nil {
 		return nil, err
+	}
+	if cmd.ExitStatus != 0 {
+		log.Debug().Err(systemctlError("systemctl show", cmd)).Str("unit", unit).
+			Msg("mql[systemd]> could not read timer properties through systemctl, reading the unit file instead")
+		return m.fsFallback().ShowTimerProperties(name)
 	}
 
 	return parseShowProperties(cmd.Stdout)

--- a/providers/os/resources/services/systemd_unit.go
+++ b/providers/os/resources/services/systemd_unit.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/coreos/go-systemd/unit"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"go.mondoo.com/mql/providers/os/connection/shared"
 )
@@ -104,10 +105,35 @@ type SystemdUnitManager struct {
 	conn shared.Connection
 }
 
+// fsFallback reads the unit files off disk. systemctl needs a running systemd
+// to answer, so it is not available in a container, a chroot, a rescue boot, or
+// on a host that keeps unit files around while another init runs. It reports
+// that by exiting non-zero with nothing on stdout, which parses into an empty
+// unit list -- indistinguishable from a host that genuinely runs no services,
+// and enough to make an assertion over systemd.units pass without ever having
+// read a unit.
+func (m *SystemdUnitManager) fsFallback() *SystemdFSUnitManager {
+	return &SystemdFSUnitManager{Fs: m.conn.FileSystem()}
+}
+
 func (m *SystemdUnitManager) List() ([]*SystemdUnit, error) {
+	units, err := m.listViaSystemctl()
+	if err == nil {
+		return units, nil
+	}
+
+	log.Debug().Err(err).
+		Msg("mql[systemd]> could not list units through systemctl, reading unit files instead")
+	return m.fsFallback().List()
+}
+
+func (m *SystemdUnitManager) listViaSystemctl() ([]*SystemdUnit, error) {
 	cmd, err := m.conn.RunCommand("systemctl list-unit-files --type service --all --no-legend")
 	if err != nil {
 		return nil, err
+	}
+	if cmd.ExitStatus != 0 {
+		return nil, systemctlError("systemctl list-unit-files", cmd)
 	}
 
 	names, err := parseSystemdUnitFileNames(cmd.Stdout)
@@ -127,6 +153,9 @@ func (m *SystemdUnitManager) List() ([]*SystemdUnit, error) {
 		if err != nil {
 			return nil, err
 		}
+		if showCmd.ExitStatus != 0 {
+			return nil, systemctlError("systemctl show", showCmd)
+		}
 
 		records, err := parseSystemdShowRecords(showCmd.Stdout)
 		if err != nil {
@@ -140,13 +169,42 @@ func (m *SystemdUnitManager) List() ([]*SystemdUnit, error) {
 		}
 	}
 
+	// systemctl named the units, so it knowing nothing about any of them is a
+	// failure to report rather than a host with nothing on it
+	if len(res) == 0 {
+		return nil, fmt.Errorf("systemctl show returned no properties for any of the %d service units", len(names))
+	}
+
 	return res, nil
+}
+
+// systemctlError turns a non-zero systemctl exit into an error carrying the
+// reason systemctl printed, which is the part that says what went wrong
+// ("System has not been booted with systemd as init system (PID 1)").
+func systemctlError(what string, cmd *shared.Command) error {
+	reason := ""
+	if cmd.Stderr != nil {
+		if out, err := io.ReadAll(cmd.Stderr); err == nil {
+			reason = strings.TrimSpace(string(out))
+		}
+	}
+	if reason == "" {
+		return fmt.Errorf("%s exited %d", what, cmd.ExitStatus)
+	}
+	return fmt.Errorf("%s exited %d: %s", what, cmd.ExitStatus, reason)
 }
 
 func (m *SystemdUnitManager) Get(name string) (*SystemdUnit, error) {
 	cmd, err := m.conn.RunCommand(buildSystemdUnitShowCommand([]string{name}))
 	if err != nil {
 		return nil, err
+	}
+	if cmd.ExitStatus != 0 {
+		// same reason as List: a systemctl that cannot answer must not read as
+		// "there is no such unit"
+		log.Debug().Err(systemctlError("systemctl show", cmd)).Str("unit", name).
+			Msg("mql[systemd]> could not read unit through systemctl, reading the unit file instead")
+		return m.fsFallback().Get(name)
 	}
 
 	records, err := parseSystemdShowRecords(cmd.Stdout)

--- a/providers/os/resources/services/systemd_unit_fallback_test.go
+++ b/providers/os/resources/services/systemd_unit_fallback_test.go
@@ -1,0 +1,185 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package services
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+	"go.mondoo.com/mql/providers/os/connection/shared"
+)
+
+// unitFileListing is what `systemctl list-unit-files` prints. It keeps working
+// when systemd is not running, because it only reads the unit files off disk.
+const unitFileListing = `sshd.service     enabled  enabled
+chronyd.service  enabled  enabled
+`
+
+// bootedElsewhere is what systemctl prints on stderr, exiting non-zero, when it
+// cannot reach the bus -- in a container, a chroot, a rescue boot, or on a host
+// running another init.
+const bootedElsewhere = "System has not been booted with systemd as init system (PID 1). Can't operate.\nFailed to connect to bus: Host is down\n"
+
+// fsConn is a mock connection whose filesystem is one we control, so the
+// unit-file fallback has something to read.
+type fsConn struct {
+	shared.Connection
+	fs afero.Fs
+}
+
+func (c *fsConn) FileSystem() afero.Fs { return c.fs }
+
+func unitFallbackConn(t *testing.T, cmds map[string]*mock.Command) shared.Connection {
+	t.Helper()
+
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:    "almalinux",
+			Version: "9.8",
+			Family:  []string{"redhat", "linux", "unix", "os"},
+		},
+	}, mock.WithData(&mock.TomlData{Commands: cmds}))
+	require.NoError(t, err)
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/usr/lib/systemd/system/sshd.service", []byte(`[Unit]
+Description=OpenSSH server daemon
+
+[Service]
+Type=notify
+ExecStart=/usr/sbin/sshd -D
+User=root
+NoNewPrivileges=no
+`), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/usr/lib/systemd/system/chronyd.service", []byte(`[Unit]
+Description=NTP client/server
+
+[Service]
+Type=forking
+ExecStart=/usr/sbin/chronyd
+User=chrony
+NoNewPrivileges=yes
+ProtectSystem=full
+`), 0o644))
+
+	return &fsConn{Connection: conn, fs: fs}
+}
+
+// systemctl can name the units without a running systemd, but cannot report
+// their properties: `systemctl show` exits non-zero with nothing on stdout.
+// That parses into zero records, so before the fix systemd.units reported an
+// empty list -- a host with no services at all -- and an assertion like
+// `systemd.units.where(noNewPrivileges == false)` passed without a unit ever
+// having been read.
+func TestSystemdUnitManager_FallsBackToUnitFilesWhenShowCannotRun(t *testing.T) {
+	conn := unitFallbackConn(t, map[string]*mock.Command{
+		"systemctl list-unit-files --type service --all --no-legend": {
+			Stdout: unitFileListing,
+		},
+		buildSystemdUnitShowCommand([]string{"sshd.service", "chronyd.service"}): {
+			Stderr:     bootedElsewhere,
+			ExitStatus: 1,
+		},
+	})
+
+	units, err := (&SystemdUnitManager{conn: conn}).List()
+	require.NoError(t, err)
+	require.Len(t, units, 2)
+
+	byName := map[string]*SystemdUnit{}
+	for _, u := range units {
+		byName[u.Name] = u
+	}
+
+	require.Contains(t, byName, "sshd.service")
+	assert.Equal(t, "OpenSSH server daemon", byName["sshd.service"].Description)
+	assert.Equal(t, "/usr/sbin/sshd -D", byName["sshd.service"].ExecStart)
+	assert.False(t, byName["sshd.service"].NoNewPrivileges)
+
+	require.Contains(t, byName, "chronyd.service")
+	assert.True(t, byName["chronyd.service"].NoNewPrivileges)
+	assert.Equal(t, "full", byName["chronyd.service"].ProtectSystem)
+}
+
+// The same for a host where systemctl cannot even list the unit files.
+func TestSystemdUnitManager_FallsBackWhenListCannotRun(t *testing.T) {
+	conn := unitFallbackConn(t, map[string]*mock.Command{
+		"systemctl list-unit-files --type service --all --no-legend": {
+			Stderr:     bootedElsewhere,
+			ExitStatus: 1,
+		},
+	})
+
+	units, err := (&SystemdUnitManager{conn: conn}).List()
+	require.NoError(t, err)
+	assert.Len(t, units, 2)
+}
+
+// A single unit lookup degrades the same way, so service("sshd.service") does
+// not report a unit that is sitting on disk as not found.
+func TestSystemdUnitManager_GetFallsBackWhenShowCannotRun(t *testing.T) {
+	conn := unitFallbackConn(t, map[string]*mock.Command{
+		buildSystemdUnitShowCommand([]string{"sshd.service"}): {
+			Stderr:     bootedElsewhere,
+			ExitStatus: 1,
+		},
+	})
+
+	unit, err := (&SystemdUnitManager{conn: conn}).Get("sshd.service")
+	require.NoError(t, err)
+	assert.Equal(t, "sshd.service", unit.Name)
+	assert.Equal(t, "/usr/sbin/sshd -D", unit.ExecStart)
+}
+
+// When systemctl answers, its values win -- they are the ones in effect after
+// drop-ins have been merged, which the unit file on its own does not show.
+func TestSystemdUnitManager_PrefersSystemctlWhenItAnswers(t *testing.T) {
+	conn := unitFallbackConn(t, map[string]*mock.Command{
+		"systemctl list-unit-files --type service --all --no-legend": {
+			Stdout: unitFileListing,
+		},
+		buildSystemdUnitShowCommand([]string{"sshd.service", "chronyd.service"}): {
+			Stdout: `Id=sshd.service
+Description=OpenSSH server daemon
+LoadState=loaded
+ActiveState=active
+NoNewPrivileges=yes
+
+Id=chronyd.service
+Description=NTP client/server
+LoadState=loaded
+ActiveState=active
+NoNewPrivileges=yes
+`,
+		},
+	})
+
+	units, err := (&SystemdUnitManager{conn: conn}).List()
+	require.NoError(t, err)
+	require.Len(t, units, 2)
+
+	// the drop-in merged value from systemctl, not the "no" in the unit file
+	assert.Equal(t, "sshd.service", units[0].Name)
+	assert.True(t, units[0].NoNewPrivileges)
+	assert.Equal(t, "active", units[0].ActiveState)
+}
+
+// A host that really runs no service units still reports an empty list rather
+// than an error.
+func TestSystemdUnitManager_NoUnitsAtAll(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{Name: "almalinux", Version: "9.8", Family: []string{"redhat", "linux", "unix", "os"}},
+	}, mock.WithData(&mock.TomlData{Commands: map[string]*mock.Command{
+		"systemctl list-unit-files --type service --all --no-legend": {Stdout: ""},
+	}}))
+	require.NoError(t, err)
+
+	units, err := (&SystemdUnitManager{conn: &fsConn{Connection: conn, fs: afero.NewMemMapFs()}}).List()
+	require.NoError(t, err)
+	assert.Empty(t, units)
+}


### PR DESCRIPTION
> Stacked on #10527 — that PR fixes the same gap in `systemd.units` and adds the `systemctlError` helper this one reuses. Review/merge that one first; the base will retarget to `main` automatically.

## What

`systemd.sockets` and `systemd.timers` list their units with `systemctl list-unit-files`, which reads the unit files off disk and works with no systemd running, then reach for `systemctl list-units` and `systemctl show` for the description, the listen addresses and the schedule. Those two need the bus.

Where the bus is not reachable — a container, a chroot, a rescue boot, a host running another init — they exit non-zero with nothing on stdout, and nothing checked the exit status. The merge found no running state for any unit and left every description blank, and `show` returning nothing left the socket's listen addresses and the timer's schedule empty.

The units were named, but read as though they carried nothing.

On `almalinux:9`, before:

```
systemd.sockets.where(name == "dbus") {
  description: ""
  listenAddresses: []
  activates: ""
}
systemd.timers.where(name == "dnf-makecache") {
  description: ""
  activates: ""
}
```

against unit files that say:

```
# dbus.socket                       # dnf-makecache.timer
Description=D-Bus System Message…   Description=dnf makecache --timer
ListenStream=/run/dbus/system_bus_socket
```

`listenAddresses` is exactly what an exposure check reads, and it came back empty.

After:

```
systemd.sockets.where(name == "dbus") {
  description: "D-Bus System Message Bus Socket"
  listenAddresses: ["/run/dbus/system_bus_socket"]
  activates: "dbus.service"
}
systemd.timers.where(name == "dnf-makecache") {
  description: "dnf makecache --timer"
  activates: "dnf-makecache.service"
}
```

## The fix

Check the exit status and fall back to `SystemdFSSocketManager` and `SystemdFSTimerManager`, which the package already has and which the filesystem-only path already uses. systemctl still wins when it answers. `Get` degrades the same way, so a single lookup no longer reports a unit sitting on disk as not found.

## How it was found

A sweep of `mql run local` inside almalinux 8/9/10, amazonlinux 2/2023, debian 10/11/12/13, opensuse leap 15.5/15.6/16.0 + tumbleweed, and ubuntu 16.04–25.04 containers. Every socket and timer on all 19 images came back with a blank description.

## Not in scope

`systemd.targets` degrades the same way but has no filesystem manager to fall back to — its helper already checks the exit status and returns an empty property map, so targets come back named with blank `description`, `loadState` and `activeState`. Adding a `SystemdFSTargetManager` is a larger change; filing separately.

## Test plan

- `TestSystemdTimerManager_FallsBackToUnitFilesWhenListUnitsCannotRun` and the socket equivalent — `list-unit-files` succeeds, `list-units` exits 1 with the real bus error; asserts the description arrives. Both fail on the pre-fix code.
- `TestSystemdSocketManager_ShowPropertiesFallsBack` — asserts `Listen` carries `/run/dbus/system_bus_socket`. Fails pre-fix with `"" does not contain …`.
- `TestSystemdTimerManager_ShowPropertiesFallsBack`, `TestSystemdTimerManager_GetFallsBack`, `TestSystemdSocketManager_GetFallsBack`.
- `TestSystemdTimerManager_PrefersSystemctlWhenItAnswers` — a working systemctl still wins, `running` comes from `list-units`.
- `go test ./providers/os/resources/services/` passes; verified live in `almalinux:9`.