### PR TITLE
🛑 gcp: encode protobuf-backed dicts with protojson, not encoding/json

### DIFF
--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -224,6 +224,22 @@ func protoToDict(msg proto.Message) (map[string]any, error) {
 	return result, nil
 }
 
+// protoToDictSlice converts a slice of protobuf messages the same way
+// protoToDict converts one. Use it instead of convert.JsonToDictSlice for
+// protobuf-generated types: encoding/json emits their snake_case json tags and
+// renders enums as numbers, neither of which matches what the schema documents.
+func protoToDictSlice[T proto.Message](msgs []T) ([]any, error) {
+	res := make([]any, 0, len(msgs))
+	for _, msg := range msgs {
+		d, err := protoToDict(msg)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, d)
+	}
+	return res, nil
+}
+
 func (g *mqlGcpRetryConfig) id() (string, error) {
 	return g.Id.Data, g.Id.Error
 }

--- a/providers/gcp/resources/insights.go
+++ b/providers/gcp/resources/insights.go
@@ -93,7 +93,10 @@ func newMqlInsight(runtime *plugin.Runtime, item *recommenderpb.Insight) (*mqlGc
 	if item.GetContent() != nil {
 		content = item.GetContent().AsMap()
 	}
-	stateInfo, err := convert.JsonToDict(item.GetStateInfo())
+	// protojson, not encoding/json: encoding/json over a protobuf-generated
+	// struct emits the snake_case json tags, so this dict documented `state`
+	// and `stateMetadata` while carrying `state` and `state_metadata`.
+	stateInfo, err := protoToDict(item.GetStateInfo())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gcp/resources/network_connectivity.go
+++ b/providers/gcp/resources/network_connectivity.go
@@ -159,7 +159,7 @@ func (g *mqlGcpProjectNetworkConnectivityService) hubs() ([]any, error) {
 			return nil, err
 		}
 
-		routingVpcs, err := convert.JsonToDictSlice(hub.GetRoutingVpcs())
+		routingVpcs, err := protoToDictSlice(hub.GetRoutingVpcs())
 		if err != nil {
 			return nil, err
 		}
@@ -265,7 +265,7 @@ func (g *mqlGcpProjectNetworkConnectivityService) spokes() ([]any, error) {
 			return nil, err
 		}
 
-		reasons, err := convert.JsonToDictSlice(spoke.GetReasons())
+		reasons, err := protoToDictSlice(spoke.GetReasons())
 		if err != nil {
 			return nil, err
 		}

--- a/providers/gcp/resources/privileged_access_manager.go
+++ b/providers/gcp/resources/privileged_access_manager.go
@@ -152,7 +152,7 @@ func (g *mqlGcpProjectPrivilegedAccessManagerService) entitlements() ([]any, err
 			return nil, err
 		}
 
-		eligibleUsers, err := convert.JsonToDictSlice(e.GetEligibleUsers())
+		eligibleUsers, err := protoToDictSlice(e.GetEligibleUsers())
 		if err != nil {
 			return nil, err
 		}

--- a/providers/gcp/resources/proto_encoding_test.go
+++ b/providers/gcp/resources/proto_encoding_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/recommender/apiv1/recommenderpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
 	dns "google.golang.org/api/dns/v1"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -85,4 +87,47 @@ func TestDnssecStateEnabled(t *testing.T) {
 			assert.Equal(t, tt.want, dnssecStateEnabled(tt.cfg))
 		})
 	}
+}
+
+// TestProtoToDictEmitsDocumentedKeysAndEnumNames pins the encoding bug that
+// made several shipped dicts undocumentable.
+//
+// convert.JsonToDict is encoding/json over a protobuf-generated struct, and
+// those structs carry snake_case json tags with enums rendered as their numeric
+// value. gcp.recommendation.primaryImpact therefore documented `category`,
+// `costProjection` and friends while actually emitting `{"category": 2, ...}`.
+// protoToDict marshals through protojson, which is what the schema documents.
+func TestProtoToDictEmitsDocumentedKeysAndEnumNames(t *testing.T) {
+	impact := &recommenderpb.Impact{
+		Category: recommenderpb.Impact_SECURITY,
+		Service:  "compute.googleapis.com",
+	}
+
+	// The hazard being guarded against.
+	viaEncodingJSON, err := convert.JsonToDict(impact)
+	require.NoError(t, err)
+	assert.EqualValues(t, float64(recommenderpb.Impact_SECURITY), viaEncodingJSON["category"],
+		"encoding/json renders the enum as its number")
+
+	got, err := protoToDict(impact)
+	require.NoError(t, err)
+	assert.Equal(t, "SECURITY", got["category"])
+	assert.Equal(t, "compute.googleapis.com", got["service"])
+}
+
+// TestProtoToDictSlicePreservesOrderAndNilInput guards the helper the recommender,
+// Network Connectivity and Privileged Access Manager listers share.
+func TestProtoToDictSlicePreservesOrderAndNilInput(t *testing.T) {
+	got, err := protoToDictSlice([]*recommenderpb.Impact{
+		{Category: recommenderpb.Impact_COST},
+		{Category: recommenderpb.Impact_SECURITY},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "COST", got[0].(map[string]any)["category"])
+	assert.Equal(t, "SECURITY", got[1].(map[string]any)["category"])
+
+	empty, err := protoToDictSlice([]*recommenderpb.Impact{})
+	require.NoError(t, err)
+	assert.Empty(t, empty)
 }

--- a/providers/gcp/resources/recommendations.go
+++ b/providers/gcp/resources/recommendations.go
@@ -11,7 +11,6 @@ import (
 
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/providers/gcp/connection"
 
 	recommender "cloud.google.com/go/recommender/apiv1"
@@ -27,12 +26,28 @@ func newMqlRecommendation(runtime *plugin.Runtime, item *recommenderpb.Recommend
 		category = item.PrimaryImpact.Category.String()
 	}
 
-	primaryImpact, _ := convert.JsonToDict(item.PrimaryImpact)
-	additionalImpact, _ := convert.JsonToDictSlice(item.AdditionalImpact)
-	content, _ := convert.JsonToDict(item.Content)
+	// protojson, not encoding/json: encoding/json over a protobuf-generated
+	// struct emits the snake_case json tags and renders enums as their numeric
+	// values, so `category` came back as `2` and the projection oneof appeared
+	// under its bare Go field name rather than as `costProjection` and friends.
+	primaryImpact, err := protoToDict(item.PrimaryImpact)
+	if err != nil {
+		return nil, err
+	}
+	additionalImpact, err := protoToDictSlice(item.AdditionalImpact)
+	if err != nil {
+		return nil, err
+	}
+	content, err := protoToDict(item.Content)
+	if err != nil {
+		return nil, err
+	}
 	lastRefreshTime := item.LastRefreshTime.AsTime()
 	priority := item.Priority.String()
-	state, _ := convert.JsonToDict(item.StateInfo)
+	state, err := protoToDict(item.StateInfo)
+	if err != nil {
+		return nil, err
+	}
 
 	// projects/{projectid}/locations/{zone}/recommenders/{recommender}/recommendations/{id}
 	values := strings.Split(item.Name, "/")


### PR DESCRIPTION
## Breaking

The keys and values inside **six shipped `dict` fields** change. Read the compatibility note before merging.

## What was wrong

`convert.JsonToDict` is `encoding/json` over protobuf-generated structs. Those structs carry **snake_case** json tags, and enums marshal as their **numeric** value. A protobuf `oneof` has no json tag at all, so it surfaces under its bare Go field name. The result is that these six fields have been emitting keys no documentation ever described:

| field | doc promises | actually emitted |
|---|---|---|
| `gcp.recommendation.primaryImpact` | `category` as `COST`/`SECURITY`, `costProjection` | `{"category": 2, "Projection": {...}}` |
| `gcp.recommendation.state` | `stateMetadata` | `state_metadata` |
| `gcp.insight.stateInfo` | `stateMetadata` | `state_metadata` |
| `...networkConnectivityService.hub.routingVpcs` | `requiredForNewSiteToSiteDataTransferSpokes` | `required_for_new_site_to_site_data_transfer_spokes` |
| `...networkConnectivityService.spoke.reasons` | `userDetails` | `user_details` |
| `...privilegedAccessManager.entitlement.eligibleUsers` | camelCase | snake_case |

Anyone following our own schema docs got `null` from these fields. In MQL a null operand makes a denylist check **pass**, so a policy reading `primaryImpact.category == "SECURITY"` has been silently matching nothing rather than erroring.

## The fix

`protoToDict` already marshals through `protojson`, which produces exactly the camelCase keys and enum names the schema documents. All six sites move onto it, and `protoToDictSlice` is added for the list-valued ones.

The four recommender sites also discarded their conversion error with `_`, so a marshal failure produced a nil dict indistinguishable from "the API returned nothing". They now return the error.

## Why this is marked breaking, not a bugfix

It changes the output of fields that have already shipped:

- A query written against the **actual** snake_case keys, or comparing an enum to its number, **stops resolving**.
- A query written against the **documented** names **starts working for the first time**.

There is no encoding that satisfies both. The schema is the contract, so the documented names win — but that is a deliberate call, not a silent repair, which is why it ships on its own rather than buried inside a larger schema PR.

Worth a `content/`-side check in cnspec for `primaryImpact[`, `stateInfo[`, and `state[` index reads before this lands.

## Test plan

- [x] `go build ./...` in `providers/gcp`
- [x] `go test ./resources/` — new `proto_encoding_test.go` pins both halves: that `encoding/json` renders `Impact_SECURITY` as the number `2`, and that `protoToDict` renders it as `"SECURITY"`. The test fails if anyone reverts the encoder.
- [x] `protoToDictSlice` covered for ordering and the empty-input case
- [ ] Live verification pending the batched `provider-verification` run covering the four provider schema PRs in this series
