### PR TITLE
🐛 os: keep systemd.units from losing generator units to a template unit

### DIFF
--- a/providers/os/resources/services/systemd_template_batch_test.go
+++ b/providers/os/resources/services/systemd_template_batch_test.go
@@ -1,0 +1,136 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package services
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+	"go.mondoo.com/mql/providers/os/connection/shared"
+)
+
+func TestIsSystemdTemplateUnit(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want bool
+	}{
+		{"autovt@.service", true},
+		{"getty@.service", true},
+		{"user@.service", true},
+		{"sshd@.service", true},
+		{"getty@tty1.service", false},
+		{"user@1000.service", false},
+		{"sshd.service", false},
+		{"dbus-broker.service", false},
+		{"weird@", false},
+		{"@.service", true},
+		{"", false},
+		{".service", false},
+	} {
+		assert.Equal(t, tc.want, isSystemdTemplateUnit(tc.name), "name %q", tc.name)
+	}
+}
+
+func TestSplitSystemdTemplateUnits(t *testing.T) {
+	concrete, templates := splitSystemdTemplateUnits([]string{
+		"sshd.service", "autovt@.service", "getty@tty1.service", "user@.service",
+	})
+	assert.Equal(t, []string{"sshd.service", "getty@tty1.service"}, concrete)
+	assert.Equal(t, []string{"autovt@.service", "user@.service"}, templates)
+}
+
+// systemctl refuses to show an uninstantiated template -- "Unit name
+// autovt@.service is neither a valid invocation ID nor unit name" -- and exits
+// non-zero for the whole batch when one is in it. Nearly every host has a
+// template, so leaving them in the batch made every batch fail, which sent the
+// whole resource to the unit-file fallback. That fallback does not look in
+// /run, so it silently lost every unit a generator had produced: 10 of them on
+// openSUSE Leap 16.
+func TestSystemdUnitManager_TemplateDoesNotFailTheWholeBatch(t *testing.T) {
+	listing := `sshd.service         enabled  enabled
+autovt@.service      alias    -
+home-relabel.service generated -
+`
+	// systemctl answers for the concrete names only
+	concreteShow := buildSystemdUnitShowCommand([]string{"sshd.service", "home-relabel.service"})
+
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{Name: "opensuse-leap", Version: "16.0", Family: []string{"suse", "linux", "unix", "os"}},
+	}, mock.WithData(&mock.TomlData{Commands: map[string]*mock.Command{
+		"systemctl list-unit-files --type service --all --no-legend": {Stdout: listing},
+		concreteShow: {Stdout: `Id=sshd.service
+Description=OpenSSH server daemon
+LoadState=loaded
+ActiveState=active
+NoNewPrivileges=yes
+
+Id=home-relabel.service
+Description=Relabel /home
+LoadState=loaded
+ActiveState=inactive
+NoNewPrivileges=no
+`},
+		// the batch that still contains the template is what systemctl rejects
+		buildSystemdUnitShowCommand([]string{"sshd.service", "autovt@.service", "home-relabel.service"}): {
+			Stderr:     "Failed to get properties: Unit name autovt@.service is neither a valid invocation ID nor unit name.\n",
+			ExitStatus: 1,
+		},
+	}}))
+	require.NoError(t, err)
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/usr/lib/systemd/system/autovt@.service", []byte(`[Unit]
+Description=Getty on %I
+
+[Service]
+ExecStart=/sbin/agetty -o '-p -- \u' --noclear %I
+`), 0o644))
+
+	units, err := (&SystemdUnitManager{conn: &fsConn{Connection: conn, fs: fs}}).List()
+	require.NoError(t, err)
+
+	byName := map[string]*SystemdUnit{}
+	for _, u := range units {
+		byName[u.Name] = u
+	}
+
+	// the generator-produced unit survives, which is what the wholesale
+	// fallback used to lose
+	require.Contains(t, byName, "home-relabel.service")
+	assert.Equal(t, "Relabel /home", byName["home-relabel.service"].Description)
+
+	// the concrete units still carry systemctl's values, so the resource did
+	// not quietly degrade to reading unit files for everything
+	require.Contains(t, byName, "sshd.service")
+	assert.Equal(t, "active", byName["sshd.service"].ActiveState)
+	assert.True(t, byName["sshd.service"].NoNewPrivileges)
+
+	// and the template is reported too, read from its unit file
+	require.Contains(t, byName, "autovt@.service")
+	assert.Equal(t, "Getty on %I", byName["autovt@.service"].Description)
+
+	assert.Len(t, units, 3)
+}
+
+// A template with no unit file of its own (an alias) is skipped rather than
+// failing the listing.
+func TestSystemdUnitManager_TemplateWithoutUnitFileIsSkipped(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{Name: "debian", Version: "13", Family: []string{"debian", "linux", "unix", "os"}},
+	}, mock.WithData(&mock.TomlData{Commands: map[string]*mock.Command{
+		"systemctl list-unit-files --type service --all --no-legend": {Stdout: "sshd.service enabled enabled\nsshd-unix-local@.service alias -\n"},
+		buildSystemdUnitShowCommand([]string{"sshd.service"}):        {Stdout: "Id=sshd.service\nLoadState=loaded\n"},
+	}}))
+	require.NoError(t, err)
+
+	var _ shared.Connection = conn
+	units, err := (&SystemdUnitManager{conn: &fsConn{Connection: conn, fs: afero.NewMemMapFs()}}).List()
+	require.NoError(t, err)
+	require.Len(t, units, 1)
+	assert.Equal(t, "sshd.service", units[0].Name)
+}

--- a/providers/os/resources/services/systemd_unit.go
+++ b/providers/os/resources/services/systemd_unit.go
@@ -144,11 +144,22 @@ func (m *SystemdUnitManager) listViaSystemctl() ([]*SystemdUnit, error) {
 		return []*SystemdUnit{}, nil
 	}
 
-	res := make([]*SystemdUnit, 0, len(names))
-	for start := 0; start < len(names); start += systemdUnitShowChunk {
-		end := min(start+systemdUnitShowChunk, len(names))
+	// systemctl refuses to show an uninstantiated template ("Unit name
+	// autovt@.service is neither a valid invocation ID nor unit name") and
+	// exits non-zero for the whole batch when one is in it. Almost every host
+	// has at least one template, so leaving them in meant every batch failed
+	// and the whole resource fell back to reading unit files -- which loses the
+	// units a generator produced into /run, since the filesystem search path
+	// deliberately does not look there. On openSUSE Leap 16 that was 10 real
+	// units missing. Ask systemctl only about the concrete names and read the
+	// templates off disk, where they always have a unit file.
+	concrete, templates := splitSystemdTemplateUnits(names)
 
-		chunk := names[start:end]
+	res := make([]*SystemdUnit, 0, len(names))
+	for start := 0; start < len(concrete); start += systemdUnitShowChunk {
+		end := min(start+systemdUnitShowChunk, len(concrete))
+
+		chunk := concrete[start:end]
 		showCmd, err := m.conn.RunCommand(buildSystemdUnitShowCommand(chunk))
 		if err != nil {
 			return nil, err
@@ -171,11 +182,47 @@ func (m *SystemdUnitManager) listViaSystemctl() ([]*SystemdUnit, error) {
 
 	// systemctl named the units, so it knowing nothing about any of them is a
 	// failure to report rather than a host with nothing on it
-	if len(res) == 0 {
-		return nil, fmt.Errorf("systemctl show returned no properties for any of the %d service units", len(names))
+	if len(concrete) > 0 && len(res) == 0 {
+		return nil, fmt.Errorf("systemctl show returned no properties for any of the %d service units", len(concrete))
+	}
+
+	fs := m.fsFallback()
+	for _, name := range templates {
+		u, err := fs.Get(name)
+		if err != nil {
+			// the template was named by list-unit-files, so it has a unit file
+			// somewhere; if we cannot read it, say so rather than dropping it
+			log.Debug().Err(err).Str("unit", name).
+				Msg("mql[systemd]> could not read template unit file")
+			continue
+		}
+		res = append(res, u)
 	}
 
 	return res, nil
+}
+
+// splitSystemdTemplateUnits separates uninstantiated template units
+// (`name@.service`) from concrete ones.
+func splitSystemdTemplateUnits(names []string) (concrete, templates []string) {
+	for _, name := range names {
+		if isSystemdTemplateUnit(name) {
+			templates = append(templates, name)
+			continue
+		}
+		concrete = append(concrete, name)
+	}
+	return concrete, templates
+}
+
+// isSystemdTemplateUnit reports whether name is a template rather than an
+// instance: the instance part, between the "@" and the type suffix, is empty.
+func isSystemdTemplateUnit(name string) bool {
+	dot := strings.LastIndexByte(name, '.')
+	if dot < 1 {
+		return false
+	}
+	return name[dot-1] == '@'
 }
 
 // systemctlError turns a non-zero systemctl exit into an error carrying the


### PR DESCRIPTION
## What

systemctl refuses to show an uninstantiated template unit:

```
$ systemctl show --property=Id -- autovt@.service
Failed to get properties: Unit name autovt@.service is neither a valid invocation ID nor unit name.
exit=1
```

and it exits non-zero for the **whole batch** when one is in it. Nearly every systemd host ships at least one template, so every batch failed, and the exit check added in #10527 then sent the whole resource to the unit-file fallback.

That fallback does not look in `/run` — deliberately, an fs scan should not describe a running system — so it silently dropped **every unit a generator had produced**. On openSUSE Leap 16 that was 10 real units (`*-relabel.service` under `/run/systemd/generator`) missing from `systemd.units` against a host that reports 214.

This is a follow-up to #10527: the exit check was right in principle but too coarse.

## The fix

Ask systemctl only about the **concrete** names, and read the templates off disk where they have a unit file. Concrete units keep their systemctl-derived values, so the resource no longer degrades to reading unit files for everything just because a template was in the list. A template that is only an alias has no unit file of its own and is skipped, matching how aliases are already collapsed onto their canonical unit.

## Verified live

17 EC2 instances over SSH with `--sudo`:

| host | before | after | `systemctl list-unit-files` |
|---|---|---|---|
| opensuse-leap-16 | 204 | **214** | 214 |
| ubuntu-24.04 | 239 | **241** | 241 |
| rhel-9 | 186 | **186** | 186 |
| debian-13 | 152 | **153** | 154 |
| centos-stream-10 | 208 | **208** | 210 |

The residual 1–2 on debian and centos are **aliases**, and mql is right to collapse them: `systemctl list-unit-files` lists `ssh.service` *and* `sshd.service` separately, while `systemctl show` reports one canonical `Id` with `Names=ssh.service sshd.service`. Diffing the name lists, every remaining difference is of that shape (`dbus-org.freedesktop.login1.service` → `systemd-logind.service`, `sshd-unix-local@.service` → `sshd@.service`).

## Test plan

- `TestSystemdUnitManager_TemplateDoesNotFailTheWholeBatch` — a listing with a concrete unit, a template, and a generator-produced unit, where the batch containing the template exits 1 with the real systemd error. Asserts the generator unit survives, the concrete units still carry systemctl's `ActiveState`/`NoNewPrivileges` (proving no wholesale fallback), and the template is read from its unit file. Fails on the old batching with `does not contain "home-relabel.service"`.
- `TestSystemdUnitManager_TemplateWithoutUnitFileIsSkipped` — an alias template is skipped rather than failing the listing.
- `TestIsSystemdTemplateUnit` (12 cases, including `getty@tty1.service` and `user@1000.service` which are instances, not templates) and `TestSplitSystemdTemplateUnits`.
- `go test ./providers/os/...` passes. (`connection/device/linux` fails to build on `main` already — unrelated.)