### PR TITLE
🐛 os: run a shell command line through a shell when elevating with sudo

### DIFF
--- a/providers/os/connection/shared/shared.go
+++ b/providers/os/connection/shared/shared.go
@@ -266,26 +266,133 @@ func ShellEscape(s string) string {
 	return s
 }
 
-func BuildSudoCommand(sudo *inventory.Sudo, cmd string) string {
-	var sb strings.Builder
+// shellReservedWords are the words a shell treats as syntax when they open a
+// command line. sudo would take one as the name of a program to run.
+var shellReservedWords = map[string]bool{
+	"if": true, "then": true, "elif": true, "else": true, "fi": true,
+	"for": true, "while": true, "until": true, "do": true, "done": true,
+	"case": true, "esac": true, "function": true, "select": true,
+	"time": true, "{": true, "!": true,
+}
 
+// needsShellForSudo reports whether cmd is something other than a plain argv,
+// and so has to be handed to a shell rather than straight to sudo.
+//
+// sudo takes a command, not a shell command line: it binds to the first word
+// and passes the rest as that command's arguments. That is right for the great
+// majority of what the provider runs (`uname -s`, `rpm -qa ...`), and those
+// keep their existing shape so recorded command lines still match. It is wrong
+// whenever the shell would have done something with the line first.
+func needsShellForSudo(cmd string) bool {
+	var single, double bool
+	firstWordEnd := -1
+
+	for i := 0; i < len(cmd); i++ {
+		c := cmd[i]
+		switch {
+		case single:
+			if c == '\'' {
+				single = false
+			}
+			continue
+		case double:
+			if c == '\\' {
+				i++
+			} else if c == '"' {
+				double = false
+			}
+			continue
+		}
+
+		switch c {
+		case '\'':
+			single = true
+		case '"':
+			double = true
+		case '\\':
+			i++
+		case ' ', '\t':
+			if firstWordEnd < 0 {
+				firstWordEnd = i
+			}
+		case '|', '&', ';', '<', '>', '(', ')', '\n', '`':
+			// a control operator, redirect, subshell or substitution: the
+			// shell owns it, and sudo would only ever have covered the part
+			// before it
+			return true
+		}
+	}
+
+	if single || double {
+		// unbalanced quoting is not an argv we can reason about; let the shell
+		// deal with it rather than handing sudo half a word
+		return true
+	}
+
+	first := cmd
+	if firstWordEnd >= 0 {
+		first = cmd[:firstWordEnd]
+	}
+	first = strings.TrimSpace(first)
+	if first == "" {
+		return false
+	}
+	if shellReservedWords[first] {
+		return true
+	}
+	// a leading VAR=value is an assignment the shell applies to the
+	// environment, not a program sudo can run
+	if eq := strings.IndexByte(first, '='); eq > 0 && !strings.ContainsAny(first[:eq], "/.") {
+		return true
+	}
+
+	return false
+}
+
+// BuildSudoCommand elevates a command line with sudo.
+//
+// sudo takes a command, not a shell command line: it binds to the first word.
+// Prefixing the string is therefore wrong for anything that is not a plain
+// argv --
+//
+//	if [ -r x ]; then ...  ->  sudo if [ -r x ]; then ...   (syntax error)
+//	a | b                  ->  sudo a | b                   (only a is root)
+//	a > /root/f            ->  sudo a > /root/f             (redirect is not)
+//
+// -- and the caller cannot tell, because the shell reports the syntax error on
+// stderr with a non-zero exit that reads like "the command is not available".
+// The cgroups probe hit exactly that: `cgroups` reported version 0 and no
+// controllers on every host scanned with --sudo, while the same host answered
+// correctly without it.
+//
+// Such a line is run through a shell that is itself under sudo, quoted so the
+// shell sees it as one word. A plain argv keeps the bare `sudo <cmd>` form, so
+// the command lines the provider already issues -- and the recordings keyed on
+// them -- are unchanged.
+func BuildSudoCommand(sudo *inventory.Sudo, cmd string) string {
 	if sudo == nil || !sudo.Active {
 		return cmd
 	}
 
+	var sb strings.Builder
 	sb.WriteString(sudo.Executable)
 
 	if len(sudo.User) > 0 {
 		sb.WriteString(" -u " + sudo.User)
 	}
 
-	if len(sudo.Shell) > 0 {
-		sb.WriteString(" " + sudo.Shell + " -c " + cmd)
-	} else {
-		sb.WriteString(" ")
-		sb.WriteString(cmd)
+	if shell := sudo.Shell; shell != "" {
+		sb.WriteString(" " + shell + " -c " + ShellEscape(cmd))
+		return sb.String()
 	}
 
+	if needsShellForSudo(cmd) {
+		sb.WriteString(" sh -c " + ShellEscape(cmd))
+		return sb.String()
+	}
+
+	sb.WriteString(" ")
+	sb.WriteString(cmd)
 	return sb.String()
 }
 

--- a/providers/os/connection/shared/shared.go
+++ b/providers/os/connection/shared/shared.go
@@ -284,18 +284,24 @@ var shellReservedWords = map[string]bool{
 // keep their existing shape so recorded command lines still match. It is wrong
 // whenever the shell would have done something with the line first.
 func needsShellForSudo(cmd string) bool {
+	// Leading blanks are the shell's, not part of the first word. Trimming
+	// them keeps "  if foo" from ending its first word at index 0 and so
+	// reading as a command with no name at all. Only spaces and tabs: a
+	// leading newline is a command separator and has to reach the scan below.
+	cmd = strings.TrimLeft(cmd, " \t")
+
 	var single, double bool
 	firstWordEnd := -1
 
 	for i := 0; i < len(cmd); i++ {
 		c := cmd[i]
-		switch {
-		case single:
+		if single {
 			if c == '\'' {
 				single = false
 			}
 			continue
-		case double:
+		}
+		if double {
 			if c == '\\' {
 				i++
 			} else if c == '"' {

--- a/providers/os/connection/shared/shared.go
+++ b/providers/os/connection/shared/shared.go
@@ -302,9 +302,10 @@ func needsShellForSudo(cmd string) bool {
 			continue
 		}
 		if double {
-			if c == '\\' {
+			switch c {
+			case '\\':
 				i++
-			} else if c == '"' {
+			case '"':
 				double = false
 			}
 			continue

--- a/providers/os/connection/shared/sudo_test.go
+++ b/providers/os/connection/shared/sudo_test.go
@@ -65,6 +65,29 @@ func TestBuildSudoCommand_ShellSyntaxIsWrapped(t *testing.T) {
 	}
 }
 
+// Leading blanks are the shell's, not part of the first word. Without trimming
+// them the first word ends at index 0, the command reads as having no name at
+// all, and a leading reserved word slips through unwrapped.
+func TestBuildSudoCommand_LeadingWhitespace(t *testing.T) {
+	for _, cmd := range []string{
+		"  if [ -r /x ]; then echo y; fi",
+		"\tif [ -r /x ]; then echo y; fi",
+		" \t  for f in a; do echo $f; done",
+		"  DEBIAN_FRONTEND=noninteractive apt-get update",
+	} {
+		got := BuildSudoCommand(sudoOn(), cmd)
+		assert.Equal(t, "sudo sh -c "+ShellEscape(cmd), got, "cmd %q", cmd)
+	}
+
+	// a leading newline is a command separator, not padding, so it still has
+	// to force the wrap
+	nl := "\necho hi"
+	assert.Equal(t, "sudo sh -c "+ShellEscape(nl), BuildSudoCommand(sudoOn(), nl))
+
+	// and leading blanks on a plain argv still leave it bare
+	assert.Equal(t, "sudo   uname -s", BuildSudoCommand(sudoOn(), "  uname -s"))
+}
+
 // A control character inside quotes belongs to the command, not the shell, so
 // it must not trigger the wrap -- the file stat helper already hand-wraps
 // itself and its recorded command line has to stay byte-identical.

--- a/providers/os/connection/shared/sudo_test.go
+++ b/providers/os/connection/shared/sudo_test.go
@@ -1,0 +1,103 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+)
+
+func sudoOn() *inventory.Sudo {
+	return &inventory.Sudo{Active: true, Executable: "sudo"}
+}
+
+func TestBuildSudoCommand_Inactive(t *testing.T) {
+	assert.Equal(t, "uname -s", BuildSudoCommand(nil, "uname -s"))
+	assert.Equal(t, "uname -s", BuildSudoCommand(&inventory.Sudo{Executable: "sudo"}, "uname -s"))
+}
+
+// A plain argv keeps the bare form. The provider issues hundreds of these, and
+// the recording/replay system keys on the exact command line, so changing their
+// shape would invalidate every recording taken so far.
+func TestBuildSudoCommand_PlainArgvIsUnchanged(t *testing.T) {
+	for _, cmd := range []string{
+		"uname -s",
+		"rpm -qa --queryformat '%{NAME}\n'",
+		"ls -1 '/etc/ssh'",
+		"systemctl show --property=Id -- sshd.service",
+		"cat /etc/shadow",
+		"find /proc/1/fd -maxdepth 1",
+	} {
+		assert.Equal(t, "sudo "+cmd, BuildSudoCommand(sudoOn(), cmd), "cmd %q", cmd)
+	}
+}
+
+// sudo binds to the first word, so a line the shell would have acted on first
+// has to go through a shell that is itself under sudo. The cgroups probe is the
+// case that was found in the wild: `sudo if [ -r ... ]; then ...` is a syntax
+// error, which surfaced as `cgroups` reporting version 0 and no controllers on
+// every host scanned with --sudo.
+func TestBuildSudoCommand_ShellSyntaxIsWrapped(t *testing.T) {
+	for _, tc := range []struct{ name, cmd string }{
+		{"leading if", `if [ -r /sys/fs/cgroup/cgroup.controllers ]; then echo V2; else echo NONE; fi`},
+		{"leading for", `for f in a b; do echo $f; done`},
+		{"leading while", `while read l; do echo $l; done`},
+		{"pipeline", `rpm -qa | wc -l`},
+		{"and-list", `test -d /x && echo yes`},
+		{"semicolon", `cd /tmp; ls`},
+		{"redirect out", `apt-get update > /dev/null`},
+		{"redirect in", `wc -l < /etc/shadow`},
+		{"subshell", `(cd /tmp && ls)`},
+		{"substitution", "echo $(hostname)"},
+		{"backticks", "echo `hostname`"},
+		{"env assignment", `DEBIAN_FRONTEND=noninteractive apt-get update`},
+		{"newline", "echo a\necho b"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := BuildSudoCommand(sudoOn(), tc.cmd)
+			assert.Equal(t, "sudo sh -c "+ShellEscape(tc.cmd), got)
+			// the whole original line survives inside the quoted argument
+			assert.Contains(t, got, "sh -c ")
+		})
+	}
+}
+
+// A control character inside quotes belongs to the command, not the shell, so
+// it must not trigger the wrap -- the file stat helper already hand-wraps
+// itself and its recorded command line has to stay byte-identical.
+func TestBuildSudoCommand_QuotedOperatorsDoNotWrap(t *testing.T) {
+	for _, cmd := range []string{
+		`sh -c 'SL=0; test -L "$1" && SL=1' _ /etc/hosts`,
+		`awk '{print $1 "|" $2}' /etc/passwd`,
+		`grep -E 'a|b' /etc/hosts`,
+	} {
+		assert.Equal(t, "sudo "+cmd, BuildSudoCommand(sudoOn(), cmd), "cmd %q", cmd)
+	}
+}
+
+func TestBuildSudoCommand_User(t *testing.T) {
+	s := sudoOn()
+	s.User = "postgres"
+	assert.Equal(t, "sudo -u postgres psql -V", BuildSudoCommand(s, "psql -V"))
+	assert.Equal(t, `sudo -u postgres sh -c 'psql -V | head -1'`, BuildSudoCommand(s, "psql -V | head -1"))
+}
+
+// An explicit shell always wraps, and the command is quoted -- it was
+// concatenated bare before, which broke on the first space.
+func TestBuildSudoCommand_ExplicitShellQuotes(t *testing.T) {
+	s := sudoOn()
+	s.Shell = "bash"
+	assert.Equal(t, `sudo bash -c 'if [ -r /x ]; then echo y; fi'`,
+		BuildSudoCommand(s, "if [ -r /x ]; then echo y; fi"))
+	assert.Equal(t, `sudo bash -c 'uname -s'`, BuildSudoCommand(s, "uname -s"))
+}
+
+// Unbalanced quoting is not an argv we can reason about; hand it to a shell
+// rather than giving sudo half a word.
+func TestBuildSudoCommand_UnbalancedQuotes(t *testing.T) {
+	got := BuildSudoCommand(sudoOn(), `echo 'oops`)
+	assert.Equal(t, "sudo sh -c "+ShellEscape(`echo 'oops`), got)
+}

--- a/providers/os/connection/ssh/ssh.go
+++ b/providers/os/connection/ssh/ssh.go
@@ -769,8 +769,11 @@ func (c *Connection) verify() error {
 	var out *shared.Command
 	var err error
 	if c.Sudo != nil {
-		// Wrap sudo command, to see proper error messages. We set /dev/null to disable stdin
-		command := "sh -c '" + shared.BuildSudoCommand(c.Sudo, "echo 'hi'") + " < /dev/null'"
+		// Check sudo works, with proper error messages. /dev/null disables
+		// stdin so a sudo that wants a password fails instead of hanging; it
+		// is appended outside the quoted command so the redirect is the outer
+		// shell's, not something sudo is asked to run.
+		command := shared.BuildSudoCommand(c.Sudo, "echo hi") + " < /dev/null"
 		out, err = c.runRawCommand(command)
 	} else {
 		out, err = c.runRawCommand("echo 'hi'")


### PR DESCRIPTION
## What

`sudo` takes a *command*, not a shell command line: it binds to the first word and passes the rest as that command's arguments. `BuildSudoCommand` prefixed the string, which is right for a plain argv and wrong for anything the shell would have acted on first:

```
if [ -r x ]; then ...  ->  sudo if [ -r x ]; then ...   syntax error
a | b                  ->  sudo a | b                   only a runs as root
a > /root/f            ->  sudo a > /root/f             redirect is not root's
```

The caller cannot tell, because the shell reports the syntax error on stderr with a non-zero exit that reads exactly like "that command is not available here".

## What it cost

`cgroups` probes with a shell conditional:

```sh
if [ -r /sys/fs/cgroup/cgroup.controllers ]; then echo V2; elif [ -d /sys/fs/cgroup/memory ]; then echo V1; else echo NONE; fi
```

Under `--sudo` that became `sudo if [ -r ... ]; then ...`:

```
exitcode: 2
stderr:   bash: -c: line 1: syntax error near unexpected token `then'
```

`runShellCmd` treats a non-zero exit as "not available" and returns the empty detection, so on **every host scanned with `--sudo`** the resource reported:

```
cgroups.version: 0
cgroups.controllers.length: 0
cgroups.list.length: 0
```

while the *same host* without `--sudo` answered version 2, 8 controllers, 34 cgroups. **Elevating privileges lost the data**, and `--sudo` is the normal way these scans run.

## The fix

Run such a line through a shell that is itself under sudo, quoted so the shell sees it as one word.

A **plain argv keeps the bare `sudo <cmd>` form**. This matters: the provider issues hundreds of those, and the recording/replay system keys on the exact command line, so wrapping everything would invalidate every recording taken so far. I tried the unconditional wrap first and it broke the `cat`/`file` fixtures for exactly that reason.

A control character *inside quotes* belongs to the command rather than the shell and does not trigger the wrap, so the file stat helper that already hand-wraps its own `sh -c '...'` is byte-for-byte untouched.

Also quotes the explicit-`Shell` branch, which concatenated the command bare and so broke on the first space, and stops the SSH sudo preflight double-wrapping its own `sh -c`.

## Verified live

17 EC2 instances — ubuntu 18.04/20.04/22.04/24.04, debian 11/12/13, rhel 8/9/10, centos stream 9/10, sles 12-SP5/15-SP6/15-SP7/16, opensuse leap 16 — scanned over SSH with `--sudo`:

| host | before | after |
|---|---|---|
| debian-13 | 0 / 0 / 0 | 2 / 8 / 34 |
| rhel-9 | 0 / 0 / 0 | 2 / 8 / 39 |
| sles-15-sp7 | 0 / 0 / 0 | 2 / 8 / 40 |
| ubuntu-24.04 | 0 / 0 / 0 | 2 / 9 / 52 |
| centos-stream-10 | 0 / 0 / 0 | 2 / 9 / 40 |
| opensuse-leap-16 | 0 / 0 / 0 | 2 / 8 / 42 |

(`cgroups.version` / `controllers.length` / `list.length`)

## Test plan

- `TestBuildSudoCommand_ShellSyntaxIsWrapped` — 13 shapes: leading `if`/`for`/`while`, pipeline, `&&`-list, `;`-list, in/out redirect, subshell, `$(…)`, backticks, `VAR=value` prefix, embedded newline.
- `TestBuildSudoCommand_PlainArgvIsUnchanged` — the common provider commands keep the bare form, so recordings still match.
- `TestBuildSudoCommand_QuotedOperatorsDoNotWrap` — `;`/`|` inside quotes belong to the command; pins the file stat helper's line.
- `TestBuildSudoCommand_User` / `_ExplicitShellQuotes` / `_UnbalancedQuotes` / `_Inactive`.
- `go test ./providers/os/...` passes with **no fixture changes**. (`connection/device/linux` fails to build on `main` already — `undefined: snapshot.MockVolumeMounter` — unrelated to this PR.)

## Blast radius

This is the core connection layer, so it is worth being explicit: the only command lines whose shape changes are the ones that were already producing a shell syntax error or silently running unprivileged. Everything else is byte-identical, which the fixture tests now enforce.