### PR TITLE
✨ digitalocean: expose the routes leaving a VPC

### DIFF
--- a/providers/digitalocean/go.mod
+++ b/providers/digitalocean/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.37
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.3
 	github.com/aws/smithy-go v1.27.9
-	github.com/digitalocean/godo v1.204.0
+	github.com/digitalocean/godo v1.205.0
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.12.1
 	go.mondoo.com/mql v0.0.0-20260824053258-a0a7399274d4

--- a/providers/digitalocean/go.sum
+++ b/providers/digitalocean/go.sum
@@ -124,8 +124,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.204.0 h1:jeYzhQ4T1ZgCEAQtGmy/qjzc4t9jH7kWj1xitHWfsHA=
-github.com/digitalocean/godo v1.204.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
+github.com/digitalocean/godo v1.205.0 h1:zD3RcCcByV0zGRnW7xiOEG1nATsk2U6QEE6RT+G1MOc=
+github.com/digitalocean/godo v1.205.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v29.7.2+incompatible h1:dlkwallR8XqfeVnA2ELEhdwvb4lsSwuB4IgsG8Q9cLY=

--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -1026,6 +1026,8 @@ digitalocean.vpc @defaults("id name region") {
   urn string
   // Resources placed inside the VPC
   members() []digitalocean.vpc.member
+  // Routes directing traffic out of the VPC
+  routes() []digitalocean.vpc.route
 }
 
 // Resource placed inside a DigitalOcean VPC
@@ -1045,6 +1047,37 @@ private digitalocean.vpc.member @defaults("name urn") {
   // Member name
   name string
   // Time the resource joined the VPC; null when the API reports no join time
+  createdAt time
+}
+
+// DigitalOcean VPC route
+//
+// Static or dynamic route attached to a VPC, directing traffic for a
+// destination range at one or more resources inside the network. Read
+// `destinationCidr` together with `targetUrns` to see where traffic for a
+// range actually leaves the VPC, which is what decides whether a subnet
+// egresses through an inspected appliance or straight out. The
+// `modifiable` field separates routes DigitalOcean creates and manages
+// from routes an operator added, and `type` reports whether the route was
+// configured statically or learned dynamically.
+private digitalocean.vpc.route @defaults("destinationCidr type targetUrns") {
+  // Route ID
+  id string
+  // How the route was configured
+  //
+  // One of STATIC for a route an operator configured, or DYNAMIC for a
+  // route the network learned.
+  type string
+  // Destination IP range (CIDR) the route matches
+  destinationCidr string
+  // Uniform resource names (URNs) of the resources traffic is directed to
+  targetUrns []string
+  // Whether the route can be changed
+  //
+  // False for routes DigitalOcean creates and manages itself, which an
+  // operator cannot edit or remove.
+  modifiable bool
+  // Time the route was created; null when the API reports no creation time
   createdAt time
 }
 

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -40,6 +40,7 @@ const (
 	ResourceDigitaloceanLoadBalancerListener                            string = "digitalocean.loadBalancer.listener"
 	ResourceDigitaloceanVpc                                             string = "digitalocean.vpc"
 	ResourceDigitaloceanVpcMember                                       string = "digitalocean.vpc.member"
+	ResourceDigitaloceanVpcRoute                                        string = "digitalocean.vpc.route"
 	ResourceDigitaloceanVpcPeering                                      string = "digitalocean.vpcPeering"
 	ResourceDigitaloceanKubernetesCluster                               string = "digitalocean.kubernetes.cluster"
 	ResourceDigitaloceanKubernetesNodePool                              string = "digitalocean.kubernetes.nodePool"
@@ -206,6 +207,10 @@ func init() {
 		"digitalocean.vpc.member": {
 			// to override args, implement: initDigitaloceanVpcMember(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createDigitaloceanVpcMember,
+		},
+		"digitalocean.vpc.route": {
+			// to override args, implement: initDigitaloceanVpcRoute(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createDigitaloceanVpcRoute,
 		},
 		"digitalocean.vpcPeering": {
 			// to override args, implement: initDigitaloceanVpcPeering(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -1489,6 +1494,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.vpc.members": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanVpc).GetMembers()).ToDataRes(types.Array(types.Resource("digitalocean.vpc.member")))
 	},
+	"digitalocean.vpc.routes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanVpc).GetRoutes()).ToDataRes(types.Array(types.Resource("digitalocean.vpc.route")))
+	},
 	"digitalocean.vpc.member.vpcId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanVpcMember).GetVpcId()).ToDataRes(types.String)
 	},
@@ -1503,6 +1511,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.vpc.member.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanVpcMember).GetCreatedAt()).ToDataRes(types.Time)
+	},
+	"digitalocean.vpc.route.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanVpcRoute).GetId()).ToDataRes(types.String)
+	},
+	"digitalocean.vpc.route.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanVpcRoute).GetType()).ToDataRes(types.String)
+	},
+	"digitalocean.vpc.route.destinationCidr": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanVpcRoute).GetDestinationCidr()).ToDataRes(types.String)
+	},
+	"digitalocean.vpc.route.targetUrns": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanVpcRoute).GetTargetUrns()).ToDataRes(types.Array(types.String))
+	},
+	"digitalocean.vpc.route.modifiable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanVpcRoute).GetModifiable()).ToDataRes(types.Bool)
+	},
+	"digitalocean.vpc.route.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanVpcRoute).GetCreatedAt()).ToDataRes(types.Time)
 	},
 	"digitalocean.vpcPeering.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanVpcPeering).GetId()).ToDataRes(types.String)
@@ -5066,6 +5092,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanVpc).Members, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"digitalocean.vpc.routes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanVpc).Routes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"digitalocean.vpc.member.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanVpcMember).__id, ok = v.Value.(string)
 		return
@@ -5088,6 +5118,34 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.vpc.member.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanVpcMember).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"digitalocean.vpc.route.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanVpcRoute).__id, ok = v.Value.(string)
+		return
+	},
+	"digitalocean.vpc.route.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanVpcRoute).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.vpc.route.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanVpcRoute).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.vpc.route.destinationCidr": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanVpcRoute).DestinationCidr, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.vpc.route.targetUrns": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanVpcRoute).TargetUrns, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.vpc.route.modifiable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanVpcRoute).Modifiable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"digitalocean.vpc.route.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanVpcRoute).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"digitalocean.vpcPeering.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11805,6 +11863,7 @@ type mqlDigitaloceanVpc struct {
 	Default     plugin.TValue[bool]
 	Urn         plugin.TValue[string]
 	Members     plugin.TValue[[]any]
+	Routes      plugin.TValue[[]any]
 }
 
 // createDigitaloceanVpc creates a new instance of this resource
@@ -11892,6 +11951,22 @@ func (c *mqlDigitaloceanVpc) GetMembers() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlDigitaloceanVpc) GetRoutes() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Routes, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.vpc", c.__id, "routes")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.routes()
+	})
+}
+
 // mqlDigitaloceanVpcMember for the digitalocean.vpc.member resource
 type mqlDigitaloceanVpcMember struct {
 	MqlRuntime *plugin.Runtime
@@ -11953,6 +12028,75 @@ func (c *mqlDigitaloceanVpcMember) GetName() *plugin.TValue[string] {
 }
 
 func (c *mqlDigitaloceanVpcMember) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
+}
+
+// mqlDigitaloceanVpcRoute for the digitalocean.vpc.route resource
+type mqlDigitaloceanVpcRoute struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlDigitaloceanVpcRouteInternal it will be used here
+	Id              plugin.TValue[string]
+	Type            plugin.TValue[string]
+	DestinationCidr plugin.TValue[string]
+	TargetUrns      plugin.TValue[[]any]
+	Modifiable      plugin.TValue[bool]
+	CreatedAt       plugin.TValue[*time.Time]
+}
+
+// createDigitaloceanVpcRoute creates a new instance of this resource
+func createDigitaloceanVpcRoute(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlDigitaloceanVpcRoute{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("digitalocean.vpc.route", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlDigitaloceanVpcRoute) MqlName() string {
+	return "digitalocean.vpc.route"
+}
+
+func (c *mqlDigitaloceanVpcRoute) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlDigitaloceanVpcRoute) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlDigitaloceanVpcRoute) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlDigitaloceanVpcRoute) GetDestinationCidr() *plugin.TValue[string] {
+	return &c.DestinationCidr
+}
+
+func (c *mqlDigitaloceanVpcRoute) GetTargetUrns() *plugin.TValue[[]any] {
+	return &c.TargetUrns
+}
+
+func (c *mqlDigitaloceanVpcRoute) GetModifiable() *plugin.TValue[bool] {
+	return &c.Modifiable
+}
+
+func (c *mqlDigitaloceanVpcRoute) GetCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CreatedAt
 }
 

--- a/providers/digitalocean/resources/digitalocean.lr.versions
+++ b/providers/digitalocean/resources/digitalocean.lr.versions
@@ -1111,6 +1111,14 @@ digitalocean.vpc.member.vpcId 13.15.3
 digitalocean.vpc.members 13.15.3
 digitalocean.vpc.name 13.0.1
 digitalocean.vpc.region 13.0.1
+digitalocean.vpc.route 13.15.3
+digitalocean.vpc.route.createdAt 13.15.3
+digitalocean.vpc.route.destinationCidr 13.15.3
+digitalocean.vpc.route.id 13.15.3
+digitalocean.vpc.route.modifiable 13.15.3
+digitalocean.vpc.route.targetUrns 13.15.3
+digitalocean.vpc.route.type 13.15.3
+digitalocean.vpc.routes 13.15.3
 digitalocean.vpc.urn 13.10.2
 digitalocean.vpcNatGateway 13.4.2
 digitalocean.vpcNatGateway.createdAt 13.4.2

--- a/providers/digitalocean/resources/digitalocean_coverage.go
+++ b/providers/digitalocean/resources/digitalocean_coverage.go
@@ -101,6 +101,75 @@ func (r *mqlDigitaloceanVpc) members() ([]interface{}, error) {
 	return out, nil
 }
 
+// ----- VPC routes -----
+
+// routes lists the routes directing traffic out of the VPC.
+func (r *mqlDigitaloceanVpc) routes() ([]interface{}, error) {
+	vpcID := r.Id.Data
+	if vpcID == "" {
+		return nil, errors.New("cannot list VPC routes without a VPC id")
+	}
+
+	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
+	client := conn.Client()
+
+	routes, err := paginate(context.Background(), func(c context.Context, o *godo.ListOptions) ([]*godo.Route, *godo.Response, error) {
+		return client.Routes.ListVPCRoutes(c, vpcID, o)
+	})
+	if err != nil {
+		// A VPC removed between the listing and this call answers 404, which
+		// is genuinely an empty route table. Denied and transient reads
+		// propagate rather than being reported as "no routes".
+		if isDoNotFound(err) {
+			return []interface{}{}, nil
+		}
+		return nil, err
+	}
+
+	out := make([]interface{}, 0, len(routes))
+	for _, rt := range routes {
+		// godo hands back a slice of pointers; a nil entry would panic the
+		// provider and take the whole scan with it.
+		if rt == nil || rt.ID == "" {
+			continue
+		}
+		args, err := vpcRouteArgs(vpcID, rt)
+		if err != nil {
+			return nil, err
+		}
+		res, err := CreateResource(r.MqlRuntime, "digitalocean.vpc.route", args)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
+// vpcRouteArgs maps a godo route onto the resource arguments. The route ID is
+// only unique within its VPC, so the cache key carries both.
+func vpcRouteArgs(vpcID string, rt *godo.Route) (map[string]*llx.RawData, error) {
+	id, err := resourceID("digitalocean.vpc.route", vpcID, rt.ID)
+	if err != nil {
+		return nil, err
+	}
+	targets := make([]interface{}, len(rt.TargetURNs))
+	for i, u := range rt.TargetURNs {
+		targets[i] = u
+	}
+	return map[string]*llx.RawData{
+		"__id":            llx.StringData(id),
+		"id":              llx.StringData(rt.ID),
+		"type":            llx.StringData(rt.Type),
+		"destinationCidr": llx.StringData(rt.DestinationCIDR),
+		"targetUrns":      llx.ArrayData(targets, types.String),
+		"modifiable":      llx.BoolData(rt.Modifiable),
+		// An absent creation time stays null rather than becoming the zero
+		// time, which would report 1 January year 1 as a real date.
+		"createdAt": llx.TimeDataPtr(timePtr(rt.CreatedAt)),
+	}, nil
+}
+
 // ----- Kubernetes cluster identity -----
 
 // kubeconfigUsername returns the RBAC subject the platform-issued

--- a/providers/digitalocean/resources/digitalocean_vpc_routes_test.go
+++ b/providers/digitalocean/resources/digitalocean_vpc_routes_test.go
@@ -1,0 +1,63 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/digitalocean/godo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVpcRouteArgs(t *testing.T) {
+	created := time.Date(2026, 3, 14, 9, 30, 0, 0, time.UTC)
+	args, err := vpcRouteArgs("vpc-1", &godo.Route{
+		ID:              "route-1",
+		Type:            godo.RouteTypeStatic,
+		DestinationCIDR: "10.20.0.0/16",
+		TargetURNs:      []string{"do:droplet:12345", "do:load_balancer:abcde"},
+		Modifiable:      true,
+		CreatedAt:       created,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "route-1", args["id"].Value)
+	assert.Equal(t, "STATIC", args["type"].Value)
+	assert.Equal(t, "10.20.0.0/16", args["destinationCidr"].Value)
+	assert.Equal(t, []interface{}{"do:droplet:12345", "do:load_balancer:abcde"}, args["targetUrns"].Value,
+		"every target must survive the mapping: a route's egress is the whole target set, not the first one")
+	assert.Equal(t, true, args["modifiable"].Value)
+	assert.Equal(t, created, *args["createdAt"].Value.(*time.Time))
+}
+
+// A route ID is only unique within its VPC, so two VPCs carrying the same
+// route ID must not collide in the resource cache. Dropping the VPC from the
+// key makes the second VPC's route resolve to the first one's.
+func TestVpcRouteArgsScopesTheCacheKeyToTheVpc(t *testing.T) {
+	a, err := vpcRouteArgs("vpc-1", &godo.Route{ID: "route-1"})
+	require.NoError(t, err)
+	b, err := vpcRouteArgs("vpc-2", &godo.Route{ID: "route-1"})
+	require.NoError(t, err)
+
+	assert.NotEqual(t, a["__id"].Value, b["__id"].Value)
+}
+
+// A route the API reports without a creation time must read as null. The zero
+// time would report 1 January year 1 as a real date, which an age check would
+// then treat as an extremely old route.
+func TestVpcRouteArgsCreatedAtIsNullWhenAbsent(t *testing.T) {
+	args, err := vpcRouteArgs("vpc-1", &godo.Route{ID: "route-1", DestinationCIDR: "0.0.0.0/0"})
+	require.NoError(t, err)
+	assert.Nil(t, args["createdAt"].Value)
+}
+
+// A route with no targets must map to an empty list, not to null, so a policy
+// counting targets sees zero rather than an unread field.
+func TestVpcRouteArgsEmptyTargetsAreAnEmptyList(t *testing.T) {
+	args, err := vpcRouteArgs("vpc-1", &godo.Route{ID: "route-1"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{}, args["targetUrns"].Value)
+}


### PR DESCRIPTION
`godo v1.204.0 → v1.205.0` added a Routes service. This exposes it as `digitalocean.vpc.route`, reached through a new `routes` accessor on `digitalocean.vpc`.

A VPC's routes are where traffic for a destination range actually leaves the network, which decides whether a subnet egresses through an inspected appliance or straight out. That was not answerable before — `digitalocean.vpc` had members but no routing.

```
digitalocean.vpcs { name routes { destinationCidr targetUrns modifiable type } }
```

`modifiable` separates routes DigitalOcean creates and manages from routes an operator added; `type` reports `STATIC` or `DYNAMIC`. Routes are read-only in the public API, so only the list call is used.

### Notes for review

- **The cache key carries the VPC.** A route ID is unique only within its VPC, so keying on the route ID alone would make two VPCs' identically-named routes collide in the resource cache and resolve to whichever was fetched first. `TestVpcRouteArgsScopesTheCacheKeyToTheVpc` pins this.
- **A 404 between the listing and this call is an empty route table**, not a failure — a VPC can be removed mid-scan. Denied and transient reads still propagate, so "not allowed to look" never degrades into "no routes". This matches the existing `members()` accessor.
- **`createdAt` stays null when absent** rather than becoming the zero time, which would date a route to 1 January year 1.
- godo returns `[]*Route`; a nil entry is skipped rather than dereferenced, since a panic in a resource accessor takes the whole scan down.

### Verification

`go build ./... && go test ./... && gofmt -l .` in `providers/digitalocean/` — clean. Four new tests cover the mapping, the cache key, the absent timestamp and the empty target list.

Not verified against a live DigitalOcean account.
