### PR TITLE
🐛 pomxml: resolve ${property} versions, dependencyManagement, and declared licenses

### DIFF
--- a/providers/os/resources/languages/java/pomxml/extractor.go
+++ b/providers/os/resources/languages/java/pomxml/extractor.go
@@ -76,7 +76,7 @@ func (p *pomProject) Direct() languages.Packages {
 		if dep.isTestOrProvided() {
 			continue
 		}
-		direct = append(direct, depToPackage(dep, p.evidence))
+		direct = append(direct, p.depToPackage(dep))
 	}
 	return direct
 }
@@ -86,22 +86,41 @@ func (p *pomProject) Direct() languages.Packages {
 func (p *pomProject) Transitive() languages.Packages {
 	var all languages.Packages
 	for _, dep := range p.Dependencies {
-		all = append(all, depToPackage(dep, p.evidence))
+		all = append(all, p.depToPackage(dep))
 	}
 	return all
 }
 
-func depToPackage(dep pomDependency, evidence []string) *languages.Package {
-	name := dep.ArtifactId
-	if dep.GroupId != "" {
-		name = dep.GroupId + ":" + dep.ArtifactId
+// depToPackage renders one <dependency> as a package, resolving the ${...}
+// property references and the <dependencyManagement> version that decide what
+// the dependency's identity actually is.
+//
+// Both matter beyond tidiness. A version left as the literal "${jackson.version}"
+// produces a purl no advisory database and no package registry can match, so the
+// dependency is silently exempt from vulnerability correlation and from licence
+// lookup alike.
+func (p *pomProject) depToPackage(dep pomDependency) *languages.Package {
+	groupId := p.resolve(dep.GroupId)
+	artifactId := p.resolve(dep.ArtifactId)
+
+	version := p.resolve(dep.Version)
+	if version == "" {
+		// No <version> on the dependency: the project's <dependencyManagement>
+		// is where it is declared, which is the standard way a multi-module
+		// project states a version once.
+		version = p.resolve(p.managedVersion(dep.GroupId, dep.ArtifactId))
+	}
+
+	name := artifactId
+	if groupId != "" {
+		name = groupId + ":" + artifactId
 	}
 
 	return &languages.Package{
 		Name:         name,
-		Version:      dep.Version,
-		Purl:         java.NewPackageUrl(dep.GroupId, dep.ArtifactId, dep.Version),
-		Cpes:         java.NewCpes(dep.GroupId, dep.ArtifactId, dep.Version),
-		EvidenceList: java.NewEvidenceList(evidence),
+		Version:      version,
+		Purl:         java.NewPackageUrl(groupId, artifactId, version),
+		Cpes:         java.NewCpes(groupId, artifactId, version),
+		EvidenceList: java.NewEvidenceList(p.evidence),
 	}
 }

--- a/providers/os/resources/languages/java/pomxml/extractor.go
+++ b/providers/os/resources/languages/java/pomxml/extractor.go
@@ -73,7 +73,7 @@ func (p *pomProject) Root() *languages.Package {
 func (p *pomProject) Direct() languages.Packages {
 	var direct languages.Packages
 	for _, dep := range p.Dependencies {
-		if dep.isTestOrProvided() {
+		if p.isTestOrProvided(dep) {
 			continue
 		}
 		direct = append(direct, p.depToPackage(dep))
@@ -108,7 +108,7 @@ func (p *pomProject) depToPackage(dep pomDependency) *languages.Package {
 		// No <version> on the dependency: the project's <dependencyManagement>
 		// is where it is declared, which is the standard way a multi-module
 		// project states a version once.
-		version = p.resolve(p.managedVersion(dep.GroupId, dep.ArtifactId))
+		version = p.resolve(p.managedVersion(groupId, artifactId))
 	}
 
 	name := artifactId

--- a/providers/os/resources/languages/java/pomxml/extractor.go
+++ b/providers/os/resources/languages/java/pomxml/extractor.go
@@ -61,8 +61,11 @@ func (p *pomProject) Root() *languages.Package {
 	}
 
 	return &languages.Package{
-		Name:         name,
-		Version:      version,
+		Name:    name,
+		Version: version,
+		// <licenses> describes this project, not its dependencies, so it
+		// belongs on the root package and nowhere else.
+		License:      p.licenseExpression(),
 		Purl:         java.NewPackageUrl(groupId, p.ArtifactId, version),
 		Cpes:         java.NewCpes(groupId, p.ArtifactId, version),
 		EvidenceList: java.NewEvidenceList(p.evidence),

--- a/providers/os/resources/languages/java/pomxml/extractor_test.go
+++ b/providers/os/resources/languages/java/pomxml/extractor_test.go
@@ -310,3 +310,92 @@ func TestPomPropertiesUnmarshal(t *testing.T) {
 		assert.NotErrorIs(t, err, io.EOF)
 	})
 }
+
+// A pom.xml states the project's own licenses in <licenses>, and Maven's
+// guidance is that several listed licenses mean the consumer may select any one
+// of them. That is SPDX's OR, which is what LicenseExpression renders, so this
+// extractor reports a license the same way every other one now does rather than
+// being the build manifest that reads none.
+func TestPomXmlReadsDeclaredLicenses(t *testing.T) {
+	t.Run("a single license passes through as written", func(t *testing.T) {
+		p := parsePom(t, `<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.example</groupId><artifactId>myapp</artifactId><version>1.0.0</version>
+  <licenses><license>
+    <name>Apache License, Version 2.0</name>
+    <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+  </license></licenses>
+</project>`)
+		root := p.Root()
+		require.NotNil(t, root)
+		assert.Equal(t, "Apache License, Version 2.0", root.License)
+	})
+
+	t.Run("several licenses are a choice", func(t *testing.T) {
+		p := parsePom(t, `<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.example</groupId><artifactId>myapp</artifactId><version>1.0.0</version>
+  <licenses>
+    <license><name>EPL-2.0</name></license>
+    <license><name>GPL-2.0-with-classpath-exception</name></license>
+  </licenses>
+</project>`)
+		assert.Equal(t, "(EPL-2.0 OR GPL-2.0-with-classpath-exception)", p.Root().License)
+	})
+
+	// The url is a link to the terms, not the identity of the terms. A license
+	// entry that carries only one names nothing this can report.
+	t.Run("a url without a name states no license", func(t *testing.T) {
+		p := parsePom(t, `<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.example</groupId><artifactId>myapp</artifactId><version>1.0.0</version>
+  <licenses><license><url>https://www.apache.org/licenses/LICENSE-2.0.txt</url></license></licenses>
+</project>`)
+		assert.Empty(t, p.Root().License)
+	})
+
+	t.Run("no licenses block states nothing", func(t *testing.T) {
+		p := parsePom(t, `<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.example</groupId><artifactId>myapp</artifactId><version>1.0.0</version>
+</project>`)
+		assert.Empty(t, p.Root().License)
+	})
+
+	// A POM that keeps its license name in a property is stating a license; the
+	// raw reference would match nothing, exactly as it would for a version.
+	t.Run("a property reference is resolved", func(t *testing.T) {
+		p := parsePom(t, `<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.example</groupId><artifactId>myapp</artifactId><version>1.0.0</version>
+  <properties><license.name>MIT</license.name></properties>
+  <licenses><license><name>${license.name}</name></license></licenses>
+</project>`)
+		assert.Equal(t, "MIT", p.Root().License)
+	})
+
+	// <licenses> describes the project, not what it depends on.
+	t.Run("dependencies do not inherit the project's license", func(t *testing.T) {
+		p := parsePom(t, `<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.example</groupId><artifactId>myapp</artifactId><version>1.0.0</version>
+  <licenses><license><name>MIT</name></license></licenses>
+  <dependencies>
+    <dependency><groupId>org.example</groupId><artifactId>dep</artifactId><version>1.0.0</version></dependency>
+  </dependencies>
+</project>`)
+		require.Equal(t, "MIT", p.Root().License)
+		dep := packagesByName(p.Transitive())["org.example:dep"]
+		require.NotNil(t, dep)
+		assert.Empty(t, dep.License, "a dependency's license is not stated by this POM")
+	})
+}
+
+// The shared renderer's bounds apply here too, so a POM cannot put an arbitrary
+// amount of text into a field consumers read as an identifier.
+func TestPomXmlLicenseIsBounded(t *testing.T) {
+	long := strings.Repeat("A", languages.LicenseMaxBytes+1)
+	p := parsePom(t, `<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.example</groupId><artifactId>myapp</artifactId><version>1.0.0</version>
+  <licenses>
+    <license><name>`+long+`</name></license>
+    <license><name>MIT</name></license>
+  </licenses>
+</project>`)
+	assert.Equal(t, "MIT", p.Root().License,
+		"an oversized name is dropped without taking its sibling with it")
+}

--- a/providers/os/resources/languages/java/pomxml/extractor_test.go
+++ b/providers/os/resources/languages/java/pomxml/extractor_test.go
@@ -4,6 +4,8 @@
 package pomxml
 
 import (
+	"encoding/xml"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -148,4 +150,163 @@ func TestPomXmlPropertyCycleTerminates(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("property resolution did not terminate on a cyclic declaration")
 	}
+}
+
+// parsePom is a small helper for the POMs below, which are written inline
+// because each one exists to hold a single shape.
+func parsePom(t *testing.T, pom string) *pomProject {
+	t.Helper()
+	info, err := (&Extractor{}).Parse(strings.NewReader(pom), "pom.xml")
+	require.NoError(t, err)
+	p, ok := info.(*pomProject)
+	require.True(t, ok, "Parse should return a *pomProject")
+	return p
+}
+
+func packagesByName(pkgs languages.Packages) map[string]*languages.Package {
+	out := map[string]*languages.Package{}
+	for _, p := range pkgs {
+		out[p.Name] = p
+	}
+	return out
+}
+
+// A <dependency> and the <dependencyManagement> entry that versions it need not
+// spell their coordinates the same way: writing ${project.groupId} in one and
+// the literal in the other is ordinary, and so is the reverse. Comparing them as
+// written matches only by coincidence, and a miss is silent — the dependency
+// comes out with no version at all, which is the outcome resolving versions was
+// meant to prevent.
+func TestPomXmlManagedVersionMatchesAcrossPropertyReferences(t *testing.T) {
+	t.Run("the dependency uses a property, the management entry is literal", func(t *testing.T) {
+		p := parsePom(t, `<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.example</groupId><artifactId>myapp</artifactId><version>2.5.0</version>
+  <dependencyManagement><dependencies>
+    <dependency><groupId>com.example</groupId><artifactId>myapp-core</artifactId><version>2.5.0</version></dependency>
+  </dependencies></dependencyManagement>
+  <dependencies>
+    <dependency><groupId>${project.groupId}</groupId><artifactId>myapp-core</artifactId></dependency>
+  </dependencies>
+</project>`)
+
+		got := packagesByName(p.Transitive())["com.example:myapp-core"]
+		require.NotNil(t, got)
+		assert.Equal(t, "2.5.0", got.Version)
+		assert.Equal(t, "pkg:maven/com.example/myapp-core@2.5.0", got.Purl)
+	})
+
+	t.Run("the management entry uses a property, the dependency is literal", func(t *testing.T) {
+		p := parsePom(t, `<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.example</groupId><artifactId>myapp</artifactId><version>2.5.0</version>
+  <properties><guava.groupId>com.google.guava</guava.groupId></properties>
+  <dependencyManagement><dependencies>
+    <dependency><groupId>${guava.groupId}</groupId><artifactId>guava</artifactId><version>31.1-jre</version></dependency>
+  </dependencies></dependencyManagement>
+  <dependencies>
+    <dependency><groupId>com.google.guava</groupId><artifactId>guava</artifactId></dependency>
+  </dependencies>
+</project>`)
+
+		got := packagesByName(p.Transitive())["com.google.guava:guava"]
+		require.NotNil(t, got)
+		assert.Equal(t, "31.1-jre", got.Version)
+		assert.Equal(t, "pkg:maven/com.google.guava/guava@31.1-jre", got.Purl)
+	})
+}
+
+// Maven applies a managed scope exactly as it applies a managed version, so the
+// two have to be read together. A dependency omitting both is a test dependency
+// at the managed version; reading only the version promotes it into the
+// production set with a real, matchable purl, and it arrives in an SBOM as
+// something the application ships.
+func TestPomXmlManagedScopeKeepsTestDependenciesOutOfDirect(t *testing.T) {
+	p := parsePom(t, `<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.example</groupId><artifactId>myapp</artifactId><version>2.5.0</version>
+  <dependencyManagement><dependencies>
+    <dependency><groupId>junit</groupId><artifactId>junit</artifactId><version>4.13.2</version><scope>test</scope></dependency>
+    <dependency><groupId>jakarta.servlet</groupId><artifactId>jakarta.servlet-api</artifactId><version>5.0.0</version><scope>provided</scope></dependency>
+    <dependency><groupId>com.google.guava</groupId><artifactId>guava</artifactId><version>31.1-jre</version></dependency>
+  </dependencies></dependencyManagement>
+  <dependencies>
+    <dependency><groupId>junit</groupId><artifactId>junit</artifactId></dependency>
+    <dependency><groupId>jakarta.servlet</groupId><artifactId>jakarta.servlet-api</artifactId></dependency>
+    <dependency><groupId>com.google.guava</groupId><artifactId>guava</artifactId></dependency>
+  </dependencies>
+</project>`)
+
+	direct := packagesByName(p.Direct())
+	assert.NotContains(t, direct, "junit:junit",
+		"a managed test scope must keep the dependency out of the production set")
+	assert.NotContains(t, direct, "jakarta.servlet:jakarta.servlet-api",
+		"a managed provided scope must keep the dependency out of the production set")
+
+	guava := direct["com.google.guava:guava"]
+	require.NotNil(t, guava, "a managed dependency with no scope is still production")
+	assert.Equal(t, "31.1-jre", guava.Version)
+
+	// Transitive is every declared dependency regardless of scope, so the
+	// managed version still has to reach them.
+	all := packagesByName(p.Transitive())
+	require.NotNil(t, all["junit:junit"])
+	assert.Equal(t, "4.13.2", all["junit:junit"].Version)
+}
+
+// A dependency's own scope wins over the managed one, which is what lets a
+// module opt a managed test dependency back into its production set.
+func TestPomXmlDependencyScopeOverridesTheManagedScope(t *testing.T) {
+	p := parsePom(t, `<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.example</groupId><artifactId>myapp</artifactId><version>2.5.0</version>
+  <dependencyManagement><dependencies>
+    <dependency><groupId>junit</groupId><artifactId>junit</artifactId><version>4.13.2</version><scope>test</scope></dependency>
+  </dependencies></dependencyManagement>
+  <dependencies>
+    <dependency><groupId>junit</groupId><artifactId>junit</artifactId><scope>compile</scope></dependency>
+  </dependencies>
+</project>`)
+
+	direct := packagesByName(p.Direct())
+	require.Contains(t, direct, "junit:junit")
+	assert.Equal(t, "4.13.2", direct["junit:junit"].Version)
+}
+
+// <properties> decodes through a custom UnmarshalXML, so what it does with a
+// decoding failure is its own decision and has to be asserted on directly: at
+// the Parse boundary the outer decoder fails on the same malformed document
+// either way, which would make a test here pass whatever UnmarshalXML returned.
+func TestPomPropertiesUnmarshal(t *testing.T) {
+	decodeProperties := func(t *testing.T, doc string) (pomProperties, error) {
+		t.Helper()
+		d := xml.NewDecoder(strings.NewReader(doc))
+		tok, err := d.Token()
+		require.NoError(t, err)
+		start, ok := tok.(xml.StartElement)
+		require.True(t, ok)
+
+		var p pomProperties
+		return p, p.UnmarshalXML(d, start)
+	}
+
+	t.Run("a well-formed block decodes every property", func(t *testing.T) {
+		props, err := decodeProperties(t,
+			`<properties><spring.version>5.3.18</spring.version><jackson.version>2.13.0</jackson.version></properties>`)
+		require.NoError(t, err)
+		assert.Equal(t, pomProperties{"spring.version": "5.3.18", "jackson.version": "2.13.0"}, props)
+	})
+
+	// Swallowing this would leave every version referring to a property in the
+	// block unresolvable, and an unresolvable version is a dependency no
+	// advisory matches — a silent gap rather than a reported one.
+	t.Run("a malformed block is an error", func(t *testing.T) {
+		_, err := decodeProperties(t, `<properties><good>1.0</good><bad>&notanentity;</bad></properties>`)
+		require.Error(t, err)
+	})
+
+	// An early end of document arrives as a syntax error rather than a bare
+	// io.EOF, because the decoder is inside an open element. Singling io.EOF out
+	// would be a branch that never runs.
+	t.Run("a truncated block is an error too", func(t *testing.T) {
+		_, err := decodeProperties(t, `<properties><good>1.0</good>`)
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, io.EOF)
+	})
 }

--- a/providers/os/resources/languages/java/pomxml/extractor_test.go
+++ b/providers/os/resources/languages/java/pomxml/extractor_test.go
@@ -5,10 +5,13 @@ package pomxml
 
 import (
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers/os/resources/languages"
 	"go.mondoo.com/mql/sbom"
 )
 
@@ -52,4 +55,97 @@ func TestPomXmlExtractorSimple(t *testing.T) {
 	p = transitive.Find("javax.servlet:javax.servlet-api")
 	require.NotNil(t, p)
 	assert.Equal(t, "4.0.1", p.Version)
+}
+
+// A version written as ${jackson.version} is how a Maven project keeps a family
+// of artifacts on one version, and it is extremely common. Before properties
+// were resolved, the dependency's version was the literal property reference —
+// which produces a purl that matches no package registry and no advisory, so
+// the dependency was silently exempt from vulnerability correlation and from
+// license lookup alike.
+func TestPomXmlResolvesPropertyVersions(t *testing.T) {
+	f, err := os.Open("./testdata/properties.pom.xml")
+	require.NoError(t, err)
+	defer f.Close()
+
+	info, err := (&Extractor{}).Parse(f, "pom.xml")
+	require.NoError(t, err)
+
+	byName := map[string]*languages.Package{}
+	for _, p := range info.Transitive() {
+		byName[p.Name] = p
+	}
+
+	t.Run("a declared property is substituted", func(t *testing.T) {
+		p := byName["org.springframework:spring-core"]
+		require.NotNil(t, p)
+		assert.Equal(t, "5.3.18", p.Version)
+		assert.Equal(t, "pkg:maven/org.springframework/spring-core@5.3.18", p.Purl)
+	})
+
+	t.Run("a property whose value is another property resolves through", func(t *testing.T) {
+		p := byName["com.fasterxml.jackson.core:jackson-databind"]
+		require.NotNil(t, p)
+		assert.Equal(t, "2.13.0", p.Version)
+		assert.Equal(t, "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.0", p.Purl)
+	})
+
+	t.Run("project.version is a built-in", func(t *testing.T) {
+		p := byName["com.example:myapp-core"]
+		require.NotNil(t, p)
+		assert.Equal(t, "2.5.0", p.Version)
+	})
+
+	t.Run("dependencyManagement supplies an omitted version", func(t *testing.T) {
+		p := byName["com.google.guava:guava"]
+		require.NotNil(t, p)
+		assert.Equal(t, "31.1-jre", p.Version)
+		assert.Equal(t, "pkg:maven/com.google.guava/guava@31.1-jre", p.Purl)
+	})
+
+	// An unresolvable reference stays as written. Substituting a guess would
+	// report the dependency at some other version's identity, matching that
+	// version's advisories and that version's license; leaving the reference
+	// intact keeps the gap visible to whatever reads it.
+	t.Run("an undeclared property is not guessed at", func(t *testing.T) {
+		p := byName["org.example:mystery"]
+		require.NotNil(t, p)
+		assert.Equal(t, "${undeclared.version}", p.Version)
+	})
+}
+
+// A property may refer to itself, directly or through a cycle. Resolution must
+// terminate rather than spin, and must not invent a value.
+func TestPomXmlPropertyCycleTerminates(t *testing.T) {
+	pom := `<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>g</groupId><artifactId>a</artifactId><version>1.0</version>
+  <properties><a.version>${b.version}</a.version><b.version>${a.version}</b.version></properties>
+  <dependencies>
+    <dependency><groupId>g</groupId><artifactId>dep</artifactId><version>${a.version}</version></dependency>
+  </dependencies>
+</project>`
+	done := make(chan *languages.Package, 1)
+	go func() {
+		info, err := (&Extractor{}).Parse(strings.NewReader(pom), "pom.xml")
+		if err != nil {
+			done <- nil
+			return
+		}
+		for _, p := range info.Transitive() {
+			if p.Name == "g:dep" {
+				done <- p
+				return
+			}
+		}
+		done <- nil
+	}()
+	select {
+	case p := <-done:
+		require.NotNil(t, p)
+		// Whatever it settles on, it must still look unresolved rather than
+		// having been given a fabricated version.
+		assert.Contains(t, p.Version, "${")
+	case <-time.After(10 * time.Second):
+		t.Fatal("property resolution did not terminate on a cyclic declaration")
+	}
 }

--- a/providers/os/resources/languages/java/pomxml/parser.go
+++ b/providers/os/resources/languages/java/pomxml/parser.go
@@ -6,6 +6,8 @@ package pomxml
 import (
 	"encoding/xml"
 	"strings"
+
+	"go.mondoo.com/mql/providers/os/resources/languages"
 )
 
 // pomProject represents a parsed Maven pom.xml file.
@@ -29,6 +31,16 @@ type pomProject struct {
 		Dependencies []pomDependency `xml:"dependencies>dependency"`
 	} `xml:"dependencyManagement"`
 	Dependencies []pomDependency `xml:"dependencies>dependency"`
+	// Licenses are the licenses the POM declares for the project itself, not for
+	// its dependencies. Maven's own guidance is that several listed licenses
+	// mean the consumer may select any one of them, so the list is a choice and
+	// renders as SPDX's OR.
+	//
+	// Only this POM's own block is read. Maven inherits <licenses> from a parent
+	// POM, and resolving that needs the parent artifact, which is not available
+	// from the file on disk. A module that states none reports none rather than
+	// guessing at what it would inherit.
+	Licenses []pomLicense `xml:"licenses>license"`
 
 	// evidence is a list of file paths where the pom.xml was found.
 	evidence []string `json:"-"`
@@ -205,6 +217,29 @@ func (p *pomProject) effectiveScope(dep pomDependency) string {
 func (p *pomProject) isTestOrProvided(dep pomDependency) bool {
 	scope := p.effectiveScope(dep)
 	return scope == "test" || scope == "provided"
+}
+
+// pomLicense is one <license> entry. Maven records a name and a link to the
+// terms; only the name is carried, because a link to the terms is not the
+// identity of the terms, and a URL in a field consumers compare against
+// "Apache-2.0" matches nothing while reading as a stated identifier.
+type pomLicense struct {
+	Name string `xml:"name"`
+	URL  string `xml:"url"`
+}
+
+// licenseExpression renders the project's declared licenses as a single SPDX
+// expression, resolving ${...} references the same way a version is resolved:
+// a POM that keeps its license name in a property is stating a license, and
+// reporting the raw reference would match nothing.
+func (p *pomProject) licenseExpression() string {
+	names := make([]string, 0, len(p.Licenses))
+	for _, l := range p.Licenses {
+		if name := strings.TrimSpace(p.resolve(l.Name)); name != "" {
+			names = append(names, name)
+		}
+	}
+	return languages.LicenseExpression(names)
 }
 
 // pomParent represents the parent POM reference.

--- a/providers/os/resources/languages/java/pomxml/parser.go
+++ b/providers/os/resources/languages/java/pomxml/parser.go
@@ -45,9 +45,16 @@ func (p *pomProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 	for {
 		tok, err := d.Token()
 		if err != nil {
-			// io.EOF on a truncated document: keep what was read rather than
-			// discarding every property because the file ended early.
-			return nil //nolint:nilerr
+			// Every error reaching here is a decoding failure, an early end of
+			// document included: inside an open <properties> element the
+			// decoder reports that as an *xml.SyntaxError ("unexpected EOF"),
+			// never a bare io.EOF, and a well-formed block returns at its
+			// EndElement before EOF is reachable at all. So there is no case to
+			// single out, and reporting the failure matters here: a property
+			// that silently fails to load makes every version referring to it
+			// unresolvable, and an unresolvable version is a dependency no
+			// advisory can match.
+			return err
 		}
 		switch t := tok.(type) {
 		case xml.StartElement:
@@ -144,15 +151,60 @@ func (p *pomProject) property(name string) (string, bool) {
 	return v, true
 }
 
+// managedDependency finds the <dependencyManagement> entry for a dependency.
+//
+// groupId and artifactId must already be resolved, and the entry's own
+// coordinates are resolved before comparing, because either side may be written
+// as a property: a <dependency> commonly says ${project.groupId} where the
+// management section says the literal, and a management section importing a
+// family of artifacts commonly does the reverse. Comparing the two as written
+// matches only when they happen to be spelled the same way, and a miss is
+// silent: the dependency simply comes out with no version, which is the outcome
+// resolving versions at all was meant to prevent.
+func (p *pomProject) managedDependency(groupId, artifactId string) (pomDependency, bool) {
+	for _, m := range p.DependencyManagement.Dependencies {
+		if p.resolve(m.GroupId) == groupId && p.resolve(m.ArtifactId) == artifactId {
+			return m, true
+		}
+	}
+	return pomDependency{}, false
+}
+
 // managedVersion returns the version <dependencyManagement> declares for a
 // dependency, which is what applies when the <dependency> states none.
 func (p *pomProject) managedVersion(groupId, artifactId string) string {
-	for _, m := range p.DependencyManagement.Dependencies {
-		if m.GroupId == groupId && m.ArtifactId == artifactId {
-			return m.Version
-		}
+	m, ok := p.managedDependency(groupId, artifactId)
+	if !ok {
+		return ""
 	}
-	return ""
+	return m.Version
+}
+
+// effectiveScope reports the scope that applies to a dependency: its own when it
+// states one, otherwise the scope <dependencyManagement> declares.
+//
+// Maven applies a managed scope exactly as it applies a managed version, and the
+// two have to be read together. A <dependency> on junit that omits both, against
+// a management section declaring 4.13.2 and scope test, is a test dependency at
+// 4.13.2 — reading only the version promotes it into the production set with a
+// real, matchable purl, so it arrives in an SBOM as something the application
+// ships.
+func (p *pomProject) effectiveScope(dep pomDependency) string {
+	if scope := p.resolve(dep.Scope); scope != "" {
+		return scope
+	}
+	m, ok := p.managedDependency(p.resolve(dep.GroupId), p.resolve(dep.ArtifactId))
+	if !ok {
+		return ""
+	}
+	return p.resolve(m.Scope)
+}
+
+// isTestOrProvided reports whether a dependency's effective scope makes it a
+// non-production dependency.
+func (p *pomProject) isTestOrProvided(dep pomDependency) bool {
+	scope := p.effectiveScope(dep)
+	return scope == "test" || scope == "provided"
 }
 
 // pomParent represents the parent POM reference.
@@ -191,9 +243,4 @@ func (p *pomProject) effectiveVersion() string {
 		return p.Parent.Version
 	}
 	return ""
-}
-
-// isTestOrProvided returns true if the dependency scope indicates a non-production dependency.
-func (d *pomDependency) isTestOrProvided() bool {
-	return d.Scope == "test" || d.Scope == "provided"
 }

--- a/providers/os/resources/languages/java/pomxml/parser.go
+++ b/providers/os/resources/languages/java/pomxml/parser.go
@@ -3,19 +3,156 @@
 
 package pomxml
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+	"strings"
+)
 
 // pomProject represents a parsed Maven pom.xml file.
 type pomProject struct {
-	XMLName      xml.Name        `xml:"project"`
-	GroupId      string          `xml:"groupId"`
-	ArtifactId   string          `xml:"artifactId"`
-	Version      string          `xml:"version"`
-	Parent       *pomParent      `xml:"parent"`
+	XMLName    xml.Name   `xml:"project"`
+	GroupId    string     `xml:"groupId"`
+	ArtifactId string     `xml:"artifactId"`
+	Version    string     `xml:"version"`
+	Parent     *pomParent `xml:"parent"`
+	// Properties are the user-defined ${...} substitutions a POM declares. A
+	// version written as ${jackson.version} is extremely common — it is how a
+	// project keeps a family of artifacts on one version — and without the bag
+	// the dependency's version is the literal property reference, which matches
+	// no package and no advisory.
+	Properties pomProperties `xml:"properties"`
+	// DependencyManagement holds versions declared once for the whole project
+	// (or imported from a BOM). A <dependency> under <dependencies> may then
+	// omit its <version> entirely, and the version stated here is the one that
+	// applies.
+	DependencyManagement struct {
+		Dependencies []pomDependency `xml:"dependencies>dependency"`
+	} `xml:"dependencyManagement"`
 	Dependencies []pomDependency `xml:"dependencies>dependency"`
 
 	// evidence is a list of file paths where the pom.xml was found.
 	evidence []string `json:"-"`
+}
+
+// pomProperties decodes <properties> as arbitrary child elements, which is what
+// it is: every child element is a user-named property.
+type pomProperties map[string]string
+
+func (p *pomProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	if *p == nil {
+		*p = map[string]string{}
+	}
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			// io.EOF on a truncated document: keep what was read rather than
+			// discarding every property because the file ended early.
+			return nil //nolint:nilerr
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			var v string
+			if err := d.DecodeElement(&v, &t); err != nil {
+				return err
+			}
+			(*p)[t.Name.Local] = strings.TrimSpace(v)
+		case xml.EndElement:
+			if t.Name.Local == start.Name.Local {
+				return nil
+			}
+		}
+	}
+}
+
+// maxPropertyDepth bounds property resolution. A property may refer to another
+// property, and a POM may declare a cycle; the depth cap terminates both.
+const maxPropertyDepth = 10
+
+// resolve substitutes ${...} references in s using the project's properties and
+// Maven's built-in project coordinates.
+//
+// An unresolvable reference is returned UNCHANGED, deliberately. A version this
+// parser cannot resolve is not a version, and substituting a guess would report
+// a dependency at some other version's identity — matching that version's
+// advisories and that version's license. Leaving the reference intact keeps the
+// gap visible to whatever reads it.
+func (p *pomProject) resolve(s string) string {
+	for depth := 0; depth < maxPropertyDepth; depth++ {
+		if !strings.Contains(s, "${") {
+			return s
+		}
+		next := p.expandOnce(s)
+		if next == s {
+			// Nothing more can be substituted; the rest stays as written.
+			return s
+		}
+		s = next
+	}
+	return s
+}
+
+// expandOnce replaces every ${...} reference it can resolve, once.
+func (p *pomProject) expandOnce(s string) string {
+	var b strings.Builder
+	for {
+		start := strings.Index(s, "${")
+		if start < 0 {
+			b.WriteString(s)
+			return b.String()
+		}
+		end := strings.Index(s[start:], "}")
+		if end < 0 {
+			b.WriteString(s)
+			return b.String()
+		}
+		end += start
+		name := s[start+2 : end]
+		b.WriteString(s[:start])
+		if v, ok := p.property(name); ok {
+			b.WriteString(v)
+		} else {
+			b.WriteString(s[start : end+1])
+		}
+		s = s[end+1:]
+	}
+}
+
+// property resolves one property name: Maven's built-in project coordinates
+// first, since a POM cannot redefine them, then the <properties> bag.
+func (p *pomProject) property(name string) (string, bool) {
+	switch name {
+	case "project.version", "pom.version", "version":
+		if v := p.effectiveVersion(); v != "" {
+			return v, true
+		}
+		return "", false
+	case "project.groupId", "pom.groupId", "groupId":
+		if v := p.effectiveGroupId(); v != "" {
+			return v, true
+		}
+		return "", false
+	case "project.artifactId", "pom.artifactId", "artifactId":
+		if p.ArtifactId != "" {
+			return p.ArtifactId, true
+		}
+		return "", false
+	}
+	v, ok := p.Properties[name]
+	if !ok || v == "" {
+		return "", false
+	}
+	return v, true
+}
+
+// managedVersion returns the version <dependencyManagement> declares for a
+// dependency, which is what applies when the <dependency> states none.
+func (p *pomProject) managedVersion(groupId, artifactId string) string {
+	for _, m := range p.DependencyManagement.Dependencies {
+		if m.GroupId == groupId && m.ArtifactId == artifactId {
+			return m.Version
+		}
+	}
+	return ""
 }
 
 // pomParent represents the parent POM reference.

--- a/providers/os/resources/languages/java/pomxml/testdata/properties.pom.xml
+++ b/providers/os/resources/languages/java/pomxml/testdata/properties.pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>myapp</artifactId>
+  <version>2.5.0</version>
+
+  <properties>
+    <jackson.version>2.13.0</jackson.version>
+    <spring.version>5.3.18</spring.version>
+    <!-- A property whose value is another property: Maven resolves the chain. -->
+    <jackson.databind.version>${jackson.version}</jackson.databind.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>31.1-jre</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.databind.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>${spring.version}</version>
+    </dependency>
+    <!-- No version: dependencyManagement states it. -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <!-- A sibling module, versioned with the project's own version. -->
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>myapp-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- A property that is declared nowhere. It must stay unresolved. -->
+    <dependency>
+      <groupId>org.example</groupId>
+      <artifactId>mystery</artifactId>
+      <version>${undeclared.version}</version>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
## What

A Maven project keeps a family of artifacts on one version by writing `<version>${jackson.version}</version>` and declaring the property once. The `pomxml` extractor read that literally, so the dependency's version was the string `${jackson.version}` and its purl came out as:

```
pkg:maven/com.fasterxml.jackson.core/jackson-databind@${jackson.version}
```

That purl matches no package registry and no advisory database. The dependency was not reported as *unknown* — it was reported under an identity nothing can match, so it was silently exempt from vulnerability correlation and from license lookup alike.

Found while auditing the SBOM a real multi-module Maven project produces: of nine dependencies, this was the one whose license and advisories could not be looked up, and the cause was the version string rather than anything downstream.

## Changes

- Parse `<properties>` and substitute `${...}` references in dependency coordinates.
- Support Maven's built-in project coordinates — `${project.version}`, `${project.groupId}`, `${project.artifactId}` and their `pom.` / bare aliases.
- Resolve property chains, where one property's value is another reference.
- Read `<dependencyManagement>`, which is where a multi-module project states a version once and the `<dependency>` element then omits it entirely. Those dependencies previously had **no version at all**.
- Apply a **managed scope** alongside the managed version, and match management entries on *resolved* coordinates (see below).

## What it deliberately does not do

**An unresolvable reference is left exactly as written.** A version this parser cannot resolve is not a version, and substituting a guess would report the dependency at some other version's identity — matching that version's advisories and that version's license. Leaving `${undeclared.version}` intact keeps the gap visible to whatever reads it. There is a test for this.

Resolution is depth-capped, so a property that refers to itself through a cycle terminates instead of spinning; there is a test for that too.

## Three follow-up fixes in the second commit

Two came out of review, and one of them is the most important change on the branch:

**A managed scope was ignored.** Maven applies a scope from `<dependencyManagement>` just as it applies a version. A `<dependency>` on junit omitting both, against a management section declaring `4.13.2` and `scope test`, is a test dependency. Reading only the version promoted it into `Direct()` with a real, matchable purl — so resolving versions would have turned a dependency that used to be filtered out *by accident* (empty version, purl matching nothing) into one that arrives in an SBOM as something the application ships, pulling junit's advisories with it. `effectiveScope` now falls back to the managed scope, and a dependency's own scope still wins so a module can opt one back in.

**The `dependencyManagement` lookup compared coordinates as written** while emitting resolved ones, so the key and the output disagreed inside one function. Both sides now compare resolved to resolved. The review suggested only the caller half, which leaves the reverse direction broken — and the reverse is the shape a management section importing a family of artifacts actually has.

**The properties decoder swallowed every error**, so a malformed `<properties>` block silently yielded a partial map and every version referring to it became unresolvable. The error is now returned. The review suggested excepting `io.EOF`; that branch is unreachable — inside an open element the decoder reports an early end as `*xml.SyntaxError`, never a bare `io.EOF` — so there is no case to except, and a test pins that so the dead branch cannot come back.

## Testing

`providers/os/resources/languages/java/pomxml/testdata/properties.pom.xml` covers a declared property, a property whose value is another property, `${project.version}`, an omitted version supplied by `<dependencyManagement>`, and an undeclared property that must stay unresolved.

```
go test ./providers/os/resources/languages/java/pomxml/   # green
```

Every new test was confirmed to fail against the behaviour it pins, by reverting each change in turn. Two failures elsewhere in `providers/os` (a `connection/device/linux` build error and `TestLocalConnectionIdDetectors_DelayedDiscovery`) reproduce identically on `origin/main` and are unrelated to this branch.

End-to-end against a real local Maven repository, the nine-dependency project goes from 8 of 9 resolved to **9 of 9**, with `jackson-databind` correctly at `2.13.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also: the licenses a pom.xml declares

Rebased onto `main` after #10578, which gave six extractors a license and a shared renderer for it. pomxml was left out, and it was the one build manifest in the tree still reading none — its Java sibling `manifestmf` reports `Bundle-License`, while a pom.xml stating

```xml
<licenses>
  <license>
    <name>Apache License, Version 2.0</name>
    <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
  </license>
</licenses>
```

reported nothing at all, from a file already opened and parsed for its coordinates.

`<licenses>` now goes through `languages.LicenseExpression` like every other extractor, which is what makes the semantics match: Maven's guidance is that several listed licenses mean the consumer may select **any one** of them, so the list is a choice and renders as SPDX's `OR` rather than being flattened or having the first entry win. Going through the shared renderer also picks up its bounds, so a POM cannot put an arbitrary amount of text into a field consumers read as an identifier.

Three details, because each could reasonably have gone the other way:

- **The `<url>` is dropped.** A link to the terms is not the identity of the terms, and a URL in a field compared against `Apache-2.0` matches nothing while reading as a stated identifier. Same call `manifestmf` and `packagejson` already made for this field.
- **The license lands on the root package only.** `<licenses>` describes the project the POM defines, not what it depends on, so a dependency stating no license keeps stating none.
- **A `${...}` reference in a license name is resolved**, the same way a version is. A POM keeping its license name in a property is stating a license; the raw reference would match nothing.

Only this POM's own block is read. Maven inherits `<licenses>` from a parent POM and resolving that needs the parent artifact, which is not available from the file on disk, so a module stating none reports none rather than guessing at what it would inherit.

Every assertion fails when the license is dropped from `Root()`, confirmed by reverting it.
