### PR TITLE
🐛 languages: read the declared licenses three more extractors drop, and bound them all

### DIFF
--- a/providers/os/resources/languages/java/manifestmf/extractor.go
+++ b/providers/os/resources/languages/java/manifestmf/extractor.go
@@ -125,6 +125,10 @@ func (m *manifest) Root() *languages.Package {
 		pkg.Vendor = v
 	}
 
+	if l := m.license(); l != "" {
+		pkg.License = l
+	}
+
 	return pkg
 }
 

--- a/providers/os/resources/languages/java/manifestmf/license.go
+++ b/providers/os/resources/languages/java/manifestmf/license.go
@@ -1,0 +1,119 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package manifestmf
+
+import (
+	"regexp"
+	"strings"
+)
+
+// OSGi states a bundle's license in Bundle-License, and the header is
+// structured rather than a plain name (OSGi Core, Module Layer):
+//
+//	Bundle-License ::= '<<EXTERNAL>>' | ( license ( ',' license ) * )
+//	license        ::= license-identifier ( ';' license-attr ) *
+//	license-attr   ::= description | link
+//	description    ::= 'description' '=' string
+//	link           ::= 'link' '=' <url>
+//
+// so a real header looks like any of:
+//
+//	Bundle-License: Apache-2.0;link="https://www.apache.org/licenses/LICENSE-2.0"
+//	Bundle-License: The Apache License, Version 2.0;link="http://www.apache.org/..."
+//	Bundle-License: https://www.eclipse.org/legal/epl-2.0/
+//	Bundle-License: <<EXTERNAL>>
+//
+// Only the license-identifier is carried into the inventory. The attributes are
+// dropped: `link` points at the license text and `description` is prose — the
+// bnd documentation's own example is a full sentence — and neither is the
+// identity of the license.
+
+// bundleLicenseExternal is the magic identifier meaning "this artifact states
+// no license here; it is provided some other way". It is a statement that the
+// header is empty, so it is treated as one.
+const bundleLicenseExternal = "<<EXTERNAL>>"
+
+// urlPattern matches a value that is a URL rather than a license name.
+var urlPattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.\-]*://`)
+
+// license returns the license the manifest declares, or "" when it declares
+// none this can name.
+//
+// The value is returned as the manifest wrote it. Normalizing a name to a
+// canonical SPDX identifier is a consumer's decision, not a parser's.
+func (m *manifest) license() string {
+	raw := strings.TrimSpace(m.Headers[headerBundleLicense])
+	if raw == "" {
+		return ""
+	}
+
+	names := make([]string, 0, 1)
+	for _, entry := range splitOutsideQuotes(raw, ',') {
+		name := licenseIdentifier(entry)
+		// A URL is a link to the terms, not the identity of the terms.
+		// Reporting one in a field consumers compare against "Apache-2.0" or
+		// "MIT" matches nothing while reading as a stated identifier, which is
+		// worse than the honest blank they get today. The header is
+		// URL-only on most real bundles, so most of them keep reporting
+		// nothing — this only adds the ones that name a license.
+		if name == "" || name == bundleLicenseExternal || urlPattern.MatchString(name) {
+			continue
+		}
+		names = append(names, name)
+	}
+
+	// The grammar makes ',' a separator between licenses, but real manifests
+	// also write an identifier that contains one: "The Apache License, Version
+	// 2.0;link=..." is a single license, and it is what Eclipse/Tycho bundles
+	// emit. Nothing distinguishes that from a genuine two-license header, so
+	// the members are rejoined into one value rather than OR-joined. Rejoining
+	// reproduces what the manifest said; OR-joining would report a bundle as
+	// dual-licensed under "The Apache License" or "Version 2.0", inventing a
+	// choice the bundle never offered.
+	return strings.Join(names, ", ")
+}
+
+// licenseIdentifier returns the license-identifier of one entry: everything
+// before its first attribute, unquoted and trimmed.
+func licenseIdentifier(entry string) string {
+	parts := splitOutsideQuotes(entry, ';')
+	if len(parts) == 0 {
+		return ""
+	}
+	return unquote(strings.TrimSpace(parts[0]))
+}
+
+// splitOutsideQuotes splits on sep, ignoring separators inside a quoted string.
+// Attribute values are quoted and do carry both separators —
+// `description="Apache License, Version 2.0"` holds a comma, and a `link` URL
+// can hold anything.
+func splitOutsideQuotes(s string, sep byte) []string {
+	var (
+		parts []string
+		start int
+		quote byte
+	)
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			}
+		case c == '"' || c == '\'':
+			quote = c
+		case c == sep:
+			parts = append(parts, s[start:i])
+			start = i + 1
+		}
+	}
+	return append(parts, s[start:])
+}
+
+// unquote strips one layer of matching surrounding quotes.
+func unquote(s string) string {
+	if len(s) >= 2 && (s[0] == '"' || s[0] == '\'') && s[len(s)-1] == s[0] {
+		return strings.TrimSpace(s[1 : len(s)-1])
+	}
+	return s
+}

--- a/providers/os/resources/languages/java/manifestmf/license.go
+++ b/providers/os/resources/languages/java/manifestmf/license.go
@@ -6,6 +6,8 @@ package manifestmf
 import (
 	"regexp"
 	"strings"
+
+	"go.mondoo.com/mql/providers/os/resources/languages"
 )
 
 // OSGi states a bundle's license in Bundle-License, and the header is
@@ -49,6 +51,9 @@ func (m *manifest) license() string {
 	}
 
 	names := make([]string, 0, 1)
+	// Running total of the identifiers kept, so a manifest carrying a header of
+	// arbitrary size is never joined into one string before it is rejected.
+	sum := 0
 	for _, entry := range splitOutsideQuotes(raw, ',') {
 		name := licenseIdentifier(entry)
 		// A URL is a link to the terms, not the identity of the terms.
@@ -59,6 +64,17 @@ func (m *manifest) license() string {
 		// nothing — this only adds the ones that name a license.
 		if name == "" || name == bundleLicenseExternal || urlPattern.MatchString(name) {
 			continue
+		}
+		// A manifest comes out of an artifact someone else built, and nothing
+		// in the OSGi grammar bounds an identifier. Past languages.LicenseMaxBytes
+		// the entry is not a license name, so it is dropped — the entries beside
+		// it are still reported, and truncating it would state a different
+		// license rather than a shortened one.
+		if len(name) > languages.LicenseMaxBytes {
+			continue
+		}
+		if sum += len(name); sum > languages.LicenseExpressionMaxBytes {
+			return ""
 		}
 		names = append(names, name)
 	}
@@ -71,7 +87,16 @@ func (m *manifest) license() string {
 	// reproduces what the manifest said; OR-joining would report a bundle as
 	// dual-licensed under "The Apache License" or "Version 2.0", inventing a
 	// choice the bundle never offered.
-	return strings.Join(names, ", ")
+	//
+	// The rejoined value carries the same total bound as an OR-joined one: past
+	// it the header is not a license statement, and the whole value is dropped
+	// rather than part of it kept, which would report a bundle as licensed
+	// under some of the terms it named.
+	joined := strings.Join(names, ", ")
+	if len(joined) > languages.LicenseExpressionMaxBytes {
+		return ""
+	}
+	return joined
 }
 
 // licenseIdentifier returns the license-identifier of one entry: everything

--- a/providers/os/resources/languages/java/manifestmf/license.go
+++ b/providers/os/resources/languages/java/manifestmf/license.go
@@ -37,7 +37,15 @@ import (
 const bundleLicenseExternal = "<<EXTERNAL>>"
 
 // urlPattern matches a value that is a URL rather than a license name.
-var urlPattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.\-]*://`)
+//
+// Both spellings that occur in the header, because a scheme is not what makes
+// the value a link: `https://www.eclipse.org/legal/epl-2.0/` and
+// `www.apache.org/licenses/LICENSE-2.0` are the same statement, and reporting
+// the second as a license identifier is the outcome dropping the first exists
+// to avoid. The schemeless form requires a dotted host followed by a path, so
+// it cannot match a license name: those carry no dot-then-slash, and anything
+// with a space has already been ruled out by the host pattern.
+var urlPattern = regexp.MustCompile(`^([a-zA-Z][a-zA-Z0-9+.\-]*://|[a-zA-Z0-9\-]+(\.[a-zA-Z0-9\-]+)+/)`)
 
 // license returns the license the manifest declares, or "" when it declares
 // none this can name.

--- a/providers/os/resources/languages/java/manifestmf/license_test.go
+++ b/providers/os/resources/languages/java/manifestmf/license_test.go
@@ -155,3 +155,72 @@ func TestManifestLicenseFixtures(t *testing.T) {
 		})
 	}
 }
+
+// TestManifestLicenseBounds covers the size bounds on Bundle-License. A
+// MANIFEST.MF is read out of a JAR someone else built, and nothing in the OSGi
+// grammar bounds a license-identifier — the value flows into SBOM documents and
+// generated NOTICE files exactly as the artifact wrote it.
+//
+// The caps are literals here rather than the constants the implementation
+// reads: an expectation taken from the same constant would move with it and pin
+// nothing.
+func TestManifestLicenseBounds(t *testing.T) {
+	// A license identifier of exactly n bytes. It carries no ',' or ';', so the
+	// header parses as one entry.
+	name := func(n int) string { return strings.Repeat("a", n) }
+
+	for _, c := range []struct {
+		name   string
+		header string
+		want   string
+	}{
+		// A real identifier is nowhere near the cap, and must not start
+		// reporting "" because someone tightened it.
+		{
+			name:   "a real identifier is well under the cap",
+			header: "Bundle-License: GNU Lesser General Public License, Version 2.1;link=\"https://www.gnu.org/licenses/lgpl-2.1.html\"",
+			want:   "GNU Lesser General Public License, Version 2.1",
+		},
+		{
+			name:   "an identifier at the cap is kept",
+			header: "Bundle-License: " + name(256),
+			want:   name(256),
+		},
+		{
+			name:   "an identifier one byte over the cap is dropped",
+			header: "Bundle-License: " + name(257),
+			want:   "",
+		},
+		{
+			// Dropped whole, never truncated: a cut-off identifier reads as a
+			// different license rather than a shortened one.
+			name:   "a pasted license text is dropped rather than truncated",
+			header: "Bundle-License: " + strings.Repeat("Permission is hereby granted free of charge to any person ", 10),
+			want:   "",
+		},
+		{
+			// The oversized entry is the only thing wrong with the header.
+			name:   "an oversized identifier does not take its siblings with it",
+			header: "Bundle-License: " + name(300) + ",MIT",
+			want:   "MIT",
+		},
+		{
+			// Individually valid identifiers rejoin into a value of any size.
+			// ", " is not SPDX's OR, but it is carried into the same field, so
+			// it takes the same total bound.
+			name:   "many valid identifiers past the total cap are dropped",
+			header: "Bundle-License: " + strings.Repeat("Apache-2.0,", 200) + "MIT",
+			want:   "",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			mf := "Manifest-Version: 1.0\nBundle-SymbolicName: com.example\nBundle-Version: 1.0.0\n" + c.header + "\n"
+			info, err := (&Extractor{}).Parse(strings.NewReader(mf), "META-INF/MANIFEST.MF")
+			require.NoError(t, err)
+
+			root := info.Root()
+			require.NotNil(t, root)
+			assert.Equal(t, c.want, root.License)
+		})
+	}
+}

--- a/providers/os/resources/languages/java/manifestmf/license_test.go
+++ b/providers/os/resources/languages/java/manifestmf/license_test.go
@@ -1,0 +1,157 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package manifestmf
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestManifestLicense is the regression test for Bundle-License being parsed
+// into Headers and then never reported: a bundle naming its license reported
+// none.
+//
+// Every input below is the shape of a real manifest — they were taken from a
+// sample of MANIFEST.MF files on GitHub, which is also where the frequencies
+// cited in the comments come from.
+func TestManifestLicense(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{
+			// The canonical form: an identifier plus a link to its text.
+			name:   "identifier with a link",
+			header: `Bundle-License: Apache-2.0;link="https://www.apache.org/licenses/LICENSE-2.0"`,
+			want:   "Apache-2.0",
+		},
+		{
+			// Not SPDX, but it is what the bundle said, and normalizing it is
+			// a consumer's decision.
+			name:   "bare identifier",
+			header: "Bundle-License: Apache 2.0",
+			want:   "Apache 2.0",
+		},
+		{
+			name:   "identifier with a link, no quotes",
+			header: "Bundle-License: EPL-2.0;link=https://www.eclipse.org/legal/epl-2.0",
+			want:   "EPL-2.0",
+		},
+		{
+			// The grammar makes ',' a separator, but Eclipse/Tycho bundles
+			// write an identifier that contains one. OR-joining this would
+			// report the bundle as offered under "The Apache License" or
+			// "Version 2.0" — a choice it never offered.
+			name:   "identifier containing a comma",
+			header: `Bundle-License: The Apache License, Version 2.0;link="http://www.apache.org/licenses/LICENSE-2.0.txt"`,
+			want:   "The Apache License, Version 2.0",
+		},
+		{
+			name:   "identifier with a version suffix",
+			header: `Bundle-License: Eclipse Public License v2.0;link="http://www.eclipse.org/legal/epl-2.0"`,
+			want:   "Eclipse Public License v2.0",
+		},
+		{
+			// A quoted attribute value carries both separators, so splitting
+			// must not see them.
+			name:   "comma inside a quoted description",
+			header: `Bundle-License: Apache-2.0;description="Apache License, Version 2.0";link="https://www.apache.org/licenses/LICENSE-2.0"`,
+			want:   "Apache-2.0",
+		},
+		{
+			// Two licenses, both stated as identifiers. Rejoined rather than
+			// OR-joined, because a comma here is not reliably a separator.
+			name:   "two identifiers",
+			header: `Bundle-License: MIT;link="https://opensource.org/licenses/MIT",Apache-2.0;link="https://www.apache.org/licenses/LICENSE-2.0"`,
+			want:   "MIT, Apache-2.0",
+		},
+		{
+			// The most common real header by a wide margin, and the reason
+			// this fix leaves most bundles reporting nothing. A link to the
+			// terms is not the identity of the terms: a URL in a field
+			// consumers compare against "Apache-2.0" matches nothing while
+			// reading as a stated identifier.
+			name:   "url only",
+			header: "Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt",
+			want:   "",
+		},
+		{
+			// A genuine dual license, stated as two URLs. Nothing nameable.
+			name:   "two urls",
+			header: "Bundle-License: https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt, https://www.gnu.org/software/classpath/license.html",
+			want:   "",
+		},
+		{
+			// The description names the license where the identifier is a URL,
+			// but it is prose — bnd's own example is a whole sentence — so it
+			// is not promoted to an identifier.
+			name:   "url identifier with a describing attribute",
+			header: "Bundle-License: https://opensource.org/licenses/BSD-2-Clause;description=BSD 2-Clause License",
+			want:   "",
+		},
+		{
+			// The magic value states that the license is *not* here.
+			name:   "external",
+			header: "Bundle-License: <<EXTERNAL>>",
+			want:   "",
+		},
+		{
+			name:   "no Bundle-License header",
+			header: "Bundle-Name: Example",
+			want:   "",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			mf := "Manifest-Version: 1.0\nBundle-SymbolicName: com.example\nBundle-Version: 1.0.0\n" + c.header + "\n"
+			info, err := (&Extractor{}).Parse(strings.NewReader(mf), "META-INF/MANIFEST.MF")
+			require.NoError(t, err)
+
+			root := info.Root()
+			require.NotNil(t, root)
+			assert.Equal(t, c.want, root.License)
+		})
+	}
+}
+
+// TestManifestLicenseContinuationLine covers a Bundle-License wrapped across
+// source lines, which is how a manifest carrying a link is normally written —
+// the header limit is 72 bytes, so the real ones are nearly always wrapped.
+func TestManifestLicenseContinuationLine(t *testing.T) {
+	mf := "Manifest-Version: 1.0\n" +
+		"Bundle-SymbolicName: com.example\n" +
+		"Bundle-License: The Apache License, Version 2.0;link=\"http://www.apache.\n" +
+		" org/licenses/LICENSE-2.0.txt\"\n"
+
+	info, err := (&Extractor{}).Parse(strings.NewReader(mf), "META-INF/MANIFEST.MF")
+	require.NoError(t, err)
+
+	root := info.Root()
+	require.NotNil(t, root)
+	assert.Equal(t, "The Apache License, Version 2.0", root.License)
+}
+
+// TestManifestLicenseFixtures pins the checked-in fixtures. The OSGi one states
+// its license as a URL, so it reports none — the same as before this fix, and
+// deliberately: it must not start emitting the URL as an identifier.
+func TestManifestLicenseFixtures(t *testing.T) {
+	for _, c := range []struct{ fixture, want string }{
+		{"./testdata/osgi.MANIFEST.MF", ""},
+		{"./testdata/simple.MANIFEST.MF", ""},
+	} {
+		t.Run(c.fixture, func(t *testing.T) {
+			f, err := os.Open(c.fixture)
+			require.NoError(t, err)
+			defer f.Close()
+
+			info, err := (&Extractor{}).Parse(f, "META-INF/MANIFEST.MF")
+			require.NoError(t, err)
+			assert.Equal(t, c.want, info.Root().License)
+		})
+	}
+}

--- a/providers/os/resources/languages/java/manifestmf/license_test.go
+++ b/providers/os/resources/languages/java/manifestmf/license_test.go
@@ -224,3 +224,25 @@ func TestManifestLicenseBounds(t *testing.T) {
 		})
 	}
 }
+
+// A URL is a link to the terms, not the identity of the terms, and a scheme is
+// not what makes it one. Reporting a schemeless URL as a license identifier is
+// the outcome dropping the schemeful form exists to avoid.
+func TestBundleLicenseDropsSchemelessURLs(t *testing.T) {
+	for _, tc := range []struct{ header, want string }{
+		{"https://www.eclipse.org/legal/epl-2.0/", ""},
+		{"http://www.apache.org/licenses/LICENSE-2.0.txt", ""},
+		{"www.apache.org/licenses/LICENSE-2.0", ""},
+		{"eclipse.org/legal/epl-2.0/", ""},
+		// Still a license name, not a link: no dotted host followed by a path.
+		{"Apache-2.0", "Apache-2.0"},
+		{"MIT", "MIT"},
+		{"GPL-2.0-only WITH Classpath-exception-2.0", "GPL-2.0-only WITH Classpath-exception-2.0"},
+		{"The Apache License, Version 2.0", "The Apache License, Version 2.0"},
+		// A name beside a link keeps the name and drops the link.
+		{"Apache-2.0, www.apache.org/licenses/LICENSE-2.0", "Apache-2.0"},
+	} {
+		m := &manifest{Headers: map[string]string{headerBundleLicense: tc.header}}
+		assert.Equal(t, tc.want, m.license(), "Bundle-License: %s", tc.header)
+	}
+}

--- a/providers/os/resources/languages/java/manifestmf/parser.go
+++ b/providers/os/resources/languages/java/manifestmf/parser.go
@@ -21,4 +21,5 @@ const (
 	headerBundleVersion         = "Bundle-Version"
 	headerBundleName            = "Bundle-Name"
 	headerBundleVendor          = "Bundle-Vendor"
+	headerBundleLicense         = "Bundle-License"
 )

--- a/providers/os/resources/languages/javascript/packagejson/extractor.go
+++ b/providers/os/resources/languages/javascript/packagejson/extractor.go
@@ -66,15 +66,28 @@ func (p *packageJson) authorName() string {
 	return p.Author.Name
 }
 
-// licenseExpression returns the SPDX expression from package.json
-// `license`. Older packages may use the deprecated `licenses` array;
-// we don't support that here yet — surface empty in that case and add
-// it later if a real package hits it.
+// licenseExpression returns the SPDX expression the package.json states.
+//
+// `license` is the current field and wins whenever it names a license. Packages
+// published before npm settled on it instead carry a `licenses` array, whose
+// members are `{"type": ..., "url": ...}` objects; a package listing several is
+// offering a choice among them, which LicenseExpression renders as SPDX's OR.
+//
+// npm deprecated `licenses` in 2014, but a registry does not rewrite what was
+// published: packages carrying only the array are still installed today, and
+// reading only `license` reported them as stating no license at all.
 func (p *packageJson) licenseExpression() string {
-	if p.License == nil {
-		return ""
+	if p.License != nil {
+		if expr := languages.LicenseExpression([]string{p.License.Value}); expr != "" {
+			return expr
+		}
 	}
-	return p.License.Value
+
+	values := make([]string, 0, len(p.Licenses))
+	for _, l := range p.Licenses {
+		values = append(values, l.Value)
+	}
+	return languages.LicenseExpression(values)
 }
 
 func (p *packageJson) Direct() languages.Packages {

--- a/providers/os/resources/languages/javascript/packagejson/extractor_test.go
+++ b/providers/os/resources/languages/javascript/packagejson/extractor_test.go
@@ -110,3 +110,116 @@ func TestPackageJsonExtractorAuthorForms(t *testing.T) {
 		})
 	}
 }
+
+// TestPackageJsonLicenseForms is the regression test for the deprecated
+// `licenses` array being ignored: `licenseExpression` read only `license`, so a
+// package published before npm settled on that field reported no license at
+// all. npm deprecated the array in 2014, but the registry does not rewrite what
+// was already published, and those packages are still installed today.
+//
+// The testdata fixtures for both deprecated shapes were already checked in —
+// only the parser never read them.
+func TestPackageJsonLicenseForms(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "current license string",
+			raw:  `{"name":"x","version":"1","license":"MIT"}`,
+			want: "MIT",
+		},
+		{
+			// An SPDX expression is one string and must survive intact.
+			name: "license string carrying an expression",
+			raw:  `{"name":"x","version":"1","license":"(MIT OR Apache-2.0)"}`,
+			want: "(MIT OR Apache-2.0)",
+		},
+		{
+			// The deprecated object form of `license`.
+			name: "license object",
+			raw:  `{"name":"x","version":"1","license":{"type":"ISC","url":"https://opensource.org/licenses/ISC"}}`,
+			want: "ISC",
+		},
+		{
+			// The form this fix is about, and the one that read empty before.
+			name: "deprecated licenses array",
+			raw: `{"name":"x","version":"1","licenses":[` +
+				`{"type":"MIT","url":"https://www.opensource.org/licenses/mit-license.php"},` +
+				`{"type":"Apache-2.0","url":"https://opensource.org/licenses/apache2.0.php"}]}`,
+			want: "(MIT OR Apache-2.0)",
+		},
+		{
+			// A one-member array must not acquire parentheses: "(MIT)" is a
+			// different string to every consumer comparing identifiers.
+			name: "licenses array with one member",
+			raw:  `{"name":"x","version":"1","licenses":[{"type":"MIT","url":"https://example.com"}]}`,
+			want: "MIT",
+		},
+		{
+			// Some packages wrote the array members as bare strings.
+			name: "licenses array of strings",
+			raw:  `{"name":"x","version":"1","licenses":["MIT","Apache-2.0"]}`,
+			want: "(MIT OR Apache-2.0)",
+		},
+		{
+			// `license` is the field npm kept; the array is the legacy fallback.
+			name: "license wins over licenses",
+			raw:  `{"name":"x","version":"1","license":"MIT","licenses":[{"type":"Apache-2.0"}]}`,
+			want: "MIT",
+		},
+		{
+			// A `license` that names nothing is not a statement, so the legacy
+			// array is still read.
+			name: "license naming nothing falls through to licenses",
+			raw:  `{"name":"x","version":"1","license":{"url":"https://example.com"},"licenses":[{"type":"MIT"}]}`,
+			want: "MIT",
+		},
+		{
+			// A link to the terms is not the identity of the terms. Reporting
+			// the URL in a field consumers read as an identifier is worse than
+			// reporting nothing.
+			name: "a url alone is not a license",
+			raw:  `{"name":"x","version":"1","licenses":[{"url":"https://opensource.org/licenses/ISC"}]}`,
+			want: "",
+		},
+		{
+			name: "no license stated",
+			raw:  `{"name":"x","version":"1"}`,
+			want: "",
+		},
+		{
+			name: "empty license string",
+			raw:  `{"name":"x","version":"1","license":""}`,
+			want: "",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			info, err := (&Extractor{}).Parse(strings.NewReader(c.raw), "p/package.json")
+			require.NoError(t, err)
+			assert.Equal(t, c.want, info.Root().License)
+		})
+	}
+}
+
+// TestPackageJsonLicenseFixtures runs the same fix against the checked-in
+// fixtures for the two deprecated shapes, which reported "" before.
+func TestPackageJsonLicenseFixtures(t *testing.T) {
+	for _, c := range []struct{ fixture, want string }{
+		{"./testdata/license_spdx.json", "BSD-3-Clause"},
+		{"./testdata/license_spdx_expression.json", "(MIT OR Apache-2.0)"},
+		{"./testdata/license_deprecated_01.json", "ISC"},
+		{"./testdata/license_deprecated_02.json", "(MIT OR Apache-2.0)"},
+	} {
+		t.Run(c.fixture, func(t *testing.T) {
+			f, err := os.Open(c.fixture)
+			require.NoError(t, err)
+			defer f.Close()
+
+			info, err := (&Extractor{}).Parse(f, "p/package.json")
+			require.NoError(t, err)
+			assert.Equal(t, c.want, info.Root().License)
+		})
+	}
+}

--- a/providers/os/resources/languages/javascript/packagejson/extractor_test.go
+++ b/providers/os/resources/languages/javascript/packagejson/extractor_test.go
@@ -223,3 +223,67 @@ func TestPackageJsonLicenseFixtures(t *testing.T) {
 		})
 	}
 }
+
+// TestPackageJsonLicenseBounds covers the size bounds on package.json's license
+// fields. The deprecated `licenses` array is the worst case in any ecosystem
+// here: it is a JSON array of registry-supplied strings with no bound of its
+// own, and what it produces flows into SBOM documents, SARIF and generated
+// NOTICE files.
+//
+// The cap is a literal here rather than the constant the implementation reads:
+// an expectation taken from the same constant would move with it and pin
+// nothing.
+func TestPackageJsonLicenseBounds(t *testing.T) {
+	// A license identifier of exactly n bytes, carrying nothing that needs JSON
+	// escaping.
+	name := func(n int) string { return strings.Repeat("a", n) }
+
+	// 500 members, each individually a valid identifier.
+	many := make([]string, 500)
+	for i := range many {
+		many[i] = `{"type":"MIT"}`
+	}
+
+	for _, c := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			// A real name is nowhere near the cap and must keep being reported.
+			name: "a full license name is well under the cap",
+			raw:  `{"name":"x","version":"1","license":"GNU Lesser General Public License, Version 2.1"}`,
+			want: "GNU Lesser General Public License, Version 2.1",
+		},
+		{
+			name: "an oversized license string is dropped",
+			raw:  `{"name":"x","version":"1","license":"` + name(300) + `"}`,
+			want: "",
+		},
+		{
+			// An oversized `license` names nothing usable, so the legacy array
+			// is still consulted — the same fallthrough as a `license` that
+			// carries only a url.
+			name: "an oversized license falls through to the legacy array",
+			raw:  `{"name":"x","version":"1","license":"` + name(300) + `","licenses":[{"type":"MIT"}]}`,
+			want: "MIT",
+		},
+		{
+			// The oversized member is the only thing wrong with the array.
+			name: "an oversized member does not take its siblings with it",
+			raw:  `{"name":"x","version":"1","licenses":[{"type":"` + name(300) + `"},{"type":"MIT"}]}`,
+			want: "MIT",
+		},
+		{
+			name: "an array past the total cap is dropped",
+			raw:  `{"name":"x","version":"1","licenses":[` + strings.Join(many, ",") + `]}`,
+			want: "",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			info, err := (&Extractor{}).Parse(strings.NewReader(c.raw), "p/package.json")
+			require.NoError(t, err)
+			assert.Equal(t, c.want, info.Root().License)
+		})
+	}
+}

--- a/providers/os/resources/languages/javascript/packagejson/parser.go
+++ b/providers/os/resources/languages/javascript/packagejson/parser.go
@@ -24,10 +24,10 @@ type packageJson struct {
 	Licenses        []packageJsonLicense  `json:"licenses"`
 	Author          *packageJsonPeople    `json:"author"`
 	Contributors    []packageJsonPeople   `json:"contributors"`
-	Dependencies    map[string]string     `jsonn:"dependencies"`
-	DevDependencies map[string]string     `jsonn:"devDependencies"`
+	Dependencies    map[string]string     `json:"dependencies"`
+	DevDependencies map[string]string     `json:"devDependencies"`
 	Repository      packageJsonRepository `json:"repository"`
-	Engines         enginesField          `jsonn:"engines"`
+	Engines         enginesField          `json:"engines"`
 	CPU             []string              `json:"cpu"`
 	OS              []string              `json:"os"`
 

--- a/providers/os/resources/languages/javascript/packagejson/parser.go
+++ b/providers/os/resources/languages/javascript/packagejson/parser.go
@@ -21,6 +21,7 @@ type packageJson struct {
 	Private         booleanField          `json:"private"`
 	Homepage        string                `json:"homepage"`
 	License         *packageJsonLicense   `json:"license"`
+	Licenses        []packageJsonLicense  `json:"licenses"`
 	Author          *packageJsonPeople    `json:"author"`
 	Contributors    []packageJsonPeople   `json:"contributors"`
 	Dependencies    map[string]string     `jsonn:"dependencies"`
@@ -188,18 +189,41 @@ type packageJsonLicense struct {
 	Value string `json:"value"`
 }
 
-// UnmarshalJSON implements the json.Unmarshaler interface
-// package.json license can be a string or a structured object
-// For now we only support the plain string format and ignore the structured object
+// UnmarshalJSON implements the json.Unmarshaler interface.
+//
+// A license is stated as a plain SPDX string today:
+//
+//	"license": "MIT"
+//
+// Before npm settled on that it was an object naming the license and linking
+// its text, and the same object is what the members of the deprecated
+// `licenses` array are:
+//
+//	"license":  { "type": "ISC", "url": "https://opensource.org/licenses/ISC" }
+//	"licenses": [ { "type": "MIT", "url": "..." }, { "type": "Apache-2.0", ... } ]
+//
+// Both forms are read, and the object's `type` is the license. Its `url` is
+// dropped: a link to the terms is not the identity of the terms, and a URL in a
+// field consumers read as an identifier is worse than an empty one.
 func (a *packageJsonLicense) UnmarshalJSON(b []byte) error {
-	var licenseStr string
-
 	// try to unmarshal as string
-	err := json.Unmarshal(b, &licenseStr)
-	if err == nil {
+	var licenseStr string
+	if err := json.Unmarshal(b, &licenseStr); err == nil {
 		a.Value = licenseStr
+		return nil
 	}
 
-	// we intentionally ignore the structured object
+	// try to unmarshal as the deprecated object form
+	var obj struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(b, &obj); err == nil {
+		a.Value = obj.Type
+		return nil
+	}
+
+	// Any other shape states no license this can read. Leaving the value empty
+	// keeps the rest of the package.json parsing rather than failing the file
+	// over one malformed field.
 	return nil
 }

--- a/providers/os/resources/languages/javascript/packagejson/parser_test.go
+++ b/providers/os/resources/languages/javascript/packagejson/parser_test.go
@@ -150,19 +150,25 @@ func TestPackageJson(t *testing.T) {
 			},
 		},
 		{
+			// the deprecated object form of `license`: the `type` is the
+			// license, the `url` only links its text
 			Fixture: "./testdata/license_deprecated_01.json",
 			Expected: packageJson{
-				// we ignore those licenses for now
 				License: &packageJsonLicense{
-					Value: "",
+					Value: "ISC",
 				},
 			},
 		},
 		{
+			// the deprecated `licenses` array, which npm replaced with the
+			// single `license` string
 			Fixture: "./testdata/license_deprecated_02.json",
 			Expected: packageJson{
-				// we ignore those licenses for now
 				License: nil,
+				Licenses: []packageJsonLicense{
+					{Value: "MIT"},
+					{Value: "Apache-2.0"},
+				},
 			},
 		},
 		{

--- a/providers/os/resources/languages/javascript/packagelockjson/parser.go
+++ b/providers/os/resources/languages/javascript/packagelockjson/parser.go
@@ -113,7 +113,7 @@ type packageLock struct {
 	Packages map[string]packageLockPackage `json:"packages"`
 	// Dependencies contains legacy data for supporting versions of npm that use lockfileVersion: 1 or lower.
 	// We can ignore that for lockfileVersion: 2+
-	Dependencies map[string]packageLockDependency `jsonn:"dependencies"`
+	Dependencies map[string]packageLockDependency `json:"dependencies"`
 
 	// evidence is a list of file paths where the package-lock was found
 	evidence []string `json:"-"`

--- a/providers/os/resources/languages/license.go
+++ b/providers/os/resources/languages/license.go
@@ -5,6 +5,46 @@ package languages
 
 import "strings"
 
+// A license value arrives from a package index or a manifest inside an
+// artifact, not from the scanned host, so its size is chosen by whoever
+// published the package. It then flows into SBOM documents, SARIF and
+// generated NOTICE files, none of which bound it either.
+//
+// Being well-formed supplies no bound of its own: `MIT OR MIT OR ...` is a
+// valid SPDX expression at any length, and a `licenses` array may hold any
+// number of members. So the bound has to come from what a license value *is*.
+//
+// Neither bound truncates. A truncated identifier is a *wrong* license — a
+// consumer comparing against "Apache-2.0" would read "Apache-2" as a
+// different license rather than as a cut-off one — and a wrong license is
+// worse than none. The oversized value is dropped instead, which reports the
+// license as undetermined: true, and distinct from a stated license.
+const (
+	// LicenseMaxBytes bounds a single license operand — one member of a
+	// `licenses` array, or the whole value when only one was stated.
+	//
+	// License identifiers are short. The longest identifier in the SPDX list
+	// is under 60 bytes and the longest full license *name* under about 120,
+	// and the free-text names that appear instead ("The Apache License,
+	// Version 2.0") are shorter still. Past 256 bytes the value is not a
+	// license name: it is a pasted license *text*, a URL list, or padding.
+	// This is the same bound wheelegg already applies to the same kind of
+	// value in Python core metadata.
+	LicenseMaxBytes = 256
+
+	// LicenseExpressionMaxBytes bounds the rendered expression.
+	//
+	// A per-operand bound alone stops nothing: thousands of short, individually
+	// valid identifiers still join into an unbounded expression. A joined
+	// expression legitimately needs more room than a single name, so this is
+	// larger — three full-length license names, or around sixty typical SPDX
+	// identifiers. A package genuinely offering a choice states a handful;
+	// past this the value is not a choice anyone could exercise, and the whole
+	// expression is dropped rather than half of it kept, because a subset of
+	// an OR is a different statement about what the package permits.
+	LicenseExpressionMaxBytes = 1024
+)
+
 // LicenseExpression renders one or more license strings as a single SPDX
 // expression for Package.License.
 //
@@ -22,15 +62,29 @@ import "strings"
 // declared nothing, and distinct from a package that declared a license this
 // function could not render.
 //
+// Oversized input is dropped, not truncated: a member longer than
+// LicenseMaxBytes is not a license identifier and is skipped, keeping the
+// members around it, and a result longer than LicenseExpressionMaxBytes is not
+// a license statement at all, so "" is returned.
+//
 // The strings are passed through as the manifest wrote them. Normalizing a
 // license name to a canonical identifier is a consumer's decision, not a
 // parser's, and doing it here would discard what the file actually said.
 func LicenseExpression(licenses []string) string {
 	parts := make([]string, 0, len(licenses))
+	// Running total of the operands alone. It is always at most the length of
+	// the rendered expression, so bailing on it is safe, and it keeps an array
+	// of a million members from being materialized into one string before the
+	// exact check below rejects it.
+	sum := 0
 	for _, l := range licenses {
-		if l = strings.TrimSpace(l); l != "" {
-			parts = append(parts, l)
+		if l = strings.TrimSpace(l); l == "" || len(l) > LicenseMaxBytes {
+			continue
 		}
+		if sum += len(l); sum > LicenseExpressionMaxBytes {
+			return ""
+		}
+		parts = append(parts, l)
 	}
 	switch len(parts) {
 	case 0:
@@ -38,5 +92,11 @@ func LicenseExpression(licenses []string) string {
 	case 1:
 		return parts[0]
 	}
-	return "(" + strings.Join(parts, " OR ") + ")"
+	// The separators count toward the bound too, so the rendered expression is
+	// what gets measured.
+	expr := "(" + strings.Join(parts, " OR ") + ")"
+	if len(expr) > LicenseExpressionMaxBytes {
+		return ""
+	}
+	return expr
 }

--- a/providers/os/resources/languages/license_test.go
+++ b/providers/os/resources/languages/license_test.go
@@ -4,9 +4,11 @@
 package languages_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/providers/os/resources/languages"
 )
 
@@ -47,4 +49,91 @@ func TestLicenseExpression(t *testing.T) {
 			assert.Equal(t, c.want, languages.LicenseExpression(c.in))
 		})
 	}
+}
+
+// TestLicenseExpressionBounds covers the size bounds on registry-supplied
+// license values. Every ecosystem feeding this function reads its input from a
+// package index or an artifact, so the length of a license value is chosen by
+// whoever published the package, and it flows on into SBOM documents, SARIF and
+// generated NOTICE files unbounded.
+//
+// The caps are written as literals here rather than read from the package they
+// bound: a test that took its expectation from the same constant as the
+// implementation would move with it and pin nothing.
+func TestLicenseExpressionBounds(t *testing.T) {
+	// A license identifier of exactly n bytes.
+	name := func(n int) string { return strings.Repeat("a", n) }
+
+	// What a distribution actually pastes into a license field when it pastes
+	// the terms instead of naming them.
+	licenseText := "Permission is hereby granted, free of charge, to any person obtaining a copy " +
+		"of this software and associated documentation files (the \"Software\"), to deal " +
+		"in the Software without restriction, including without limitation the rights " +
+		"to use, copy, modify, merge, publish, distribute, sublicense, and/or sell " +
+		"copies of the Software, and to permit persons to whom the Software is " +
+		"furnished to do so, subject to the following conditions:"
+
+	// An expression of exactly 1024 bytes: three operands at the per-operand
+	// cap, one of 242, two parens and three " OR " separators.
+	atExprCap := []string{name(256), name(256), name(256), name(242)}
+
+	for _, c := range []struct {
+		name string
+		in   []string
+		want string
+	}{
+		// --- the per-operand bound -----------------------------------------
+		//
+		// Real names are far shorter than the cap, and none of these may start
+		// reporting "" because someone tightened it.
+		{"a full SPDX license name is well under the cap",
+			[]string{"GNU Free Documentation License v1.3 or later - no invariants - with cover texts"},
+			"GNU Free Documentation License v1.3 or later - no invariants - with cover texts"},
+		{"a real multi-license choice is well under the cap",
+			[]string{"MPL-2.0", "GPL-2.0-or-later", "LGPL-2.1-or-later", "Apache-2.0", "MIT"},
+			"(MPL-2.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later OR Apache-2.0 OR MIT)"},
+		{"an operand at the cap is kept", []string{name(256)}, name(256)},
+		{"an operand one byte over the cap is dropped", []string{name(257)}, ""},
+		// Dropped whole, never truncated: "Apache-2" is a different license to
+		// every consumer comparing identifiers, not a shortened one.
+		{"a pasted license text is dropped rather than truncated", []string{licenseText}, ""},
+		// The oversized member is the only thing wrong with the list. A package
+		// that names MIT and then pastes the terms still named MIT.
+		{"an oversized operand does not take its siblings with it",
+			[]string{"MIT", name(257), "Apache-2.0"}, "(MIT OR Apache-2.0)"},
+		{"an oversized operand alone among blanks", []string{"", name(257), " "}, ""},
+
+		// --- the total bound ------------------------------------------------
+		//
+		// Individually valid members join into an expression of any size: this
+		// is what a `licenses` array with thousands of entries produces, and
+		// the per-operand bound does not touch it.
+		{"an expression one byte over the cap is dropped",
+			[]string{name(256), name(256), name(256), name(243)}, ""},
+		{"thousands of valid short members are not a license statement",
+			repeated("MIT", 5000), ""},
+		{"a long list of real identifiers past the cap is dropped",
+			repeated("GPL-2.0-or-later", 100), ""},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, languages.LicenseExpression(c.in))
+		})
+	}
+
+	// Checked apart from the table because the assertion is on the length: it
+	// is the byte before the cliff, and it must survive.
+	t.Run("an expression at the cap is kept", func(t *testing.T) {
+		got := languages.LicenseExpression(atExprCap)
+		require.NotEmpty(t, got, "an expression exactly at the cap must not be dropped")
+		assert.Equal(t, 1024, len(got))
+		assert.Equal(t, "("+strings.Join(atExprCap, " OR ")+")", got)
+	})
+}
+
+func repeated(s string, n int) []string {
+	out := make([]string, n)
+	for i := range out {
+		out[i] = s
+	}
+	return out
 }

--- a/providers/os/resources/languages/python/wheelegg/license.go
+++ b/providers/os/resources/languages/python/wheelegg/license.go
@@ -30,39 +30,48 @@ import (
 // never read — and reports no license at all, from a file already opened and
 // parsed.
 
-// licenseValueMaxBytes bounds a single license header's value.
+// The two headers are bounded, for the same reason and by different numbers.
 //
 // The `License` field was historically free text with no length limit, and
 // distributions routinely paste an entire license *text* into it, continuation
 // line by continuation line — one of the concrete problems PEP 639 exists to
 // solve. That is a license text, not a license name: carried into
 // Package.License it reaches every SBOM this produces as though it were an
-// identifier, and no consumer can match it against one.
+// identifier, and no consumer can match it against one. It is a name, so it
+// gets the name bound.
 //
-// Past this length the field is discarded rather than reported, which also lets
-// the trove classifiers below it answer instead. Every identifier and
-// expression that occurs in practice is far under this.
-const licenseValueMaxBytes = 256
+// `License-Expression` needs the *expression* bound instead. Being well-formed
+// supplies no limit of its own — `MIT OR MIT OR ...` is valid SPDX at any
+// length — but a genuine choice is legitimately longer than any single name,
+// and every other extractor renders one through LicenseExpression and allows it
+// that room. Holding this field to the name bound would drop an
+// `Apache-2.0 OR BSD-3-Clause OR MIT OR ...` that those extractors accept, for
+// no reason but which ecosystem stated it.
+//
+// Both bounds come from the shared pair rather than being written out here, so
+// this file and the renderer cannot drift apart. Past the limit the field is
+// discarded rather than reported, which also lets the trove classifiers below
+// it answer instead.
 
 // metadataLicense picks the license out of a parsed METADATA/PKG-INFO header,
 // in the precedence described above. It returns "" when nothing states a
 // license — the honest answer, and distinct from a package whose license this
 // could not render.
 func metadataLicense(h textproto.MIMEHeader) string {
-	if v := licenseValue(h.Get("License-Expression")); v != "" {
+	if v := licenseValue(h.Get("License-Expression"), languages.LicenseExpressionMaxBytes); v != "" {
 		return v
 	}
-	if v := licenseValue(h.Get("License")); v != "" {
+	if v := licenseValue(h.Get("License"), languages.LicenseMaxBytes); v != "" {
 		return v
 	}
 	return classifierExpression(h.Values("Classifier"))
 }
 
-// licenseValue trims a header value and drops it when it is too long to be a
-// license name. See licenseValueMaxBytes.
-func licenseValue(v string) string {
+// licenseValue trims a header value and drops it when it is longer than a value
+// of its kind can legitimately be.
+func licenseValue(v string, maxBytes int) string {
 	v = strings.TrimSpace(v)
-	if len(v) > licenseValueMaxBytes {
+	if len(v) > maxBytes {
 		return ""
 	}
 	return v

--- a/providers/os/resources/languages/python/wheelegg/license_test.go
+++ b/providers/os/resources/languages/python/wheelegg/license_test.go
@@ -4,6 +4,7 @@
 package wheelegg
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -140,7 +141,7 @@ Summary: says nothing about licensing
 // match.
 func TestPastedLicenseTextIsNotReportedAsAName(t *testing.T) {
 	body := strings.Repeat("Redistribution and use in source and binary forms are permitted. ", 20)
-	require.Greater(t, len(body), licenseValueMaxBytes)
+	require.Greater(t, len(body), 256, "must exceed the name bound")
 
 	assert.Equal(t, "", license(t, `Metadata-Version: 2.1
 Name: verbose
@@ -153,7 +154,7 @@ License: `+body+`
 // the case the length bound exists to reach.
 func TestPastedTextFallsThroughToTheClassifier(t *testing.T) {
 	body := strings.Repeat("BSD-3-Clause, full text follows. ", 20)
-	require.Greater(t, len(body), licenseValueMaxBytes)
+	require.Greater(t, len(body), 256, "must exceed the name bound")
 
 	assert.Equal(t, "BSD License", license(t, `Metadata-Version: 2.1
 Name: verbose
@@ -168,8 +169,8 @@ Classifier: License :: OSI Approved :: BSD License
 // size, and metadata arrives from a package index rather than from the
 // repository being scanned.
 func TestOversizedExpressionIsDropped(t *testing.T) {
-	huge := "MIT" + strings.Repeat(" OR MIT", 100)
-	require.Greater(t, len(huge), licenseValueMaxBytes)
+	huge := "MIT" + strings.Repeat(" OR MIT", 200)
+	require.Greater(t, len(huge), 1024, "must exceed the expression bound, not merely the name bound")
 
 	assert.Equal(t, "", license(t, `Metadata-Version: 2.4
 Name: huge
@@ -189,4 +190,50 @@ Version: 1.0
 License: GPL-3.0-only
 Classifier: License :: OSI Approved :: MIT License
 `))
+}
+
+// The two headers get different bounds, and the difference is the point: a
+// genuine PEP 639 choice is legitimately longer than any single license name,
+// and every other extractor renders one through LicenseExpression with that
+// room. Holding this field to the name bound dropped an expression those
+// extractors accept, for no reason but which ecosystem stated it.
+//
+// The caps are literals here rather than reads of the constants the
+// implementation reads, so both sides cannot move together and pin nothing.
+func TestExpressionGetsTheExpressionBoundNotTheNameBound(t *testing.T) {
+	expr := "Apache-2.0 OR BSD-3-Clause OR MIT OR GPL-3.0-or-later OR MPL-2.0"
+	for len(expr) <= 256 {
+		expr += " OR ISC"
+	}
+	require.Greater(t, len(expr), 256, "must exceed the name bound to be a regression test")
+	require.LessOrEqual(t, len(expr), 1024, "must stay within the expression bound")
+
+	assert.Equal(t, expr, license(t, `Metadata-Version: 2.4
+Name: wide
+Version: 1.0
+License-Expression: `+expr+`
+`), "an expression under the expression bound must survive")
+
+	// The free-text field keeps the name bound: a 300-byte value there is prose
+	// or a pasted text, not an identifier.
+	assert.Equal(t, "", license(t, `Metadata-Version: 2.1
+Name: wordy
+Version: 1.0
+License: `+strings.Repeat("a", 300)+`
+`), "a 300-byte free-text License is still dropped")
+}
+
+// The classifier path renders through LicenseExpression, so it is bounded by
+// the same rule rather than being the one place that joins without limit.
+// METADATA is text from a package index; nothing stops a crafted distribution
+// carrying thousands of `License ::` lines.
+func TestManyClassifiersAreBounded(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("Metadata-Version: 2.1\nName: many\nVersion: 1.0\n")
+	// Distinct names, so dedup cannot collapse them.
+	for i := 0; i < 400; i++ {
+		fmt.Fprintf(&b, "Classifier: License :: OSI Approved :: Fake-%d License\n", i)
+	}
+	assert.Equal(t, "", license(t, b.String()),
+		"hundreds of classifiers must not render an unbounded expression")
 }

--- a/providers/os/resources/languages/ruby/gemspec/extractor.go
+++ b/providers/os/resources/languages/ruby/gemspec/extractor.go
@@ -25,6 +25,16 @@ var (
 	namePattern = regexp.MustCompile(`\.name\s*=\s*["']([^"']+)["']`)
 	// spec.version = "1.0.0" or spec.version = '1.0.0'
 	versionPattern = regexp.MustCompile(`\.version\s*=\s*["']([^"']+)["']`)
+	// spec.license = "Apache-2.0" — the singular form. A gemspec may state its
+	// license either way, and the two are the same field: RubyGems' `license=`
+	// is a one-element `licenses=`.
+	licensePattern = regexp.MustCompile(`\.license\s*=\s*["']([^"']*)["']`)
+	// spec.licenses = ["MIT", "Apache-2.0"] — the plural form, a list. Matching
+	// is line-scoped like every other pattern here, so a list broken across
+	// source lines is not read; gemspecs write this one on a single line.
+	licensesPattern = regexp.MustCompile(`\.licenses\s*=\s*\[([^\]]*)\]`)
+	// the quoted members of that list
+	quotedStringPattern = regexp.MustCompile(`["']([^"']*)["']`)
 	// spec.add_dependency "foo", "~> 1.0"
 	// spec.add_runtime_dependency "foo", "~> 1.0"
 	// spec.add_development_dependency "foo", "~> 1.0"
@@ -68,6 +78,20 @@ func parseGemspec(r io.Reader) (*gemSpec, error) {
 			spec.Version = m[1]
 		}
 
+		// Both license forms write the same field, so the last one the file
+		// states wins — which is what Ruby does when a gemspec sets both.
+		if m := licensePattern.FindStringSubmatch(line); len(m) > 1 {
+			spec.Licenses = []string{m[1]}
+		}
+
+		if m := licensesPattern.FindStringSubmatch(line); len(m) > 1 {
+			var licenses []string
+			for _, q := range quotedStringPattern.FindAllStringSubmatch(m[1], -1) {
+				licenses = append(licenses, q[1])
+			}
+			spec.Licenses = licenses
+		}
+
 		if m := depPattern.FindStringSubmatch(line); len(m) > 2 {
 			depType := m[1]
 			depName := m[2]
@@ -98,8 +122,11 @@ func (s *gemSpec) Root() *languages.Package {
 	}
 
 	return &languages.Package{
-		Name:         s.Name,
-		Version:      s.Version,
+		Name:    s.Name,
+		Version: s.Version,
+		// A gemspec listing several licenses offers a choice among them, which
+		// is SPDX's OR. Values are passed through as the gemspec wrote them.
+		License:      languages.LicenseExpression(s.Licenses),
 		Purl:         ruby.NewPackageUrl(s.Name, s.Version),
 		Cpes:         ruby.NewCpes(s.Name, s.Version),
 		EvidenceList: ruby.NewEvidenceList(s.evidence),

--- a/providers/os/resources/languages/ruby/gemspec/extractor.go
+++ b/providers/os/resources/languages/ruby/gemspec/extractor.go
@@ -70,6 +70,15 @@ func parseGemspec(r io.Reader) (*gemSpec, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 
+		// A commented-out line states nothing. Reading one is how a gemspec
+		// that commented its license out while changing it gets reported under
+		// the old one, and a wrong license is worse than none: a consumer
+		// cannot tell it from a license the gem actually declares. The same
+		// applies to a commented-out name or version.
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+
 		if m := namePattern.FindStringSubmatch(line); len(m) > 1 {
 			spec.Name = m[1]
 		}

--- a/providers/os/resources/languages/ruby/gemspec/extractor_test.go
+++ b/providers/os/resources/languages/ruby/gemspec/extractor_test.go
@@ -232,3 +232,31 @@ func TestGemspecLicenseBounds(t *testing.T) {
 		})
 	}
 }
+
+// A commented-out line states nothing. Reading one reports a gem under a
+// license it does not declare, and a wrong license is worse than none: nothing
+// downstream can tell it from a real declaration.
+func TestGemspecIgnoresCommentedOutLines(t *testing.T) {
+	spec, err := parseGemspec(strings.NewReader(`Gem::Specification.new do |spec|
+  spec.name = "demo"
+  spec.version = "1.0.0"
+  # spec.license = "GPL-3.0"
+  # spec.licenses = ["AGPL-3.0-only"]
+end`))
+	require.NoError(t, err)
+
+	assert.Empty(t, spec.Licenses, "a commented-out license must not be read")
+	assert.Equal(t, "demo", spec.Name)
+	assert.Equal(t, "1.0.0", spec.Version)
+}
+
+// The commented-out form must not shadow a real one stated elsewhere.
+func TestGemspecReadsTheUncommentedLicense(t *testing.T) {
+	spec, err := parseGemspec(strings.NewReader(`Gem::Specification.new do |spec|
+  spec.name = "demo"
+  # spec.license = "GPL-3.0"
+  spec.license = "MIT"
+end`))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"MIT"}, spec.Licenses)
+}

--- a/providers/os/resources/languages/ruby/gemspec/extractor_test.go
+++ b/providers/os/resources/languages/ruby/gemspec/extractor_test.go
@@ -166,3 +166,69 @@ end`,
 		})
 	}
 }
+
+// TestGemspecLicenseBounds covers the size bounds on a gemspec's license. The
+// patterns here are line-scoped but unbounded within a line, and a .gemspec is
+// read out of a gem someone else published, so the length of the value is the
+// publisher's choice — and it flows on into SBOM documents and generated NOTICE
+// files.
+//
+// The cap is a literal here rather than the constant the implementation reads:
+// an expectation taken from the same constant would move with it and pin
+// nothing.
+func TestGemspecLicenseBounds(t *testing.T) {
+	// A license identifier of exactly n bytes, carrying no quote to close the
+	// Ruby string early.
+	name := func(n int) string { return strings.Repeat("a", n) }
+
+	// 100 valid identifiers on one `licenses = [...]` line. Each is fine on its
+	// own; the expression they join into is not a license statement.
+	many := "\"" + strings.Join(func() []string {
+		out := make([]string, 100)
+		for i := range out {
+			out[i] = "GPL-2.0-or-later"
+		}
+		return out
+	}(), "\", \"") + "\""
+
+	for _, c := range []struct {
+		name string
+		spec string
+		want string
+	}{
+		{
+			// A real name is nowhere near the cap and must keep being reported.
+			name: "a full license name is well under the cap",
+			spec: "Gem::Specification.new do |spec|\n  spec.name = \"example\"\n" +
+				"  spec.license = \"GNU Lesser General Public License, Version 2.1\"\nend",
+			want: "GNU Lesser General Public License, Version 2.1",
+		},
+		{
+			name: "an oversized singular license is dropped",
+			spec: "Gem::Specification.new do |spec|\n  spec.name = \"example\"\n" +
+				"  spec.license = \"" + name(300) + "\"\nend",
+			want: "",
+		},
+		{
+			// The oversized member is the only thing wrong with the list.
+			name: "an oversized member does not take its siblings with it",
+			spec: "Gem::Specification.new do |spec|\n  spec.name = \"example\"\n" +
+				"  spec.licenses = [\"" + name(300) + "\", \"MIT\"]\nend",
+			want: "MIT",
+		},
+		{
+			name: "a list past the total cap is dropped",
+			spec: "Gem::Specification.new do |spec|\n  spec.name = \"example\"\n" +
+				"  spec.licenses = [" + many + "]\nend",
+			want: "",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			info, err := (&Extractor{}).Parse(strings.NewReader(c.spec), "example.gemspec")
+			require.NoError(t, err)
+			root := info.Root()
+			require.NotNil(t, root)
+			assert.Equal(t, c.want, root.License)
+		})
+	}
+}

--- a/providers/os/resources/languages/ruby/gemspec/extractor_test.go
+++ b/providers/os/resources/languages/ruby/gemspec/extractor_test.go
@@ -5,6 +5,7 @@ package gemspec
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,6 +26,9 @@ func TestGemspecExtractor(t *testing.T) {
 	assert.Equal(t, "inspec", root.Name)
 	assert.Equal(t, "6.8.1", root.Version)
 	assert.Equal(t, "pkg:gem/inspec@6.8.1", root.Purl)
+	// The fixture states `spec.license = "Apache-2.0"`. It was parsed and then
+	// dropped on the floor until this was fixed.
+	assert.Equal(t, "Apache-2.0", root.License)
 
 	// Direct = non-dev deps
 	direct := info.Direct()
@@ -56,4 +60,109 @@ func TestGemspecExtractor(t *testing.T) {
 	require.NotNil(t, rake)
 	assert.Equal(t, "", rake.Version)
 	assert.Equal(t, "pkg:gem/rake", rake.Purl)
+}
+
+// TestGemspecLicenseForms is the regression test for a gemspec's license being
+// read but never reported: the extractor matched name, version and
+// dependencies, and left Package.License empty even when the file said
+// `spec.license = "Apache-2.0"` — which the checked-in fixture does.
+//
+// RubyGems accepts two spellings of the same field. `license=` sets a
+// one-element list and `licenses=` sets the list directly, so a gemspec that
+// writes both ends up with whichever it wrote last.
+func TestGemspecLicenseForms(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		spec string
+		want string
+	}{
+		{
+			name: "singular license",
+			spec: `Gem::Specification.new do |spec|
+  spec.name = "example"
+  spec.license = "Apache-2.0"
+end`,
+			want: "Apache-2.0",
+		},
+		{
+			name: "singular license, single quotes",
+			spec: "Gem::Specification.new do |spec|\n  spec.name = 'example'\n  spec.license = 'MIT'\nend",
+			want: "MIT",
+		},
+		{
+			// A list is a choice among the members, rendered as SPDX's OR.
+			name: "plural licenses",
+			spec: `Gem::Specification.new do |spec|
+  spec.name = "example"
+  spec.licenses = ["MIT", "Apache-2.0"]
+end`,
+			want: "(MIT OR Apache-2.0)",
+		},
+		{
+			// A one-element list must not acquire parentheses: "(MIT)" is a
+			// different string to every consumer comparing identifiers.
+			name: "plural licenses with one member",
+			spec: `Gem::Specification.new do |spec|
+  spec.name = "example"
+  spec.licenses = ["MIT"]
+end`,
+			want: "MIT",
+		},
+		{
+			// The plural form must not be mistaken for the singular one, which
+			// would report only the first member.
+			name: "plural form is not read as the singular one",
+			spec: `Gem::Specification.new do |spec|
+  spec.name = "example"
+  spec.licenses = ["MIT", "GPL-2.0", "BSD-3-Clause"]
+end`,
+			want: "(MIT OR GPL-2.0 OR BSD-3-Clause)",
+		},
+		{
+			// Ruby semantics: the second assignment replaces the first.
+			name: "last assignment wins",
+			spec: `Gem::Specification.new do |spec|
+  spec.name = "example"
+  spec.licenses = ["MIT", "Apache-2.0"]
+  spec.license = "MIT"
+end`,
+			want: "MIT",
+		},
+		{
+			// A gemspec that declared nothing must report nothing rather than
+			// an empty expression that reads as a declaration.
+			name: "no license stated",
+			spec: `Gem::Specification.new do |spec|
+  spec.name = "example"
+  spec.version = "1.0.0"
+end`,
+			want: "",
+		},
+		{
+			name: "empty license value",
+			spec: `Gem::Specification.new do |spec|
+  spec.name = "example"
+  spec.license = ""
+end`,
+			want: "",
+		},
+		{
+			// The name is not a license: an unrelated `.name =` line must not
+			// leak into the field.
+			name: "license is not confused with other fields",
+			spec: `Gem::Specification.new do |spec|
+  spec.name = "example"
+  spec.homepage = "https://example.com"
+end`,
+			want: "",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			info, err := (&Extractor{}).Parse(strings.NewReader(c.spec), "example.gemspec")
+			require.NoError(t, err)
+			root := info.Root()
+			require.NotNil(t, root)
+			assert.Equal(t, c.want, root.License)
+		})
+	}
 }

--- a/providers/os/resources/languages/ruby/gemspec/parser.go
+++ b/providers/os/resources/languages/ruby/gemspec/parser.go
@@ -9,6 +9,11 @@ type gemSpec struct {
 	Name string
 	// Version is the gem version (may be empty if it references a constant).
 	Version string
+	// Licenses holds the licenses the gemspec declares, in the order it wrote
+	// them. A gemspec states them with either `spec.license = "MIT"` or
+	// `spec.licenses = ["MIT", "Apache-2.0"]`; RubyGems keeps a single list
+	// either way, so this does too.
+	Licenses []string
 	// Dependencies is the list of declared dependencies.
 	Dependencies []gemDep
 


### PR DESCRIPTION
#10577 has merged, and `main` is merged in here — this now targets `main` directly with no stacking left.

This originally carried its own Python `wheelegg` fix. #10577 was opened 48 minutes earlier and did the same thing, so this branch was rebased onto it and that duplicate commit dropped. Its classifier handling was better than mine and is kept as-is: it excludes eleven trove categories that name no specific license, where I excluded two. `License :: Public Domain` and `License :: Other/Proprietary License` are categories, not identifiers — CC0 and Unlicense are the identifiers — and reporting either as a license asserts a fact the distribution never stated.

What remains here is the same class of bug in three other ecosystems, plus bounds for all of them.

## Three more extractors parse a license and report none

- **`ruby/gemspec`** — `spec.license` and `spec.licenses`. `spec.license = "Apache-2.0"` was sitting in the extractor's own fixture, unparsed. Both forms write one field, so the last assignment wins, matching Ruby's own semantics. `%w[...]` word arrays and multi-line arrays are deliberately unsupported, and no test claims otherwise.
- **`javascript/packagejson`** — the deprecated `licenses: [{type, url}]` array, plus the object form of singular `license`, which was the same bug in the same struct. The object's `url` is dropped: a link to the terms is not their identity.
- **`java/manifestmf`** — `Bundle-License`, parsed per the OSGi grammar and quote-aware, because an attribute value legitimately contains `,` and `;`.

## Two deliberate deviations in the OSGi parser

Both are anti-fabrication choices, and both are pinned by tests rather than only by comments.

**A URL-only header emits nothing.** Roughly two thirds of a 30-manifest sample is URL-only (Apache, Eclipse, jsoup, H2, JaCoCo, GlassFish). A URL in a field consumers compare against `Apache-2.0` matches nothing while *reading* as a stated identifier — worse than the honest blank those bundles get today. Nothing regresses; this adds the ~1 in 3 that names a license.

**Members rejoin with `", "` rather than OR-joining.** Eclipse/Tycho bundles write `The Apache License, Version 2.0` as a *single* identifier — 8 of the 30 sampled — and nothing distinguishes that from a genuine two-license header. OR-joining would report those as offered under "The Apache License" OR "Version 2.0", inventing a choice the bundle never made.

## Bounds

These values come from a package index, not the scanned host, and they flow into SBOM documents, SARIF and generated NOTICE files. Nothing bounded them.

`LicenseExpression` is the chokepoint — composerlock, installedjson, packagelockjson, packagejson, gemspec and wheelegg's classifier path all route through it — so bounding it once covered every site but `manifestmf`, which deliberately bypasses it and got the same two bounds.

- **256 bytes per operand.** The longest SPDX identifier is under 60 bytes and the longest full license *name* around 120.
- **1024 bytes on the rendered expression**, separators counted. A per-operand bound alone stops nothing: thousands of individually valid short identifiers still join without limit.

**Dropped, never truncated** — a cut-off identifier reads as a *different* license to any consumer comparing strings. Overflow drops the whole expression rather than a prefix, because a subset of an `OR` is a different statement about what the package permits. A running operand sum bails early so a million-member array is never materialized into one string.

## Two fixes carried onto the wheelegg file #10577 added

**`License-Expression` was held to the name bound.** #10577 applies one 256-byte limit to both its headers, but they are different kinds of value: `License` is a name, `License-Expression` is the same kind of expression `LicenseExpression` renders elsewhere. A genuine choice that every other extractor accepts was dropped there. Both bounds now come from the shared pair, so the file and the renderer cannot drift.

One inherited test needed a real fix, not a mechanical one: `TestOversizedExpressionIsDropped` built a 703-byte expression, over the old shared bound but *under* the expression bound — it would have started asserting the opposite of its name. Its input now exceeds 1024. Two other bound assertions moved from reading the implementation's constant to literals, since a test that reads the constant it is checking moves with it and pins nothing.

**`jsonn:` struct tags** at four sites (packagejson ×3, packagelockjson ×1). A review bot filed this as critical on the grounds those fields are never populated. That part is wrong, and verified against the real unmarshaler: an unrecognized tag leaves the field *untagged*, and `encoding/json` then matches by field name, case-insensitively. All four have been decoding correctly. Fixed anyway — the tag reads as authoritative and would silently stop working the moment a field is renamed — but nothing was broken.

## Tests

Every test was checked against the unfixed implementation, because a test that cannot fail is worse than none:

| area | subtests failing on revert |
|---|---|
| ruby gemspec | 6 of 9 |
| javascript packagejson | 9 |
| java manifestmf | 8 of 15 |
| bounds (unbounded) | 7 + 4 |
| bounds (over-tightened caps) | 3 + 2 |

The bound tables run **both** directions — exactly-at-cap survives, one byte over drops — because the real regression risk is over-tightening and silently dropping real licenses.

`go test ./providers/os/resources/languages/... -count=1` → exit 0, 57 packages ok, 0 FAIL, after merging current `main`.

## Not in this PR

- `sbom.Package.Licenses` (proto field 31) — #10579 did that, and has merged.
- gemspec `%w[...]` word arrays and multi-line `licenses` arrays.
- OSGi `description=` as a fallback when the identifier is a URL — bnd's own documented example of that attribute is a full sentence, so promoting it would report prose as an identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)