### PR TITLE
🐛 os: a WinRM command over the command-line limit fails silently

### DIFF
--- a/providers/os/connection/winrm/utf16len_test.go
+++ b/providers/os/connection/winrm/utf16len_test.go
@@ -1,0 +1,111 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package winrm
+
+import (
+	"testing"
+	"unicode/utf16"
+
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers/os/resources/powershell"
+)
+
+// Windows measures a command line in UTF-16 code units. Neither obvious
+// shorthand matches that: len() counts UTF-8 bytes and over-counts anything
+// non-ASCII, RuneCountInString counts code points and under-counts anything
+// outside the basic multilingual plane.
+func TestUtf16Len(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"empty", "", 0},
+		{"ascii", "powershell.exe -NoProfile", 25},
+		// 2 bytes in UTF-8, 1 UTF-16 code unit
+		{"latin1", "é", 1},
+		// 3 bytes in UTF-8, 1 UTF-16 code unit -- a ja-JP path
+		{"cjk", "C:\\ユーザー", 7},
+		// 4 bytes in UTF-8, 2 UTF-16 code units: the case RuneCountInString
+		// gets wrong
+		{"supplementary", "\U0001F600", 2},
+		{"mixed", "a\U0001F600é", 4},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, utf16Len(tc.in))
+			// agree with the standard library's encoder, which is the
+			// definition of the unit
+			assert.Equal(t, len(utf16.Encode([]rune(tc.in))), utf16Len(tc.in))
+		})
+	}
+}
+
+// The two shorthands this helper exists to avoid disagree with it in opposite
+// directions, which is why neither was used.
+func TestUtf16Len_DiffersFromBytesAndRunes(t *testing.T) {
+	cjk := "ユーザー"
+	assert.Greater(t, len(cjk), utf16Len(cjk), "byte length over-counts, and would refuse commands that fit")
+
+	emoji := "\U0001F600\U0001F600"
+	assert.Less(t, len([]rune(emoji)), utf16Len(emoji), "rune count under-counts, and would let a truncated command through")
+}
+
+// TestRunCommandRejectsOverLongCommand covers the guard itself rather than the
+// counter behind it.
+//
+// The connection carries no client on purpose: the guard has to fire before
+// anything touches it, which is also what makes this testable without a
+// Windows host. If the check were ever moved below the client call, this test
+// would panic instead of returning an error.
+func TestRunCommandRejectsOverLongCommand(t *testing.T) {
+	conn := &Connection{}
+	cmd := strings.Repeat("a", powershell.MaxCommandLength+1)
+
+	res, err := conn.RunCommand(cmd)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "would be truncated before it ran",
+		"the error has to say why, or it reads like a transport failure")
+	assert.Contains(t, err.Error(), strconv.Itoa(powershell.MaxCommandLength+1),
+		"the error names the actual length")
+	require.NotNil(t, res, "the command result is still returned for timing")
+	assert.Equal(t, cmd, res.Command)
+}
+
+// The boundary case. A command exactly at the limit is allowed through, which
+// here means it reaches the nil client and panics - that panic is the
+// observation: the guard is not what stopped it. An off-by-one in the
+// comparison would return an error instead and fail this.
+func TestRunCommandAllowsCommandAtTheLimit(t *testing.T) {
+	defer func() {
+		assert.NotNil(t, recover(),
+			"a command at exactly the limit must pass the guard and reach the client")
+	}()
+
+	conn := &Connection{}
+	_, _ = conn.RunCommand(strings.Repeat("a", powershell.MaxCommandLength))
+
+	t.Fatal("expected to reach the client rather than return from the guard")
+}
+
+// The limit is measured in UTF-16 code units, which is what Windows counts.
+// Each of these emoji is one rune but two UTF-16 units, so a command that
+// utf8.RuneCountInString would call comfortably short is actually over - the
+// exact case a rune-based check would wave through to be truncated.
+func TestRunCommandCountsUtf16NotRunes(t *testing.T) {
+	conn := &Connection{}
+	cmd := strings.Repeat("😀", powershell.MaxCommandLength/2+1)
+
+	require.Less(t, utf8.RuneCountInString(cmd), powershell.MaxCommandLength,
+		"the fixture must be short in runes, or it proves nothing")
+
+	_, err := conn.RunCommand(cmd)
+
+	require.Error(t, err, "over the limit in UTF-16 units, so it must be rejected")
+}

--- a/providers/os/connection/winrm/winrm.go
+++ b/providers/os/connection/winrm/winrm.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/masterzen/winrm"
@@ -17,6 +18,7 @@ import (
 	"go.mondoo.com/mql/providers-sdk/v1/vault"
 	"go.mondoo.com/mql/providers/os/connection/shared"
 	"go.mondoo.com/mql/providers/os/connection/winrm/cat"
+	"go.mondoo.com/mql/providers/os/resources/powershell"
 )
 
 var _ shared.Connection = (*Connection)(nil)
@@ -117,6 +119,28 @@ func (p *Connection) Capabilities() shared.Capabilities {
 	return shared.Capability_File | shared.Capability_RunCommand
 }
 
+// utf16Len counts the UTF-16 code units in s, which is the unit Windows
+// measures a command line in.
+//
+// Neither obvious shorthand is right. len(s) counts UTF-8 bytes, which
+// over-counts every non-ASCII character and would refuse commands that would
+// have run. utf8.RuneCountInString counts code points, which *under*-counts:
+// anything outside the basic multilingual plane is one rune but two UTF-16
+// code units, so a command padded with emoji could slip past the check and be
+// truncated anyway -- the exact failure this guard exists to prevent. Counting
+// the code units directly is neither, and costs one pass with no allocation.
+func utf16Len(s string) int {
+	n := 0
+	for _, r := range s {
+		if r > 0xFFFF {
+			n += 2
+		} else {
+			n++
+		}
+	}
+	return n
+}
+
 func (p *Connection) RunCommand(command string) (*shared.Command, error) {
 	log.Debug().Str("command", command).Str("provider", "winrm").Msg("winrm> run command")
 
@@ -134,6 +158,19 @@ func (p *Connection) RunCommand(command string) (*shared.Command, error) {
 	defer func() {
 		res.Stats.Duration = time.Since(res.Stats.Start)
 	}()
+
+	if n := utf16Len(command); n > powershell.MaxCommandLength {
+		// Past this the command never runs: WinRM hands it to cmd.exe, which
+		// truncates, and stdout comes back empty with a zero exit. A caller
+		// parsing that output reports whatever an empty string means to it --
+		// "unexpected end of JSON input" -- and never learns the command was
+		// too long. Say so instead.
+		err := fmt.Errorf(
+			"command is %d characters, over the %d WinRM allows, so it would be truncated before it ran: %.120s",
+			n, powershell.MaxCommandLength, command)
+		log.Error().Err(err).Msg("winrm command too long")
+		return res, err
+	}
 
 	// Note: winrm does not return err of the command was executed with a non-zero exit code
 	exitCode, err := p.Client.RunWithContext(context.Background(), command, stdoutBuffer, stderrBuffer)


### PR DESCRIPTION
> **Reworked.** This PR previously also rewrote the Windows local-users script to fit the command line. [#10456](https://github.com/mondoohq/mql/pull/10456) has since merged a different fix for that script — it is staged to a file and run with `-File` — so the script rewrite, its fixture, and the `knownOverCap` edit are dropped. What remains is the transport guard, which #10456 does not cover.

## What

WinRM hands the command to `cmd.exe`, whose command line stops at **8191** characters. Past that the command never runs: it is truncated, stdout comes back empty, and **the exit status is zero**.

The caller then parses that empty output and reports whatever an empty string means to it. For the Windows user manager it was `unexpected end of JSON input` — a parse error for a transport failure. For anything checking whether a feature is installed, it reads as *not installed*.

That is how the bug behind #10456 survived long enough to be catalogued in `knownOverCap` rather than noticed in a scan.

## The fix

Reject the command at the transport, naming its length and the limit:

```
command is 14150 characters, over the 8191 WinRM allows,
so it would be truncated before it ran: <first 120 chars>
```

`scriptlength_test.go` already guards embedded script **literals** — but only those. Nothing catches a command assembled at runtime, and nothing covers a script that grows past the cap in a provider that test does not sweep. This closes the gap where the truncation actually happens.

## Why UTF-16 code units

The limit is measured in the unit Windows counts, and neither shorthand is correct:

| approach | failure |
|---|---|
| `len(s)` | counts UTF-8 bytes — **over**-counts every non-ASCII character, refusing commands that would have run |
| `utf8.RuneCountInString(s)` | counts code points — **under**-counts, since anything outside the BMP is one rune but two UTF-16 units, so a command padded with such characters slips past and is truncated anyway |

Counting the code units directly is neither, in one pass with no allocation.

## Tests

`utf16len_test.go` covers the counter (ASCII, latin-1, CJK, supplementary-plane, mixed, and that it differs from both alternatives) and now the guard itself:

- **`TestRunCommandRejectsOverLongCommand`** — the connection deliberately carries no client, so the guard must fire before anything touches it. If the check ever moved below the client call this panics instead of returning.
- **`TestRunCommandAllowsCommandAtTheLimit`** — a command at exactly the limit passes the guard and reaches the client.
- **`TestRunCommandCountsUtf16NotRunes`** — a fixture that is comfortably short in runes but over in UTF-16 units must still be rejected.

Both subtle cases were mutation-checked:

```
'>' -> '>='                       -> FAIL: a command at exactly the limit
                                           must pass the guard
utf16Len -> RuneCountInString     -> FAIL: over the limit in UTF-16 units,
                                           so it must be rejected
```

The guard is testable without a Windows host precisely because it runs before the client is used. The truncation behaviour it prevents was observed on a live Windows Server 2022 host while verifying the v13→v14 diff: 8069 characters ran, 8269 returned empty stdout with no error.
