### PR TITLE
✨ openai: report which geography a project's data is pinned to

### DIFF
--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -5,7 +5,7 @@ replace go.mondoo.com/mql => ../..
 go 1.26.6
 
 require (
-	github.com/openai/openai-go/v3 v3.52.0
+	github.com/openai/openai-go/v3 v3.54.0
 	github.com/stretchr/testify v1.12.1
 	go.mondoo.com/mql v0.0.0-20260824053258-a0a7399274d4
 )

--- a/providers/openai/go.sum
+++ b/providers/openai/go.sum
@@ -320,8 +320,8 @@ github.com/olekukonko/tablewriter v1.1.4 h1:ORUMI3dXbMnRlRggJX3+q7OzQFDdvgbN9nVW
 github.com/olekukonko/tablewriter v1.1.4/go.mod h1:+kedxuyTtgoZLwif3P1Em4hARJs+mVnzKxmsCL/C5RY=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
-github.com/openai/openai-go/v3 v3.52.0 h1:VDSjIvI5Sr2/AzGJI6219sM2Il+zBWuopvluMy6KdjE=
-github.com/openai/openai-go/v3 v3.52.0/go.mod h1:Vy3y2/I2H/MbqvJGXEK8VbN5+avZV6zxux4I3eBdvaA=
+github.com/openai/openai-go/v3 v3.54.0 h1:qeNvIpFB/wzX7pI8USN1eruvzCS+XqOZ8mx73lGF6Lg=
+github.com/openai/openai-go/v3 v3.54.0/go.mod h1:ufI1+K+t0ijRB3gk8eztiw1crcDpsBuxRQL4sbLIrts=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=

--- a/providers/openai/resources/decode_test.go
+++ b/providers/openai/resources/decode_test.go
@@ -342,3 +342,37 @@ func TestRoleAssignmentIsDirectIsUnknownWithoutSources(t *testing.T) {
 	assert.True(t, known)
 	assert.False(t, isDirect)
 }
+
+func TestMapProjectResidency(t *testing.T) {
+	var p openai.Project
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"id": "proj_0000",
+		"object": "organization.project",
+		"name": "Production",
+		"status": "active",
+		"residency": "EU_STORAGE_PROCESSING",
+		"created_at": 1711471533
+	}`), &p))
+
+	args := mapProject(p)
+	assert.Equal(t, "EU_STORAGE_PROCESSING", args["residency"].Value,
+		"a project pinned to a region must report that region, not the SDK's typed wrapper")
+}
+
+// A project with no residency configuration must read as null. The SDK types
+// Residency as a bare string, so a mapping that skips the empty check reports
+// "" -- which a policy comparing against a region name cannot distinguish from
+// a project that was never read.
+func TestMapProjectResidencyIsNullWhenAbsent(t *testing.T) {
+	var p openai.Project
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"id": "proj_0001",
+		"object": "organization.project",
+		"name": "Sandbox",
+		"status": "active",
+		"created_at": 1711471533
+	}`), &p))
+
+	args := mapProject(p)
+	assert.Nil(t, args["residency"].Value)
+}

--- a/providers/openai/resources/openai.go
+++ b/providers/openai/resources/openai.go
@@ -35,6 +35,16 @@ func unixToNullableTime(ts int64) *time.Time {
 	return &t
 }
 
+// emptyToNil maps an empty string to nil so an absent enum reaches MQL as null
+// rather than as "". The OpenAI API omits these fields entirely when unset, and
+// an empty string would read as a real value the project does not have.
+func emptyToNil(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
 // dataPlaneClient returns the project-scoped client used for data-plane
 // collections (models, files, vector stores, fine-tuning). It returns a
 // descriptive error when the connection was built from an admin key (which

--- a/providers/openai/resources/openai.lr
+++ b/providers/openai/resources/openai.lr
@@ -522,6 +522,17 @@ openai.project @defaults("id name status") @maturity("preview") {
   createdAt time
   // Archive timestamp (null if active)
   archivedAt time
+  // Geography the project's data is stored and processed in
+  //
+  // One of GLOBAL, US_STORAGE_PROCESSING, EU_STORAGE_PROCESSING,
+  // JP_STORAGE, KR_STORAGE, CA_STORAGE, SG_STORAGE, IN_STORAGE,
+  // AU_STORAGE, GB_STORAGE, AE_STORAGE, or AE_STORAGE_PROCESSING. A
+  // value ending in STORAGE_PROCESSING pins both storage and inference
+  // to the region, where a plain STORAGE value pins storage only and
+  // lets inference run elsewhere. Null when the organization has no
+  // residency configuration, in which case data is not pinned to any
+  // region.
+  residency string
   // API keys in this project (requires admin API key)
   apiKeys() []openai.project.apiKey
   // Service accounts in this project (requires admin API key)

--- a/providers/openai/resources/openai.lr.go
+++ b/providers/openai/resources/openai.lr.go
@@ -622,6 +622,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openai.project.archivedAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenaiProject).GetArchivedAt()).ToDataRes(types.Time)
 	},
+	"openai.project.residency": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenaiProject).GetResidency()).ToDataRes(types.String)
+	},
 	"openai.project.apiKeys": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenaiProject).GetApiKeys()).ToDataRes(types.Array(types.Resource("openai.project.apiKey")))
 	},
@@ -1533,6 +1536,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"openai.project.archivedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenaiProject).ArchivedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"openai.project.residency": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenaiProject).Residency, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"openai.project.apiKeys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3570,6 +3577,7 @@ type mqlOpenaiProject struct {
 	Status                  plugin.TValue[string]
 	CreatedAt               plugin.TValue[*time.Time]
 	ArchivedAt              plugin.TValue[*time.Time]
+	Residency               plugin.TValue[string]
 	ApiKeys                 plugin.TValue[[]any]
 	ServiceAccounts         plugin.TValue[[]any]
 	Users                   plugin.TValue[[]any]
@@ -3642,6 +3650,10 @@ func (c *mqlOpenaiProject) GetCreatedAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlOpenaiProject) GetArchivedAt() *plugin.TValue[*time.Time] {
 	return &c.ArchivedAt
+}
+
+func (c *mqlOpenaiProject) GetResidency() *plugin.TValue[string] {
+	return &c.Residency
 }
 
 func (c *mqlOpenaiProject) GetApiKeys() *plugin.TValue[[]any] {

--- a/providers/openai/resources/openai.lr.versions
+++ b/providers/openai/resources/openai.lr.versions
@@ -187,6 +187,7 @@ openai.project.rateLimit.maxRequestsPerMinute 13.0.12
 openai.project.rateLimit.maxTokensPerMinute 13.0.12
 openai.project.rateLimit.model 13.0.12
 openai.project.rateLimits 13.0.12
+openai.project.residency 13.1.3
 openai.project.roles 13.0.12
 openai.project.serviceAccount 13.0.0
 openai.project.serviceAccount.createdAt 13.0.0

--- a/providers/openai/resources/openai_project.go
+++ b/providers/openai/resources/openai_project.go
@@ -23,6 +23,7 @@ func mapProject(p openai.Project) map[string]*llx.RawData {
 		"status":     llx.StringData(string(p.Status)),
 		"createdAt":  llx.TimeDataPtr(unixToNullableTime(p.CreatedAt)),
 		"archivedAt": llx.TimeDataPtr(unixToNullableTime(p.ArchivedAt)),
+		"residency":  llx.StringDataPtr(emptyToNil(string(p.Residency))),
 	}
 }
 


### PR DESCRIPTION
`openai-go v3.52.0 → v3.54.0` added `Project.Residency`. This exposes it as `openai.project.residency`.

Residency is the geography a project's data is stored and processed in. A value ending in `STORAGE_PROCESSING` pins both storage and inference to the region; a plain `STORAGE` value pins storage only and lets inference run elsewhere — a distinction a data-residency policy has to be able to make, and one that was not queryable before.

```
openai.projects { name residency }
```

### Null, not empty

The SDK types `Residency` as a bare string, so an unconfigured project decodes to `""`. That maps to **null**: a policy comparing against a region name cannot otherwise tell a project with no residency configuration from one whose field was never read. `TestMapProjectResidencyIsNullWhenAbsent` pins this — the mapping that skips the empty check fails it.

### Verification

`go build ./... && go test ./... && gofmt -l .` in `providers/openai/` — clean. Two new tests cover the configured and absent cases.

Not verified against a live OpenAI organization; there are no admin credentials for one here. The enum values in the field's doc comment come from the SDK's own constant block (12 values, all listed).
