### PR TITLE
🐛 stackit: keep a null observability parameter from reading as empty

### DIFF
--- a/providers/stackit/go.mod
+++ b/providers/stackit/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/modelserving v0.13.0
 	github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.12.1
 	github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.1
-	github.com/stackitcloud/stackit-sdk-go/services/observability v0.24.0
+	github.com/stackitcloud/stackit-sdk-go/services/observability v0.25.0
 	github.com/stackitcloud/stackit-sdk-go/services/opensearch v1.3.0
 	github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.13.0
 	github.com/stackitcloud/stackit-sdk-go/services/rabbitmq v1.3.0

--- a/providers/stackit/go.sum
+++ b/providers/stackit/go.sum
@@ -428,8 +428,8 @@ github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.12.1 h1:lLR6Ouu3H
 github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.12.1/go.mod h1:0hHEPiOEMAA23EzEl42Rm3FlyKIzkW+LWLvDkuFTZ+Q=
 github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.1 h1:9n1BrPj6gAuKnyJ1OmsN+MEl2DBg9KJHgUfkijN84Rs=
 github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.1/go.mod h1:QsPtoqAYvumyPU6ToX/5j1PbudN+VSTuvh6mp154ecM=
-github.com/stackitcloud/stackit-sdk-go/services/observability v0.24.0 h1:KhuWPXr1hl8BFLGLSi6wjxh5o6OQXH9amfquMhYQROU=
-github.com/stackitcloud/stackit-sdk-go/services/observability v0.24.0/go.mod h1:0fEZQHm729mBdvg4sNrAhM6KmHROHJSeS2FwCMRk46k=
+github.com/stackitcloud/stackit-sdk-go/services/observability v0.25.0 h1:r3URNI19iuD455mbceuL5ZIGxRTURUVNw240ukzc45A=
+github.com/stackitcloud/stackit-sdk-go/services/observability v0.25.0/go.mod h1:0fEZQHm729mBdvg4sNrAhM6KmHROHJSeS2FwCMRk46k=
 github.com/stackitcloud/stackit-sdk-go/services/opensearch v1.3.0 h1:j8327l7QFhdL4ETg3kV9Q7Jle5GFYtfxMkBS3IvalDo=
 github.com/stackitcloud/stackit-sdk-go/services/opensearch v1.3.0/go.mod h1:L+NlfC1hilLOqlLLukCj/UDnxlnNrc/oMikcw3Ansyw=
 github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.13.0 h1:o8+bH3763G5oU1Y8Bf5nkQ8kzqFO7su0VUpeSGKdoPY=

--- a/providers/stackit/resources/dbaas.go
+++ b/providers/stackit/resources/dbaas.go
@@ -714,7 +714,7 @@ func (r *mqlStackitObservabilityInstance) parameters() (any, error) {
 	if !ok || params == nil {
 		return map[string]any{}, nil
 	}
-	return stringMap(*params), nil
+	return stringPtrMap(*params), nil
 }
 
 func (r *mqlStackitObservabilityInstance) isUpdatable() (bool, error) {

--- a/providers/stackit/resources/helpers.go
+++ b/providers/stackit/resources/helpers.go
@@ -125,6 +125,21 @@ func stringMap(in map[string]string) map[string]any {
 	return out
 }
 
+// stringPtrMap converts a map[string]*string into the any-valued form MQL
+// expects. A nil value stays nil so it reads as null rather than as an empty
+// string: the API distinguishes a parameter set to "" from one it did not send.
+func stringPtrMap(in map[string]*string) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		if v == nil {
+			out[k] = nil
+			continue
+		}
+		out[k] = *v
+	}
+	return out
+}
+
 // strSliceData wraps a []string for assignment to a `[]string` field.
 func strSliceData(in []string) *llx.RawData {
 	return llx.ArrayData(strSlice(in), types.String)


### PR DESCRIPTION
`stackit-sdk-go/services/observability v0.24.0 → v0.25.0` retyped `GetParametersOk()` from `map[string]string` to `map[string]*string`. That value feeds a **shipped** field, `stackit.observability.instance.parameters`, so the fix needed a decision rather than a cast.

A nil pointer now maps to **null**, not `""`. The API distinguishes a parameter explicitly set to the empty string from one it never sent, and `parameters` is where `enable_public_access` and the `sgw_acl` source-IP allow-list live — the two values `internetReachable` is derived from. Collapsing "absent" into "empty" there would report an allow-list the instance does not have.

The same retype hit five other observability structs (`Error.Errors`, `GetCredentialsResponse.CredentialsInfo`, `ServiceKeysList.CredentialsInfo`, `RouteSerializer.Routes`, and `ProjectInstanceFull.Status` going `Status1 → Status`). None of those reach a shipped `.lr` field, so they needed no change.

### Verification

`go build ./... && go test ./... && gofmt -l .` in `providers/stackit/` — clean.

Not verified against a live STACKIT project; there are no credentials for one here. The null-versus-empty behavior is covered by the compiler and by the surrounding code, not by an observed API response.
