### PR TITLE
🐛 os: read the Secure Boot EFI variables over SSH

### DIFF
--- a/providers/os/resources/secureboot.go
+++ b/providers/os/resources/secureboot.go
@@ -5,7 +5,11 @@ package resources
 
 import (
 	"errors"
+	"fmt"
 	"io"
+	iofs "io/fs"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/spf13/afero"
@@ -16,6 +20,9 @@ import (
 
 // EFI variable GUID for global Secure Boot variables.
 const efiGlobalVariable = "8be4df61-93ca-11d2-aa0d-00e098032b8c"
+
+// Directory the kernel exposes the EFI variables under.
+const efiVarsDir = "/sys/firmware/efi/efivars"
 
 type mqlMachineSecurebootInternal struct {
 	once           sync.Once
@@ -51,8 +58,11 @@ func (s *mqlMachineSecureboot) fetchStatus() error {
 		}
 		s.cacheEfi = true
 
-		s.cacheEnabled = readEfiVarBool(fs, "SecureBoot-"+efiGlobalVariable)
-		s.cacheSetupMode = readEfiVarBool(fs, "SetupMode-"+efiGlobalVariable)
+		s.cacheEnabled, s.fetchErr = readEfiVarBool(conn, fs, "SecureBoot-"+efiGlobalVariable)
+		if s.fetchErr != nil {
+			return
+		}
+		s.cacheSetupMode, s.fetchErr = readEfiVarBool(conn, fs, "SetupMode-"+efiGlobalVariable)
 	})
 	return s.fetchErr
 }
@@ -84,18 +94,74 @@ func (s *mqlMachineSecureboot) fetchWindowsStatus(conn shared.Connection) error 
 // readEfiVarBool reads an EFI variable from /sys/firmware/efi/efivars/ and
 // returns true if its data byte is 1. EFI variable files contain a 4-byte
 // attribute header followed by the variable data.
-func readEfiVarBool(fs afero.Fs, name string) bool {
-	data, err := afero.ReadFile(fs, "/sys/firmware/efi/efivars/"+name)
-	if err != nil {
-		return false
+//
+// A variable that is simply absent reads as false: firmware only exposes the
+// Secure Boot variables once it has them. Any other read failure is returned,
+// never flattened into false -- reporting "Secure Boot is off" because the
+// bytes could not be read turns an unknown into a security finding, or hides
+// one.
+func readEfiVarBool(conn shared.Connection, fs afero.Fs, name string) (bool, error) {
+	path := efiVarsDir + "/" + name
+
+	data, err := afero.ReadFile(fs, path)
+	if err == nil {
+		return efiVarIsOn(data)
 	}
-	// Must have at least 4 bytes of attributes + 1 byte of data.
+	if errors.Is(err, iofs.ErrNotExist) {
+		return false, nil
+	}
+
+	// efivarfs rejects the positional reads sftp issues, so over SSH every
+	// variable fails with SSH_FX_FAILURE even though the file is readable.
+	// Read the bytes through a command when the connection has one.
+	if conn.Capabilities().Has(shared.Capability_RunCommand) {
+		return readEfiVarBoolCmd(conn, path)
+	}
+
+	return false, err
+}
+
+// efiVarIsOn reads the variable's data byte. The data portion starts after the
+// 4-byte EFI variable attributes header; for SecureBoot/SetupMode it is a
+// single uint8, 1 = on, 0 = off.
+func efiVarIsOn(data []byte) (bool, error) {
 	if len(data) < 5 {
-		return false
+		return false, fmt.Errorf("EFI variable is %d bytes, expected at least 5", len(data))
 	}
-	// The data portion starts after the 4-byte EFI variable attributes header.
-	// For SecureBoot/SetupMode the data is a single uint8: 1 = on, 0 = off.
-	return data[4] == 1
+	return data[4] == 1, nil
+}
+
+// readEfiVarBoolCmd reads an EFI variable with od(1), which prints the bytes as
+// decimal so they survive the command channel intact.
+func readEfiVarBoolCmd(conn shared.Connection, path string) (bool, error) {
+	cmd, err := conn.RunCommand("od -An -tu1 -- " + shared.ShellEscape(path))
+	if err != nil {
+		return false, err
+	}
+	if cmd.ExitStatus != 0 {
+		stderr, _ := io.ReadAll(cmd.Stderr)
+		return false, fmt.Errorf("cannot read %s: %s", path, strings.TrimSpace(string(stderr)))
+	}
+
+	stdout, err := io.ReadAll(cmd.Stdout)
+	if err != nil {
+		return false, err
+	}
+	return parseEfiVarOd(string(stdout))
+}
+
+// parseEfiVarOd turns "od -An -tu1" output into the variable's data byte.
+func parseEfiVarOd(out string) (bool, error) {
+	fields := strings.Fields(out)
+	data := make([]byte, 0, len(fields))
+	for _, f := range fields {
+		b, err := strconv.ParseUint(f, 10, 8)
+		if err != nil {
+			return false, fmt.Errorf("unexpected od output %q", f)
+		}
+		data = append(data, byte(b))
+	}
+	return efiVarIsOn(data)
 }
 
 func (s *mqlMachineSecureboot) efi() (bool, error) {

--- a/providers/os/resources/secureboot_efivar_internal_test.go
+++ b/providers/os/resources/secureboot_efivar_internal_test.go
@@ -1,0 +1,56 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An EFI variable file is a 4-byte attribute header followed by the data.
+func TestEfiVarIsOn(t *testing.T) {
+	on, err := efiVarIsOn([]byte{6, 0, 0, 0, 1})
+	require.NoError(t, err)
+	assert.True(t, on)
+
+	off, err := efiVarIsOn([]byte{6, 0, 0, 0, 0})
+	require.NoError(t, err)
+	assert.False(t, off)
+}
+
+// A truncated read must be an error, not a quiet "off". Reporting Secure Boot
+// as disabled because the bytes were short is a false security finding.
+func TestEfiVarIsOnRejectsShortReads(t *testing.T) {
+	for _, data := range [][]byte{nil, {}, {6}, {6, 0, 0, 0}} {
+		_, err := efiVarIsOn(data)
+		assert.Error(t, err, "%d bytes must not read as a value", len(data))
+	}
+}
+
+// od(1) is how the variable is read when the filesystem cannot serve it --
+// efivarfs rejects the positional reads sftp issues, so over SSH every
+// variable otherwise fails.
+func TestParseEfiVarOd(t *testing.T) {
+	// SetupMode on this host: "Platform is in Setup Mode"
+	on, err := parseEfiVarOd("   6   0   0   0   1\n0000005\n")
+	require.NoError(t, err)
+	assert.True(t, on)
+
+	off, err := parseEfiVarOd("   6   0   0   0   0\n")
+	require.NoError(t, err)
+	assert.False(t, off)
+}
+
+func TestParseEfiVarOdRejectsGarbage(t *testing.T) {
+	_, err := parseEfiVarOd("od: /sys/firmware/efi/efivars/x: Permission denied")
+	assert.Error(t, err)
+
+	_, err = parseEfiVarOd("")
+	assert.Error(t, err, "empty output must not read as off")
+
+	_, err = parseEfiVarOd("   6   0   0   0")
+	assert.Error(t, err, "a short variable must not read as off")
+}

--- a/providers/os/resources/secureboot_test.go
+++ b/providers/os/resources/secureboot_test.go
@@ -8,41 +8,45 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestReadEfiVarBool(t *testing.T) {
-	t.Run("enabled variable", func(t *testing.T) {
-		fs := afero.NewMemMapFs()
-		// 4-byte attribute header + 1-byte data (0x01 = enabled)
-		err := afero.WriteFile(fs, "/sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c",
-			[]byte{0x06, 0x00, 0x00, 0x00, 0x01}, 0o444)
-		assert.NoError(t, err)
+const secureBootVar = "SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"
 
-		assert.True(t, readEfiVarBool(fs, "SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"))
+func TestReadEfiVarBool(t *testing.T) {
+	write := func(t *testing.T, data []byte) afero.Fs {
+		t.Helper()
+		fs := afero.NewMemMapFs()
+		require.NoError(t, afero.WriteFile(fs, efiVarsDir+"/"+secureBootVar, data, 0o444))
+		return fs
+	}
+
+	t.Run("enabled variable", func(t *testing.T) {
+		// 4-byte attribute header + 1-byte data (0x01 = enabled)
+		on, err := readEfiVarBool(nil, write(t, []byte{0x06, 0x00, 0x00, 0x00, 0x01}), secureBootVar)
+		require.NoError(t, err)
+		assert.True(t, on)
 	})
 
 	t.Run("disabled variable", func(t *testing.T) {
-		fs := afero.NewMemMapFs()
 		// 4-byte attribute header + 1-byte data (0x00 = disabled)
-		err := afero.WriteFile(fs, "/sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c",
-			[]byte{0x06, 0x00, 0x00, 0x00, 0x00}, 0o444)
-		assert.NoError(t, err)
-
-		assert.False(t, readEfiVarBool(fs, "SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"))
+		on, err := readEfiVarBool(nil, write(t, []byte{0x06, 0x00, 0x00, 0x00, 0x00}), secureBootVar)
+		require.NoError(t, err)
+		assert.False(t, on)
 	})
 
-	t.Run("missing variable", func(t *testing.T) {
-		fs := afero.NewMemMapFs()
-		assert.False(t, readEfiVarBool(fs, "SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"))
+	t.Run("missing variable reads as off", func(t *testing.T) {
+		// firmware only exposes the variable once it has one, so absent is a
+		// real answer rather than a failure
+		on, err := readEfiVarBool(nil, afero.NewMemMapFs(), secureBootVar)
+		require.NoError(t, err)
+		assert.False(t, on)
 	})
 
-	t.Run("truncated file", func(t *testing.T) {
-		fs := afero.NewMemMapFs()
-		// Only 3 bytes — too short to contain attributes + data
-		err := afero.WriteFile(fs, "/sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c",
-			[]byte{0x06, 0x00, 0x00}, 0o444)
-		assert.NoError(t, err)
-
-		assert.False(t, readEfiVarBool(fs, "SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"))
+	t.Run("truncated file is an error, not off", func(t *testing.T) {
+		// Only 3 bytes -- too short to contain attributes + data. Reporting
+		// this as "Secure Boot disabled" would be a fabricated finding.
+		_, err := readEfiVarBool(nil, write(t, []byte{0x06, 0x00, 0x00}), secureBootVar)
+		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
## What

`readEfiVarBool` returned `false` on **any** read error, so a variable it could not read was reported as a firmware setting that is off.

Over SSH it can never read them. efivarfs rejects the positional reads sftp issues, so every variable comes back `SSH_FX_FAILURE` even though the file stats fine:

```
$ mql run ssh root@debian -c 'file("/sys/firmware/efi/efivars/SetupMode-8be4df61-...") { exists size content.length }'
exists: true
size: 5
content.length: sftp: "Failure" (SSH_FX_FAILURE)
```

The result is that **both** Secure Boot readings are `false` over SSH regardless of the firmware state. On a Debian 13 host where `mokutil --sb-state` reports *"SecureBoot disabled / Platform is in Setup Mode"*:

```
ssh:    machine.secureboot { enabled: false  setupMode: false }   # wrong
local:  machine.secureboot { enabled: false  setupMode: true  }   # right
```

Both directions are wrong in the unsafe way:

- a host **with Secure Boot enabled** is reported as having it disabled, so an audit asserting `machine.secureboot.enabled` fails a compliant machine
- a host **in Setup Mode** — no platform key, anyone can enroll one — passes a `!setupMode` check

The raw bytes on that host are `06 00 00 00 01` for `SetupMode` (on) and `06 00 00 00 00` for `SecureBoot` (off), so the data was there to be read.

## Fix

- Read the bytes with `od -An -tu1` when the filesystem cannot serve them and the connection can run commands. `od` prints decimal, so the bytes survive the command channel intact.
- Return the remaining read failures instead of flattening them to `false`. A truncated read is now an error, not a fabricated "Secure Boot is off".
- An absent variable still reads as `false` — firmware only exposes these once it has them, so absent is a real answer rather than a failure.

## Test plan

- [x] `TestEfiVarIsOn` / `TestParseEfiVarOd` — the header+data layout and the `od` output, both directions
- [x] `TestEfiVarIsOnRejectsShortReads` / `TestParseEfiVarOdRejectsGarbage` — short reads, empty output and an `od` error message must be errors, not `false`
- [x] `TestReadEfiVarBool` updated: absent variable still reads `false`, truncated file is now an error (this subtest asserted the old flatten-to-false behaviour)
- [x] Verified live on Debian 13 over SSH after the fix: `setupMode: true`, `enabled: false`, `efi: true` — matching both `mokutil --sb-state` and the local connection