### PR TITLE
🧹 mongodbatlas: move to atlas-sdk v20250312024

### DIFF
--- a/providers/mongodbatlas/connection/connection.go
+++ b/providers/mongodbatlas/connection/connection.go
@@ -11,7 +11,7 @@ import (
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers-sdk/v1/vault"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 const (

--- a/providers/mongodbatlas/go.mod
+++ b/providers/mongodbatlas/go.mod
@@ -7,7 +7,7 @@ go 1.26.6
 require (
 	github.com/stretchr/testify v1.12.1
 	go.mondoo.com/mql v0.0.0-20260824053258-a0a7399274d4
-	go.mongodb.org/atlas-sdk/v20250312023 v20250312023.1.0
+	go.mongodb.org/atlas-sdk/v20250312024 v20250312024.0.0
 )
 
 require (

--- a/providers/mongodbatlas/go.sum
+++ b/providers/mongodbatlas/go.sum
@@ -430,8 +430,8 @@ go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7 h1:4RpHzZRqq3RwB9Oa6k
 go.mondoo.com/mondoo-go v0.0.0-20260822000727-1d813d6a83c7/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
 go.mondoo.com/ranger-rpc v0.8.1 h1:DynUWByDnxI4wMHbFpXUMw+lndYJ21BAHOxrhGyVCD4=
 go.mondoo.com/ranger-rpc v0.8.1/go.mod h1:HP3hjWjgRFxCFAnY86YLMiY0bU7eqhKuP8Qm+QlFBbI=
-go.mongodb.org/atlas-sdk/v20250312023 v20250312023.1.0 h1:7IIFoyOZvTp5CdS0FxXA2Nkb672/VrZxjsCbuUGWPk8=
-go.mongodb.org/atlas-sdk/v20250312023 v20250312023.1.0/go.mod h1:ZOQisJgGQ+iDbdSwgVU0ClrUlqUSpffW9pVX06+c7nc=
+go.mongodb.org/atlas-sdk/v20250312024 v20250312024.0.0 h1:VJ64FYnJqryrQ6Lx/upzn8ka3Pj9loiO1eB5JDT+t88=
+go.mongodb.org/atlas-sdk/v20250312024 v20250312024.0.0/go.mod h1:nbFTQgDnI90xUP4scIsFYvh48kuZtQBo2BIPBC60ifY=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0 h1:LMuyCAyfalSjDyjdC65nK6N0zoTT63+E/u95X0JovZI=

--- a/providers/mongodbatlas/resources/access_lists.go
+++ b/providers/mongodbatlas/resources/access_lists.go
@@ -9,7 +9,7 @@ import (
 
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 // apiAccessListEntry is the normalized form of an access list entry. Atlas

--- a/providers/mongodbatlas/resources/access_lists_test.go
+++ b/providers/mongodbatlas/resources/access_lists_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 func TestApiKeyAccessEntry(t *testing.T) {

--- a/providers/mongodbatlas/resources/alerts.go
+++ b/providers/mongodbatlas/resources/alerts.go
@@ -9,7 +9,7 @@ import (
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/types"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 // mqlMongodbatlasAlertConfigInternal keeps the notification targets that

--- a/providers/mongodbatlas/resources/backup.go
+++ b/providers/mongodbatlas/resources/backup.go
@@ -10,7 +10,7 @@ import (
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/types"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 type mqlMongodbatlasBackupScheduleConfigInternal struct {

--- a/providers/mongodbatlas/resources/backup_compliance.go
+++ b/providers/mongodbatlas/resources/backup_compliance.go
@@ -10,7 +10,7 @@ import (
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/types"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 func (r *mqlMongodbatlas) backupCompliancePolicy() (*mqlMongodbatlasBackupComplianceConfig, error) {

--- a/providers/mongodbatlas/resources/cluster.go
+++ b/providers/mongodbatlas/resources/cluster.go
@@ -11,7 +11,7 @@ import (
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/types"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 // newMqlMongodbatlasCluster maps a cluster to its resource, shared by the

--- a/providers/mongodbatlas/resources/cluster_advanced.go
+++ b/providers/mongodbatlas/resources/cluster_advanced.go
@@ -10,7 +10,7 @@ import (
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/types"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 // mqlMongodbatlasClusterInternal carries the project the cluster was listed

--- a/providers/mongodbatlas/resources/converters_test.go
+++ b/providers/mongodbatlas/resources/converters_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 func TestIsAccessDenied(t *testing.T) {

--- a/providers/mongodbatlas/resources/data_federation.go
+++ b/providers/mongodbatlas/resources/data_federation.go
@@ -9,7 +9,7 @@ import (
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/types"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 // mqlMongodbatlasDataFederationInternal carries the project the instance was

--- a/providers/mongodbatlas/resources/decode_test.go
+++ b/providers/mongodbatlas/resources/decode_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 // The tests below pin the SDK struct tags for the security-relevant fields this

--- a/providers/mongodbatlas/resources/federation.go
+++ b/providers/mongodbatlas/resources/federation.go
@@ -10,7 +10,7 @@ import (
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/types"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 type mqlMongodbatlasFederationConfigInternal struct {

--- a/providers/mongodbatlas/resources/federation_orgs.go
+++ b/providers/mongodbatlas/resources/federation_orgs.go
@@ -10,7 +10,7 @@ import (
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/types"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 // mqlMongodbatlasConnectedOrgConfigInternal carries the federation the

--- a/providers/mongodbatlas/resources/helpers_test.go
+++ b/providers/mongodbatlas/resources/helpers_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 func TestForEachPageStopsOnShortPage(t *testing.T) {

--- a/providers/mongodbatlas/resources/integrations.go
+++ b/providers/mongodbatlas/resources/integrations.go
@@ -9,7 +9,7 @@ import (
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/types"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 // integrationEndpoint picks the destination address out of a third-party

--- a/providers/mongodbatlas/resources/mcp.go
+++ b/providers/mongodbatlas/resources/mcp.go
@@ -10,7 +10,7 @@ import (
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/types"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 // mcpUnavailable reports whether the endpoint answered in a way that means

--- a/providers/mongodbatlas/resources/mcp_test.go
+++ b/providers/mongodbatlas/resources/mcp_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 func TestMcpUnavailable(t *testing.T) {

--- a/providers/mongodbatlas/resources/mongodbatlas.go
+++ b/providers/mongodbatlas/resources/mongodbatlas.go
@@ -13,7 +13,7 @@ import (
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers/mongodbatlas/connection"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 type mqlMongodbatlasInternal struct {

--- a/providers/mongodbatlas/resources/org.go
+++ b/providers/mongodbatlas/resources/org.go
@@ -11,7 +11,7 @@ import (
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/types"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 // pageSize is the per-request page size used for the SDK's manual pagination.

--- a/providers/mongodbatlas/resources/search.go
+++ b/providers/mongodbatlas/resources/search.go
@@ -11,7 +11,7 @@ import (
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/types"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 // searchIndexes lists the Atlas Search and Atlas Vector Search indexes defined

--- a/providers/mongodbatlas/resources/settings.go
+++ b/providers/mongodbatlas/resources/settings.go
@@ -9,7 +9,7 @@ import (
 
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 // isAccessDenied reports whether the API response indicates the credential is

--- a/providers/mongodbatlas/resources/settings_test.go
+++ b/providers/mongodbatlas/resources/settings_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/types"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 // projectConfigFlags lists every boolean field of mongodbatlas.projectConfig

--- a/providers/mongodbatlas/resources/user_security.go
+++ b/providers/mongodbatlas/resources/user_security.go
@@ -10,7 +10,7 @@ import (
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/types"
-	"go.mongodb.org/atlas-sdk/v20250312023/admin"
+	"go.mongodb.org/atlas-sdk/v20250312024/admin"
 )
 
 // userSecurity reads the project's external authentication configuration. A


### PR DESCRIPTION
`go.mongodb.org/atlas-sdk v20250312023 → v20250312024`.

At our call sites this is a pure import-path rewrite across 21 files. Atlas's date-stamped majors are the ones that rename functions off operation-ID changes, so the interesting part is what the major **removes** and whether any of it reaches us.

It removes the entire Serverless backup surface — `CloudBackupsAPI.{List,Get,Create}ServerlessBackupSnapshot/RestoreJob` and their param, request and paginated-response types — plus `ClustersAPI.ValidateGroupClusterConfigurations` with its validation types, and `EventViewForNdsGroup.ModifiedBy`. It also changes the `NewStreamsProcessorWithStats` constructor signature.

**This provider references none of them.** Greps for `Serverless`, `ValidateGroupClusterConfigurations`, `ClusterConfigurationValidation`, `StreamsProcessorWithStats`, `ModifiedBy` and `EventViewForNdsGroup` across `providers/mongodbatlas/**/*.go` all return zero hits, so no shipped `.lr` field loses its source.

### Verification

`go build ./... && go test ./... && gofmt -l .` in `providers/mongodbatlas/` — clean.

Not verified against a live Atlas organization.
