### PR TITLE
🎉 network-13.3.1

### DIFF
--- a/providers/network/config/config.go
+++ b/providers/network/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "network",
 	ID:              "go.mondoo.com/cnquery/v9/providers/network",
-	Version:         "13.3.0",
+	Version:         "13.3.1",
 	ConnectionTypes: []string{provider.HostConnectionType},
 	Platforms:       provider.Platforms,
 	CrossProviderTypes: []string{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### network (13.3.1)
- 🐛 network: retry the NS walk instead of silently answering from the parent zone (#10544)