### PR TITLE
🎉 network-13.3.2

### DIFF
--- a/providers/network/config/config.go
+++ b/providers/network/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "network",
 	ID:              "go.mondoo.com/cnquery/v9/providers/network",
-	Version:         "13.3.1",
+	Version:         "13.3.2",
 	ConnectionTypes: []string{provider.HostConnectionType},
 	Platforms:       provider.Platforms,
 	CrossProviderTypes: []string{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### network (13.3.2)
- 🌙 network: backport dns.zone and the zone walk's NS retry (#10542, #10543) (#10559)
