### PR TITLE
🌙 network: backport dns.zone and the zone walk's NS retry (#10542, #10543)

### DIFF
--- a/providers/network/resources/dns.go
+++ b/providers/network/resources/dns.go
@@ -76,6 +76,53 @@ func initDns(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]
 	return args, nil, nil
 }
 
+// zone reports the apex of the zone that contains the domain, as a dns resource
+// for that name.
+//
+// The records that describe a zone as a whole (DNSKEY, NS, SOA) exist at its
+// apex and nowhere else inside it, so a question about how a zone is signed, or
+// how many nameservers serve it, has an answer at this name and no answer at
+// any other name the zone contains. Reading those fields through here answers
+// for the containing zone; comparing fqdn against the returned fqdn tells an
+// apex from a name that merely sits inside a zone.
+//
+// The zone is null rather than an error when the name belongs to no zone, which
+// covers an unregistered domain and a scan target given as an IP address (see
+// params for the empty-fqdn substitution). A failed query is still an error: a
+// resolver outage must not read as a name that has no zone.
+func (d *mqlDns) zone(fqdn string) (*mqlDns, error) {
+	if fqdn == "" {
+		d.Zone.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	dnsShaker, err := dnsshake.New(fqdn)
+	if err != nil {
+		return nil, err
+	}
+
+	zone, err := dnsShaker.Zone()
+	if err != nil {
+		return nil, err
+	}
+	if zone == "" {
+		d.Zone.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	// An apex is its own zone. NewResource consults the runtime cache, so this
+	// resolves back to the receiver rather than building a second resource for
+	// the same name, and the record sweep behind it is shared either way.
+	res, err := NewResource(d.MqlRuntime, "dns", map[string]*llx.RawData{
+		"fqdn": llx.StringData(zone),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return res.(*mqlDns), nil
+}
+
 func (d *mqlDns) params(fqdn string) (any, error) {
 	// initDns substitutes an empty fqdn when the scan target is an IP address
 	// rather than a hostname. Querying an empty name resolves the DNS ROOT ZONE,

--- a/providers/network/resources/dnsshake/dnsshake.go
+++ b/providers/network/resources/dnsshake/dnsshake.go
@@ -284,14 +284,15 @@ func (d *DnsClient) QueryAuthoritative(dnsTypes ...string) (map[string]DnsRecord
 // queryNS asks for the NS records at a name, retrying across the configured
 // resolvers before reporting failure.
 //
-// queryDnsTypeAt sends one datagram to one server and reports a lost reply as a
-// failure, and the walk below reads a failure at a name as that name not being
-// a zone, so it climbs to the parent and answers with the parent's nameservers.
-// Those serve referrals rather than the records the caller wanted, which is how
-// a single dropped UDP packet turned authoritativeRecords into a silently wrong
-// answer instead of a slow one. A resolver is asked config.Attempts times, and
-// every configured resolver is asked, so reaching the walk's failure path means
-// no resolver could answer rather than that one packet went missing.
+// walkToDelegation treats a query that did not happen as a reason to stop
+// rather than to climb, because climbing would answer with whichever ancestor
+// did respond and hide the delegation below it. That is only sound if a query
+// that could have been answered was: queryDnsTypeAt sends one datagram to one
+// server and reports a lost reply as a failure, so a single dropped UDP packet
+// would otherwise end the walk and surface as an error on every field behind
+// it. A resolver is asked config.Attempts times, and every configured resolver
+// is asked, so the error means no resolver could answer rather than that one
+// packet went missing.
 //
 // Only a transport failure is retried. Any answer is the resolver having
 // answered, NXDOMAIN and a response carrying no NS records included, and what

--- a/providers/network/resources/dnsshake/dnsshake.go
+++ b/providers/network/resources/dnsshake/dnsshake.go
@@ -330,37 +330,33 @@ func (d *DnsClient) queryNS(zone string) (map[string]DnsRecord, error) {
 	return nil, errors.Wrapf(lastErr, "querying NS for %s", zone)
 }
 
-// authoritativeNameservers finds the addresses of the nameservers serving the
-// zone that contains the client's fqdn.
+// walkToDelegation walks up the labels of the client's fqdn and reports the
+// closest enclosing name that answers with NS records of its own, together with
+// those records.
 //
-// The NS records live at the zone apex, not at every name within it, so this
-// walks up the labels until a delegation is found: a query for
-// "www.example.com" finds nothing at that name and succeeds at "example.com".
-// The walk stops before the root so a name that resolves nowhere fails rather
-// than returning the root servers, which would answer referrals instead of the
+// NS records live at a zone apex and at the delegation points within it, not at
+// every name a zone contains, so a query for "www.example.com" answers with no
+// NS records and the walk continues at "example.com", which does. The walk
+// stops before the root so a name that resolves nowhere reports not-found
+// rather than the root servers, which would answer referrals instead of the
 // records the caller wants.
-func (d *DnsClient) authoritativeNameservers() ([]string, error) {
+//
+// accept decides whether a name that answered is the one the caller wanted;
+// returning false continues the walk. It is how authoritativeNameservers keeps
+// climbing past a delegation whose nameservers do not resolve, while Zone,
+// which only needs the name, stops at the first one.
+func (d *DnsClient) walkToDelegation(accept func(zone string, ns DnsRecord) bool) (string, bool, error) {
 	name := dns.Fqdn(d.fqdn)
 	if name == "." {
-		return nil, errors.New("cannot determine authoritative nameservers without a domain name")
+		return "", false, errors.New("cannot determine the authoritative zone without a domain name")
 	}
-
-	// queryErr remembers the last query that could not be answered, so a walk
-	// that failed everywhere says why instead of only that it found nothing.
-	var queryErr error
 
 	for labels := dns.SplitDomainName(name); len(labels) > 0; labels = labels[1:] {
 		zone := strings.Join(labels, ".")
 
 		records, err := d.queryNS(zone)
 		if err != nil {
-			// Every resolver failed for this name. Climbing on is the behaviour
-			// this branch has always had and it is kept deliberately, but the
-			// cause is worth carrying: without it a walk that failed at every
-			// label reports only that nothing was found, which reads as a fact
-			// about the name rather than a resolver that could not be reached.
-			queryErr = err
-			continue
+			return "", false, err
 		}
 
 		ns, ok := records["NS"]
@@ -368,7 +364,54 @@ func (d *DnsClient) authoritativeNameservers() ([]string, error) {
 			continue
 		}
 
-		addrs := []string{}
+		if !accept(zone, ns) {
+			continue
+		}
+
+		return zone, true, nil
+	}
+
+	return "", false, nil
+}
+
+// Zone reports the apex of the zone that contains the client's fqdn: the
+// closest enclosing name that is served as a zone of its own.
+//
+// This is the name the zone-wide configuration belongs to. DNSKEY, NS and SOA
+// records exist at a zone apex and nowhere else inside the zone, so a question
+// about how a zone is signed, or how many nameservers serve it, has an answer
+// at this name and no answer at any other name the zone contains.
+//
+// It is found by delegation rather than by the public suffix list, which is
+// what makes it the zone the name actually belongs to rather than the
+// registrable domain. The two agree for "www.example.com", whose zone is
+// "example.com"; they differ for a delegated subdomain such as
+// "corp.example.com", which is its own zone, signed with its own keys and
+// served by its own nameservers.
+//
+// It reports an empty zone, and no error, for a name that nothing answers for
+// as a zone: an unregistered domain has no apex to report, which is a fact
+// about the name rather than a failure to establish it. A query that fails is
+// the error case, and is reported as one, so a resolver outage is never
+// mistaken for a name that belongs to no zone.
+func (d *DnsClient) Zone() (string, error) {
+	zone, found, err := d.walkToDelegation(func(string, DnsRecord) bool { return true })
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", nil
+	}
+	return zone, nil
+}
+
+// authoritativeNameservers finds the addresses of the nameservers serving the
+// zone that contains the client's fqdn.
+func (d *DnsClient) authoritativeNameservers() ([]string, error) {
+	var addrs []string
+
+	_, found, err := d.walkToDelegation(func(_ string, ns DnsRecord) bool {
+		addrs = addrs[:0]
 		for _, host := range ns.RData {
 			// Nameservers are named, so each one needs resolving to an address
 			// before it can be queried. Skip any that do not resolve; as long as
@@ -379,17 +422,16 @@ func (d *DnsClient) authoritativeNameservers() ([]string, error) {
 			}
 			addrs = append(addrs, ips...)
 		}
-
-		if len(addrs) > 0 {
-			return addrs, nil
-		}
+		return len(addrs) > 0
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errors.New("no authoritative nameserver found for " + d.fqdn)
 	}
 
-	if queryErr != nil {
-		return nil, errors.Wrapf(queryErr, "no authoritative nameserver found for %s", d.fqdn)
-	}
-
-	return nil, errors.New("no authoritative nameserver found for " + d.fqdn)
+	return addrs, nil
 }
 
 // queryDnsTypeAt performs the lookup against a named server.

--- a/providers/network/resources/dnsshake/walk_resilience_internal_test.go
+++ b/providers/network/resources/dnsshake/walk_resilience_internal_test.go
@@ -214,16 +214,18 @@ func TestAuthoritativeNameserversStillClimbsPastAnUnresolvableDelegation(t *test
 		"the unresolvable delegation is tried first, then the walk continues to the parent")
 }
 
-// TestAuthoritativeNameserversReportsWhyWhenNoResolverAnswers: a walk that could
-// not reach a resolver at any label used to report only that it found nothing,
-// which reads as a fact about the name.
-func TestAuthoritativeNameserversReportsWhyWhenNoResolverAnswers(t *testing.T) {
+// TestAuthoritativeNameserversEndsTheWalkOnAQueryFailure pins the behaviour
+// change this backport makes to a shipped field. Before it, a lost reply at the
+// queried name climbed to the parent and returned the parent's nameservers,
+// which answer referrals rather than the records the caller wanted. It is an
+// error now, and after queryNS's retry it takes a resolver that really cannot
+// answer.
+func TestAuthoritativeNameserversEndsTheWalkOnAQueryFailure(t *testing.T) {
 	c := &DnsClient{config: deadResolverConfig(t, 2, 2), fqdn: "vpn.corp.example.test"}
 
 	addrs, err := c.authoritativeNameservers()
 	require.Error(t, err)
 	assert.Empty(t, addrs)
-	assert.Contains(t, err.Error(), "no authoritative nameserver found for vpn.corp.example.test")
 	assert.Contains(t, err.Error(), "querying NS for",
 		"the terminal error should carry the query that could not be answered")
 }

--- a/providers/network/resources/dnsshake/walk_resilience_internal_test.go
+++ b/providers/network/resources/dnsshake/walk_resilience_internal_test.go
@@ -5,7 +5,6 @@ package dnsshake
 
 import (
 	"net"
-	"strconv"
 	"sync"
 	"testing"
 
@@ -14,25 +13,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// authoritativeNameservers walks up the labels until a name answers with NS
-// records, and reads a query it could not get an answer to as that name not
-// being a zone. It then climbs, and answers with the parent's nameservers.
+// The delegation walk ends on a query that did not happen rather than climbing
+// past it, because climbing would answer with whichever ancestor did respond and
+// hide the delegation below it. That is only a safe reading if a query that
+// could have been answered was, and a single UDP datagram is not that: one lost
+// reply would otherwise read as "this resolver cannot answer" and fail every
+// field behind the walk.
 //
-// That is only a safe reading if a query that could have been answered was, and
-// one UDP datagram to one resolver is not that. A lost reply at a delegated
-// subzone silently returned the parent's nameservers, which serve referrals
-// rather than the records the caller asked for. Since authoritativeRecords
-// exists to read the TTLs a zone is configured with rather than a cache's
-// countdown, that is a wrong answer, not a slow one.
+// These tests fix the two halves of that: a transient loss is retried and does
+// not surface, while a resolver that genuinely cannot answer still errors.
 
-// walkFixture serves a small zone tree, optionally dropping the first replies
-// for one name so a caller sees a lost datagram before a real answer:
-//
-//   - example.test answers NS at its own name
-//   - corp.example.test is delegated, so it answers NS too and is a zone of its
-//     own, which is the name a climb would skip past
-//   - every other name answers NOERROR with nothing
-type walkFixture struct {
+// flakyResolver serves the zone tree of zoneFixture, dropping the first
+// dropFirst queries it receives for dropName so a caller sees a lost reply
+// before a real answer.
+type flakyResolver struct {
 	mu        sync.Mutex
 	dropName  string
 	dropFirst int
@@ -40,13 +34,8 @@ type walkFixture struct {
 	dropped   int
 }
 
-func (f *walkFixture) serve(t *testing.T) *dns.ClientConfig {
+func (f *flakyResolver) serve(t *testing.T) *dns.ClientConfig {
 	t.Helper()
-
-	delegations := map[string][]string{
-		"example.test.":      {"ns1.example.test.", "ns2.example.test."},
-		"corp.example.test.": {"ns1.corp.example.test."},
-	}
 
 	mux := dns.NewServeMux()
 	mux.HandleFunc(".", func(w dns.ResponseWriter, r *dns.Msg) {
@@ -54,7 +43,7 @@ func (f *walkFixture) serve(t *testing.T) *dns.ClientConfig {
 
 		f.mu.Lock()
 		f.queries++
-		drop := q.Name == f.dropName && f.dropped < f.dropFirst
+		drop := (f.dropName == "" || q.Name == f.dropName) && f.dropped < f.dropFirst
 		if drop {
 			f.dropped++
 		}
@@ -62,20 +51,18 @@ func (f *walkFixture) serve(t *testing.T) *dns.ClientConfig {
 
 		if drop {
 			// No reply at all: the client waits and reports a timeout, which is
-			// what a lost datagram looks like.
+			// exactly what a lost datagram looks like.
 			return
 		}
 
 		m := new(dns.Msg)
 		m.SetReply(r)
 		m.Authoritative = true
-		if q.Qtype == dns.TypeNS {
-			for _, ns := range delegations[q.Name] {
-				m.Answer = append(m.Answer, &dns.NS{
-					Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 300},
-					Ns:  ns,
-				})
-			}
+		if q.Qtype == dns.TypeNS && q.Name == "example.test." {
+			m.Answer = append(m.Answer, &dns.NS{
+				Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 300},
+				Ns:  "ns1.example.test.",
+			})
 		}
 		_ = w.WriteMsg(m)
 	})
@@ -90,38 +77,18 @@ func (f *walkFixture) serve(t *testing.T) *dns.ClientConfig {
 	host, port, err := net.SplitHostPort(pc.LocalAddr().String())
 	require.NoError(t, err)
 
-	// Attempts is honoured by queryNS. Timeout is not, because queryDnsTypeAt
-	// builds a dns.Client with the library default and never reads it.
 	return &dns.ClientConfig{Servers: []string{host}, Port: port, Attempts: 2}
 }
 
-func (f *walkFixture) counts() (queries, dropped int) {
+func (f *flakyResolver) counts() (queries, dropped int) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.queries, f.dropped
 }
 
-// resolveEachNameserver resolves any nameserver name to a distinct address and
-// records what it was asked, which is how these tests see which zone the walk
-// settled on.
-func resolveEachNameserver(asked *[]string) func(string) ([]string, error) {
-	addrs := map[string]string{
-		"ns1.corp.example.test": "192.0.2.10",
-		"ns1.example.test":      "192.0.2.1",
-		"ns2.example.test":      "192.0.2.2",
-	}
-	return func(name string) ([]string, error) {
-		*asked = append(*asked, name)
-		if ip, ok := addrs[name]; ok {
-			return []string{ip}, nil
-		}
-		return nil, &net.DNSError{Err: "no such host", Name: name, IsNotFound: true}
-	}
-}
-
 // deadResolverConfig points at a port nothing listens on, so every query is
 // lost rather than answered.
-func deadResolverConfig(t *testing.T, servers, attempts int) *dns.ClientConfig {
+func deadResolverConfig(t *testing.T, servers int, attempts int) *dns.ClientConfig {
 	t.Helper()
 
 	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
@@ -137,39 +104,29 @@ func deadResolverConfig(t *testing.T, servers, attempts int) *dns.ClientConfig {
 	return &dns.ClientConfig{Servers: addrs, Port: port, Attempts: attempts}
 }
 
-// TestAuthoritativeNameserversRetriesALostReply is the bug: one lost datagram at
-// a delegated subzone used to hand back the parent's nameservers, and nothing
-// said so.
-func TestAuthoritativeNameserversRetriesALostReply(t *testing.T) {
-	f := &walkFixture{dropName: "corp.example.test.", dropFirst: 1}
+// TestZoneRetriesALostReply is the case that made the walk's strictness a
+// liability: the apex answers fine, one datagram on the way to it goes missing,
+// and before the retry that reported an error on dns.zone and on every
+// authoritative field.
+func TestZoneRetriesALostReply(t *testing.T) {
+	f := &flakyResolver{dropName: "example.test.", dropFirst: 1}
+	c := &DnsClient{config: f.serve(t), fqdn: "example.test"}
 
-	var asked []string
-	c := &DnsClient{
-		config:     f.serve(t),
-		fqdn:       "vpn.corp.example.test",
-		lookupHost: resolveEachNameserver(&asked),
-	}
+	zone, err := c.Zone()
+	require.NoError(t, err, "one lost reply must not fail the walk")
+	assert.Equal(t, "example.test", zone)
 
-	addrs, err := c.authoritativeNameservers()
-	require.NoError(t, err)
-
-	assert.Equal(t, []string{"192.0.2.10"}, addrs,
-		"a retried query should settle on corp.example.test, not climb to its parent")
-	assert.Equal(t, []string{"ns1.corp.example.test"}, asked,
-		"the parent's nameservers should never have been reached")
-
-	_, dropped := f.counts()
+	queries, dropped := f.counts()
 	assert.Equal(t, 1, dropped, "the fixture should have dropped exactly one reply")
+	assert.Equal(t, 2, queries, "the lost query should have been retried once")
 }
 
-// TestAuthoritativeNameserversFailsOverToTheNextResolver: resolv.conf commonly
-// lists several nameservers, and asking only the first throws away the
-// redundancy the host is configured for.
-func TestAuthoritativeNameserversFailsOverToTheNextResolver(t *testing.T) {
-	f := &walkFixture{}
-	live := f.serve(t)
+// TestQueryNSFailsOverToTheNextResolver: resolv.conf commonly lists several
+// nameservers, and asking only the first throws away the redundancy the host is
+// configured for. One unreachable resolver should cost latency, not the answer.
+func TestQueryNSFailsOverToTheNextResolver(t *testing.T) {
+	live := zoneFixture(t)
 
-	var asked []string
 	c := &DnsClient{
 		config: &dns.ClientConfig{
 			// Nothing listens on 127.0.0.2 at the fixture's port, so answering
@@ -178,77 +135,76 @@ func TestAuthoritativeNameserversFailsOverToTheNextResolver(t *testing.T) {
 			Port:     live.Port,
 			Attempts: 1,
 		},
-		fqdn:       "corp.example.test",
-		lookupHost: resolveEachNameserver(&asked),
+		fqdn: "example.test",
 	}
 
-	addrs, err := c.authoritativeNameservers()
-	require.NoError(t, err, "an unreachable first resolver must fail over, not fall through the walk")
-	assert.Equal(t, []string{"192.0.2.10"}, addrs)
+	zone, err := c.Zone()
+	require.NoError(t, err, "an unreachable first resolver must fail over, not fail")
+	assert.Equal(t, "example.test", zone)
 }
 
-// TestAuthoritativeNameserversStillClimbsPastAnUnresolvableDelegation is the
-// leniency this backport keeps. A delegation whose nameservers do not resolve is
-// not usable, so the walk continues to one that is. This is behaviour, not an
-// accident, and the retry must not change it.
-func TestAuthoritativeNameserversStillClimbsPastAnUnresolvableDelegation(t *testing.T) {
-	f := &walkFixture{}
+// TestZoneStillErrorsWhenNoResolverAnswers keeps the property the retry must not
+// weaken. A resolver outage is not evidence that a name belongs to no zone, and
+// reporting an empty zone for it would make a check filtered on the zone skip
+// silently.
+func TestZoneStillErrorsWhenNoResolverAnswers(t *testing.T) {
+	c := &DnsClient{config: deadResolverConfig(t, 2, 2), fqdn: "www.example.test"}
 
-	var asked []string
-	c := &DnsClient{
-		config: f.serve(t),
-		fqdn:   "vpn.corp.example.test",
-		lookupHost: func(name string) ([]string, error) {
-			asked = append(asked, name)
-			if name == "ns1.corp.example.test" {
-				return nil, &net.DNSError{Err: "no such host", Name: name, IsNotFound: true}
-			}
-			return resolveEachNameserver(new([]string))(name)
-		},
-	}
-
-	addrs, err := c.authoritativeNameservers()
-	require.NoError(t, err)
-	assert.Equal(t, []string{"192.0.2.1", "192.0.2.2"}, addrs)
-	assert.Equal(t, []string{"ns1.corp.example.test", "ns1.example.test", "ns2.example.test"}, asked,
-		"the unresolvable delegation is tried first, then the walk continues to the parent")
-}
-
-// TestAuthoritativeNameserversEndsTheWalkOnAQueryFailure pins the behaviour
-// change this backport makes to a shipped field. Before it, a lost reply at the
-// queried name climbed to the parent and returned the parent's nameservers,
-// which answer referrals rather than the records the caller wanted. It is an
-// error now, and after queryNS's retry it takes a resolver that really cannot
-// answer.
-func TestAuthoritativeNameserversEndsTheWalkOnAQueryFailure(t *testing.T) {
-	c := &DnsClient{config: deadResolverConfig(t, 2, 2), fqdn: "vpn.corp.example.test"}
-
-	addrs, err := c.authoritativeNameservers()
-	require.Error(t, err)
-	assert.Empty(t, addrs)
-	assert.Contains(t, err.Error(), "querying NS for",
-		"the terminal error should carry the query that could not be answered")
-}
-
-func TestAuthoritativeNameserversRejectsRootStill(t *testing.T) {
-	for _, fqdn := range []string{"", "."} {
-		c := &DnsClient{config: deadResolverConfig(t, 1, 1), fqdn: fqdn}
-		_, err := c.authoritativeNameservers()
-		assert.Error(t, err, "fqdn %q must not walk to the root", fqdn)
-	}
+	zone, err := c.Zone()
+	require.Error(t, err, "an unreachable resolver must not read as a name with no zone")
+	assert.Empty(t, zone)
+	assert.Contains(t, err.Error(), "querying NS for")
 }
 
 func TestQueryNSWithoutAResolverIsAnError(t *testing.T) {
 	c := &DnsClient{config: &dns.ClientConfig{Port: "53"}, fqdn: "example.test"}
 
 	_, err := c.queryNS("example.test")
-	require.Error(t, err, "no configured resolver cannot silently mean no delegation")
+	require.Error(t, err, "no configured resolver cannot silently mean no zone")
 }
 
-func TestWalkFixturePortIsNumeric(t *testing.T) {
-	// Guards the fixture itself: a non-numeric port would make every query fail
-	// and every assertion above would be testing the failure path by accident.
-	f := &walkFixture{}
-	_, err := strconv.Atoi(f.serve(t).Port)
+// TestAuthoritativeNameserversEndsTheWalkOnAQueryFailure pins the behaviour
+// change #10542 made to a shipped field. Before it, a lost reply at the queried
+// name climbed to the parent and returned the parent's nameservers, which answer
+// referrals rather than the records the caller wanted. It is an error now, and
+// after the retry above it takes a resolver that really cannot answer.
+func TestAuthoritativeNameserversEndsTheWalkOnAQueryFailure(t *testing.T) {
+	c := &DnsClient{config: deadResolverConfig(t, 1, 1), fqdn: "www.example.test"}
+
+	addrs, err := c.authoritativeNameservers()
+	require.Error(t, err)
+	assert.Empty(t, addrs)
+	assert.Contains(t, err.Error(), "querying NS for")
+}
+
+// TestAuthoritativeNameserversClimbsPastAnUnresolvableDelegation is the
+// leniency the walk keeps, and the reason walkToDelegation takes an accept
+// callback: a delegation whose nameservers do not resolve is not usable, so the
+// walk continues to one that is. The injected resolver is what makes this
+// reachable in a test at all.
+func TestAuthoritativeNameserversClimbsPastAnUnresolvableDelegation(t *testing.T) {
+	var asked []string
+	c := &DnsClient{
+		config: zoneFixture(t),
+		fqdn:   "vpn.corp.example.test",
+		lookupHost: func(name string) ([]string, error) {
+			asked = append(asked, name)
+			// corp.example.test's nameserver does not resolve; example.test's does.
+			switch name {
+			case "ns1.corp.example.test":
+				return nil, &net.DNSError{Err: "no such host", Name: name, IsNotFound: true}
+			case "ns1.example.test":
+				return []string{"192.0.2.1"}, nil
+			default:
+				return []string{"192.0.2.2"}, nil
+			}
+		},
+	}
+
+	addrs, err := c.authoritativeNameservers()
 	require.NoError(t, err)
+	assert.Equal(t, []string{"192.0.2.1", "192.0.2.2"}, addrs,
+		"every resolvable nameserver of the accepted zone should be returned")
+	assert.Equal(t, []string{"ns1.corp.example.test", "ns1.example.test", "ns2.example.test"}, asked,
+		"the unresolvable delegation should be tried first, then the walk continues to the parent")
 }

--- a/providers/network/resources/dnsshake/zone_internal_test.go
+++ b/providers/network/resources/dnsshake/zone_internal_test.go
@@ -1,0 +1,160 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package dnsshake
+
+import (
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// zoneFixture serves a synthetic tree that carries the three shapes the walk has
+// to tell apart, none of which a live domain can be relied on to hold still:
+//
+//   - example.test is a zone apex and answers NS at its own name
+//   - www.example.test is a name inside it, published as a CNAME. A resolver
+//     answers an NS query for it with NOERROR and the CNAME in the answer
+//     section, which is the shape that makes "answered successfully" and
+//     "carries NS records" two different questions
+//   - corp.example.test is delegated, so it answers NS at its own name and is a
+//     zone in its own right, which is where the delegation walk and the public
+//     suffix list disagree
+//
+// Every other name answers NOERROR with nothing, so a name under no zone walks
+// to the top without finding one.
+func zoneFixture(t *testing.T) *dns.ClientConfig {
+	t.Helper()
+
+	delegations := map[string][]string{
+		"example.test.":      {"ns1.example.test.", "ns2.example.test."},
+		"corp.example.test.": {"ns1.corp.example.test."},
+	}
+
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Authoritative = true
+
+		q := r.Question[0]
+		switch {
+		case q.Qtype == dns.TypeNS && len(delegations[q.Name]) > 0:
+			for _, ns := range delegations[q.Name] {
+				m.Answer = append(m.Answer, &dns.NS{
+					Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 300},
+					Ns:  ns,
+				})
+			}
+		case q.Name == "www.example.test.":
+			// A CNAME is what a resolver returns for any type asked of this
+			// name, NS included. It answers successfully and carries no NS.
+			m.Answer = append(m.Answer, &dns.CNAME{
+				Hdr:    dns.RR_Header{Name: q.Name, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+				Target: "example.test.",
+			})
+		}
+
+		_ = w.WriteMsg(m)
+	})
+
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := &dns.Server{PacketConn: pc, Handler: mux}
+	go func() { _ = srv.ActivateAndServe() }()
+	t.Cleanup(func() { _ = srv.Shutdown() })
+
+	host, port, err := net.SplitHostPort(pc.LocalAddr().String())
+	require.NoError(t, err)
+
+	return &dns.ClientConfig{Servers: []string{host}, Port: port, Timeout: 2, Attempts: 1}
+}
+
+func fixtureClient(t *testing.T, fqdn string) *DnsClient {
+	t.Helper()
+	return &DnsClient{config: zoneFixture(t), fqdn: fqdn}
+}
+
+func TestZone(t *testing.T) {
+	tests := []struct {
+		name string
+		fqdn string
+		want string
+	}{
+		{"an apex is its own zone", "example.test", "example.test"},
+		{"a name inside a zone reports the apex", "www.example.test", "example.test"},
+		{"a CNAME answer is not a delegation", "www.example.test", "example.test"},
+		{"a delegated subdomain is its own zone", "corp.example.test", "corp.example.test"},
+		{"a name inside a delegated subzone reports that subzone", "vpn.corp.example.test", "corp.example.test"},
+		{"a name under no zone reports none", "absent.test", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			zone, err := fixtureClient(t, tc.fqdn).Zone()
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, zone)
+		})
+	}
+}
+
+func TestZoneRejectsRoot(t *testing.T) {
+	// The root is a zone, and reporting it would make every name look like it
+	// sits in one. A name that cannot name a zone has to fail instead.
+	for _, fqdn := range []string{"", "."} {
+		_, err := fixtureClient(t, fqdn).Zone()
+		assert.Error(t, err, "fqdn %q must not walk to the root", fqdn)
+	}
+}
+
+func TestZoneReportsQueryFailureAsError(t *testing.T) {
+	// A resolver that cannot be reached must not read as a name that belongs to
+	// no zone: the first is unknown, the second is a fact, and a check filtered
+	// on the zone would silently skip on the strength of the difference.
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	_, port, err := net.SplitHostPort(pc.LocalAddr().String())
+	require.NoError(t, err)
+	require.NoError(t, pc.Close()) // nothing listens here now
+
+	c := &DnsClient{
+		config: &dns.ClientConfig{Servers: []string{"127.0.0.1"}, Port: port, Timeout: 1, Attempts: 1},
+		fqdn:   "www.example.test",
+	}
+
+	_, err = c.Zone()
+	assert.Error(t, err)
+}
+
+func TestWalkToDelegationContinuesWhenTheCallerRejectsAZone(t *testing.T) {
+	// authoritativeNameservers depends on this: a delegation whose nameservers
+	// do not resolve is not usable to it, and the walk has to climb past it
+	// rather than stopping at the first name that merely answered.
+	c := fixtureClient(t, "vpn.corp.example.test")
+
+	var offered []string
+	zone, found, err := c.walkToDelegation(func(zone string, _ DnsRecord) bool {
+		offered = append(offered, zone)
+		return zone == "example.test"
+	})
+
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "example.test", zone)
+	assert.Equal(t, []string{"corp.example.test", "example.test"}, offered,
+		"the rejected delegation should be offered first, then the walk continues")
+}
+
+func TestPortIsNumeric(t *testing.T) {
+	// Guards the fixture itself: a non-numeric port would make every query fail
+	// and every zone come back empty, which the table above would read as a
+	// passing "no zone" case.
+	cfg := zoneFixture(t)
+	_, err := strconv.Atoi(cfg.Port)
+	require.NoError(t, err)
+}

--- a/providers/network/resources/dnsshake/zone_internal_test.go
+++ b/providers/network/resources/dnsshake/zone_internal_test.go
@@ -72,7 +72,9 @@ func zoneFixture(t *testing.T) *dns.ClientConfig {
 	host, port, err := net.SplitHostPort(pc.LocalAddr().String())
 	require.NoError(t, err)
 
-	return &dns.ClientConfig{Servers: []string{host}, Port: port, Timeout: 2, Attempts: 1}
+	// Attempts is honoured by queryNS; Timeout is not, because queryDnsTypeAt
+	// builds a dns.Client with the library default and never reads it.
+	return &dns.ClientConfig{Servers: []string{host}, Port: port, Attempts: 1}
 }
 
 func fixtureClient(t *testing.T, fqdn string) *DnsClient {
@@ -87,8 +89,9 @@ func TestZone(t *testing.T) {
 		want string
 	}{
 		{"an apex is its own zone", "example.test", "example.test"},
+		// www.example.test is a CNAME, so this also covers that answering
+		// successfully and carrying NS records are two different questions.
 		{"a name inside a zone reports the apex", "www.example.test", "example.test"},
-		{"a CNAME answer is not a delegation", "www.example.test", "example.test"},
 		{"a delegated subdomain is its own zone", "corp.example.test", "corp.example.test"},
 		{"a name inside a delegated subzone reports that subzone", "vpn.corp.example.test", "corp.example.test"},
 		{"a name under no zone reports none", "absent.test", ""},

--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -545,6 +545,24 @@ dns @defaults("fqdn") {
   init(fqdn string)
   // Fully qualified domain name (FQDN)
   fqdn string
+  // Apex of the zone that contains this name
+  //
+  // The closest enclosing name that is served as a zone of its own, which is
+  // where a zone-wide question has an answer. DNSKEY, NS and SOA records exist
+  // at a zone apex and nowhere else inside the zone, so `zone.dnssec` and
+  // `zone.records` report how the containing zone is signed and served even
+  // when the name itself publishes neither. Comparing `fqdn` against
+  // `zone.fqdn` tells an apex from a name that merely sits inside a zone,
+  // which is what scopes a zone-wide audit to the one name it can hold for.
+  //
+  // The zone is established by delegation rather than by the public suffix
+  // list, so it is the zone the name belongs to and not the registrable
+  // domain. The two agree for `www.example.com`, whose zone is `example.com`.
+  // They differ for a delegated subdomain such as `corp.example.com`, which is
+  // a zone of its own, signed with its own keys and served by its own
+  // nameservers. Null when nothing answers as a zone, such as for a name that
+  // does not resolve or a scan target given as an IP address.
+  zone(fqdn) dns
   // DNS query results keyed by record type
   //
   // Map keyed by DNS record type (such as `A`, `AAAA`, `MX`, or `TXT`),

--- a/providers/network/resources/network.lr.go
+++ b/providers/network/resources/network.lr.go
@@ -696,6 +696,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"dns.fqdn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDns).GetFqdn()).ToDataRes(types.String)
 	},
+	"dns.zone": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDns).GetZone()).ToDataRes(types.Resource("dns"))
+	},
 	"dns.params": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDns).GetParams()).ToDataRes(types.Dict)
 	},
@@ -1552,6 +1555,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"dns.fqdn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDns).Fqdn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"dns.zone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDns).Zone, ok = plugin.RawToTValue[*mqlDns](v.Value, v.Error)
 		return
 	},
 	"dns.params": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3876,6 +3883,7 @@ type mqlDns struct {
 	__id       string
 	// optional: if you define mqlDnsInternal it will be used here
 	Fqdn                 plugin.TValue[string]
+	Zone                 plugin.TValue[*mqlDns]
 	Params               plugin.TValue[any]
 	AuthoritativeParams  plugin.TValue[any]
 	Records              plugin.TValue[[]any]
@@ -3928,6 +3936,27 @@ func (c *mqlDns) MqlID() string {
 
 func (c *mqlDns) GetFqdn() *plugin.TValue[string] {
 	return &c.Fqdn
+}
+
+func (c *mqlDns) GetZone() *plugin.TValue[*mqlDns] {
+	return plugin.GetOrCompute[*mqlDns](&c.Zone, func() (*mqlDns, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("dns", c.__id, "zone")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDns), nil
+			}
+		}
+
+		vargFqdn := c.GetFqdn()
+		if vargFqdn.Error != nil {
+			return nil, vargFqdn.Error
+		}
+
+		return c.zone(vargFqdn.Data)
+	})
 }
 
 func (c *mqlDns) GetParams() *plugin.TValue[any] {

--- a/providers/network/resources/network.lr.versions
+++ b/providers/network/resources/network.lr.versions
@@ -94,6 +94,7 @@ dns.spfRecord.allQualifier 13.1.1
 dns.spfRecord.dnsTxt 13.1.1
 dns.spfRecord.mechanisms 13.1.1
 dns.spfRecord.version 13.1.1
+dns.zone 13.3.2
 domainName 9.0.1
 domainName.effectiveTLDPlusOne 9.0.1
 domainName.fqdn 9.0.1


### PR DESCRIPTION
Backports #10542 and #10543 to the v13 branch, as two cherry-picks.

## How this lands on a branch that already has #10544

#10544 (network-13.3.1) already ported #10543's `queryNS` retry to this branch, but deliberately kept the old walk behaviour: a name whose NS query failed was climbed past, because #10542's strict walk was not here to make stopping correct. This PR brings that other half:

- **#10542** adds `dns.zone` (the apex of the zone containing the name, established by delegation rather than the public suffix list) and refactors the delegation walk into the shared `walkToDelegation`/`Zone()`. With it comes the behaviour change #10544 explicitly deferred: a query that no resolver could answer now ends the walk with an error instead of climbing, because climbing answers with whichever ancestor did respond and hides the delegation below it. Since `queryNS` already existed here, the strict walk goes through it from the start — the retry #10544 shipped is never regressed, even between the two commits. The one #10544 test that pinned the climb is updated in the same commit to pin the strict behaviour.
- **#10543** then reconciles the `queryNS` doc comment and the test files to main's final state (`flakyResolver`/`zoneFixture`, plus the strict-walk and failover tests).

After both, `dnsshake.go` and its tests are byte-identical to main's, except the `/v13` module path.

## Versioning

`dns.zone` enters `.lr.versions` as **13.3.2** on this branch: 13.3.1 already shipped from v13 (via #10544) without the field, so main's 13.3.1 entry would claim it exists in a release it is not in.

## Verification

- `go test ./...` green in `providers/network` (the walk and retry are pinned by fixture-served tests that cover the whole delegation walk).
- Live, with a v13-built mql and this provider: `www.mondoo.com` reports zone `mondoo.com`; a scan target given as an IP (`1.1.1.1`) reports `dns.zone: null`; `dns.authoritativeParams` reads through. The delegated-subzone row (`www.cs.cmu.edu` → `cs.cmu.edu`) could not be reproduced here because the local router's resolver times out on that NS query (confirmed with dig against the router directly, which also times out while `NS mondoo.com` answers); the walk correctly reports that as an error rather than answering from the parent zone, which is the behaviour this backport ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)