### PR TITLE
🛑 gcp: stop publishing the GKE control-plane password and the IAP client secret

### DIFF
--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -2973,10 +2973,11 @@ func (g *mqlGcpProjectComputeService) backendServices() ([]any, error) {
 
 				var mqlIap any
 				if b.Iap != nil {
+					// Oauth2ClientSecret is deliberately not published. The
+					// sha256 below is the form callers should compare against.
 					mqlIap = map[string]any{
 						"serviceEnabled":           b.Iap.Enabled,
 						"oauth2ClientId":           b.Iap.Oauth2ClientId,
-						"oauth2ClientSecret":       b.Iap.Oauth2ClientSecret,
 						"oauth2ClientSecretSha256": b.Iap.Oauth2ClientSecretSha256,
 					}
 				}

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -2751,7 +2751,12 @@ private gcp.project.computeService.backendService @defaults("name") {
   healthChecks []string
   // Health checks that probe this backend service
   healthCheckRefs() []gcp.project.computeService.healthCheck
-  // Identity-aware proxy configuration
+  // Identity-Aware Proxy configuration
+  //
+  // Keys: `serviceEnabled` (bool, whether IAP gates access to the backend
+  // service), `oauth2ClientId` (OAuth2 client ID used by IAP), and
+  // `oauth2ClientSecretSha256` (SHA-256 hash of the OAuth2 client secret).
+  // The OAuth2 client secret itself is deliberately not published.
   iap dict
   // Load balancer type
   loadBalancingScheme string
@@ -4703,7 +4708,15 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   legacyAbac dict
   // Whether the legacy ABAC authorizer is enabled on the cluster
   legacyAbacEnabled bool
-  // Authentication information for accessing the master endpoint
+  // Control plane authentication information
+  //
+  // Keys: `username` (basic-auth username, empty when basic auth is off),
+  // `clientCertificateConfig` (whether the cluster issues a client
+  // certificate), `clusterCaCertificate` (the cluster certificate authority
+  // certificate), and `clientCertificate` (the issued client certificate).
+  // The basic-auth password and the client private key are deliberately not
+  // published; read `basicAuthEnabled` and `clientCertificateEnabled` for the
+  // audit signals instead.
   masterAuth dict
   // Whether client certificate authentication to the control plane is enabled
   //

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -632,13 +632,15 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 			// Username is the deprecated HTTP basic-auth field; a non-empty value
 			// means basic auth is enabled (read solely for the audit signal).
 			basicAuthEnabled = c.MasterAuth.Username != ""
+			// Password and ClientKey are deliberately not published. They are
+			// the control-plane basic-auth password and the client private
+			// key; the audit signals they would serve are already carried by
+			// basicAuthEnabled and clientCertificateEnabled above.
 			masterAuth = map[string]any{
 				"username":                c.MasterAuth.Username,
-				"password":                c.MasterAuth.Password,
 				"clientCertificateConfig": clientCertCfg,
 				"clusterCaCertificate":    c.MasterAuth.ClusterCaCertificate,
 				"clientCertificate":       c.MasterAuth.ClientCertificate,
-				"clientKey":               c.MasterAuth.ClientKey,
 			}
 		}
 


### PR DESCRIPTION
## What

Three pieces of secret material were being serialized into shipped `dict` fields and are now dropped:

| file | field | what was published |
|---|---|---|
| `providers/gcp/resources/gke.go` | `gkeService.cluster.masterAuth` | `MasterAuth.Password` — the GKE control-plane HTTP basic-auth password |
| `providers/gcp/resources/gke.go` | `gkeService.cluster.masterAuth` | `MasterAuth.ClientKey` — the client **private** key |
| `providers/gcp/resources/compute.go` | `computeService.backendService.iap` | `Iap.Oauth2ClientSecret` — the plaintext IAP OAuth2 client secret |

## Why none of them is load-bearing

- `basicAuthEnabled` and `clientCertificateEnabled` are computed from the same struct a few lines above the `masterAuth` map, and are the audit signals a policy actually wants.
- `oauth2ClientSecretSha256` was already sitting in the *same map* as the plaintext secret, and is the form a caller should compare against.
- `grep` finds no consumer of the removed keys anywhere in the provider.

The App Engine `iap` field is the existing counter-example done right: it decodes into a hand-rolled struct (`appengine.go:284`) carrying only `oauth2ClientSecretSha256`. This change makes the Compute backend service match it.

## Compatibility

The remaining keys are untouched, so any query reading `username`, `clusterCaCertificate`, `clientCertificate`, `clientCertificateConfig`, `serviceEnabled`, `oauth2ClientId` or `oauth2ClientSecretSha256` behaves exactly as before. A query that read one of the three removed keys now resolves to null. That is a deliberate trade: a schema that hands out a control-plane password and a private key is worse than one that returns null for them.

## Doc comments

Both fields had comments that did not enumerate their keys, so nothing recorded which values were intentional. Both now list the keys the dict actually carries and state that the secrets are deliberately omitted, so a future SDK upgrade plus a mechanical `convert.JsonToDict` does not quietly reintroduce them.

`serviceEnabled` is documented as-is. It is a rename of the SDK's `Enabled`, which means the intuitive `iap.enabled` returns null today — noted here rather than changed, since it belongs with the broader dict-typing work.

## Test plan

- [x] `./mqlr generate providers/gcp/resources/gcp.lr` — no schema drift, `gcp.lr.versions` unchanged (doc-only `.lr` edit)
- [x] `go build ./...` in `providers/gcp`
- [x] `gofmt` clean
- [ ] Live verification pending the batched `provider-verification` run covering the four provider schema PRs in this series
