### PR TITLE
🐛 os: stop the docker resource reading the scanner's daemon

### DIFF
--- a/providers/os/resources/docker.go
+++ b/providers/os/resources/docker.go
@@ -5,18 +5,21 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/moby/moby/client"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/providers/os/connection/dockerclient"
+	"go.mondoo.com/mql/providers/os/connection/shared"
 	"go.mondoo.com/mql/types"
 )
 
 func (p *mqlDocker) images() ([]any, error) {
-	cl, err := dockerClient()
+	cl, err := dockerClient(p.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +60,7 @@ func (p *mqlDocker) images() ([]any, error) {
 }
 
 func (p *mqlDocker) containers() ([]any, error) {
-	cl, err := dockerClient()
+	cl, err := dockerClient(p.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +131,7 @@ func (p *mqlDockerContainer) id() (string, error) {
 }
 
 func (p *mqlDockerContainer) hostConfig() (any, error) {
-	cl, err := dockerClient()
+	cl, err := dockerClient(p.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +144,16 @@ func (p *mqlDockerContainer) hostConfig() (any, error) {
 	return convert.JsonToDict(res.Container.HostConfig)
 }
 
-func dockerClient() (*client.Client, error) {
+// dockerClient builds a client from the provider process's own environment, so
+// it always reaches the daemon on the machine running mql. That is the asset's
+// daemon only when the connection is local or docker-backed; on any other
+// transport the resource would report the scanner's images and containers as
+// the scanned host's.
+func dockerClient(runtime *plugin.Runtime) (*client.Client, error) {
+	if err := checkDockerDaemonIsTheAssets(runtime); err != nil {
+		return nil, err
+	}
+
 	// Honor DOCKER_HOST and the active docker CLI context (rootless / remote),
 	// not just DOCKER_HOST. See dockerclient.FromDockerEnv for the why.
 	cl, err := dockerclient.NewDockerClient()
@@ -150,4 +162,32 @@ func dockerClient() (*client.Client, error) {
 	}
 	log.Debug().Msgf("docker client> negotiated API version %s", cl.ClientVersion())
 	return cl, nil
+}
+
+// dockerLocalDaemonConnections are the connections whose asset is served by the
+// daemon mql itself talks to. Everything else reaches the host over a transport
+// the docker client knows nothing about.
+var dockerLocalDaemonConnections = map[shared.ConnectionType]struct{}{
+	shared.Type_Local:             {},
+	shared.Type_DockerContainer:   {},
+	shared.Type_DockerImage:       {},
+	shared.Type_DockerSnapshot:    {},
+	shared.Type_DockerFile:        {},
+	shared.Type_DockerRegistry:    {},
+	shared.Type_ContainerRegistry: {},
+	shared.Type_RegistryImage:     {},
+	"mock":                        {},
+}
+
+func checkDockerDaemonIsTheAssets(runtime *plugin.Runtime) error {
+	conn, ok := runtime.Connection.(shared.Connection)
+	if !ok {
+		return nil
+	}
+	if _, ok := dockerLocalDaemonConnections[conn.Type()]; ok {
+		return nil
+	}
+	return fmt.Errorf(
+		"the docker resource reads the Docker daemon on the machine running mql, which is not the daemon of this %s connection",
+		conn.Type())
 }

--- a/providers/os/resources/docker_daemon_internal_test.go
+++ b/providers/os/resources/docker_daemon_internal_test.go
@@ -1,0 +1,60 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/connection/shared"
+)
+
+type typedConnection struct {
+	shared.Connection
+	connType shared.ConnectionType
+}
+
+func (c *typedConnection) Type() shared.ConnectionType { return c.connType }
+
+// The docker client is built from the provider process's environment, so it
+// reaches the daemon on the machine running mql. For a remote transport that
+// daemon belongs to the scanner, not the asset.
+func TestCheckDockerDaemonIsTheAssets(t *testing.T) {
+	allowed := []shared.ConnectionType{
+		shared.Type_Local,
+		shared.Type_DockerContainer,
+		shared.Type_DockerImage,
+		shared.Type_DockerSnapshot,
+		shared.Type_DockerFile,
+		shared.Type_DockerRegistry,
+		shared.Type_ContainerRegistry,
+		shared.Type_RegistryImage,
+		"mock",
+	}
+	for _, ct := range allowed {
+		t.Run("allows "+ct.String(), func(t *testing.T) {
+			runtime := &plugin.Runtime{Connection: &typedConnection{connType: ct}}
+			require.NoError(t, checkDockerDaemonIsTheAssets(runtime))
+		})
+	}
+
+	refused := []shared.ConnectionType{
+		shared.Type_SSH,
+		shared.Type_Winrm,
+		shared.Type_Vagrant,
+		shared.Type_FileSystem,
+		shared.Type_Tar,
+		shared.Type_Device,
+	}
+	for _, ct := range refused {
+		t.Run("refuses "+ct.String(), func(t *testing.T) {
+			runtime := &plugin.Runtime{Connection: &typedConnection{connType: ct}}
+			err := checkDockerDaemonIsTheAssets(runtime)
+			require.Error(t, err, "%s must not be served by the scanner's daemon", ct)
+			assert.Contains(t, err.Error(), ct.String())
+		})
+	}
+}


### PR DESCRIPTION
## What

`dockerClient` builds a moby client from the **provider process's own environment**, so it always reaches the Docker daemon on the machine running mql. Nothing in it consults the connection. On a remote scan the resource therefore reports the *scanner's* images and containers as the scanned host's.

Found sweeping the os provider against a live Debian 13 host from a Mac:

```
$ mql run ssh root@debian -c 'docker { images.length containers.length }'
containers.length: failed to connect to the docker API at unix:///Users/tsmith/.docker/run/docker.sock;
                   check if the path is correct and if the daemon is running
```

That is the **client machine's** socket path, on a scan whose asset is a Linux host that has its own daemon with 4 running containers. The error is only visible here because Docker Desktop happened to be down on the Mac — had it been running, the scan would have reported the Mac's containers against the Debian asset, with nothing to indicate the data came from the wrong machine.

`podman` does not have this problem: it shells out over the connection (`podman ps` correctly failed with `podman: command not found` on the target). The asymmetry is what made this visible.

## Fix

Refuse the resource when the connection is not one whose asset that daemon actually serves — `local` plus the docker-backed connections (`docker-container`, `docker-image`, `docker-snapshot`, `docker-file`, `docker-registry`, `container-registry`, `registry-image`) and `mock` for recordings. Everything else (ssh, winrm, vagrant, filesystem, tar, device) reaches the host over a transport the docker client knows nothing about, and now gets an error naming the connection instead of another host's inventory.

This is deliberately a correctness fix rather than a capability one: making `docker` work over SSH means routing `images`/`containers`/`hostConfig` through the command channel, which is a larger change. Reporting nothing beats reporting the wrong host.

## Test plan

- [x] `TestCheckDockerDaemonIsTheAssets` — table over every allowed and refused connection type; the refusal names the connection
- [x] Verified live on Debian 13:
  - over SSH the fields now report why they cannot be read, instead of reaching for the Mac's socket
  - running mql **on** the host still reads its daemon: `containers.length: 4`, matching `docker ps -q | wc -l`