### PR TITLE
🐛 os: read the root CA bundle when its path is a symlink

### DIFF
--- a/providers/os/resources/os_rootcertificates.go
+++ b/providers/os/resources/os_rootcertificates.go
@@ -52,7 +52,7 @@ func initOsRootCertificates(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	} else if platform.IsFamily("bsd") {
 		paths = BsdCertFiles
 	} else {
-		return nil, nil, errors.New("root certificates are not unsupported on this platform: " + platform.Name + " " + platform.Version)
+		return nil, nil, errors.New("root certificates are not supported on this platform: " + platform.Name + " " + platform.Version)
 	}
 
 	// Take the first bundle that exists, which is what Go's own root pool does.

--- a/providers/os/resources/os_rootcertificates.go
+++ b/providers/os/resources/os_rootcertificates.go
@@ -55,7 +55,11 @@ func initOsRootCertificates(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		return nil, nil, errors.New("root certificates are not unsupported on this platform: " + platform.Name + " " + platform.Version)
 	}
 
-	// search the first file that exists, it mimics the behavior go is doing
+	// Take the first bundle that exists, which is what Go's own root pool does.
+	// Collecting every path that exists instead would count one bundle several
+	// times over: on RHEL 9 all three of /etc/pki/tls/certs/ca-bundle.crt,
+	// /etc/ssl/cert.pem and /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+	// are the same 146 certificates, two of them by symlink.
 	files := []any{}
 	for i := range paths {
 		f, err := CreateResource(runtime, "file", map[string]*llx.RawData{
@@ -67,19 +71,26 @@ func initOsRootCertificates(runtime *plugin.Runtime, args map[string]*llx.RawDat
 
 		file := f.(*mqlFile)
 		if !file.GetExists().Data {
-			log.Trace().Err(err).Str("path", paths[i]).Msg("os.rootcertificates> file does not exist")
+			log.Trace().Str("path", paths[i]).Msg("os.rootcertificates> file does not exist")
 			continue
 		}
 		perm := file.GetPermissions()
 		if perm.Error != nil {
-			log.Trace().Err(err).Str("path", paths[i]).Msg("os.rootcertificates> failed to get permissions")
+			log.Trace().Err(perm.Error).Str("path", paths[i]).Msg("os.rootcertificates> failed to get permissions")
 			continue
 		}
-		if !perm.Data.GetIsFile().Data {
+		// A directory is not a bundle. Anything else is: the permissions come
+		// from an lstat, so the canonical bundle path being a symlink -- which
+		// it is on every SUSE, where /etc/ssl/ca-bundle.pem points into
+		// /var/lib/ca-certificates -- must not be mistaken for "not a file".
+		// Requiring isFile reported zero trusted roots on all of SLES 12, 15
+		// and 16 and openSUSE Leap, which reads as a host that trusts nothing.
+		if perm.Data.GetIsDirectory().Data {
 			continue
 		}
 
 		files = append(files, file)
+		break
 	}
 
 	args["files"] = llx.ArrayData(files, types.Resource("file"))
@@ -95,7 +106,11 @@ func (s *mqlOsRootCertificates) content(files []any) ([]any, error) {
 
 		content := file.GetContent()
 		if content.Error != nil {
-			return nil, content.Error
+			// a bundle we cannot read is one bundle's worth of certificates
+			// missing, not a reason to report none at all
+			log.Warn().Err(content.Error).Str("path", file.Path.Data).
+				Msg("os.rootcertificates> could not read certificate bundle")
+			continue
 		}
 		contents = append(contents, content.Data)
 	}

--- a/providers/os/resources/os_rootcertificates_test.go
+++ b/providers/os/resources/os_rootcertificates_test.go
@@ -1,0 +1,110 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+	"go.mondoo.com/mql/utils/syncx"
+)
+
+// certBundleRuntime builds a runtime whose filesystem holds only the named
+// bundle paths. A path mapped to a symlink mode is what an lstat reports for
+// the canonical bundle path on SUSE and RHEL.
+func certBundleRuntime(t *testing.T, files map[string]*mock.MockFileData) *plugin.Runtime {
+	t.Helper()
+
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:    "sles",
+			Version: "15.7",
+			Family:  []string{"suse", "linux", "unix", "os"},
+		},
+	}, mock.WithData(&mock.TomlData{Files: files}))
+	require.NoError(t, err)
+
+	return &plugin.Runtime{Connection: conn, Resources: &syncx.Map[plugin.Resource]{}}
+}
+
+func bundleFile(mode os.FileMode) *mock.MockFileData {
+	return &mock.MockFileData{
+		Content:  "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n",
+		StatData: mock.FileInfo{Mode: mode, Size: 60},
+	}
+}
+
+func initedPaths(t *testing.T, runtime *plugin.Runtime) []string {
+	t.Helper()
+
+	args, _, err := initOsRootCertificates(runtime, map[string]*llx.RawData{})
+	require.NoError(t, err)
+
+	raw, ok := args["files"]
+	require.True(t, ok)
+
+	paths := []string{}
+	for _, f := range raw.Value.([]any) {
+		paths = append(paths, f.(*mqlFile).Path.Data)
+	}
+	return paths
+}
+
+// Every SUSE ships /etc/ssl/ca-bundle.pem as a symlink into
+// /var/lib/ca-certificates. The permissions come from an lstat, so requiring
+// isFile skipped it and os.rootCertificates reported zero trusted roots on all
+// of SLES 12, 15 and 16 and openSUSE Leap -- which reads as a host that trusts
+// nothing.
+func TestOsRootCertificates_SymlinkedBundleIsUsed(t *testing.T) {
+	runtime := certBundleRuntime(t, map[string]*mock.MockFileData{
+		"/etc/ssl/ca-bundle.pem": bundleFile(os.ModeSymlink | 0o777),
+	})
+
+	assert.Equal(t, []string{"/etc/ssl/ca-bundle.pem"}, initedPaths(t, runtime))
+}
+
+// On RHEL 9 all three of ca-bundle.crt, cert.pem and tls-ca-bundle.pem are the
+// same 146 certificates, two of them by symlink. Accepting symlinks without
+// stopping at the first match would report the bundle three times over.
+func TestOsRootCertificates_DuplicateBundlesAreNotCountedTwice(t *testing.T) {
+	runtime := certBundleRuntime(t, map[string]*mock.MockFileData{
+		"/etc/pki/tls/certs/ca-bundle.crt":                  bundleFile(os.ModeSymlink | 0o777),
+		"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem": bundleFile(0o644),
+		"/etc/ssl/cert.pem":                                 bundleFile(os.ModeSymlink | 0o777),
+	})
+
+	// the first path that exists wins, which is what Go's own root pool does
+	assert.Equal(t, []string{"/etc/pki/tls/certs/ca-bundle.crt"}, initedPaths(t, runtime))
+}
+
+func TestOsRootCertificates_PlainFileBundle(t *testing.T) {
+	runtime := certBundleRuntime(t, map[string]*mock.MockFileData{
+		"/etc/ssl/certs/ca-certificates.crt": bundleFile(0o644),
+	})
+
+	assert.Equal(t, []string{"/etc/ssl/certs/ca-certificates.crt"}, initedPaths(t, runtime))
+}
+
+// A directory sitting on a bundle path is not a bundle.
+func TestOsRootCertificates_DirectoryIsSkipped(t *testing.T) {
+	runtime := certBundleRuntime(t, map[string]*mock.MockFileData{
+		"/etc/ssl/certs/ca-certificates.crt": {StatData: mock.FileInfo{Mode: os.ModeDir | 0o755, IsDir: true}},
+		"/etc/ssl/ca-bundle.pem":             bundleFile(0o644),
+	})
+
+	assert.Equal(t, []string{"/etc/ssl/ca-bundle.pem"}, initedPaths(t, runtime))
+}
+
+// A host with no bundle at all reports none, without erroring.
+func TestOsRootCertificates_NoBundle(t *testing.T) {
+	runtime := certBundleRuntime(t, map[string]*mock.MockFileData{})
+
+	assert.Empty(t, initedPaths(t, runtime))
+}


### PR DESCRIPTION
## What

Every SUSE ships `/etc/ssl/ca-bundle.pem` as a **symlink** into `/var/lib/ca-certificates`:

```
$ ls -l /etc/ssl/ca-bundle.pem
lrwxrwxrwx 1 root root 38 /etc/ssl/ca-bundle.pem -> /var/lib/ca-certificates/ca-bundle.pem
```

The permissions on the `file` resource come from an **lstat**, so `isFile` is `false` for the symlink and the init skipped it. No other candidate path exists on SUSE, so `os.rootCertificates` reported **zero** trusted roots on SLES 12, SLES 15, SLES 16 and openSUSE Leap.

That is not a thing a host can be, and it passes silently: a check asking whether an unexpected CA is in the trust store finds nothing to object to. mql was reading the file fine — `file("/etc/ssl/ca-bundle.pem").content.length` returned 220300 — it just never got that far.

```
sles-15-sp7   os.rootCertificates.length: 0     (the bundle holds 146)
```

## The fix

Skip only a **directory**, so a symlink to a bundle counts.

That alone would over-count elsewhere. On RHEL 9 all three of `/etc/pki/tls/certs/ca-bundle.crt`, `/etc/ssl/cert.pem` and `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` are the same 146 certificates, two of them by symlink — and the loop collected *every* path that existed. Only the `isFile` guard was keeping that from reporting the bundle three times over. So take the **first** bundle that exists and stop, which is what the comment above it already claimed ("search the first file that exists, it mimics the behavior go is doing") and what Go's own root pool does.

A bundle that cannot be read is now logged and skipped rather than failing the whole resource — for the same reason one unreadable file should not mean "this host trusts nothing".

## Verified live

17 EC2 instances, every count matching `grep -c "BEGIN CERTIFICATE"` on the host:

| host | before | after | bundle holds |
|---|---|---|---|
| sles-12-sp5 | **0** | 146 | 146 |
| sles-15-sp6 | **0** | 146 | 146 |
| sles-15-sp7 | **0** | 146 | 146 |
| sles-16-0 | **0** | 145 | 145 |
| opensuse-leap-16 | **0** | 145 | 145 |
| rhel-9 | 146 | 146 | 146 |
| centos-stream-10 | 121 | 121 | 121 |
| ubuntu-24.04 | 121 | 121 | 121 |
| debian-13 | 150 | 150 | 150 |

The RHEL/CentOS/Ubuntu/Debian numbers are unchanged, which is the point — the dedup change offsets the symlink change exactly where three paths pointed at one bundle.

## Test plan

- `TestOsRootCertificates_SymlinkedBundleIsUsed` — SUSE layout, only path is a symlink. Fails on the old code.
- `TestOsRootCertificates_DuplicateBundlesAreNotCountedTwice` — RHEL layout, two symlinks plus the real file; asserts one path is selected. Fails on the old code once symlinks are accepted.
- `TestOsRootCertificates_PlainFileBundle`, `_DirectoryIsSkipped`, `_NoBundle`.
- `go test ./providers/os/...` passes. (`connection/device/linux` fails to build on `main` already — unrelated.)