### PR TITLE
🐛 network: retry the zone walk's NS query instead of failing on one lost packet

### DIFF
--- a/providers/network/resources/dnsshake/dnsshake.go
+++ b/providers/network/resources/dnsshake/dnsshake.go
@@ -19,6 +19,22 @@ type DnsClient struct {
 	config *dns.ClientConfig
 	fqdn   string
 	sync   sync.Mutex
+
+	// lookupHost resolves a nameserver's name to addresses, defaulting to
+	// net.LookupHost. It is a field so a test can serve the whole delegation
+	// walk from its own fixture: authoritativeNameservers is otherwise
+	// untestable, because the nameserver names a fixture hands back would have
+	// to resolve through the host's real resolver.
+	lookupHost func(string) ([]string, error)
+}
+
+// resolveHost resolves a nameserver name, through the injected resolver when a
+// test supplied one.
+func (d *DnsClient) resolveHost(name string) ([]string, error) {
+	if d.lookupHost != nil {
+		return d.lookupHost(name)
+	}
+	return net.LookupHost(name)
 }
 
 type DnsRecord struct {
@@ -265,6 +281,56 @@ func (d *DnsClient) QueryAuthoritative(dnsTypes ...string) (map[string]DnsRecord
 	return res, errs.Deduplicate()
 }
 
+// queryNS asks for the NS records at a name, retrying across the configured
+// resolvers before reporting failure.
+//
+// walkToDelegation treats a query that did not happen as a reason to stop
+// rather than to climb, because climbing would answer with whichever ancestor
+// did respond and hide the delegation below it. That is only sound if a query
+// that could have been answered was: queryDnsTypeAt sends one datagram to one
+// server and reports a lost reply as a failure, so a single dropped UDP packet
+// would otherwise end the walk and surface as an error on every field behind
+// it. A resolver is asked config.Attempts times, and every configured resolver
+// is asked, so the error means no resolver could answer rather than that one
+// packet went missing.
+//
+// Only a transport failure is retried. Any answer is the resolver having
+// answered, NXDOMAIN and a response carrying no NS records included, and what
+// it means is the caller's decision.
+func (d *DnsClient) queryNS(zone string) (map[string]DnsRecord, error) {
+	if len(d.config.Servers) == 0 {
+		return nil, errors.New("no resolver configured to query NS for " + zone)
+	}
+
+	attempts := d.config.Attempts
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < attempts; attempt++ {
+		for _, server := range d.config.Servers {
+			records, err := d.queryDnsTypeAt(server, true, zone, "NS")
+			if err != nil {
+				lastErr = err
+				continue
+			}
+
+			// queryDnsTypeAt reports a transport failure inside the record
+			// rather than as an error, so this is where a lost reply looks like
+			// one.
+			if ns, ok := records["NS"]; ok && ns.Error != nil {
+				lastErr = ns.Error
+				continue
+			}
+
+			return records, nil
+		}
+	}
+
+	return nil, errors.Wrapf(lastErr, "querying NS for %s", zone)
+}
+
 // walkToDelegation walks up the labels of the client's fqdn and reports the
 // closest enclosing name that answers with NS records of its own, together with
 // those records.
@@ -289,23 +355,12 @@ func (d *DnsClient) walkToDelegation(accept func(zone string, ns DnsRecord) bool
 	for labels := dns.SplitDomainName(name); len(labels) > 0; labels = labels[1:] {
 		zone := strings.Join(labels, ".")
 
-		records, err := d.queryDnsTypeAt(d.config.Servers[0], true, zone, "NS")
+		records, err := d.queryNS(zone)
 		if err != nil {
 			return "", false, err
 		}
 
 		ns, ok := records["NS"]
-
-		// queryDnsTypeAt reports a transport failure in the record rather than
-		// as an error, and climbing past one would answer with whichever
-		// ancestor did respond: a failed query at "corp.example.com" would
-		// report "example.com" as the zone, and the delegated subzone below it
-		// would never be seen. A query that did not happen is not evidence that
-		// the name is not a zone, so it ends the walk.
-		if ok && ns.Error != nil {
-			return "", false, errors.Wrapf(ns.Error, "querying NS for %s", zone)
-		}
-
 		if !ok || ns.RCode != dns.RcodeToString[dns.RcodeSuccess] || len(ns.RData) == 0 {
 			continue
 		}
@@ -362,7 +417,7 @@ func (d *DnsClient) authoritativeNameservers() ([]string, error) {
 			// Nameservers are named, so each one needs resolving to an address
 			// before it can be queried. Skip any that do not resolve; as long as
 			// one does, the zone is reachable.
-			ips, err := net.LookupHost(strings.TrimSuffix(host, "."))
+			ips, err := d.resolveHost(strings.TrimSuffix(host, "."))
 			if err != nil {
 				continue
 			}

--- a/providers/network/resources/dnsshake/walk_resilience_internal_test.go
+++ b/providers/network/resources/dnsshake/walk_resilience_internal_test.go
@@ -1,0 +1,210 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package dnsshake
+
+import (
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The delegation walk ends on a query that did not happen rather than climbing
+// past it, because climbing would answer with whichever ancestor did respond and
+// hide the delegation below it. That is only a safe reading if a query that
+// could have been answered was, and a single UDP datagram is not that: one lost
+// reply would otherwise read as "this resolver cannot answer" and fail every
+// field behind the walk.
+//
+// These tests fix the two halves of that: a transient loss is retried and does
+// not surface, while a resolver that genuinely cannot answer still errors.
+
+// flakyResolver serves the zone tree of zoneFixture, dropping the first
+// dropFirst queries it receives for dropName so a caller sees a lost reply
+// before a real answer.
+type flakyResolver struct {
+	mu        sync.Mutex
+	dropName  string
+	dropFirst int
+	queries   int
+	dropped   int
+}
+
+func (f *flakyResolver) serve(t *testing.T) *dns.ClientConfig {
+	t.Helper()
+
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", func(w dns.ResponseWriter, r *dns.Msg) {
+		q := r.Question[0]
+
+		f.mu.Lock()
+		f.queries++
+		drop := (f.dropName == "" || q.Name == f.dropName) && f.dropped < f.dropFirst
+		if drop {
+			f.dropped++
+		}
+		f.mu.Unlock()
+
+		if drop {
+			// No reply at all: the client waits and reports a timeout, which is
+			// exactly what a lost datagram looks like.
+			return
+		}
+
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Authoritative = true
+		if q.Qtype == dns.TypeNS && q.Name == "example.test." {
+			m.Answer = append(m.Answer, &dns.NS{
+				Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 300},
+				Ns:  "ns1.example.test.",
+			})
+		}
+		_ = w.WriteMsg(m)
+	})
+
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := &dns.Server{PacketConn: pc, Handler: mux}
+	go func() { _ = srv.ActivateAndServe() }()
+	t.Cleanup(func() { _ = srv.Shutdown() })
+
+	host, port, err := net.SplitHostPort(pc.LocalAddr().String())
+	require.NoError(t, err)
+
+	return &dns.ClientConfig{Servers: []string{host}, Port: port, Attempts: 2}
+}
+
+func (f *flakyResolver) counts() (queries, dropped int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.queries, f.dropped
+}
+
+// deadResolverConfig points at a port nothing listens on, so every query is
+// lost rather than answered.
+func deadResolverConfig(t *testing.T, servers int, attempts int) *dns.ClientConfig {
+	t.Helper()
+
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	_, port, err := net.SplitHostPort(pc.LocalAddr().String())
+	require.NoError(t, err)
+	require.NoError(t, pc.Close())
+
+	addrs := make([]string, servers)
+	for i := range addrs {
+		addrs[i] = "127.0.0.1"
+	}
+	return &dns.ClientConfig{Servers: addrs, Port: port, Attempts: attempts}
+}
+
+// TestZoneRetriesALostReply is the case that made the walk's strictness a
+// liability: the apex answers fine, one datagram on the way to it goes missing,
+// and before the retry that reported an error on dns.zone and on every
+// authoritative field.
+func TestZoneRetriesALostReply(t *testing.T) {
+	f := &flakyResolver{dropName: "example.test.", dropFirst: 1}
+	c := &DnsClient{config: f.serve(t), fqdn: "example.test"}
+
+	zone, err := c.Zone()
+	require.NoError(t, err, "one lost reply must not fail the walk")
+	assert.Equal(t, "example.test", zone)
+
+	queries, dropped := f.counts()
+	assert.Equal(t, 1, dropped, "the fixture should have dropped exactly one reply")
+	assert.Equal(t, 2, queries, "the lost query should have been retried once")
+}
+
+// TestQueryNSFailsOverToTheNextResolver: resolv.conf commonly lists several
+// nameservers, and asking only the first throws away the redundancy the host is
+// configured for. One unreachable resolver should cost latency, not the answer.
+func TestQueryNSFailsOverToTheNextResolver(t *testing.T) {
+	live := zoneFixture(t)
+
+	c := &DnsClient{
+		config: &dns.ClientConfig{
+			// Nothing listens on 127.0.0.2 at the fixture's port, so answering
+			// at all requires moving on to the second resolver.
+			Servers:  []string{"127.0.0.2", live.Servers[0]},
+			Port:     live.Port,
+			Attempts: 1,
+		},
+		fqdn: "example.test",
+	}
+
+	zone, err := c.Zone()
+	require.NoError(t, err, "an unreachable first resolver must fail over, not fail")
+	assert.Equal(t, "example.test", zone)
+}
+
+// TestZoneStillErrorsWhenNoResolverAnswers keeps the property the retry must not
+// weaken. A resolver outage is not evidence that a name belongs to no zone, and
+// reporting an empty zone for it would make a check filtered on the zone skip
+// silently.
+func TestZoneStillErrorsWhenNoResolverAnswers(t *testing.T) {
+	c := &DnsClient{config: deadResolverConfig(t, 2, 2), fqdn: "www.example.test"}
+
+	zone, err := c.Zone()
+	require.Error(t, err, "an unreachable resolver must not read as a name with no zone")
+	assert.Empty(t, zone)
+	assert.Contains(t, err.Error(), "querying NS for")
+}
+
+func TestQueryNSWithoutAResolverIsAnError(t *testing.T) {
+	c := &DnsClient{config: &dns.ClientConfig{Port: "53"}, fqdn: "example.test"}
+
+	_, err := c.queryNS("example.test")
+	require.Error(t, err, "no configured resolver cannot silently mean no zone")
+}
+
+// TestAuthoritativeNameserversEndsTheWalkOnAQueryFailure pins the behaviour
+// change #10542 made to a shipped field. Before it, a lost reply at the queried
+// name climbed to the parent and returned the parent's nameservers, which answer
+// referrals rather than the records the caller wanted. It is an error now, and
+// after the retry above it takes a resolver that really cannot answer.
+func TestAuthoritativeNameserversEndsTheWalkOnAQueryFailure(t *testing.T) {
+	c := &DnsClient{config: deadResolverConfig(t, 1, 1), fqdn: "www.example.test"}
+
+	addrs, err := c.authoritativeNameservers()
+	require.Error(t, err)
+	assert.Empty(t, addrs)
+	assert.Contains(t, err.Error(), "querying NS for")
+}
+
+// TestAuthoritativeNameserversClimbsPastAnUnresolvableDelegation is the
+// leniency the walk keeps, and the reason walkToDelegation takes an accept
+// callback: a delegation whose nameservers do not resolve is not usable, so the
+// walk continues to one that is. The injected resolver is what makes this
+// reachable in a test at all.
+func TestAuthoritativeNameserversClimbsPastAnUnresolvableDelegation(t *testing.T) {
+	var asked []string
+	c := &DnsClient{
+		config: zoneFixture(t),
+		fqdn:   "vpn.corp.example.test",
+		lookupHost: func(name string) ([]string, error) {
+			asked = append(asked, name)
+			// corp.example.test's nameserver does not resolve; example.test's does.
+			switch name {
+			case "ns1.corp.example.test":
+				return nil, &net.DNSError{Err: "no such host", Name: name, IsNotFound: true}
+			case "ns1.example.test":
+				return []string{"192.0.2.1"}, nil
+			default:
+				return []string{"192.0.2.2"}, nil
+			}
+		},
+	}
+
+	addrs, err := c.authoritativeNameservers()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"192.0.2.1", "192.0.2.2"}, addrs,
+		"every resolvable nameserver of the accepted zone should be returned")
+	assert.Equal(t, []string{"ns1.corp.example.test", "ns1.example.test", "ns2.example.test"}, asked,
+		"the unresolvable delegation should be tried first, then the walk continues to the parent")
+}

--- a/providers/network/resources/dnsshake/zone_internal_test.go
+++ b/providers/network/resources/dnsshake/zone_internal_test.go
@@ -72,7 +72,9 @@ func zoneFixture(t *testing.T) *dns.ClientConfig {
 	host, port, err := net.SplitHostPort(pc.LocalAddr().String())
 	require.NoError(t, err)
 
-	return &dns.ClientConfig{Servers: []string{host}, Port: port, Timeout: 2, Attempts: 1}
+	// Attempts is honoured by queryNS; Timeout is not, because queryDnsTypeAt
+	// builds a dns.Client with the library default and never reads it.
+	return &dns.ClientConfig{Servers: []string{host}, Port: port, Attempts: 1}
 }
 
 func fixtureClient(t *testing.T, fqdn string) *DnsClient {
@@ -87,8 +89,9 @@ func TestZone(t *testing.T) {
 		want string
 	}{
 		{"an apex is its own zone", "example.test", "example.test"},
+		// www.example.test is a CNAME, so this also covers that answering
+		// successfully and carrying NS records are two different questions.
 		{"a name inside a zone reports the apex", "www.example.test", "example.test"},
-		{"a CNAME answer is not a delegation", "www.example.test", "example.test"},
 		{"a delegated subdomain is its own zone", "corp.example.test", "corp.example.test"},
 		{"a name inside a delegated subzone reports that subzone", "vpn.corp.example.test", "corp.example.test"},
 		{"a name under no zone reports none", "absent.test", ""},


### PR DESCRIPTION
Follow-up to #10542.

## The problem

#10542 made the delegation walk end on a query that did not happen rather than climb past it, and that is the right call: climbing answered with whichever ancestor did respond and hid the delegation below it, so a failed query at `cs.cmu.edu` reported `cmu.edu` as the zone.

But the query it is strict about sends **one UDP datagram to one resolver**. `queryDnsTypeAt` builds a `dns.Client{}` that reads neither `config.Attempts` nor `config.Servers` past the first entry — with two resolvers configured and `Attempts: 3`, the wire carries exactly one question. So a single dropped reply read as "no resolver could answer" and failed `dns.zone`, `dns.authoritativeParams` and `dns.authoritativeRecords`.

Not hypothetical. Against live DNS on an ordinary connection:

```
error: querying NS for mondoo.com: read udp 192.168.x.x:53632->8.8.8.8:53: i/o timeout
```

`authoritativeNameservers` is the sharper edge, because it is a field that shipped long before #10542. It used to `continue` past a lost reply and return the parent's nameservers; now one lost packet errors the field.

## The fix

The walk's NS query goes through a new `queryNS`, which asks every configured resolver, `config.Attempts` times each, before reporting failure.

The strictness is unchanged and so is every answer. Only a **transport failure** is retried; anything the resolver actually said — NXDOMAIN, or a response carrying no NS records — returns immediately for the caller to interpret exactly as before. What changes is what an error *means*: no resolver could answer, which is the claim the walk needs in order to treat it as a reason to stop.

## Making the changed field testable

The behaviour change #10542 made to `authoritativeNameservers` had no test either way, and could not easily have one: it resolves nameserver names through `net.LookupHost`, so a fixture's answers would have to resolve on the host running the tests. `lookupHost` is now a field on `DnsClient` defaulting to `net.LookupHost`, which lets a test serve the whole walk from its own fixture. Two tests use it to pin both sides of that field's contract — a query failure ends the walk with an error, and a delegation whose nameservers do not resolve is still climbed past.

## Tests

All confirmed to fail without the change, by reverting `queryNS` to single-shot / first-resolver-only:

- a lost reply is retried and does not surface — and the fixture asserts the retry *happened*, rather than only that nothing went wrong
- an unreachable first resolver fails over to the second
- every resolver failing is still an error, because a resolver outage is not evidence that a name belongs to no zone
- no configured resolver is an error, not an empty zone

Two smaller things in the existing test file: a table case repeated the previous row's input and expectation verbatim under a second name, and the fixture set a `Timeout` that `queryDnsTypeAt` never reads. The duplicate is gone, and the comment now says which of the two fields is in effect — `Attempts` being one `queryNS` honours.

## Verification

`go test ./...` green in `providers/network`. Re-verified with a provider built from this branch that #10542's behaviour is untouched:

| target | `dns.zone.fqdn` |
|---|---|
| `mondoo.com` | `mondoo.com` |
| `www.mondoo.com` | `mondoo.com` |
| `cs.cmu.edu` | `cs.cmu.edu` |
| `www.cs.cmu.edu` | `cs.cmu.edu` |
| `eecs.berkeley.edu` | `eecs.berkeley.edu` |
| `1.1.1.1` | null |
| `nonexistent-zone-476.example` | null |

`dns.zone.dnssec.enabled` still reads `true` through a name that publishes no DNSSEC of its own, and `dns.authoritativeRecords` still resolves.

No schema change, so no `.lr` or `.lr.versions` entry; `config.go` untouched.

## Known, not addressed

`queryDnsTypeAt` still ignores `config.Timeout` and still queries only `Servers[0]` for every non-NS record type. Giving the whole record sweep the same treatment is a larger change with a wider blast radius on scan latency, so this stays scoped to the walk whose strictness created the exposure.
