### PR TITLE
✨ oci: report the Autonomous Database long-term backup schedule

### DIFF
--- a/providers/oci/go.mod
+++ b/providers/oci/go.mod
@@ -5,7 +5,7 @@ go 1.26.6
 replace go.mondoo.com/mql => ../..
 
 require (
-	github.com/oracle/oci-go-sdk/v65 v65.123.2
+	github.com/oracle/oci-go-sdk/v65 v65.124.0
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.12.1
 	go.mondoo.com/mql v0.0.0-20260824053258-a0a7399274d4

--- a/providers/oci/go.sum
+++ b/providers/oci/go.sum
@@ -326,8 +326,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/oracle/oci-go-sdk/v65 v65.123.2 h1:Xg/OEjuj+xNkJKgjTVDG9R5rq7oxKIKHWIeNFZd9etU=
-github.com/oracle/oci-go-sdk/v65 v65.123.2/go.mod h1:Pzy+BpgkDesvGZXEHgslwhIYobHCPHg6wRta1mWnlqQ=
+github.com/oracle/oci-go-sdk/v65 v65.124.0 h1:R2UkEZWDgJ1/Fvxz1oRDBnBuDxrGzbcurio3bY6ex/U=
+github.com/oracle/oci-go-sdk/v65 v65.124.0/go.mod h1:Pzy+BpgkDesvGZXEHgslwhIYobHCPHg6wRta1mWnlqQ=
 github.com/package-url/packageurl-go v0.1.5 h1:O4efRXja2XQ5CtiiYiCZ22k/m7i5ugLiAghgcC+eDgk=
 github.com/package-url/packageurl-go v0.1.5/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/pandatix/go-cvss v0.6.4 h1:9w2RCO/Q4UTiJyEgpCHRiVc6CfrsFEnkoX+OtATqKio=

--- a/providers/oci/resources/database.go
+++ b/providers/oci/resources/database.go
@@ -229,40 +229,47 @@ func (o *mqlOciDatabase) autonomousDatabases() ([]any, error) {
 					}
 				}
 
+				ltb := longTermBackupArgs(a.LongTermBackupSchedule, a.NextLongTermBackupTimeStamp)
+
 				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.database.autonomousDatabase", stringValue(a.CompartmentId), map[string]*llx.RawData{
-					"id":                          llx.StringDataPtr(a.Id),
-					"name":                        llx.StringDataPtr(a.DisplayName),
-					"dbName":                      llx.StringDataPtr(a.DbName),
-					"isRefreshableClone":          llx.BoolDataPtr(a.IsRefreshableClone),
-					"dbVersion":                   llx.StringDataPtr(a.DbVersion),
-					"dbWorkload":                  llx.StringData(string(a.DbWorkload)),
-					"isDedicated":                 llx.BoolDataPtr(a.IsDedicated),
-					"isFreeTier":                  llx.BoolDataPtr(a.IsFreeTier),
-					"cpuCoreCount":                llx.IntData(intValue(a.CpuCoreCount)),
-					"dataStorageSizeInTBs":        llx.IntData(intValue(a.DataStorageSizeInTBs)),
-					"isMtlsConnectionRequired":    llx.BoolDataPtr(a.IsMtlsConnectionRequired),
-					"isAccessControlEnabled":      llx.BoolDataPtr(a.IsAccessControlEnabled),
-					"whitelistedIps":              llx.ArrayData(convert.SliceAnyToInterface(a.WhitelistedIps), types.String),
-					"standbyWhitelistedIps":       llx.ArrayData(convert.SliceAnyToInterface(a.StandbyWhitelistedIps), types.String),
-					"isAutoScalingEnabled":        llx.BoolDataPtr(a.IsAutoScalingEnabled),
-					"isLocalDataGuardEnabled":     llx.BoolDataPtr(a.IsLocalDataGuardEnabled),
-					"isRemoteDataGuardEnabled":    llx.BoolDataPtr(a.IsRemoteDataGuardEnabled),
-					"isDataGuardEnabled":          llx.BoolDataPtr(a.IsDataGuardEnabled),
-					"backupRetentionPeriodInDays": llx.IntData(intValue(a.BackupRetentionPeriodInDays)),
-					"isBackupRetentionLocked":     llx.BoolDataPtr(a.IsBackupRetentionLocked),
-					"dataSafeStatus":              llx.StringData(string(a.DataSafeStatus)),
-					"openMode":                    llx.StringData(string(a.OpenMode)),
-					"permissionLevel":             llx.StringData(string(a.PermissionLevel)),
-					"licenseModel":                llx.StringData(string(a.LicenseModel)),
-					"privateEndpointIp":           llx.StringDataPtr(a.PrivateEndpointIp),
-					"privateEndpointLabel":        llx.StringDataPtr(a.PrivateEndpointLabel),
-					"connectionUrls":              llx.DictData(connectionUrls),
-					"publicConnectionUrls":        llx.DictData(publicConnectionUrls),
-					"state":                       llx.StringData(string(a.LifecycleState)),
-					"created":                     llx.TimeDataPtr(created),
-					"freeformTags":                llx.MapData(strMapToAny(a.FreeformTags), types.String),
-					"definedTags":                 llx.MapData(definedTagsToAny(a.DefinedTags), types.Any),
-					"systemTags":                  llx.MapData(definedTagsToAny(a.SystemTags), types.Dict),
+					"id":                                  llx.StringDataPtr(a.Id),
+					"name":                                llx.StringDataPtr(a.DisplayName),
+					"dbName":                              llx.StringDataPtr(a.DbName),
+					"isRefreshableClone":                  llx.BoolDataPtr(a.IsRefreshableClone),
+					"dbVersion":                           llx.StringDataPtr(a.DbVersion),
+					"dbWorkload":                          llx.StringData(string(a.DbWorkload)),
+					"isDedicated":                         llx.BoolDataPtr(a.IsDedicated),
+					"isFreeTier":                          llx.BoolDataPtr(a.IsFreeTier),
+					"cpuCoreCount":                        llx.IntData(intValue(a.CpuCoreCount)),
+					"dataStorageSizeInTBs":                llx.IntData(intValue(a.DataStorageSizeInTBs)),
+					"isMtlsConnectionRequired":            llx.BoolDataPtr(a.IsMtlsConnectionRequired),
+					"isAccessControlEnabled":              llx.BoolDataPtr(a.IsAccessControlEnabled),
+					"whitelistedIps":                      llx.ArrayData(convert.SliceAnyToInterface(a.WhitelistedIps), types.String),
+					"standbyWhitelistedIps":               llx.ArrayData(convert.SliceAnyToInterface(a.StandbyWhitelistedIps), types.String),
+					"isAutoScalingEnabled":                llx.BoolDataPtr(a.IsAutoScalingEnabled),
+					"isLocalDataGuardEnabled":             llx.BoolDataPtr(a.IsLocalDataGuardEnabled),
+					"isRemoteDataGuardEnabled":            llx.BoolDataPtr(a.IsRemoteDataGuardEnabled),
+					"isDataGuardEnabled":                  llx.BoolDataPtr(a.IsDataGuardEnabled),
+					"backupRetentionPeriodInDays":         llx.IntData(intValue(a.BackupRetentionPeriodInDays)),
+					"isBackupRetentionLocked":             llx.BoolDataPtr(a.IsBackupRetentionLocked),
+					"longTermBackupRepeatCadence":         ltb["longTermBackupRepeatCadence"],
+					"longTermBackupTimeOfBackup":          ltb["longTermBackupTimeOfBackup"],
+					"longTermBackupRetentionPeriodInDays": ltb["longTermBackupRetentionPeriodInDays"],
+					"longTermBackupScheduleDisabled":      ltb["longTermBackupScheduleDisabled"],
+					"nextLongTermBackupTimestamp":         ltb["nextLongTermBackupTimestamp"],
+					"dataSafeStatus":                      llx.StringData(string(a.DataSafeStatus)),
+					"openMode":                            llx.StringData(string(a.OpenMode)),
+					"permissionLevel":                     llx.StringData(string(a.PermissionLevel)),
+					"licenseModel":                        llx.StringData(string(a.LicenseModel)),
+					"privateEndpointIp":                   llx.StringDataPtr(a.PrivateEndpointIp),
+					"privateEndpointLabel":                llx.StringDataPtr(a.PrivateEndpointLabel),
+					"connectionUrls":                      llx.DictData(connectionUrls),
+					"publicConnectionUrls":                llx.DictData(publicConnectionUrls),
+					"state":                               llx.StringData(string(a.LifecycleState)),
+					"created":                             llx.TimeDataPtr(created),
+					"freeformTags":                        llx.MapData(strMapToAny(a.FreeformTags), types.String),
+					"definedTags":                         llx.MapData(definedTagsToAny(a.DefinedTags), types.Any),
+					"systemTags":                          llx.MapData(definedTagsToAny(a.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
@@ -610,4 +617,47 @@ func (o *mqlOciDatabaseAutonomousDatabaseBackup) kmsVault() (*mqlOciKmsVault, er
 		return nil, err
 	}
 	return r.(*mqlOciKmsVault), nil
+}
+
+// longTermBackupArgs maps an Autonomous Database's long-term backup schedule
+// onto resource arguments.
+//
+// A database with no long-term backup schedule leaves every one of these null.
+// Defaulting them would report a cadence and a retention the database does not
+// have, and "no schedule configured" is a different finding from "a schedule
+// exists but is switched off" -- the latter reports
+// longTermBackupScheduleDisabled true rather than null.
+func longTermBackupArgs(sched *database.LongTermBackUpScheduleDetails, next *common.SDKTime) map[string]*llx.RawData {
+	var (
+		cadence   *string
+		timeOf    *time.Time
+		retention *int
+		disabled  *bool
+	)
+	if sched != nil {
+		// The SDK leaves an unset enum as "", which would otherwise reach MQL
+		// as an empty cadence rather than as null.
+		if sched.RepeatCadence != "" {
+			c := string(sched.RepeatCadence)
+			cadence = &c
+		}
+		if sched.TimeOfBackup != nil {
+			timeOf = &sched.TimeOfBackup.Time
+		}
+		retention = sched.RetentionPeriodInDays
+		disabled = sched.IsDisabled
+	}
+
+	var nextRun *time.Time
+	if next != nil {
+		nextRun = &next.Time
+	}
+
+	return map[string]*llx.RawData{
+		"longTermBackupRepeatCadence":         llx.StringDataPtr(cadence),
+		"longTermBackupTimeOfBackup":          llx.TimeDataPtr(timeOf),
+		"longTermBackupRetentionPeriodInDays": llx.IntDataPtr(retention),
+		"longTermBackupScheduleDisabled":      llx.BoolDataPtr(disabled),
+		"nextLongTermBackupTimestamp":         llx.TimeDataPtr(nextRun),
+	}
 }

--- a/providers/oci/resources/database_longterm_backup_test.go
+++ b/providers/oci/resources/database_longterm_backup_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func ltbBoolPtr(b bool) *bool { return &b }
-
 func TestLongTermBackupArgs(t *testing.T) {
 	backupAt := time.Date(2026, 6, 1, 2, 0, 0, 0, time.UTC)
 	nextAt := time.Date(2026, 7, 1, 2, 0, 0, 0, time.UTC)
@@ -23,7 +21,7 @@ func TestLongTermBackupArgs(t *testing.T) {
 		RepeatCadence:         database.LongTermBackUpScheduleDetailsRepeatCadenceMonthly,
 		TimeOfBackup:          &common.SDKTime{Time: backupAt},
 		RetentionPeriodInDays: intPtr(365),
-		IsDisabled:            ltbBoolPtr(false),
+		IsDisabled:            boolPtr(false),
 	}, &common.SDKTime{Time: nextAt})
 
 	assert.Equal(t, "MONTHLY", args["longTermBackupRepeatCadence"].Value)
@@ -58,7 +56,7 @@ func TestLongTermBackupArgsAreNullWithoutASchedule(t *testing.T) {
 func TestLongTermBackupArgsDistinguishDisabledFromAbsent(t *testing.T) {
 	disabled := longTermBackupArgs(&database.LongTermBackUpScheduleDetails{
 		RepeatCadence: database.LongTermBackUpScheduleDetailsRepeatCadenceYearly,
-		IsDisabled:    ltbBoolPtr(true),
+		IsDisabled:    boolPtr(true),
 	}, nil)
 	assert.Equal(t, true, disabled["longTermBackupScheduleDisabled"].Value)
 

--- a/providers/oci/resources/database_longterm_backup_test.go
+++ b/providers/oci/resources/database_longterm_backup_test.go
@@ -1,0 +1,79 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func ltbBoolPtr(b bool) *bool { return &b }
+
+func TestLongTermBackupArgs(t *testing.T) {
+	backupAt := time.Date(2026, 6, 1, 2, 0, 0, 0, time.UTC)
+	nextAt := time.Date(2026, 7, 1, 2, 0, 0, 0, time.UTC)
+
+	args := longTermBackupArgs(&database.LongTermBackUpScheduleDetails{
+		RepeatCadence:         database.LongTermBackUpScheduleDetailsRepeatCadenceMonthly,
+		TimeOfBackup:          &common.SDKTime{Time: backupAt},
+		RetentionPeriodInDays: intPtr(365),
+		IsDisabled:            ltbBoolPtr(false),
+	}, &common.SDKTime{Time: nextAt})
+
+	assert.Equal(t, "MONTHLY", args["longTermBackupRepeatCadence"].Value)
+	assert.Equal(t, backupAt, *args["longTermBackupTimeOfBackup"].Value.(*time.Time))
+	assert.Equal(t, int64(365), args["longTermBackupRetentionPeriodInDays"].Value)
+	assert.Equal(t, false, args["longTermBackupScheduleDisabled"].Value)
+	assert.Equal(t, nextAt, *args["nextLongTermBackupTimestamp"].Value.(*time.Time))
+}
+
+// A database with no long-term backup schedule must read null across the board.
+// A zero retention or an empty cadence would report a schedule the database
+// does not have, and a zero time would date the next backup to year 1.
+func TestLongTermBackupArgsAreNullWithoutASchedule(t *testing.T) {
+	args := longTermBackupArgs(nil, nil)
+
+	for _, k := range []string{
+		"longTermBackupRepeatCadence",
+		"longTermBackupTimeOfBackup",
+		"longTermBackupRetentionPeriodInDays",
+		"longTermBackupScheduleDisabled",
+		"nextLongTermBackupTimestamp",
+	} {
+		require.NotNil(t, args[k], k)
+		assert.Nil(t, args[k].Value, k)
+	}
+}
+
+// "No schedule configured" and "a schedule exists but is switched off" are
+// different findings. A disabled schedule reports true, not null, so a policy
+// can tell an operator who turned long-term backups off from one who never
+// set them up.
+func TestLongTermBackupArgsDistinguishDisabledFromAbsent(t *testing.T) {
+	disabled := longTermBackupArgs(&database.LongTermBackUpScheduleDetails{
+		RepeatCadence: database.LongTermBackUpScheduleDetailsRepeatCadenceYearly,
+		IsDisabled:    ltbBoolPtr(true),
+	}, nil)
+	assert.Equal(t, true, disabled["longTermBackupScheduleDisabled"].Value)
+
+	absent := longTermBackupArgs(nil, nil)
+	assert.Nil(t, absent["longTermBackupScheduleDisabled"].Value)
+}
+
+// The SDK leaves an unset enum as the empty string. Passing that straight
+// through would give a cadence of "" that compares unequal to every real
+// cadence while looking like a configured value.
+func TestLongTermBackupArgsEmptyCadenceIsNull(t *testing.T) {
+	args := longTermBackupArgs(&database.LongTermBackUpScheduleDetails{
+		RetentionPeriodInDays: intPtr(90),
+	}, nil)
+
+	assert.Nil(t, args["longTermBackupRepeatCadence"].Value)
+	assert.Equal(t, int64(90), args["longTermBackupRetentionPeriodInDays"].Value)
+}

--- a/providers/oci/resources/helpers_test.go
+++ b/providers/oci/resources/helpers_test.go
@@ -1,0 +1,15 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+// Pointer helpers shared across the resource tests.
+//
+// The OCI SDK models optional values as pointers, so a test that wants to
+// distinguish "absent" from "the zero value" needs to hand a real pointer to
+// the mapper. These live here rather than beside any one test so a new test
+// does not have to invent a differently-named copy.
+
+func intPtr(i int) *int       { return &i }
+func strPtr(s string) *string { return &s }
+func boolPtr(b bool) *bool    { return &b }

--- a/providers/oci/resources/network_security_rules_test.go
+++ b/providers/oci/resources/network_security_rules_test.go
@@ -146,10 +146,6 @@ func TestSecurityRuleFromNsgCarriesDirectionAndId(t *testing.T) {
 	assert.Equal(t, "ocid1.securityrule.oc1..abc", r.id)
 }
 
-func intPtr(i int) *int { return &i }
-
-func strPtr(s string) *string { return &s }
-
 func TestPortRangeHelperSanity(t *testing.T) {
 	pr := portRange(80, 443)
 	require.NotNil(t, pr.Min)

--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -7209,6 +7209,35 @@ private oci.database.autonomousDatabase @defaults("name") {
   // elapses, protecting recovery points against tampering or premature
   // deletion.
   isBackupRetentionLocked bool
+  // How often a long-term backup is taken
+  //
+  // One of ONE_TIME, WEEKLY, MONTHLY, or YEARLY. Null when no long-term
+  // backup schedule is configured, in which case the database keeps only
+  // the automatic backups covered by backupRetentionPeriodInDays.
+  longTermBackupRepeatCadence string
+  // Time the long-term backup schedule takes its backup
+  //
+  // For a MONTHLY cadence, a month with fewer days than the configured
+  // date takes the backup on its last day. Null when no long-term backup
+  // schedule is configured.
+  longTermBackupTimeOfBackup time
+  // Days a long-term backup is kept for
+  //
+  // Separate from backupRetentionPeriodInDays, which governs the
+  // automatic backups. Null when no long-term backup schedule is
+  // configured.
+  longTermBackupRetentionPeriodInDays int
+  // Whether the long-term backup schedule is marked for deletion
+  //
+  // True when a schedule exists but is disabled, so no long-term backup
+  // will be taken from it. Null when no schedule is configured at all,
+  // which is a different state from a schedule that was switched off.
+  longTermBackupScheduleDisabled bool
+  // Time the next long-term backup is due
+  //
+  // Null when no long-term backup schedule is configured, or when a
+  // ONE_TIME schedule has already run.
+  nextLongTermBackupTimestamp time
   // Oracle Data Safe status (REGISTERED, NOT_REGISTERED, REGISTERING, DEREGISTERING, FAILED)
   dataSafeStatus string
   // Open mode (READ_ONLY, READ_WRITE)

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -7630,6 +7630,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.database.autonomousDatabase.isBackupRetentionLocked": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetIsBackupRetentionLocked()).ToDataRes(types.Bool)
 	},
+	"oci.database.autonomousDatabase.longTermBackupRepeatCadence": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseAutonomousDatabase).GetLongTermBackupRepeatCadence()).ToDataRes(types.String)
+	},
+	"oci.database.autonomousDatabase.longTermBackupTimeOfBackup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseAutonomousDatabase).GetLongTermBackupTimeOfBackup()).ToDataRes(types.Time)
+	},
+	"oci.database.autonomousDatabase.longTermBackupRetentionPeriodInDays": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseAutonomousDatabase).GetLongTermBackupRetentionPeriodInDays()).ToDataRes(types.Int)
+	},
+	"oci.database.autonomousDatabase.longTermBackupScheduleDisabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseAutonomousDatabase).GetLongTermBackupScheduleDisabled()).ToDataRes(types.Bool)
+	},
+	"oci.database.autonomousDatabase.nextLongTermBackupTimestamp": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseAutonomousDatabase).GetNextLongTermBackupTimestamp()).ToDataRes(types.Time)
+	},
 	"oci.database.autonomousDatabase.dataSafeStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetDataSafeStatus()).ToDataRes(types.String)
 	},
@@ -19894,6 +19909,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.database.autonomousDatabase.isBackupRetentionLocked": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabaseAutonomousDatabase).IsBackupRetentionLocked, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"oci.database.autonomousDatabase.longTermBackupRepeatCadence": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseAutonomousDatabase).LongTermBackupRepeatCadence, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.database.autonomousDatabase.longTermBackupTimeOfBackup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseAutonomousDatabase).LongTermBackupTimeOfBackup, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.database.autonomousDatabase.longTermBackupRetentionPeriodInDays": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseAutonomousDatabase).LongTermBackupRetentionPeriodInDays, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"oci.database.autonomousDatabase.longTermBackupScheduleDisabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseAutonomousDatabase).LongTermBackupScheduleDisabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"oci.database.autonomousDatabase.nextLongTermBackupTimestamp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseAutonomousDatabase).NextLongTermBackupTimestamp, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"oci.database.autonomousDatabase.dataSafeStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -47661,47 +47696,52 @@ type mqlOciDatabaseAutonomousDatabase struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOciDatabaseAutonomousDatabaseInternal
-	Id                          plugin.TValue[string]
-	Name                        plugin.TValue[string]
-	Compartment                 plugin.TValue[*mqlOciCompartment]
-	DbName                      plugin.TValue[string]
-	SourceDatabase              plugin.TValue[*mqlOciDatabaseAutonomousDatabase]
-	IsRefreshableClone          plugin.TValue[bool]
-	DbVersion                   plugin.TValue[string]
-	DbWorkload                  plugin.TValue[string]
-	IsDedicated                 plugin.TValue[bool]
-	IsFreeTier                  plugin.TValue[bool]
-	CpuCoreCount                plugin.TValue[int64]
-	DataStorageSizeInTBs        plugin.TValue[int64]
-	IsMtlsConnectionRequired    plugin.TValue[bool]
-	IsAccessControlEnabled      plugin.TValue[bool]
-	WhitelistedIps              plugin.TValue[[]any]
-	InternetReachable           plugin.TValue[bool]
-	StandbyWhitelistedIps       plugin.TValue[[]any]
-	IsAutoScalingEnabled        plugin.TValue[bool]
-	IsLocalDataGuardEnabled     plugin.TValue[bool]
-	IsRemoteDataGuardEnabled    plugin.TValue[bool]
-	IsDataGuardEnabled          plugin.TValue[bool]
-	BackupRetentionPeriodInDays plugin.TValue[int64]
-	IsBackupRetentionLocked     plugin.TValue[bool]
-	DataSafeStatus              plugin.TValue[string]
-	OpenMode                    plugin.TValue[string]
-	PermissionLevel             plugin.TValue[string]
-	LicenseModel                plugin.TValue[string]
-	KmsKey                      plugin.TValue[*mqlOciKmsKey]
-	KmsVault                    plugin.TValue[*mqlOciKmsVault]
-	Subnet                      plugin.TValue[*mqlOciNetworkSubnet]
-	SecurityGroups              plugin.TValue[[]any]
-	PrivateEndpointIp           plugin.TValue[string]
-	PrivateEndpointLabel        plugin.TValue[string]
-	ConnectionUrls              plugin.TValue[any]
-	PublicConnectionUrls        plugin.TValue[any]
-	State                       plugin.TValue[string]
-	Created                     plugin.TValue[*time.Time]
-	FreeformTags                plugin.TValue[map[string]any]
-	DefinedTags                 plugin.TValue[map[string]any]
-	SystemTags                  plugin.TValue[map[string]any]
-	Backups                     plugin.TValue[[]any]
+	Id                                  plugin.TValue[string]
+	Name                                plugin.TValue[string]
+	Compartment                         plugin.TValue[*mqlOciCompartment]
+	DbName                              plugin.TValue[string]
+	SourceDatabase                      plugin.TValue[*mqlOciDatabaseAutonomousDatabase]
+	IsRefreshableClone                  plugin.TValue[bool]
+	DbVersion                           plugin.TValue[string]
+	DbWorkload                          plugin.TValue[string]
+	IsDedicated                         plugin.TValue[bool]
+	IsFreeTier                          plugin.TValue[bool]
+	CpuCoreCount                        plugin.TValue[int64]
+	DataStorageSizeInTBs                plugin.TValue[int64]
+	IsMtlsConnectionRequired            plugin.TValue[bool]
+	IsAccessControlEnabled              plugin.TValue[bool]
+	WhitelistedIps                      plugin.TValue[[]any]
+	InternetReachable                   plugin.TValue[bool]
+	StandbyWhitelistedIps               plugin.TValue[[]any]
+	IsAutoScalingEnabled                plugin.TValue[bool]
+	IsLocalDataGuardEnabled             plugin.TValue[bool]
+	IsRemoteDataGuardEnabled            plugin.TValue[bool]
+	IsDataGuardEnabled                  plugin.TValue[bool]
+	BackupRetentionPeriodInDays         plugin.TValue[int64]
+	IsBackupRetentionLocked             plugin.TValue[bool]
+	LongTermBackupRepeatCadence         plugin.TValue[string]
+	LongTermBackupTimeOfBackup          plugin.TValue[*time.Time]
+	LongTermBackupRetentionPeriodInDays plugin.TValue[int64]
+	LongTermBackupScheduleDisabled      plugin.TValue[bool]
+	NextLongTermBackupTimestamp         plugin.TValue[*time.Time]
+	DataSafeStatus                      plugin.TValue[string]
+	OpenMode                            plugin.TValue[string]
+	PermissionLevel                     plugin.TValue[string]
+	LicenseModel                        plugin.TValue[string]
+	KmsKey                              plugin.TValue[*mqlOciKmsKey]
+	KmsVault                            plugin.TValue[*mqlOciKmsVault]
+	Subnet                              plugin.TValue[*mqlOciNetworkSubnet]
+	SecurityGroups                      plugin.TValue[[]any]
+	PrivateEndpointIp                   plugin.TValue[string]
+	PrivateEndpointLabel                plugin.TValue[string]
+	ConnectionUrls                      plugin.TValue[any]
+	PublicConnectionUrls                plugin.TValue[any]
+	State                               plugin.TValue[string]
+	Created                             plugin.TValue[*time.Time]
+	FreeformTags                        plugin.TValue[map[string]any]
+	DefinedTags                         plugin.TValue[map[string]any]
+	SystemTags                          plugin.TValue[map[string]any]
+	Backups                             plugin.TValue[[]any]
 }
 
 // createOciDatabaseAutonomousDatabase creates a new instance of this resource
@@ -47857,6 +47897,26 @@ func (c *mqlOciDatabaseAutonomousDatabase) GetBackupRetentionPeriodInDays() *plu
 
 func (c *mqlOciDatabaseAutonomousDatabase) GetIsBackupRetentionLocked() *plugin.TValue[bool] {
 	return &c.IsBackupRetentionLocked
+}
+
+func (c *mqlOciDatabaseAutonomousDatabase) GetLongTermBackupRepeatCadence() *plugin.TValue[string] {
+	return &c.LongTermBackupRepeatCadence
+}
+
+func (c *mqlOciDatabaseAutonomousDatabase) GetLongTermBackupTimeOfBackup() *plugin.TValue[*time.Time] {
+	return &c.LongTermBackupTimeOfBackup
+}
+
+func (c *mqlOciDatabaseAutonomousDatabase) GetLongTermBackupRetentionPeriodInDays() *plugin.TValue[int64] {
+	return &c.LongTermBackupRetentionPeriodInDays
+}
+
+func (c *mqlOciDatabaseAutonomousDatabase) GetLongTermBackupScheduleDisabled() *plugin.TValue[bool] {
+	return &c.LongTermBackupScheduleDisabled
+}
+
+func (c *mqlOciDatabaseAutonomousDatabase) GetNextLongTermBackupTimestamp() *plugin.TValue[*time.Time] {
+	return &c.NextLongTermBackupTimestamp
 }
 
 func (c *mqlOciDatabaseAutonomousDatabase) GetDataSafeStatus() *plugin.TValue[string] {

--- a/providers/oci/resources/oci.lr.versions
+++ b/providers/oci/resources/oci.lr.versions
@@ -1075,7 +1075,12 @@ oci.database.autonomousDatabase.isRemoteDataGuardEnabled 13.10.1
 oci.database.autonomousDatabase.kmsKey 13.1.1
 oci.database.autonomousDatabase.kmsVault 13.1.1
 oci.database.autonomousDatabase.licenseModel 13.1.1
+oci.database.autonomousDatabase.longTermBackupRepeatCadence 13.21.1
+oci.database.autonomousDatabase.longTermBackupRetentionPeriodInDays 13.21.1
+oci.database.autonomousDatabase.longTermBackupScheduleDisabled 13.21.1
+oci.database.autonomousDatabase.longTermBackupTimeOfBackup 13.21.1
 oci.database.autonomousDatabase.name 13.1.1
+oci.database.autonomousDatabase.nextLongTermBackupTimestamp 13.21.1
 oci.database.autonomousDatabase.openMode 13.1.1
 oci.database.autonomousDatabase.permissionLevel 13.1.1
 oci.database.autonomousDatabase.privateEndpointIp 13.1.1


### PR DESCRIPTION
`oci-go-sdk v65.123.2 → v65.124.0`. This exposes the Autonomous Database long-term backup schedule on the existing `oci.database.autonomousDatabase`.

An Autonomous Database keeps automatic backups for `backupRetentionPeriodInDays`, which is typically weeks. A **long-term** backup schedule is the separate, much longer-lived retention — and whether one exists, and whether it is still switched on, was not queryable.

```
oci.database.autonomousDatabases {
  name
  longTermBackupRepeatCadence
  longTermBackupRetentionPeriodInDays
  longTermBackupScheduleDisabled
  nextLongTermBackupTimestamp
}
```

### No extra API call

`LongTermBackupSchedule` and `NextLongTermBackupTimeStamp` are already on `AutonomousDatabaseSummary`, the shape the existing list call returns, so this is pure mapping.

### Three states, not two

The nested schedule struct is optional and so are its members, which makes three distinct findings that must not collapse into each other:

- **No schedule configured** — every field reads null. The database keeps only its automatic backups.
- **A schedule exists but is switched off** — `longTermBackupScheduleDisabled` reads `true`. Someone turned long-term backups off, which is a different finding from never having set them up.
- **A schedule is running** — `longTermBackupScheduleDisabled` reads `false` and the cadence, retention and next-run fields are populated.

`longTermBackupScheduleDisabled` keeps the SDK's polarity (`IsDisabled`) rather than being inverted into an `enabled` field: inverting a nil-able negative is where this kind of bug lives, and a null would have had to become `true`.

The SDK also leaves an unset `RepeatCadence` enum as `""`, which is mapped to null — an empty cadence compares unequal to every real cadence while looking like a configured value. `TestLongTermBackupArgsEmptyCadenceIsNull` pins that.

### Considered and not included

The bump also adds BDS capacity reservations, MySQL blue-green deployments, Autonomous DB long-term backup *management* APIs (create/cancel — write-only, so nothing to read), and `SecurityAttributes` on `RecoveryServiceSubnet`. BDS has no `oci.bds` resource to hang off at all, so it is a new-service piece of work rather than a field addition.

### Verification

`go build ./... && go test ./... && gofmt -l .` in `providers/oci/` — clean. Four new tests cover the populated, absent, disabled and empty-enum cases.

Not verified against a live OCI tenancy.
