### PR TITLE
🐛 languages: assign the license three extractors already parse

### DIFF
--- a/providers/os/resources/languages/javascript/packagelockjson/extractor.go
+++ b/providers/os/resources/languages/javascript/packagelockjson/extractor.go
@@ -80,8 +80,12 @@ func (p *packageLock) Direct() languages.Packages {
 		}
 
 		filteredList = append(filteredList, &languages.Package{
-			Name:         name,
-			Version:      pkg.Version,
+			Name:    name,
+			Version: pkg.Version,
+			// npm's lockfile writes `license` as either a string or an array;
+			// the parser normalizes both to a slice, and an array means a
+			// choice among them.
+			License:      languages.LicenseExpression(pkg.License),
 			Purl:         idx[path],
 			Cpes:         javascript.NewCpes(name, pkg.Version),
 			EvidenceList: javascript.NewEvidenceList(p.evidence),
@@ -107,8 +111,12 @@ func (p *packageLock) Transitive() languages.Packages {
 			}
 
 			transitive = append(transitive, &languages.Package{
-				Name:         name,
-				Version:      v.Version,
+				Name:    name,
+				Version: v.Version,
+				// Only lockfileVersion 2+ (the `packages` map) records a
+				// per-package license; the legacy v1 `dependencies` tree below
+				// carries none, so there is nothing to read there.
+				License:      languages.LicenseExpression(v.License),
 				Purl:         idx[k],
 				Cpes:         javascript.NewCpes(name, v.Version),
 				EvidenceList: javascript.NewEvidenceList(p.evidence),

--- a/providers/os/resources/languages/javascript/packagelockjson/extractor_test.go
+++ b/providers/os/resources/languages/javascript/packagelockjson/extractor_test.go
@@ -150,3 +150,46 @@ func TestPackageJsonLockExtractorWithDependencies(t *testing.T) {
 		Hashes:       []languages.PackageHash{{Alg: "SHA-512", Value: "c0b1fa47360f400af2aec25a91cf48de4d1a15613f709c96a140fc750cb5f3a8f1c2d2e0790755734f8d7a037269becc20f8bb1ecbfd037871ea5335acf1fde0"}},
 	}, p)
 }
+
+// TestPackageLockLicense pins that the license an npm lockfile states reaches
+// the package, on both Direct and Transitive.
+//
+// The parser has always read `license` — it even carries a custom unmarshaler
+// for npm's string-or-array shape — but the extractor dropped it, so every npm
+// dependency reached an SBOM with an empty License.
+func TestPackageLockLicense(t *testing.T) {
+	f, err := os.Open("./testdata/lockfile-v3-dep-licenses.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	info, err := (&Extractor{}).Parse(f, "path/to/package-lock.json")
+	require.NoError(t, err)
+
+	want := map[string]string{
+		"lodash": "MIT",
+		// npm writes an array when a package is offered under either license;
+		// that is a choice, so it renders as an SPDX OR.
+		"dual-licensed": "(MIT OR Apache-2.0)",
+		// A package that states none must report none rather than an empty
+		// expression that would read as a declaration.
+		"no-license": "",
+		// A dev-only package still states a license.
+		"mocha": "MIT",
+	}
+
+	transitive := info.Transitive()
+	for name, license := range want {
+		p := transitive.Find(name)
+		require.NotNil(t, p, name)
+		assert.Equal(t, license, p.License, "transitive %s", name)
+	}
+
+	// Direct builds its packages separately from Transitive, so it needs its own
+	// assertion: the two representations of a package must not disagree.
+	direct := info.Direct()
+	for _, name := range []string{"lodash", "dual-licensed", "no-license"} {
+		p := direct.Find(name)
+		require.NotNil(t, p, name)
+		assert.Equal(t, want[name], p.License, "direct %s", name)
+	}
+}

--- a/providers/os/resources/languages/javascript/packagelockjson/testdata/lockfile-v3-dep-licenses.json
+++ b/providers/os/resources/languages/javascript/packagelockjson/testdata/lockfile-v3-dep-licenses.json
@@ -1,0 +1,42 @@
+{
+  "name": "dep-licenses",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dep-licenses",
+      "version": "1.0.0",
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "dual-licensed": "^1.0.0",
+        "no-license": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^10.0.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/dual-licensed": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dual-licensed/-/dual-licensed-1.0.0.tgz",
+      "license": ["MIT", "Apache-2.0"]
+    },
+    "node_modules/no-license": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/no-license/-/no-license-2.0.0.tgz"
+    },
+    "node_modules/mocha": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "license": "MIT",
+      "dev": true
+    }
+  }
+}

--- a/providers/os/resources/languages/license.go
+++ b/providers/os/resources/languages/license.go
@@ -1,0 +1,42 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package languages
+
+import "strings"
+
+// LicenseExpression renders one or more license strings as a single SPDX
+// expression for Package.License.
+//
+// Several ecosystems record a package's license as a LIST — composer.lock and
+// installed.json use a JSON array, npm's lockfile accepts either a string or an
+// array. In every one of them the list means a CHOICE: the package is offered
+// under any of these, and the consumer picks. That is SPDX's OR, so the members
+// are OR-joined and parenthesised, which keeps the result a valid expression
+// when it is embedded in a larger one.
+//
+// A single license passes through untouched, which is the overwhelmingly common
+// case and must not acquire parentheses it did not have. Empty entries are
+// dropped rather than joined into a malformed expression, and a list that is
+// empty or entirely blank yields "" — the honest answer when a manifest
+// declared nothing, and distinct from a package that declared a license this
+// function could not render.
+//
+// The strings are passed through as the manifest wrote them. Normalizing a
+// license name to a canonical identifier is a consumer's decision, not a
+// parser's, and doing it here would discard what the file actually said.
+func LicenseExpression(licenses []string) string {
+	parts := make([]string, 0, len(licenses))
+	for _, l := range licenses {
+		if l = strings.TrimSpace(l); l != "" {
+			parts = append(parts, l)
+		}
+	}
+	switch len(parts) {
+	case 0:
+		return ""
+	case 1:
+		return parts[0]
+	}
+	return "(" + strings.Join(parts, " OR ") + ")"
+}

--- a/providers/os/resources/languages/license_test.go
+++ b/providers/os/resources/languages/license_test.go
@@ -1,0 +1,50 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package languages_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/providers/os/resources/languages"
+)
+
+func TestLicenseExpression(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		in   []string
+		want string
+	}{
+		// The overwhelmingly common case. A single license must not acquire
+		// parentheses it did not have: "(MIT)" is a different string to every
+		// consumer that compares identifiers, even though it parses the same.
+		{"one license passes through", []string{"MIT"}, "MIT"},
+		// A list means the package is offered under any of them and the consumer
+		// chooses, which is what SPDX's OR says.
+		{"a list is a choice", []string{"MIT", "Apache-2.0"}, "(MIT OR Apache-2.0)"},
+		{"three", []string{"MIT", "Apache-2.0", "BSD-3-Clause"}, "(MIT OR Apache-2.0 OR BSD-3-Clause)"},
+		// A manifest that declared nothing must report nothing, rather than an
+		// empty or malformed expression that reads as a declaration.
+		{"nil", nil, ""},
+		{"empty", []string{}, ""},
+		{"blank entries only", []string{"", "  "}, ""},
+		// A blank among real entries must not become an empty OR operand, which
+		// would not parse.
+		{"blanks are dropped", []string{"MIT", "", "Apache-2.0"}, "(MIT OR Apache-2.0)"},
+		{"one real entry among blanks", []string{"", "MIT", " "}, "MIT"},
+		{"surrounding space is trimmed", []string{" MIT "}, "MIT"},
+		// Passed through as the manifest wrote it: normalizing a name is the
+		// consumer's decision, and rewriting here would discard what the file
+		// actually said.
+		{"non-SPDX text is not normalized", []string{"Apache License 2.0"}, "Apache License 2.0"},
+		// Already an expression. Wrapping it keeps the result valid when it is
+		// embedded in a larger one.
+		{"an expression operand stays grouped", []string{"MIT", "GPL-2.0-only WITH Classpath-exception-2.0"},
+			"(MIT OR GPL-2.0-only WITH Classpath-exception-2.0)"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, languages.LicenseExpression(c.in))
+		})
+	}
+}

--- a/providers/os/resources/languages/php/composerlock/extractor.go
+++ b/providers/os/resources/languages/php/composerlock/extractor.go
@@ -67,12 +67,13 @@ func (l *composerLock) Transitive() languages.Packages {
 }
 
 func makePackage(pkg composerPackage, evidence []string, scope string) *languages.Package {
-	// Note: License and Description are available in composer.lock but not yet
-	// exposed via the php.package MQL resource. When license support is added
-	// to the .lr schema, populate them here.
 	return &languages.Package{
-		Name:         pkg.Name,
-		Version:      pkg.Version,
+		Name:    pkg.Name,
+		Version: pkg.Version,
+		// composer.lock records the license as an array, which means a choice
+		// among them; LicenseExpression renders that as SPDX.
+		License:      languages.LicenseExpression(pkg.License),
+		Description:  pkg.Description,
 		Purl:         php.NewPackageUrl(pkg.Name, pkg.Version),
 		Cpes:         php.NewCpes(pkg.Name, pkg.Version),
 		EvidenceList: php.NewEvidenceList(evidence),

--- a/providers/os/resources/languages/php/composerlock/extractor_test.go
+++ b/providers/os/resources/languages/php/composerlock/extractor_test.go
@@ -47,3 +47,32 @@ func TestComposerLockExtractor(t *testing.T) {
 	assert.Equal(t, languages.PackageScopeDev, transitive.Find("phpunit/phpunit").Scope)
 	assert.Equal(t, languages.PackageScopeDev, transitive.Find("mockery/mockery").Scope)
 }
+
+// TestComposerLockExtractorLicense pins that the license composer.lock states
+// reaches the package.
+//
+// The parser has always read the field; makePackage dropped it, so every PHP
+// dependency reached an SBOM with an empty License and a policy evaluating them
+// could only report "unknown". Consumers worked around it by re-reading the
+// lockfile themselves.
+func TestComposerLockExtractorLicense(t *testing.T) {
+	f, err := os.Open("./testdata/simple.composer.lock")
+	require.NoError(t, err)
+	defer f.Close()
+
+	info, err := (&Extractor{}).Parse(f, "path/to/composer.lock")
+	require.NoError(t, err)
+
+	transitive := info.Transitive()
+	for name, want := range map[string]string{
+		"monolog/monolog": "MIT",
+		"symfony/console": "MIT",
+		"psr/log":         "MIT",
+		"phpunit/phpunit": "BSD-3-Clause", // a dev package still states one
+		"mockery/mockery": "BSD-3-Clause",
+	} {
+		p := transitive.Find(name)
+		require.NotNil(t, p, name)
+		assert.Equal(t, want, p.License, name)
+	}
+}

--- a/providers/os/resources/languages/php/installedjson/extractor.go
+++ b/providers/os/resources/languages/php/installedjson/extractor.go
@@ -51,8 +51,12 @@ func (ij *installedJson) Transitive() languages.Packages {
 	var packages languages.Packages
 	for _, pkg := range ij.Packages {
 		packages = append(packages, &languages.Package{
-			Name:         pkg.Name,
-			Version:      pkg.Version,
+			Name:    pkg.Name,
+			Version: pkg.Version,
+			// installed.json records the license as an array, which means a
+			// choice among them; LicenseExpression renders that as SPDX.
+			License:      languages.LicenseExpression(pkg.License),
+			Description:  pkg.Description,
 			Purl:         php.NewPackageUrl(pkg.Name, pkg.Version),
 			Cpes:         php.NewCpes(pkg.Name, pkg.Version),
 			EvidenceList: php.NewEvidenceList(ij.evidence),

--- a/providers/os/resources/languages/php/installedjson/extractor_test.go
+++ b/providers/os/resources/languages/php/installedjson/extractor_test.go
@@ -34,3 +34,26 @@ func TestInstalledJsonExtractor(t *testing.T) {
 	require.NotNil(t, p)
 	assert.Equal(t, "v6.4.1", p.Version)
 }
+
+// TestInstalledJsonLicense pins that the license installed.json states reaches
+// the package. Same defect as composer.lock: the parser read the field and the
+// extractor dropped it.
+func TestInstalledJsonLicense(t *testing.T) {
+	f, err := os.Open("./testdata/simple.installed.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	info, err := (&Extractor{}).Parse(f, "path/to/installed.json")
+	require.NoError(t, err)
+
+	transitive := info.Transitive()
+	for name, want := range map[string]string{
+		"monolog/monolog": "MIT",
+		"symfony/console": "MIT",
+		"psr/log":         "MIT",
+	} {
+		p := transitive.Find(name)
+		require.NotNil(t, p, name)
+		assert.Equal(t, want, p.License, name)
+	}
+}


### PR DESCRIPTION
`composer.lock`, `installed.json` and `package-lock.json` all record a per-package license, all three parsers read it, and all three extractors dropped it. Every PHP and npm dependency therefore reached an SBOM with an empty `License`, and a consumer evaluating a license policy could only report `unknown` for them.

One commit, `providers/os/resources/languages` only.

## The data was always there

`composerlock`'s `makePackage` even carried a note saying so:

```go
// Note: License and Description are available in composer.lock but not yet
// exposed via the php.package MQL resource. When license support is added
// to the .lr schema, populate them here.
```

`languages.Package.License` has existed since then, so that note is stale and the mapping is the whole fix. `Description` was sitting in the same gap and is populated alongside it.

Before this, only **2** of the language extractors set `License` at all — `packagejson` and `python/wheelegg`.

## A list of licenses is a choice

Three ecosystems record the license as a list (npm accepts either a string or an array, and its parser already normalizes both). In every one, a list means the package is offered under any of them and the consumer picks — SPDX's `OR`. `LicenseExpression` renders that:

| input | output |
|---|---|
| `["MIT"]` | `MIT` |
| `["MIT", "Apache-2.0"]` | `(MIT OR Apache-2.0)` |
| `["MIT", "", "Apache-2.0"]` | `(MIT OR Apache-2.0)` |
| `[]` / `nil` / `["", " "]` | `""` |

A single license passes through untouched — it is the overwhelmingly common case and must not acquire parentheses it did not have, since `"(MIT)"` is a different string to every consumer that compares identifiers. Blank entries are dropped rather than joined into a malformed expression with an empty operand. A manifest that declared nothing yields `""` rather than something that reads as a declaration.

The strings are passed through **as the manifest wrote them**. Normalizing a name to a canonical identifier is a consumer's decision, not a parser's, and doing it here would discard what the file actually said.

## Scope

npm's legacy `lockfileVersion` 1 `dependencies` tree is deliberately untouched: that format records no license at all, so there is nothing there to read. Only the v2+ `packages` map carries one.

`Direct()` and `Transitive()` build their packages separately in `packagelockjson`, so both are covered and both are tested — a package's two representations must not disagree.

## Verified end to end, not by inspection

xgrep carries a compensating shim (`pkg/sca/licenseenrich.go`) that re-reads these two lockfiles itself, precisely because these extractors dropped the field. Its doc comment says: *"Once mql populates License natively for these ecosystems, this shim can be deleted with no behavior change."*

So the test is: build xgrep against this change with that shim **switched off** (`--no-license-enrich`), on a tree with a `composer.lock` and a `package-lock.json`.

```
--- BEFORE: xgrep on current mql main, shim disabled ---
dual/licensed     ""                     unknown
express           ""                     unknown
lodash            ""                     unknown
monolog/monolog   ""                     unknown
phpunit/phpunit   ""                     unknown

--- AFTER: xgrep on this branch, shim still disabled ---
dual/licensed     (MIT OR Apache-2.0)    notice
express           MIT                    notice
lodash            MIT                    notice
monolog/monolog   MIT                    notice
phpunit/phpunit   BSD-3-Clause           notice
```

(The root project entry stays empty in both, correctly — the lockfile states no license for it.)

That makes the shim redundant. Deleting it is xgrep's change to make once this lands and the dependency is bumped, not this PR's.

## Tests

- `LicenseExpression` — the single/list/blank/absent cases, plus that non-SPDX text is passed through unnormalized and that an operand which is itself an expression stays grouped.
- One end-to-end test per extractor, asserting against the real fixtures already in `testdata`. `composerlock` and `installedjson` use the existing `simple.*` fixtures; `packagelockjson` gets a new `lockfile-v3-dep-licenses.json`, because the existing lockfile fixtures carry a license only on the root entry and never on a dependency — so the previous ones could not have caught this.
- The npm test covers a string license, an array license, a package stating none, and a dev-only package, on both `Direct` and `Transitive`.

`go test ./providers/os/resources/languages/... ./sbom/...` green; `go vet` and `gofmt` clean.