### PR TITLE
🌙 network: report the zone apex a DNS name belongs to

### DIFF
--- a/providers/network/resources/dns.go
+++ b/providers/network/resources/dns.go
@@ -74,6 +74,53 @@ func initDns(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]
 	return args, nil, nil
 }
 
+// zone reports the apex of the zone that contains the domain, as a dns resource
+// for that name.
+//
+// The records that describe a zone as a whole (DNSKEY, NS, SOA) exist at its
+// apex and nowhere else inside it, so a question about how a zone is signed, or
+// how many nameservers serve it, has an answer at this name and no answer at
+// any other name the zone contains. Reading those fields through here answers
+// for the containing zone; comparing fqdn against the returned fqdn tells an
+// apex from a name that merely sits inside a zone.
+//
+// The zone is null rather than an error when the name belongs to no zone, which
+// covers an unregistered domain and a scan target given as an IP address (see
+// params for the empty-fqdn substitution). A failed query is still an error: a
+// resolver outage must not read as a name that has no zone.
+func (d *mqlDns) zone(fqdn string) (*mqlDns, error) {
+	if fqdn == "" {
+		d.Zone.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	dnsShaker, err := dnsshake.New(fqdn)
+	if err != nil {
+		return nil, err
+	}
+
+	zone, err := dnsShaker.Zone()
+	if err != nil {
+		return nil, err
+	}
+	if zone == "" {
+		d.Zone.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	// An apex is its own zone. NewResource consults the runtime cache, so this
+	// resolves back to the receiver rather than building a second resource for
+	// the same name, and the record sweep behind it is shared either way.
+	res, err := NewResource(d.MqlRuntime, "dns", map[string]*llx.RawData{
+		"fqdn": llx.StringData(zone),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return res.(*mqlDns), nil
+}
+
 func (d *mqlDns) params(fqdn string) (any, error) {
 	// initDns substitutes an empty fqdn when the scan target is an IP address
 	// rather than a hostname. Querying an empty name resolves the DNS ROOT ZONE,

--- a/providers/network/resources/dnsshake/dnsshake.go
+++ b/providers/network/resources/dnsshake/dnsshake.go
@@ -265,19 +265,25 @@ func (d *DnsClient) QueryAuthoritative(dnsTypes ...string) (map[string]DnsRecord
 	return res, errs.Deduplicate()
 }
 
-// authoritativeNameservers finds the addresses of the nameservers serving the
-// zone that contains the client's fqdn.
+// walkToDelegation walks up the labels of the client's fqdn and reports the
+// closest enclosing name that answers with NS records of its own, together with
+// those records.
 //
-// The NS records live at the zone apex, not at every name within it, so this
-// walks up the labels until a delegation is found: a query for
-// "www.example.com" finds nothing at that name and succeeds at "example.com".
-// The walk stops before the root so a name that resolves nowhere fails rather
-// than returning the root servers, which would answer referrals instead of the
+// NS records live at a zone apex and at the delegation points within it, not at
+// every name a zone contains, so a query for "www.example.com" answers with no
+// NS records and the walk continues at "example.com", which does. The walk
+// stops before the root so a name that resolves nowhere reports not-found
+// rather than the root servers, which would answer referrals instead of the
 // records the caller wants.
-func (d *DnsClient) authoritativeNameservers() ([]string, error) {
+//
+// accept decides whether a name that answered is the one the caller wanted;
+// returning false continues the walk. It is how authoritativeNameservers keeps
+// climbing past a delegation whose nameservers do not resolve, while Zone,
+// which only needs the name, stops at the first one.
+func (d *DnsClient) walkToDelegation(accept func(zone string, ns DnsRecord) bool) (string, bool, error) {
 	name := dns.Fqdn(d.fqdn)
 	if name == "." {
-		return nil, errors.New("cannot determine authoritative nameservers without a domain name")
+		return "", false, errors.New("cannot determine the authoritative zone without a domain name")
 	}
 
 	for labels := dns.SplitDomainName(name); len(labels) > 0; labels = labels[1:] {
@@ -285,15 +291,73 @@ func (d *DnsClient) authoritativeNameservers() ([]string, error) {
 
 		records, err := d.queryDnsTypeAt(d.config.Servers[0], true, zone, "NS")
 		if err != nil {
-			return nil, err
+			return "", false, err
 		}
 
 		ns, ok := records["NS"]
+
+		// queryDnsTypeAt reports a transport failure in the record rather than
+		// as an error, and climbing past one would answer with whichever
+		// ancestor did respond: a failed query at "corp.example.com" would
+		// report "example.com" as the zone, and the delegated subzone below it
+		// would never be seen. A query that did not happen is not evidence that
+		// the name is not a zone, so it ends the walk.
+		if ok && ns.Error != nil {
+			return "", false, errors.Wrapf(ns.Error, "querying NS for %s", zone)
+		}
+
 		if !ok || ns.RCode != dns.RcodeToString[dns.RcodeSuccess] || len(ns.RData) == 0 {
 			continue
 		}
 
-		addrs := []string{}
+		if !accept(zone, ns) {
+			continue
+		}
+
+		return zone, true, nil
+	}
+
+	return "", false, nil
+}
+
+// Zone reports the apex of the zone that contains the client's fqdn: the
+// closest enclosing name that is served as a zone of its own.
+//
+// This is the name the zone-wide configuration belongs to. DNSKEY, NS and SOA
+// records exist at a zone apex and nowhere else inside the zone, so a question
+// about how a zone is signed, or how many nameservers serve it, has an answer
+// at this name and no answer at any other name the zone contains.
+//
+// It is found by delegation rather than by the public suffix list, which is
+// what makes it the zone the name actually belongs to rather than the
+// registrable domain. The two agree for "www.example.com", whose zone is
+// "example.com"; they differ for a delegated subdomain such as
+// "corp.example.com", which is its own zone, signed with its own keys and
+// served by its own nameservers.
+//
+// It reports an empty zone, and no error, for a name that nothing answers for
+// as a zone: an unregistered domain has no apex to report, which is a fact
+// about the name rather than a failure to establish it. A query that fails is
+// the error case, and is reported as one, so a resolver outage is never
+// mistaken for a name that belongs to no zone.
+func (d *DnsClient) Zone() (string, error) {
+	zone, found, err := d.walkToDelegation(func(string, DnsRecord) bool { return true })
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", nil
+	}
+	return zone, nil
+}
+
+// authoritativeNameservers finds the addresses of the nameservers serving the
+// zone that contains the client's fqdn.
+func (d *DnsClient) authoritativeNameservers() ([]string, error) {
+	var addrs []string
+
+	_, found, err := d.walkToDelegation(func(_ string, ns DnsRecord) bool {
+		addrs = addrs[:0]
 		for _, host := range ns.RData {
 			// Nameservers are named, so each one needs resolving to an address
 			// before it can be queried. Skip any that do not resolve; as long as
@@ -304,13 +368,16 @@ func (d *DnsClient) authoritativeNameservers() ([]string, error) {
 			}
 			addrs = append(addrs, ips...)
 		}
-
-		if len(addrs) > 0 {
-			return addrs, nil
-		}
+		return len(addrs) > 0
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errors.New("no authoritative nameserver found for " + d.fqdn)
 	}
 
-	return nil, errors.New("no authoritative nameserver found for " + d.fqdn)
+	return addrs, nil
 }
 
 // queryDnsTypeAt performs the lookup against a named server.

--- a/providers/network/resources/dnsshake/zone_internal_test.go
+++ b/providers/network/resources/dnsshake/zone_internal_test.go
@@ -1,0 +1,160 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package dnsshake
+
+import (
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// zoneFixture serves a synthetic tree that carries the three shapes the walk has
+// to tell apart, none of which a live domain can be relied on to hold still:
+//
+//   - example.test is a zone apex and answers NS at its own name
+//   - www.example.test is a name inside it, published as a CNAME. A resolver
+//     answers an NS query for it with NOERROR and the CNAME in the answer
+//     section, which is the shape that makes "answered successfully" and
+//     "carries NS records" two different questions
+//   - corp.example.test is delegated, so it answers NS at its own name and is a
+//     zone in its own right, which is where the delegation walk and the public
+//     suffix list disagree
+//
+// Every other name answers NOERROR with nothing, so a name under no zone walks
+// to the top without finding one.
+func zoneFixture(t *testing.T) *dns.ClientConfig {
+	t.Helper()
+
+	delegations := map[string][]string{
+		"example.test.":      {"ns1.example.test.", "ns2.example.test."},
+		"corp.example.test.": {"ns1.corp.example.test."},
+	}
+
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Authoritative = true
+
+		q := r.Question[0]
+		switch {
+		case q.Qtype == dns.TypeNS && len(delegations[q.Name]) > 0:
+			for _, ns := range delegations[q.Name] {
+				m.Answer = append(m.Answer, &dns.NS{
+					Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 300},
+					Ns:  ns,
+				})
+			}
+		case q.Name == "www.example.test.":
+			// A CNAME is what a resolver returns for any type asked of this
+			// name, NS included. It answers successfully and carries no NS.
+			m.Answer = append(m.Answer, &dns.CNAME{
+				Hdr:    dns.RR_Header{Name: q.Name, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+				Target: "example.test.",
+			})
+		}
+
+		_ = w.WriteMsg(m)
+	})
+
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := &dns.Server{PacketConn: pc, Handler: mux}
+	go func() { _ = srv.ActivateAndServe() }()
+	t.Cleanup(func() { _ = srv.Shutdown() })
+
+	host, port, err := net.SplitHostPort(pc.LocalAddr().String())
+	require.NoError(t, err)
+
+	return &dns.ClientConfig{Servers: []string{host}, Port: port, Timeout: 2, Attempts: 1}
+}
+
+func fixtureClient(t *testing.T, fqdn string) *DnsClient {
+	t.Helper()
+	return &DnsClient{config: zoneFixture(t), fqdn: fqdn}
+}
+
+func TestZone(t *testing.T) {
+	tests := []struct {
+		name string
+		fqdn string
+		want string
+	}{
+		{"an apex is its own zone", "example.test", "example.test"},
+		{"a name inside a zone reports the apex", "www.example.test", "example.test"},
+		{"a CNAME answer is not a delegation", "www.example.test", "example.test"},
+		{"a delegated subdomain is its own zone", "corp.example.test", "corp.example.test"},
+		{"a name inside a delegated subzone reports that subzone", "vpn.corp.example.test", "corp.example.test"},
+		{"a name under no zone reports none", "absent.test", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			zone, err := fixtureClient(t, tc.fqdn).Zone()
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, zone)
+		})
+	}
+}
+
+func TestZoneRejectsRoot(t *testing.T) {
+	// The root is a zone, and reporting it would make every name look like it
+	// sits in one. A name that cannot name a zone has to fail instead.
+	for _, fqdn := range []string{"", "."} {
+		_, err := fixtureClient(t, fqdn).Zone()
+		assert.Error(t, err, "fqdn %q must not walk to the root", fqdn)
+	}
+}
+
+func TestZoneReportsQueryFailureAsError(t *testing.T) {
+	// A resolver that cannot be reached must not read as a name that belongs to
+	// no zone: the first is unknown, the second is a fact, and a check filtered
+	// on the zone would silently skip on the strength of the difference.
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	_, port, err := net.SplitHostPort(pc.LocalAddr().String())
+	require.NoError(t, err)
+	require.NoError(t, pc.Close()) // nothing listens here now
+
+	c := &DnsClient{
+		config: &dns.ClientConfig{Servers: []string{"127.0.0.1"}, Port: port, Timeout: 1, Attempts: 1},
+		fqdn:   "www.example.test",
+	}
+
+	_, err = c.Zone()
+	assert.Error(t, err)
+}
+
+func TestWalkToDelegationContinuesWhenTheCallerRejectsAZone(t *testing.T) {
+	// authoritativeNameservers depends on this: a delegation whose nameservers
+	// do not resolve is not usable to it, and the walk has to climb past it
+	// rather than stopping at the first name that merely answered.
+	c := fixtureClient(t, "vpn.corp.example.test")
+
+	var offered []string
+	zone, found, err := c.walkToDelegation(func(zone string, _ DnsRecord) bool {
+		offered = append(offered, zone)
+		return zone == "example.test"
+	})
+
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "example.test", zone)
+	assert.Equal(t, []string{"corp.example.test", "example.test"}, offered,
+		"the rejected delegation should be offered first, then the walk continues")
+}
+
+func TestPortIsNumeric(t *testing.T) {
+	// Guards the fixture itself: a non-numeric port would make every query fail
+	// and every zone come back empty, which the table above would read as a
+	// passing "no zone" case.
+	cfg := zoneFixture(t)
+	_, err := strconv.Atoi(cfg.Port)
+	require.NoError(t, err)
+}

--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -557,6 +557,24 @@ dns @defaults("fqdn") {
   init(fqdn string)
   // Fully qualified domain name (FQDN)
   fqdn string
+  // Apex of the zone that contains this name
+  //
+  // The closest enclosing name that is served as a zone of its own, which is
+  // where a zone-wide question has an answer. DNSKEY, NS and SOA records exist
+  // at a zone apex and nowhere else inside the zone, so `zone.dnssec` and
+  // `zone.records` report how the containing zone is signed and served even
+  // when the name itself publishes neither. Comparing `fqdn` against
+  // `zone.fqdn` tells an apex from a name that merely sits inside a zone,
+  // which is what scopes a zone-wide audit to the one name it can hold for.
+  //
+  // The zone is established by delegation rather than by the public suffix
+  // list, so it is the zone the name belongs to and not the registrable
+  // domain. The two agree for `www.example.com`, whose zone is `example.com`.
+  // They differ for a delegated subdomain such as `corp.example.com`, which is
+  // a zone of its own, signed with its own keys and served by its own
+  // nameservers. Null when nothing answers as a zone, such as for a name that
+  // does not resolve or a scan target given as an IP address.
+  zone(fqdn) dns
   // DNS query results keyed by record type
   //
   // Map keyed by DNS record type (such as `A`, `AAAA`, `MX`, or `TXT`),

--- a/providers/network/resources/network.lr.go
+++ b/providers/network/resources/network.lr.go
@@ -714,6 +714,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"dns.fqdn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDns).GetFqdn()).ToDataRes(types.String)
 	},
+	"dns.zone": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDns).GetZone()).ToDataRes(types.Resource("dns"))
+	},
 	"dns.params": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDns).GetParams()).ToDataRes(types.Dict)
 	},
@@ -1718,6 +1721,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"dns.fqdn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDns).Fqdn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"dns.zone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDns).Zone, ok = plugin.RawToTValue[*mqlDns](v.Value, v.Error)
 		return
 	},
 	"dns.params": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4263,6 +4270,7 @@ type mqlDns struct {
 	__id       string
 	// optional: if you define mqlDnsInternal it will be used here
 	Fqdn                 plugin.TValue[string]
+	Zone                 plugin.TValue[*mqlDns]
 	Params               plugin.TValue[any]
 	AuthoritativeParams  plugin.TValue[any]
 	Records              plugin.TValue[[]any]
@@ -4316,6 +4324,27 @@ func (c *mqlDns) MqlID() string {
 
 func (c *mqlDns) GetFqdn() *plugin.TValue[string] {
 	return &c.Fqdn
+}
+
+func (c *mqlDns) GetZone() *plugin.TValue[*mqlDns] {
+	return plugin.GetOrCompute[*mqlDns](&c.Zone, func() (*mqlDns, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("dns", c.__id, "zone")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDns), nil
+			}
+		}
+
+		vargFqdn := c.GetFqdn()
+		if vargFqdn.Error != nil {
+			return nil, vargFqdn.Error
+		}
+
+		return c.zone(vargFqdn.Data)
+	})
 }
 
 func (c *mqlDns) GetParams() *plugin.TValue[any] {

--- a/providers/network/resources/network.lr.versions
+++ b/providers/network/resources/network.lr.versions
@@ -145,6 +145,7 @@ dns.spfRecord.allQualifier 13.1.1
 dns.spfRecord.dnsTxt 13.1.1
 dns.spfRecord.mechanisms 13.1.1
 dns.spfRecord.version 13.1.1
+dns.zone 13.3.1
 domainName 9.0.1
 domainName.effectiveTLDPlusOne 9.0.1
 domainName.fqdn 9.0.1


### PR DESCRIPTION
## What

Adds `dns.zone` to the `network` provider: the apex of the zone that contains a name, returned as a `dns` resource for that name.

```
> dns(fqdn: "www.mondoo.com").zone.fqdn
dns.zone.fqdn: "mondoo.com"
```

## Why

The records that describe a zone as a whole live at its apex and nowhere else inside it. DNSKEY, NS and SOA exist at the apex, so a question about how a zone is signed, or how many nameservers serve it, has an answer at exactly one name and no answer at any other name the zone contains.

Asked at a name inside the zone, those questions come back empty, and empty is indistinguishable from a zone that is unsigned and served by nothing:

```
> dns(fqdn: "www.mondoo.com").dnssec.enabled
false                                   # mondoo.com is signed
> dns(fqdn: "www.mondoo.com").records.where(type == "NS").length
0                                       # mondoo.com has four
```

There was no way to ask the provider which name to put the question to. `dns.zone` is that name, so a caller can read the containing zone's state (`dns.zone.dnssec.enabled`) or test whether a name is an apex at all (`dns.fqdn == dns.zone.fqdn`).

The immediate consumer is the `mondoo-dns-security` policy in cnspec, whose zone-wide checks (DNSSEC enabled, NS redundancy, NS/MX not pointing at IP addresses, no CNAME at the root) currently evaluate against whatever name is scanned and fail on names that cannot answer them. A companion content change on `claude/github-issue-476-90150p` in cnspec filters those four on `dns.fqdn == dns.zone.fqdn`.

## By delegation, not by the public suffix list

`domainName.effectiveTLDPlusOne` already exists and is a tempting shortcut, but it answers a different question. The eTLD+1 is the *registrable* domain; the name publishing DNSKEY, NS and SOA is the apex of the *served* zone. They diverge wherever a subdomain is delegated:

| name | `dns.zone.fqdn` | `domainName.effectiveTLDPlusOne` |
|---|---|---|
| `mondoo.com` | `mondoo.com` | `mondoo.com` |
| `www.mondoo.com` | `mondoo.com` | `mondoo.com` |
| `cs.cmu.edu` | `cs.cmu.edu` | `cmu.edu` |
| `www.cs.cmu.edu` | `cs.cmu.edu` | `cmu.edu` |
| `eecs.berkeley.edu` | `eecs.berkeley.edu` | `berkeley.edu` |

`cs.cmu.edu` is a zone with its own nameservers and its own signing state. A consumer scoping on eTLD+1 would treat it as a subdomain of `cmu.edu` and never audit it.

## Implementation

The walk this needs already existed, in `authoritativeNameservers`, which climbs the labels until a name answers with NS records of its own. It is now factored into `walkToDelegation` and shared, with an `accept` callback so `authoritativeNameservers` keeps its existing behaviour of climbing past a delegation whose nameservers do not resolve, while `Zone` stops at the first name that answers.

**Sharing it surfaced a bug in the existing walk.** `queryDnsTypeAt` reports a transport failure inside the returned record rather than as an error, so the walk treated a query that never happened the same as a name that answered with no NS records, and climbed past it. A failed query at `cs.cmu.edu` would report `cmu.edu` as the zone and hide the delegation below it. A query that did not happen is not evidence that a name is not a zone, so it now ends the walk.

That is a behaviour change to an error path `authoritativeParams` can reach: a transport failure mid-walk is now an error instead of a silent climb to the parent. The success path is unchanged.

`dns.zone` is null, not an error, for a name that belongs to no zone. That covers an unregistered domain and a scan target given as an IP address, where `initDns` substitutes an empty fqdn.

## Testing

New table tests in `zone_internal_test.go` run against a synthetic zone tree served by a local `dns.Server`, because no live domain can be relied on to hold the four shapes still: an apex, a CNAME'd name inside it (a resolver answers *any* type at such a name with the CNAME, which is what makes "answered successfully" and "carries NS records" two different questions), a delegated subzone, and a name under no zone. Also covered: the root guard, a query failure reporting as an error rather than as an absent zone, and the `accept` callback continuing the walk.

Verified against live DNS with a provider built from this branch:

| target | `dns.zone.fqdn` | own DNSKEY records |
|---|---|---|
| `mondoo.com` | `mondoo.com` | 1 |
| `www.mondoo.com` | `mondoo.com` | 0 |
| `cs.cmu.edu` | `cs.cmu.edu` | 0 |
| `www.cs.cmu.edu` | `cs.cmu.edu` | 0 |
| `eecs.berkeley.edu` | `eecs.berkeley.edu` | 0 |
| `nonexistent-zone-476.example` | null | - |
| `1.1.1.1` | null | - |

Reading the containing zone's state from a name inside it works as intended:

```
> mql run host www.mondoo.com -c 'dns.dnssec.enabled'
false
> mql run host www.mondoo.com -c 'dns.zone.dnssec.enabled'
true
> mql run host www.mondoo.com -c 'dns.zone.records.where(type == "NS").first.rdata.length'
4
```

`go test ./providers/network/resources/...` is otherwise unchanged. `TestQueryAuthoritativeReportsConfiguredTTL` is flaky in my sandbox (it queries live authoritative nameservers); it fails at the same rate on `main` and on this branch, so it is environmental rather than a regression from this change.

## Notes

- `.lr.versions` entry is `dns.zone 13.3.1`, the next patch after the provider's current `13.3.0`, matching the other in-flight `13.3.1` entries. `config.go` is untouched.
- The field is a typed accessor rather than a bare string, per the typed-reference gate in `CLAUDE.md`. Self-referential resource fields are an established pattern here (`parent()` on `azure.managementGroup`, `neon.branch`, `openstack.project` and others).
- Cost is a few NS queries against the same resolver the record sweep already uses, and only when the field is read.