### PR TITLE
🎉 github-13.9.2

### DIFF
--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "github",
 	ID:              "go.mondoo.com/cnquery/v9/providers/github",
-	Version:         "13.9.1",
+	Version:         "13.9.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
Release the github provider (13.9.1 → 13.9.2) from the v13 line.

Ships #10563, the v13 backport of #10561: a 5m request timeout on the provider's HTTP client (a scan can no longer hang forever on a dead connection), rate-limit waits logged at warn level, and no more `http.DefaultClient` fallback.

Version bump generated with `providers-sdk/v1/util/version update providers/github --increment=patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZGuHVHbbqUekkMW2c9xRB