### PR TITLE
🐛 github: add a request timeout so a scan cannot hang forever

### DIFF
--- a/providers/github/connection/connection.go
+++ b/providers/github/connection/connection.go
@@ -35,6 +35,14 @@ const (
 	OPTION_ENTERPRISE_URL          = "enterprise-url"
 )
 
+// githubRequestTimeout bounds a single HTTP attempt end-to-end (dial, TLS,
+// headers, body). Without it a connection that stops responding blocks the
+// calling goroutine indefinitely — and scans execute assets with
+// parallelism=1, so one stuck call silently wedges the entire scan until
+// something external kills the process. GitHub API responses are bounded
+// JSON documents; even large tree listings finish in seconds.
+const githubRequestTimeout = 5 * time.Minute
+
 type GithubConnection struct {
 	plugin.Connection
 	asset  *inventory.Asset
@@ -223,7 +231,12 @@ func newGithubRetryableClient(httpClient *http.Client) *http.Client {
 	retryClient.Logger = zerologadapter.New(log.Logger)
 
 	if httpClient == nil {
-		httpClient = http.DefaultClient
+		// A fresh client, not http.DefaultClient: the timeout below must not
+		// leak onto the shared default client.
+		httpClient = &http.Client{}
+	}
+	if httpClient.Timeout == 0 {
+		httpClient.Timeout = githubRequestTimeout
 	}
 	retryClient.HTTPClient = httpClient
 
@@ -260,7 +273,7 @@ func newGithubRetryableClient(httpClient *http.Client) *http.Client {
 				if err != nil {                                                      // Must be impossible to hit errors here, but just in case
 					return time.Second * 8
 				}
-				return time.Second * time.Duration(sec)
+				return rateLimitWait(time.Second*time.Duration(sec), attemptNum)
 			}
 			// Primary and Secondary rate limit
 			if resp.Header.Get("x-ratelimit-remaining") == "0" {
@@ -269,7 +282,7 @@ func newGithubRetryableClient(httpClient *http.Client) *http.Client {
 					return time.Second * 8
 				}
 				tm := time.Unix(unix, 0)
-				return tm.Sub(time.Now().UTC()) // time.Until might not use UTC, depending on the server configuration
+				return rateLimitWait(tm.Sub(time.Now().UTC()), attemptNum) // time.Until might not use UTC, depending on the server configuration
 			}
 		}
 
@@ -278,4 +291,12 @@ func newGithubRetryableClient(httpClient *http.Client) *http.Client {
 	}
 
 	return retryClient.StandardClient()
+}
+
+// rateLimitWait logs a rate-limit wait at warn level before it is slept: at
+// the default log level these sleeps are otherwise invisible, and a scan
+// waiting out a quota reset looks exactly like a hang.
+func rateLimitWait(wait time.Duration, attemptNum int) time.Duration {
+	log.Warn().Dur("wait", wait).Int("attempt", attemptNum).Msg("github API rate limited, waiting before retry")
+	return wait
 }

--- a/providers/github/connection/connection_test.go
+++ b/providers/github/connection/connection_test.go
@@ -9,8 +9,10 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/google/go-github/v90/github"
 	"github.com/stretchr/testify/require"
@@ -68,6 +70,23 @@ func TestGithubValidConnection_Password(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+}
+
+func TestGithubRetryableClientSetsRequestTimeout(t *testing.T) {
+	hc := &http.Client{}
+	newGithubRetryableClient(hc)
+	require.Equal(t, githubRequestTimeout, hc.Timeout)
+}
+
+func TestGithubRetryableClientKeepsExistingTimeout(t *testing.T) {
+	hc := &http.Client{Timeout: time.Second}
+	newGithubRetryableClient(hc)
+	require.Equal(t, time.Second, hc.Timeout)
+}
+
+func TestGithubRetryableClientDoesNotMutateDefaultClient(t *testing.T) {
+	newGithubRetryableClient(nil)
+	require.Zero(t, http.DefaultClient.Timeout)
 }
 
 func TestGithubNeedsFix(t *testing.T) {


### PR DESCRIPTION
## Problem

The github provider's HTTP client has **no timeout at any layer**: the per-attempt client is a plain `http.Client` (or `oauth2.NewClient`) with `Timeout=0`, wrapped by retryablehttp. A connection that stops responding mid-request blocks the calling goroutine indefinitely — and because scans execute assets with `parallelism=1`, one stuck call silently wedges the **entire scan**.

This is the mechanism behind a production incident where a GitHub Enterprise integration scan job intermittently failed: 13 of 41 runs over 10 days went completely silent right after policy-filter evaluation began — last outbound request was a 200 `GetPolicyFilters`, the follow-up `ResolveAndUpdateJobs` was never sent — and each pod sat mute for ~5h until the k8s Job `activeDeadlineSeconds` killed it (`DeadlineExceeded`, the failures on the job-runner dashboard).

Separately, rate-limit backoff sleeps happen at debug log level, i.e. invisibly — a scan waiting out a quota reset is indistinguishable from a hang.

## Fix

- Give every HTTP attempt a **5m end-to-end timeout** (dial, TLS, headers, body). GitHub API responses are bounded JSON documents; even large recursive tree listings finish in seconds. A timeout a caller already set is kept.
- **Log rate-limit waits at warn level** — a scan waiting on quota no longer looks identical to a hang. The reset GitHub advertises is still honored in full.
- Stop falling back to `http.DefaultClient`, so the injected timeout cannot leak onto the shared default client.

## Testing

- New unit tests for the timeout wiring (set, preserved-if-preset, `DefaultClient` untouched).
- `go build ./... && go vet ./connection/ && go test ./connection/` clean in `providers/github`.

## Notes

- `go-github`'s `SleepUntilPrimaryRateLimitResetWhenRateLimited` context value is left as-is (its internal sleep is bounded by the ~1h reset window).
- This should be backported to the v13 release line — that's what cnspec pins for the job-runner scan jobs currently hitting this in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZGuHVHbbqUekkMW2c9xRB
