### PR TITLE
🐛 network: retry the NS walk instead of silently answering from the parent zone (v13 backport)

### DIFF
--- a/providers/network/resources/dnsshake/dnsshake.go
+++ b/providers/network/resources/dnsshake/dnsshake.go
@@ -19,6 +19,22 @@ type DnsClient struct {
 	config *dns.ClientConfig
 	fqdn   string
 	sync   sync.Mutex
+
+	// lookupHost resolves a nameserver's name to addresses, defaulting to
+	// net.LookupHost. It is a field so a test can serve the whole delegation
+	// walk from its own fixture: authoritativeNameservers is otherwise
+	// untestable, because the nameserver names a fixture hands back would have
+	// to resolve through the host's real resolver.
+	lookupHost func(string) ([]string, error)
+}
+
+// resolveHost resolves a nameserver name, through the injected resolver when a
+// test supplied one.
+func (d *DnsClient) resolveHost(name string) ([]string, error) {
+	if d.lookupHost != nil {
+		return d.lookupHost(name)
+	}
+	return net.LookupHost(name)
 }
 
 type DnsRecord struct {
@@ -265,6 +281,55 @@ func (d *DnsClient) QueryAuthoritative(dnsTypes ...string) (map[string]DnsRecord
 	return res, errs.Deduplicate()
 }
 
+// queryNS asks for the NS records at a name, retrying across the configured
+// resolvers before reporting failure.
+//
+// queryDnsTypeAt sends one datagram to one server and reports a lost reply as a
+// failure, and the walk below reads a failure at a name as that name not being
+// a zone, so it climbs to the parent and answers with the parent's nameservers.
+// Those serve referrals rather than the records the caller wanted, which is how
+// a single dropped UDP packet turned authoritativeRecords into a silently wrong
+// answer instead of a slow one. A resolver is asked config.Attempts times, and
+// every configured resolver is asked, so reaching the walk's failure path means
+// no resolver could answer rather than that one packet went missing.
+//
+// Only a transport failure is retried. Any answer is the resolver having
+// answered, NXDOMAIN and a response carrying no NS records included, and what
+// it means is the caller's decision.
+func (d *DnsClient) queryNS(zone string) (map[string]DnsRecord, error) {
+	if len(d.config.Servers) == 0 {
+		return nil, errors.New("no resolver configured to query NS for " + zone)
+	}
+
+	attempts := d.config.Attempts
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < attempts; attempt++ {
+		for _, server := range d.config.Servers {
+			records, err := d.queryDnsTypeAt(server, true, zone, "NS")
+			if err != nil {
+				lastErr = err
+				continue
+			}
+
+			// queryDnsTypeAt reports a transport failure inside the record
+			// rather than as an error, so this is where a lost reply looks like
+			// one.
+			if ns, ok := records["NS"]; ok && ns.Error != nil {
+				lastErr = ns.Error
+				continue
+			}
+
+			return records, nil
+		}
+	}
+
+	return nil, errors.Wrapf(lastErr, "querying NS for %s", zone)
+}
+
 // authoritativeNameservers finds the addresses of the nameservers serving the
 // zone that contains the client's fqdn.
 //
@@ -280,12 +345,22 @@ func (d *DnsClient) authoritativeNameservers() ([]string, error) {
 		return nil, errors.New("cannot determine authoritative nameservers without a domain name")
 	}
 
+	// queryErr remembers the last query that could not be answered, so a walk
+	// that failed everywhere says why instead of only that it found nothing.
+	var queryErr error
+
 	for labels := dns.SplitDomainName(name); len(labels) > 0; labels = labels[1:] {
 		zone := strings.Join(labels, ".")
 
-		records, err := d.queryDnsTypeAt(d.config.Servers[0], true, zone, "NS")
+		records, err := d.queryNS(zone)
 		if err != nil {
-			return nil, err
+			// Every resolver failed for this name. Climbing on is the behaviour
+			// this branch has always had and it is kept deliberately, but the
+			// cause is worth carrying: without it a walk that failed at every
+			// label reports only that nothing was found, which reads as a fact
+			// about the name rather than a resolver that could not be reached.
+			queryErr = err
+			continue
 		}
 
 		ns, ok := records["NS"]
@@ -298,7 +373,7 @@ func (d *DnsClient) authoritativeNameservers() ([]string, error) {
 			// Nameservers are named, so each one needs resolving to an address
 			// before it can be queried. Skip any that do not resolve; as long as
 			// one does, the zone is reachable.
-			ips, err := net.LookupHost(strings.TrimSuffix(host, "."))
+			ips, err := d.resolveHost(strings.TrimSuffix(host, "."))
 			if err != nil {
 				continue
 			}
@@ -308,6 +383,10 @@ func (d *DnsClient) authoritativeNameservers() ([]string, error) {
 		if len(addrs) > 0 {
 			return addrs, nil
 		}
+	}
+
+	if queryErr != nil {
+		return nil, errors.Wrapf(queryErr, "no authoritative nameserver found for %s", d.fqdn)
 	}
 
 	return nil, errors.New("no authoritative nameserver found for " + d.fqdn)

--- a/providers/network/resources/dnsshake/walk_resilience_internal_test.go
+++ b/providers/network/resources/dnsshake/walk_resilience_internal_test.go
@@ -1,0 +1,252 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package dnsshake
+
+import (
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// authoritativeNameservers walks up the labels until a name answers with NS
+// records, and reads a query it could not get an answer to as that name not
+// being a zone. It then climbs, and answers with the parent's nameservers.
+//
+// That is only a safe reading if a query that could have been answered was, and
+// one UDP datagram to one resolver is not that. A lost reply at a delegated
+// subzone silently returned the parent's nameservers, which serve referrals
+// rather than the records the caller asked for. Since authoritativeRecords
+// exists to read the TTLs a zone is configured with rather than a cache's
+// countdown, that is a wrong answer, not a slow one.
+
+// walkFixture serves a small zone tree, optionally dropping the first replies
+// for one name so a caller sees a lost datagram before a real answer:
+//
+//   - example.test answers NS at its own name
+//   - corp.example.test is delegated, so it answers NS too and is a zone of its
+//     own, which is the name a climb would skip past
+//   - every other name answers NOERROR with nothing
+type walkFixture struct {
+	mu        sync.Mutex
+	dropName  string
+	dropFirst int
+	queries   int
+	dropped   int
+}
+
+func (f *walkFixture) serve(t *testing.T) *dns.ClientConfig {
+	t.Helper()
+
+	delegations := map[string][]string{
+		"example.test.":      {"ns1.example.test.", "ns2.example.test."},
+		"corp.example.test.": {"ns1.corp.example.test."},
+	}
+
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", func(w dns.ResponseWriter, r *dns.Msg) {
+		q := r.Question[0]
+
+		f.mu.Lock()
+		f.queries++
+		drop := q.Name == f.dropName && f.dropped < f.dropFirst
+		if drop {
+			f.dropped++
+		}
+		f.mu.Unlock()
+
+		if drop {
+			// No reply at all: the client waits and reports a timeout, which is
+			// what a lost datagram looks like.
+			return
+		}
+
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Authoritative = true
+		if q.Qtype == dns.TypeNS {
+			for _, ns := range delegations[q.Name] {
+				m.Answer = append(m.Answer, &dns.NS{
+					Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 300},
+					Ns:  ns,
+				})
+			}
+		}
+		_ = w.WriteMsg(m)
+	})
+
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := &dns.Server{PacketConn: pc, Handler: mux}
+	go func() { _ = srv.ActivateAndServe() }()
+	t.Cleanup(func() { _ = srv.Shutdown() })
+
+	host, port, err := net.SplitHostPort(pc.LocalAddr().String())
+	require.NoError(t, err)
+
+	// Attempts is honoured by queryNS. Timeout is not, because queryDnsTypeAt
+	// builds a dns.Client with the library default and never reads it.
+	return &dns.ClientConfig{Servers: []string{host}, Port: port, Attempts: 2}
+}
+
+func (f *walkFixture) counts() (queries, dropped int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.queries, f.dropped
+}
+
+// resolveEachNameserver resolves any nameserver name to a distinct address and
+// records what it was asked, which is how these tests see which zone the walk
+// settled on.
+func resolveEachNameserver(asked *[]string) func(string) ([]string, error) {
+	addrs := map[string]string{
+		"ns1.corp.example.test": "192.0.2.10",
+		"ns1.example.test":      "192.0.2.1",
+		"ns2.example.test":      "192.0.2.2",
+	}
+	return func(name string) ([]string, error) {
+		*asked = append(*asked, name)
+		if ip, ok := addrs[name]; ok {
+			return []string{ip}, nil
+		}
+		return nil, &net.DNSError{Err: "no such host", Name: name, IsNotFound: true}
+	}
+}
+
+// deadResolverConfig points at a port nothing listens on, so every query is
+// lost rather than answered.
+func deadResolverConfig(t *testing.T, servers, attempts int) *dns.ClientConfig {
+	t.Helper()
+
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	_, port, err := net.SplitHostPort(pc.LocalAddr().String())
+	require.NoError(t, err)
+	require.NoError(t, pc.Close())
+
+	addrs := make([]string, servers)
+	for i := range addrs {
+		addrs[i] = "127.0.0.1"
+	}
+	return &dns.ClientConfig{Servers: addrs, Port: port, Attempts: attempts}
+}
+
+// TestAuthoritativeNameserversRetriesALostReply is the bug: one lost datagram at
+// a delegated subzone used to hand back the parent's nameservers, and nothing
+// said so.
+func TestAuthoritativeNameserversRetriesALostReply(t *testing.T) {
+	f := &walkFixture{dropName: "corp.example.test.", dropFirst: 1}
+
+	var asked []string
+	c := &DnsClient{
+		config:     f.serve(t),
+		fqdn:       "vpn.corp.example.test",
+		lookupHost: resolveEachNameserver(&asked),
+	}
+
+	addrs, err := c.authoritativeNameservers()
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"192.0.2.10"}, addrs,
+		"a retried query should settle on corp.example.test, not climb to its parent")
+	assert.Equal(t, []string{"ns1.corp.example.test"}, asked,
+		"the parent's nameservers should never have been reached")
+
+	_, dropped := f.counts()
+	assert.Equal(t, 1, dropped, "the fixture should have dropped exactly one reply")
+}
+
+// TestAuthoritativeNameserversFailsOverToTheNextResolver: resolv.conf commonly
+// lists several nameservers, and asking only the first throws away the
+// redundancy the host is configured for.
+func TestAuthoritativeNameserversFailsOverToTheNextResolver(t *testing.T) {
+	f := &walkFixture{}
+	live := f.serve(t)
+
+	var asked []string
+	c := &DnsClient{
+		config: &dns.ClientConfig{
+			// Nothing listens on 127.0.0.2 at the fixture's port, so answering
+			// at all requires moving on to the second resolver.
+			Servers:  []string{"127.0.0.2", live.Servers[0]},
+			Port:     live.Port,
+			Attempts: 1,
+		},
+		fqdn:       "corp.example.test",
+		lookupHost: resolveEachNameserver(&asked),
+	}
+
+	addrs, err := c.authoritativeNameservers()
+	require.NoError(t, err, "an unreachable first resolver must fail over, not fall through the walk")
+	assert.Equal(t, []string{"192.0.2.10"}, addrs)
+}
+
+// TestAuthoritativeNameserversStillClimbsPastAnUnresolvableDelegation is the
+// leniency this backport keeps. A delegation whose nameservers do not resolve is
+// not usable, so the walk continues to one that is. This is behaviour, not an
+// accident, and the retry must not change it.
+func TestAuthoritativeNameserversStillClimbsPastAnUnresolvableDelegation(t *testing.T) {
+	f := &walkFixture{}
+
+	var asked []string
+	c := &DnsClient{
+		config: f.serve(t),
+		fqdn:   "vpn.corp.example.test",
+		lookupHost: func(name string) ([]string, error) {
+			asked = append(asked, name)
+			if name == "ns1.corp.example.test" {
+				return nil, &net.DNSError{Err: "no such host", Name: name, IsNotFound: true}
+			}
+			return resolveEachNameserver(new([]string))(name)
+		},
+	}
+
+	addrs, err := c.authoritativeNameservers()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"192.0.2.1", "192.0.2.2"}, addrs)
+	assert.Equal(t, []string{"ns1.corp.example.test", "ns1.example.test", "ns2.example.test"}, asked,
+		"the unresolvable delegation is tried first, then the walk continues to the parent")
+}
+
+// TestAuthoritativeNameserversReportsWhyWhenNoResolverAnswers: a walk that could
+// not reach a resolver at any label used to report only that it found nothing,
+// which reads as a fact about the name.
+func TestAuthoritativeNameserversReportsWhyWhenNoResolverAnswers(t *testing.T) {
+	c := &DnsClient{config: deadResolverConfig(t, 2, 2), fqdn: "vpn.corp.example.test"}
+
+	addrs, err := c.authoritativeNameservers()
+	require.Error(t, err)
+	assert.Empty(t, addrs)
+	assert.Contains(t, err.Error(), "no authoritative nameserver found for vpn.corp.example.test")
+	assert.Contains(t, err.Error(), "querying NS for",
+		"the terminal error should carry the query that could not be answered")
+}
+
+func TestAuthoritativeNameserversRejectsRootStill(t *testing.T) {
+	for _, fqdn := range []string{"", "."} {
+		c := &DnsClient{config: deadResolverConfig(t, 1, 1), fqdn: fqdn}
+		_, err := c.authoritativeNameservers()
+		assert.Error(t, err, "fqdn %q must not walk to the root", fqdn)
+	}
+}
+
+func TestQueryNSWithoutAResolverIsAnError(t *testing.T) {
+	c := &DnsClient{config: &dns.ClientConfig{Port: "53"}, fqdn: "example.test"}
+
+	_, err := c.queryNS("example.test")
+	require.Error(t, err, "no configured resolver cannot silently mean no delegation")
+}
+
+func TestWalkFixturePortIsNumeric(t *testing.T) {
+	// Guards the fixture itself: a non-numeric port would make every query fail
+	// and every assertion above would be testing the failure path by accident.
+	f := &walkFixture{}
+	_, err := strconv.Atoi(f.serve(t).Port)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Backport of #10543 to `v13`.

## Why this is not the same diff

#10543 was written against the shared delegation walk that #10542 introduced, and **neither is on `v13`** — there is no `walkToDelegation`, no `Zone()`, no `dns.zone` field here. So this ports the cause rather than the patch.

`authoritativeNameservers` on this branch has the same single-shot query, and on this branch it fails **worse**.

`queryDnsTypeAt` sends one datagram to one resolver and reports a lost reply as a failure. It reads neither `config.Attempts` nor `config.Servers` past the first entry — with two resolvers configured and `Attempts: 3`, the wire carries exactly one question. The walk then reads a failure at a name as that name not being a zone, climbs, and answers with **the parent's nameservers**.

Those serve referrals, not the zone's records. And `authoritativeRecords` exists precisely to read the TTLs a zone is configured with rather than a caching resolver's countdown, so answering from the parent is a *wrong* answer, not a slow one — and nothing reports that it happened. On `main`, since #10542, the same lost packet is an error. Here it is silent.

The test asserts exactly that. With the fix reverted:

```
--- FAIL: TestAuthoritativeNameserversRetriesALostReply
    expected: []string{"192.0.2.10"}          # corp.example.test's nameserver
    actual  : []string{"192.0.2.1", "192.0.2.2"}  # example.test's — climbed past the subzone
    Messages: a retried query should settle on corp.example.test, not climb to its parent
```

## The change

The NS query goes through a new `queryNS`, which asks every configured resolver, `config.Attempts` times each, before reporting failure. Only a **transport failure** is retried; anything the resolver actually said — NXDOMAIN, or a response carrying no NS records — returns immediately and the walk interprets it exactly as before.

**The climb is deliberately kept.** `main` stops the walk on a failed query because #10542 changed it to. That is a behaviour change and it is not coming to a maintenance branch. Here, a name whose resolvers all fail still climbs, as it always has. What changes is that reaching that path now means no resolver could answer, rather than that one packet went missing. The terminal error also carries the underlying query failure, so a walk that could not reach a resolver at any label says so instead of reporting only that it found nothing.

`lookupHost` is a new field on `DnsClient` defaulting to `net.LookupHost`. Nameserver names were resolved through the host's real resolver, which is why this function had no tests at all: a fixture's answers had to resolve on whatever machine ran them.

## Tests

All confirmed to fail without the change, by reverting `queryNS` to single-shot and first-resolver-only:

- a lost reply at a delegated subzone settles on that subzone instead of climbing — the bug stated as an assertion
- an unreachable first resolver fails over to the second
- a delegation whose nameservers do not resolve is still climbed past, pinning the leniency this backport keeps
- every resolver failing is still an error, and the error now says why
- no configured resolver is an error, not an empty walk
- a guard that the fixture's port is numeric, so a broken fixture cannot make the assertions above pass by testing the failure path

## Scope

No schema change, so no `.lr` or `.lr.versions` entry, and `config.go` is untouched. `go test ./...` green in `providers/network`.

Not backported: `dns.zone` itself (#10542). That is a feature and a new MQL field, and adding one to a maintenance branch is a separate decision — say the word if you want it and I will open that on top of this.

## Known, not addressed

`queryDnsTypeAt` still ignores `config.Timeout` and still queries only `Servers[0]` for every non-NS record type. Giving the whole record sweep the same treatment is a larger change with a wider blast radius on scan latency, and even less appropriate here than on `main`.
