### PR TITLE
🐛 os: look for systemd units in /lib/systemd/system too

### DIFF
--- a/providers/os/resources/services/systemd.go
+++ b/providers/os/resources/services/systemd.go
@@ -367,11 +367,19 @@ type SystemdFSServiceManager struct {
 // systemdUnitSearchPath is the order in which systemd looks up unit files
 // We ignore anything in /run as fs scans should not represent a running system
 // https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Unit%20File%20Load%20Path
+//
+// /lib/systemd/system is the last entry because it is the same directory as
+// /usr/lib/systemd/system wherever /lib is a symlink into /usr, which is every
+// distro that has completed the /usr merge. On the ones that have not --
+// Debian 11 and older, Ubuntu 18.04 and older -- /lib is a real directory and
+// is where every unit file actually lives, with /usr/lib/systemd/system empty
+// or absent. Leaving it out reported those hosts as running no units at all.
 var systemdUnitSearchPath = []string{
 	"/etc/systemd/system.control",
 	"/etc/systemd/system",
 	"/usr/local/lib/systemd/system",
 	"/usr/lib/systemd/system",
+	"/lib/systemd/system",
 }
 
 type unitInfo struct {

--- a/providers/os/resources/services/systemd_libpath_test.go
+++ b/providers/os/resources/services/systemd_libpath_test.go
@@ -1,0 +1,119 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package services
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Debian 11 and older and Ubuntu 18.04 and older have not completed the /usr
+// merge: /lib is a real directory, every unit file lives in
+// /lib/systemd/system, and /usr/lib/systemd/system is empty or absent. On
+// ubuntu:16.04 that is all 108 service units.
+//
+// The search path left /lib/systemd/system out, so a filesystem scan of any of
+// those hosts reported no units, no sockets and no timers at all -- and the
+// filesystem manager is the only path a filesystem, image or snapshot scan
+// ever takes.
+func TestSystemdUnitSearchPath_CoversPreUsrMergeHosts(t *testing.T) {
+	assert.Contains(t, systemdUnitSearchPath, "/lib/systemd/system")
+
+	// /usr/lib still wins where both exist, matching systemd's own precedence
+	usrLib := -1
+	lib := -1
+	for i, p := range systemdUnitSearchPath {
+		switch p {
+		case "/usr/lib/systemd/system":
+			usrLib = i
+		case "/lib/systemd/system":
+			lib = i
+		}
+	}
+	require.NotEqual(t, -1, usrLib)
+	require.NotEqual(t, -1, lib)
+	assert.Less(t, usrLib, lib, "/usr/lib must be searched before /lib")
+}
+
+func preUsrMergeFs(t *testing.T) afero.Fs {
+	t.Helper()
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/lib/systemd/system/ssh.service", []byte(`[Unit]
+Description=OpenBSD Secure Shell server
+
+[Service]
+ExecStart=/usr/sbin/sshd -D
+User=root
+NoNewPrivileges=no
+
+[Install]
+WantedBy=multi-user.target
+`), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/lib/systemd/system/cron.service", []byte(`[Unit]
+Description=Regular background program processing daemon
+
+[Service]
+ExecStart=/usr/sbin/cron -f
+NoNewPrivileges=yes
+`), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/lib/systemd/system/dbus.socket", []byte(`[Unit]
+Description=D-Bus System Message Bus Socket
+
+[Socket]
+ListenStream=/var/run/dbus/system_bus_socket
+`), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/lib/systemd/system/apt-daily.timer", []byte(`[Unit]
+Description=Daily apt download activities
+
+[Timer]
+OnCalendar=*-*-* 6,18:00
+`), 0o644))
+	return fs
+}
+
+func TestSystemdFSManagers_ReadUnitsFromLib(t *testing.T) {
+	fs := preUsrMergeFs(t)
+
+	units, err := (&SystemdFSUnitManager{Fs: fs}).List()
+	require.NoError(t, err)
+	require.Len(t, units, 2)
+
+	byName := map[string]*SystemdUnit{}
+	for _, u := range units {
+		byName[u.Name] = u
+	}
+	require.Contains(t, byName, "ssh.service")
+	assert.Equal(t, "OpenBSD Secure Shell server", byName["ssh.service"].Description)
+	assert.Equal(t, "/usr/sbin/sshd -D", byName["ssh.service"].ExecStart)
+	assert.False(t, byName["ssh.service"].NoNewPrivileges)
+	assert.True(t, byName["cron.service"].NoNewPrivileges)
+
+	sockets, err := (&SystemdFSSocketManager{Fs: fs}).List()
+	require.NoError(t, err)
+	require.Len(t, sockets, 1)
+	assert.Equal(t, "D-Bus System Message Bus Socket", sockets[0].Description)
+
+	timers, err := (&SystemdFSTimerManager{Fs: fs}).List()
+	require.NoError(t, err)
+	require.Len(t, timers, 1)
+	assert.Equal(t, "Daily apt download activities", timers[0].Description)
+}
+
+// A usr-merged host must not report the same unit twice just because /lib and
+// /usr/lib both resolve to it.
+func TestSystemdFSUnitManager_UsrMergedHostHasNoDuplicates(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	unit := []byte("[Unit]\nDescription=Demo\n\n[Service]\nExecStart=/usr/bin/demo\n")
+	require.NoError(t, afero.WriteFile(fs, "/usr/lib/systemd/system/demo.service", unit, 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/lib/systemd/system/demo.service", unit, 0o644))
+
+	units, err := (&SystemdFSUnitManager{Fs: fs}).List()
+	require.NoError(t, err)
+	require.Len(t, units, 1)
+	assert.Equal(t, "/usr/lib/systemd/system/demo.service", units[0].FragmentPath)
+}


### PR DESCRIPTION
## What

Debian 11 and older and Ubuntu 18.04 and older have not completed the `/usr` merge: `/lib` is a **real directory**, every unit file lives in `/lib/systemd/system`, and `/usr/lib/systemd/system` is empty or absent.

```
                  /lib is          units in /lib   units in /usr/lib
ubuntu:16.04      REAL DIR              108               0
ubuntu:18.04      REAL DIR                4               0
debian:10         REAL DIR                3               0
debian:11         REAL DIR                7               0
debian:13         symlink(usr/lib)        5               5
ubuntu:24.04      symlink(usr/lib)       10              10
almalinux:9       symlink(usr/lib)       60              60
```

`systemdUnitSearchPath` listed only the `/usr` path, so `SystemdFSUnitManager`, `SystemdFSSocketManager`, `SystemdFSTimerManager` and `buildEnabledSet` found nothing at all on those hosts.

That is the **whole answer** for a filesystem, image or snapshot scan, which never takes the command path: `systemd.units`, `systemd.sockets` and `systemd.timers` all reported empty for every Debian and Ubuntu image old enough to matter. On `ubuntu:16.04` that is 108 service units read as zero — and a check like `systemd.units.where(noNewPrivileges == false)` passing on a host nothing was read from.

## The fix

Add `/lib/systemd/system` as the **last** entry. On a host that has merged `/usr`, `/lib` is a symlink and the two paths are the same directory, so searching `/usr/lib` first keeps systemd's own precedence and the existing first-copy-wins de-duplication keeps a unit from being listed twice.

Verified live, unit counts now matching the `.service` files on disk:

| image | before | after | `.service` files on disk |
|---|---|---|---|
| ubuntu:16.04 | 0 | **108** | 108 |
| debian:11 | 0 | **7** | 7 |
| ubuntu:18.04 | 0 | **4** | 4 |
| debian:10 | 0 | **3** | 3 |

## How it was found

A sweep of `mql run local` inside almalinux 8/9/10, amazonlinux 2/2023, debian 10/11/12/13, opensuse leap 15.5/15.6/16.0 + tumbleweed, and ubuntu 16.04–25.04 containers. After the systemd fallback fixes (#10527, #10531), 5 of 19 images still reported zero service units; four of them turned out to be pre-usr-merge hosts. (The fifth, `amazonlinux:2`, genuinely ships no `.service` files.)

This one is independent of those PRs — it is the filesystem side, and it was already the only path an image scan took.

## Test plan

- `TestSystemdUnitSearchPath_CoversPreUsrMergeHosts` — asserts the path is present and that `/usr/lib` still precedes `/lib`.
- `TestSystemdFSManagers_ReadUnitsFromLib` — a pre-usr-merge tree with units, a socket and a timer only under `/lib`; all three managers read them, with `execStart` and `noNewPrivileges` populated. Fails on the pre-fix code with `"[]" should have 2 item(s), but has 0`.
- `TestSystemdFSUnitManager_UsrMergedHostHasNoDuplicates` — the same unit visible through both paths is reported once, keeping the `/usr/lib` fragment path.
- `go test ./providers/os/resources/services/` passes; verified live on all four affected images.