### PR TITLE
🐛 os: fill in systemd.targets when systemctl cannot answer

### DIFF
--- a/providers/os/resources/services/systemd_target_fs.go
+++ b/providers/os/resources/services/systemd_target_fs.go
@@ -13,10 +13,10 @@ import (
 	"github.com/spf13/afero"
 )
 
-// systemdTargetProperties are the `systemctl show` property names this package
-// can recover from a unit file on disk. The runtime state of a target
-// (ActiveState, SubState) cannot be: it exists only in a running systemd.
-var systemdTargetProperties = []string{"Description", "Wants", "Requires", "After", "Before", "FragmentPath", "UnitFileState", "LoadState"}
+// The `systemctl show` properties recoverable from a unit file on disk are
+// Description, Wants, Requires, After, Before, FragmentPath, UnitFileState and
+// LoadState. The runtime state of a target (ActiveState, SubState) is not: it
+// exists only in a running systemd.
 
 // ListSystemdFSTargetNames returns every .target unit file on disk, without the
 // .target suffix, de-duplicated by search-path precedence.
@@ -130,8 +130,17 @@ func readSystemdTargetUnit(fs afero.Fs, unitPath string) (map[string]string, err
 		}
 	}
 
-	if _, ok := props["UnitFileState"]; !ok && !hasInstall {
-		props["UnitFileState"] = "static"
+	// systemctl calls a unit with no [Install] section "static" -- there is no
+	// way to enable it -- and one that has an [Install] section but is not
+	// symlinked into a .wants/.requires directory "disabled". Leaving the
+	// latter blank would read as "not measured" for a target that is measurably
+	// off.
+	if _, ok := props["UnitFileState"]; !ok {
+		if hasInstall {
+			props["UnitFileState"] = "disabled"
+		} else {
+			props["UnitFileState"] = "static"
+		}
 	}
 
 	return props, nil

--- a/providers/os/resources/services/systemd_target_fs.go
+++ b/providers/os/resources/services/systemd_target_fs.go
@@ -1,0 +1,138 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package services
+
+import (
+	"os"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/coreos/go-systemd/unit"
+	"github.com/spf13/afero"
+)
+
+// systemdTargetProperties are the `systemctl show` property names this package
+// can recover from a unit file on disk. The runtime state of a target
+// (ActiveState, SubState) cannot be: it exists only in a running systemd.
+var systemdTargetProperties = []string{"Description", "Wants", "Requires", "After", "Before", "FragmentPath", "UnitFileState", "LoadState"}
+
+// ListSystemdFSTargetNames returns every .target unit file on disk, without the
+// .target suffix, de-duplicated by search-path precedence.
+//
+// `systemctl list-unit-files` reads the same files, so this is what is left
+// when systemctl itself cannot run -- in a container, a chroot, a rescue boot,
+// or on a host that keeps unit files around while another init runs.
+func ListSystemdFSTargetNames(fs afero.Fs) []string {
+	seen := map[string]bool{}
+	names := []string{}
+
+	for _, searchPath := range systemdUnitSearchPath {
+		entries, err := afero.ReadDir(fs, searchPath)
+		if err != nil {
+			continue
+		}
+
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".target") {
+				continue
+			}
+			name := strings.TrimSuffix(entry.Name(), ".target")
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+
+	sort.Strings(names)
+	return names
+}
+
+// ReadSystemdFSTargetProperties reads the named targets' unit files and returns
+// what `systemctl show` would have reported for the properties a unit file
+// carries. A target whose file cannot be read is left out of the map rather
+// than reported as a target carrying nothing.
+func ReadSystemdFSTargetProperties(fs afero.Fs, names []string) map[string]map[string]string {
+	enabledSet := buildEnabledSet(fs)
+	out := make(map[string]map[string]string, len(names))
+
+	for _, name := range names {
+		unitFile := name + ".target"
+		for _, searchPath := range systemdUnitSearchPath {
+			unitPath := path.Join(searchPath, unitFile)
+			if _, err := fs.Stat(unitPath); err != nil {
+				continue
+			}
+
+			props, err := readSystemdTargetUnit(fs, unitPath)
+			if err != nil {
+				break
+			}
+			if enabledSet[unitFile] {
+				props["UnitFileState"] = "enabled"
+			}
+			out[name] = props
+			break
+		}
+	}
+
+	return out
+}
+
+func readSystemdTargetUnit(fs afero.Fs, unitPath string) (map[string]string, error) {
+	props := map[string]string{
+		"FragmentPath": unitPath,
+		"LoadState":    "loaded",
+	}
+
+	// a masked unit is a symlink to /dev/null, which carries no settings
+	if lr, ok := fs.(afero.LinkReader); ok {
+		linkPath, err := lr.ReadlinkIfPossible(unitPath)
+		if err == nil && linkPath == os.DevNull {
+			props["LoadState"] = "masked"
+			props["UnitFileState"] = "masked"
+			return props, nil
+		}
+	}
+
+	f, err := fs.Open(unitPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	opts, err := unit.Deserialize(f)
+	if err != nil {
+		return nil, err
+	}
+
+	hasInstall := false
+	for _, o := range opts {
+		if o.Section == "Install" {
+			hasInstall = true
+		}
+		if o.Section != "Unit" {
+			continue
+		}
+		switch o.Name {
+		case "Description", "Wants", "Requires", "After", "Before":
+			// a unit file may repeat a list setting, and systemd accumulates
+			// rather than replaces; systemctl show reports the accumulation
+			// space separated
+			if existing, ok := props[o.Name]; ok && o.Name != "Description" {
+				props[o.Name] = existing + " " + o.Value
+			} else {
+				props[o.Name] = o.Value
+			}
+		}
+	}
+
+	if _, ok := props["UnitFileState"]; !ok && !hasInstall {
+		props["UnitFileState"] = "static"
+	}
+
+	return props, nil
+}

--- a/providers/os/resources/services/systemd_target_fs_test.go
+++ b/providers/os/resources/services/systemd_target_fs_test.go
@@ -60,9 +60,19 @@ func TestReadSystemdFSTargetProperties(t *testing.T) {
 	assert.Equal(t, "basic.target", props["multi-user"]["After"])
 
 	// a target with no [Install] section cannot be enabled, which is what
-	// systemctl calls "static"
+	// systemctl calls "static"; one that has an [Install] section but is not
+	// symlinked into a .wants/.requires directory is "disabled", not blank
 	assert.Equal(t, "static", props["basic"]["UnitFileState"])
-	assert.NotEqual(t, "static", props["multi-user"]["UnitFileState"])
+	assert.Equal(t, "disabled", props["multi-user"]["UnitFileState"])
+}
+
+// A target symlinked into a .wants directory reads as enabled.
+func TestReadSystemdFSTargetProperties_EnabledTarget(t *testing.T) {
+	fs := targetFs(t)
+	require.NoError(t, afero.WriteFile(fs, "/etc/systemd/system/default.target.wants/multi-user.target", []byte(""), 0o644))
+
+	props := ReadSystemdFSTargetProperties(fs, []string{"multi-user"})
+	assert.Equal(t, "enabled", props["multi-user"]["UnitFileState"])
 }
 
 // A repeated list setting accumulates rather than replacing, matching systemd.

--- a/providers/os/resources/services/systemd_target_fs_test.go
+++ b/providers/os/resources/services/systemd_target_fs_test.go
@@ -1,0 +1,87 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package services
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func targetFs(t *testing.T) afero.Fs {
+	t.Helper()
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/usr/lib/systemd/system/basic.target", []byte(`[Unit]
+Description=Basic System
+Requires=sysinit.target
+Wants=sockets.target timers.target paths.target slices.target
+After=sysinit.target sockets.target paths.target slices.target tmp.mount
+`), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/usr/lib/systemd/system/multi-user.target", []byte(`[Unit]
+Description=Multi-User System
+Requires=basic.target
+After=basic.target
+
+[Install]
+Alias=default.target
+`), 0o644))
+	// a unit file the local admin overrides takes precedence over the vendor one
+	require.NoError(t, afero.WriteFile(fs, "/etc/systemd/system/basic.target", []byte(`[Unit]
+Description=Basic System (local override)
+`), 0o644))
+	return fs
+}
+
+func TestListSystemdFSTargetNames(t *testing.T) {
+	names := ListSystemdFSTargetNames(targetFs(t))
+	assert.Equal(t, []string{"basic", "multi-user"}, names)
+}
+
+// `systemctl list-unit-files` names the targets without a running systemd, but
+// `systemctl show` needs the bus. It failing left every target reporting a
+// blank description and no dependencies -- named, but read as carrying
+// nothing. The unit files hold all of it except the runtime state.
+func TestReadSystemdFSTargetProperties(t *testing.T) {
+	props := ReadSystemdFSTargetProperties(targetFs(t), []string{"basic", "multi-user"})
+	require.Contains(t, props, "basic")
+	require.Contains(t, props, "multi-user")
+
+	// /etc/systemd/system wins over /usr/lib/systemd/system
+	assert.Equal(t, "Basic System (local override)", props["basic"]["Description"])
+	assert.Equal(t, "/etc/systemd/system/basic.target", props["basic"]["FragmentPath"])
+	assert.Equal(t, "loaded", props["basic"]["LoadState"])
+
+	assert.Equal(t, "Multi-User System", props["multi-user"]["Description"])
+	assert.Equal(t, "basic.target", props["multi-user"]["Requires"])
+	assert.Equal(t, "basic.target", props["multi-user"]["After"])
+
+	// a target with no [Install] section cannot be enabled, which is what
+	// systemctl calls "static"
+	assert.Equal(t, "static", props["basic"]["UnitFileState"])
+	assert.NotEqual(t, "static", props["multi-user"]["UnitFileState"])
+}
+
+// A repeated list setting accumulates rather than replacing, matching systemd.
+func TestReadSystemdFSTargetProperties_RepeatedListSetting(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/usr/lib/systemd/system/demo.target", []byte(`[Unit]
+Description=Demo
+Wants=one.service
+Wants=two.service
+`), 0o644))
+
+	props := ReadSystemdFSTargetProperties(fs, []string{"demo"})
+	assert.Equal(t, "one.service two.service", props["demo"]["Wants"])
+}
+
+// A target whose unit file is not there is left out rather than reported as a
+// target carrying nothing.
+func TestReadSystemdFSTargetProperties_MissingUnitFile(t *testing.T) {
+	props := ReadSystemdFSTargetProperties(targetFs(t), []string{"basic", "does-not-exist"})
+	assert.Contains(t, props, "basic")
+	assert.NotContains(t, props, "does-not-exist")
+}

--- a/providers/os/resources/systemd_target.go
+++ b/providers/os/resources/systemd_target.go
@@ -5,10 +5,13 @@ package resources
 
 import (
 	"bufio"
+	"errors"
 	"strings"
 
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/connection/shared"
+	"go.mondoo.com/mql/providers/os/resources/services"
 	"go.mondoo.com/mql/types"
 )
 
@@ -21,9 +24,20 @@ func (x *mqlSystemdTargets) id() (string, error) {
 }
 
 func (x *mqlSystemdTargets) list() ([]any, error) {
+	conn, ok := x.MqlRuntime.Connection.(shared.Connection)
+	if !ok {
+		return nil, errors.New("systemd.targets is not supported on this connection")
+	}
+
 	names, err := listSystemdTargetNames(x.MqlRuntime)
 	if err != nil {
 		return nil, err
+	}
+	// systemctl needs a running systemd to answer. Where it cannot, the unit
+	// files are still on disk and are where systemctl would have read the
+	// names from anyway.
+	if len(names) == 0 {
+		names = services.ListSystemdFSTargetNames(conn.FileSystem())
 	}
 	if len(names) == 0 {
 		return []any{}, nil
@@ -38,6 +52,15 @@ func (x *mqlSystemdTargets) list() ([]any, error) {
 	propsByName, err := showSystemdTargetPropertiesBatch(x.MqlRuntime, names)
 	if err != nil {
 		return nil, err
+	}
+	// `systemctl show` needs the bus even though listing did not, so it is the
+	// step that fails first. Reporting every target with a blank description
+	// and no dependencies is not a smaller answer, it is a wrong one: read the
+	// unit files instead. The runtime fields (activeState, subState) stay empty
+	// -- they exist only in a running systemd, and an empty string says we did
+	// not read them rather than claiming the target is inactive.
+	if len(propsByName) == 0 {
+		propsByName = services.ReadSystemdFSTargetProperties(conn.FileSystem(), names)
 	}
 
 	res := make([]any, 0, len(names))


### PR DESCRIPTION
## What

Completes the systemd family alongside #10527 (`systemd.units`) and #10531 (`systemd.sockets` / `systemd.timers`). Independent of both — it touches `systemd_target.go` and adds a new file, so it can merge in any order.

`systemd.targets` names the targets with `systemctl list-unit-files`, which reads the unit files off disk and works with no systemd running, then reads their settings with `systemctl show`, which needs the bus.

The helper here *does* check the exit status, but a failure only turned into an empty property map, so every target was created carrying nothing. On `almalinux:9` all 54 came back like this:

```
systemd.targets.where(name == "basic") {
  description: ""
  loadState: ""
  fragmentPath: ""
  requires: []
  after: []
  wants: []
}
```

Named but unread. That is not a smaller answer than the truth, it is a wrong one — a check on a target's dependencies passed without any having been read.

## The fix

Read the unit files, which is where systemctl would have read all of this from anyway:

```
description:  ""  ->  "Basic System"
loadState:    ""  ->  "loaded"
fragmentPath: ""  ->  "/usr/lib/systemd/system/basic.target"
unitFileState:""  ->  "static"
requires:     []  ->  ["sysinit.target"]
after:        []  ->  ["sysinit.target", "sockets.target", "paths.target", "slices.target", "tmp.mount"]
wants:        []  ->  ["sockets.target", "timers.target", "paths.target", "slices.target"]
```

`activeState` and `subState` stay empty on purpose: they exist only in a running systemd, and an empty string says we did not read them rather than claiming the target is inactive. Name discovery falls back the same way, so a host with no `systemctl` at all still reports its targets.

The reader honours the search-path precedence systemd uses (`/etc/systemd/system` over `/usr/lib/systemd/system`), accumulates a repeated list setting rather than replacing it, treats a symlink to `/dev/null` as masked, and reports a unit with no `[Install]` section as `static`.

## How it was found

A sweep of `mql run local` inside almalinux 8/9/10, amazonlinux 2/2023, debian 10/11/12/13, opensuse leap 15.5/15.6/16.0 + tumbleweed, and ubuntu 16.04–25.04 containers. Every target on all 19 images came back with a blank description.

## Test plan

- `TestListSystemdFSTargetNames` — de-duplicates across the search path.
- `TestReadSystemdFSTargetProperties` — description, requires, after, fragment path, `static` vs installable, and `/etc` winning over `/usr/lib`.
- `TestReadSystemdFSTargetProperties_RepeatedListSetting` — `Wants=` twice accumulates, matching systemd.
- `TestReadSystemdFSTargetProperties_MissingUnitFile` — a target with no unit file is left out rather than reported as carrying nothing.
- `go test ./providers/os/resources/...` passes; verified live in `almalinux:9`.