### PR TITLE
🐛 sbom: carry the license into the generated SBOM

### DIFF
--- a/sbom/cyclonedx.go
+++ b/sbom/cyclonedx.go
@@ -461,14 +461,26 @@ func cycloneDXLicenses(license string) *cyclonedx.Licenses {
 
 // isSPDXExpression reports whether a license string joins operands with SPDX
 // operators, which is what makes it an expression rather than an identifier.
+//
+// The operators are matched case-SENSITIVELY, because that is what the grammar
+// defines: SPDX spells them as upper-case keywords, so a license whose *name*
+// contains the ordinary English word — "Sleepycat and others" — is not a
+// conjunction. Upper-casing before the comparison read that as an expression
+// and emitted it as one, which is not parseable SPDX and is exactly the
+// malformed document the three mutually exclusive fields exist to prevent.
+//
+// Parentheses are deliberately not a signal on their own either. "BSD (see
+// LICENSE)" is a free-text name, and grouping only ever exists to order
+// operators, so a genuinely grouped expression contains one anyway and is
+// caught above.
 func isSPDXExpression(s string) bool {
 	for _, t := range strings.Fields(s) {
-		switch strings.ToUpper(t) {
+		switch t {
 		case "AND", "OR", "WITH":
 			return true
 		}
 	}
-	return strings.ContainsAny(s, "()")
+	return false
 }
 
 // isSPDXIdentifierShaped reports whether a license string could be a bare SPDX

--- a/sbom/generator/generator.go
+++ b/sbom/generator/generator.go
@@ -19,6 +19,48 @@ import (
 
 var LABEL_KERNEL_RUNNING = "mondoo.com/os/kernel-running"
 
+// languagePackages maps the packages one language ecosystem reported into SBOM
+// packages.
+//
+// Most ecosystems' mappings are identical apart from the package type, so they
+// share one constructor rather than a copy each. That is not only tidiness: a
+// field added to the mapping has to reach every ecosystem, and a row of
+// hand-maintained copies is exactly the shape where it reaches all but one, and
+// the last is found later by a user whose SBOM is missing it.
+func languagePackages(pkgs []BomPackage, pkgType string) []*sbom.Package {
+	out := make([]*sbom.Package, 0, len(pkgs))
+	for _, pkg := range pkgs {
+		out = append(out, languagePackage(pkg, pkgType))
+	}
+	return out
+}
+
+// languagePackage maps one reported package, for the ecosystems whose loop
+// carries something of its own and cannot use languagePackages.
+func languagePackage(pkg BomPackage, pkgType string) *sbom.Package {
+	bomPkg := &sbom.Package{
+		Name:    pkg.Name,
+		Version: pkg.Version,
+		Purl:    pkg.Purl,
+		Cpes:    pkg.CPEs,
+		Type:    pkgType,
+		// The legacy scalar stays written alongside the list. Nothing populates
+		// it from the list, so a consumer that has not migrated would otherwise
+		// see nothing where a license was reported.
+		License:  pkg.License,
+		Licenses: sbom.DeclaredLicenses(pkg.License),
+	}
+
+	for _, filepath := range pkg.FilePaths {
+		bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
+			Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
+			Value: filepath,
+		})
+	}
+
+	return bomPkg
+}
+
 // GenerateBom generates a BOM from a cnquery json report collection
 func GenerateBom(r *reporter.Report) []*sbom.Sbom {
 	if r == nil {
@@ -131,6 +173,8 @@ func GenerateBom(r *reporter.Report) []*sbom.Sbom {
 						Purl:         pkg.Purl,
 						Cpes:         pkg.CPEs,
 						Type:         pkg.Format,
+						License:      pkg.License,
+						Licenses:     sbom.DeclaredLicenses(pkg.License),
 					}
 
 					for _, filepath := range pkg.FilePaths {
@@ -146,11 +190,13 @@ func GenerateBom(r *reporter.Report) []*sbom.Sbom {
 
 			for _, pkg := range rb.PythonPackages {
 				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    "pypi",
+					Name:     pkg.Name,
+					Version:  pkg.Version,
+					Purl:     pkg.Purl,
+					Cpes:     pkg.CPEs,
+					Type:     "pypi",
+					License:  pkg.License,
+					Licenses: sbom.DeclaredLicenses(pkg.License),
 				}
 
 				// deprecated path, all files are now in the FilePaths field
@@ -172,126 +218,26 @@ func GenerateBom(r *reporter.Report) []*sbom.Sbom {
 				bom.Packages = append(bom.Packages, bomPkg)
 			}
 
-			for _, pkg := range rb.NpmPackages {
-				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    "npm",
-				}
+			bom.Packages = append(bom.Packages, languagePackages(rb.NpmPackages, "npm")...)
 
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
+			bom.Packages = append(bom.Packages, languagePackages(rb.GoPackages, "go-module")...)
 
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
+			bom.Packages = append(bom.Packages, languagePackages(rb.JavaPackages, "maven")...)
 
-			for _, pkg := range rb.GoPackages {
-				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    "go-module",
-				}
+			bom.Packages = append(bom.Packages, languagePackages(rb.RustPackages, "cargo")...)
 
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
+			bom.Packages = append(bom.Packages, languagePackages(rb.DotnetPackages, "nuget")...)
 
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
-
-			for _, pkg := range rb.JavaPackages {
-				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    "maven",
-				}
-
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
-
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
-
-			for _, pkg := range rb.RustPackages {
-				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    "cargo",
-				}
-
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
-
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
-
-			for _, pkg := range rb.DotnetPackages {
-				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    "nuget",
-				}
-
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
-
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
-
-			for _, pkg := range rb.PhpPackages {
-				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    "composer",
-				}
-
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
-
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
+			bom.Packages = append(bom.Packages, languagePackages(rb.PhpPackages, "composer")...)
 
 			for _, pkg := range rb.GithubActionsPackages {
 				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Type:    "github-action",
+					Name:     pkg.Name,
+					Version:  pkg.Version,
+					Purl:     pkg.Purl,
+					Type:     "github-action",
+					License:  pkg.License,
+					Licenses: sbom.DeclaredLicenses(pkg.License),
 				}
 
 				for _, filepath := range pkg.FilePaths {
@@ -310,11 +256,13 @@ func GenerateBom(r *reporter.Report) []*sbom.Sbom {
 					pkgType = "cocoapods"
 				}
 				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    pkgType,
+					Name:     pkg.Name,
+					Version:  pkg.Version,
+					Purl:     pkg.Purl,
+					Cpes:     pkg.CPEs,
+					Type:     pkgType,
+					License:  pkg.License,
+					Licenses: sbom.DeclaredLicenses(pkg.License),
 				}
 
 				for _, filepath := range pkg.FilePaths {
@@ -327,31 +275,16 @@ func GenerateBom(r *reporter.Report) []*sbom.Sbom {
 				bom.Packages = append(bom.Packages, bomPkg)
 			}
 
-			for _, pkg := range rb.TerraformPackages {
-				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    "terraform",
-				}
-
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
-
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
+			bom.Packages = append(bom.Packages, languagePackages(rb.TerraformPackages, "terraform")...)
 
 			for _, pkg := range rb.JenkinsPackages {
 				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Type:    "jenkins-plugin",
+					Name:     pkg.Name,
+					Version:  pkg.Version,
+					Purl:     pkg.Purl,
+					Type:     "jenkins-plugin",
+					License:  pkg.License,
+					Licenses: sbom.DeclaredLicenses(pkg.License),
 				}
 
 				for _, filepath := range pkg.FilePaths {
@@ -366,10 +299,12 @@ func GenerateBom(r *reporter.Report) []*sbom.Sbom {
 
 			for _, pkg := range rb.WordpressPackages {
 				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Type:    "wordpress-plugin",
+					Name:     pkg.Name,
+					Version:  pkg.Version,
+					Purl:     pkg.Purl,
+					Type:     "wordpress-plugin",
+					License:  pkg.License,
+					Licenses: sbom.DeclaredLicenses(pkg.License),
 				}
 
 				for _, filepath := range pkg.FilePaths {
@@ -382,195 +317,25 @@ func GenerateBom(r *reporter.Report) []*sbom.Sbom {
 				bom.Packages = append(bom.Packages, bomPkg)
 			}
 
-			for _, pkg := range rb.RubyPackages {
-				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    "gem",
-				}
+			bom.Packages = append(bom.Packages, languagePackages(rb.RubyPackages, "gem")...)
 
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
+			bom.Packages = append(bom.Packages, languagePackages(rb.DartPackages, "pub")...)
 
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
+			bom.Packages = append(bom.Packages, languagePackages(rb.HaskellPackages, "hackage")...)
 
-			for _, pkg := range rb.DartPackages {
-				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    "pub",
-				}
+			bom.Packages = append(bom.Packages, languagePackages(rb.ElixirPackages, "hex")...)
 
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
+			bom.Packages = append(bom.Packages, languagePackages(rb.ErlangPackages, "hex")...)
 
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
+			bom.Packages = append(bom.Packages, languagePackages(rb.PrologPackages, "swi-prolog")...)
 
-			for _, pkg := range rb.HaskellPackages {
-				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    "hackage",
-				}
+			bom.Packages = append(bom.Packages, languagePackages(rb.JuliaPackages, "julia")...)
 
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
+			bom.Packages = append(bom.Packages, languagePackages(rb.CondaPackages, "conda")...)
 
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
+			bom.Packages = append(bom.Packages, languagePackages(rb.RPackages, "cran")...)
 
-			for _, pkg := range rb.ElixirPackages {
-				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    "hex",
-				}
-
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
-
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
-
-			for _, pkg := range rb.ErlangPackages {
-				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    "hex",
-				}
-
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
-
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
-
-			for _, pkg := range rb.PrologPackages {
-				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    "swi-prolog",
-				}
-
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
-
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
-
-			for _, pkg := range rb.JuliaPackages {
-				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    "julia",
-				}
-
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
-
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
-
-			for _, pkg := range rb.CondaPackages {
-				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    "conda",
-				}
-
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
-
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
-
-			for _, pkg := range rb.RPackages {
-				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    "cran",
-				}
-
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
-
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
-
-			for _, pkg := range rb.LuaPackages {
-				bomPkg := &sbom.Package{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Purl:    pkg.Purl,
-					Cpes:    pkg.CPEs,
-					Type:    "luarocks",
-				}
-
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
-
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
+			bom.Packages = append(bom.Packages, languagePackages(rb.LuaPackages, "luarocks")...)
 		}
 
 		// Stamp a stable bom_ref on every component (purl-when-present, else a

--- a/sbom/generator/generator.go
+++ b/sbom/generator/generator.go
@@ -230,92 +230,21 @@ func GenerateBom(r *reporter.Report) []*sbom.Sbom {
 
 			bom.Packages = append(bom.Packages, languagePackages(rb.PhpPackages, "composer")...)
 
-			for _, pkg := range rb.GithubActionsPackages {
-				bomPkg := &sbom.Package{
-					Name:     pkg.Name,
-					Version:  pkg.Version,
-					Purl:     pkg.Purl,
-					Type:     "github-action",
-					License:  pkg.License,
-					Licenses: sbom.DeclaredLicenses(pkg.License),
-				}
-
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
-
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
+			bom.Packages = append(bom.Packages, languagePackages(rb.GithubActionsPackages, "github-action")...)
 
 			for _, pkg := range rb.SwiftPackages {
 				pkgType := "swift"
 				if strings.HasPrefix(pkg.Purl, "pkg:cocoapods/") {
 					pkgType = "cocoapods"
 				}
-				bomPkg := &sbom.Package{
-					Name:     pkg.Name,
-					Version:  pkg.Version,
-					Purl:     pkg.Purl,
-					Cpes:     pkg.CPEs,
-					Type:     pkgType,
-					License:  pkg.License,
-					Licenses: sbom.DeclaredLicenses(pkg.License),
-				}
-
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
-
-				bom.Packages = append(bom.Packages, bomPkg)
+				bom.Packages = append(bom.Packages, languagePackage(pkg, pkgType))
 			}
 
 			bom.Packages = append(bom.Packages, languagePackages(rb.TerraformPackages, "terraform")...)
 
-			for _, pkg := range rb.JenkinsPackages {
-				bomPkg := &sbom.Package{
-					Name:     pkg.Name,
-					Version:  pkg.Version,
-					Purl:     pkg.Purl,
-					Type:     "jenkins-plugin",
-					License:  pkg.License,
-					Licenses: sbom.DeclaredLicenses(pkg.License),
-				}
+			bom.Packages = append(bom.Packages, languagePackages(rb.JenkinsPackages, "jenkins-plugin")...)
 
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
-
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
-
-			for _, pkg := range rb.WordpressPackages {
-				bomPkg := &sbom.Package{
-					Name:     pkg.Name,
-					Version:  pkg.Version,
-					Purl:     pkg.Purl,
-					Type:     "wordpress-plugin",
-					License:  pkg.License,
-					Licenses: sbom.DeclaredLicenses(pkg.License),
-				}
-
-				for _, filepath := range pkg.FilePaths {
-					bomPkg.EvidenceList = append(bomPkg.EvidenceList, &sbom.Evidence{
-						Type:  sbom.EvidenceType_EVIDENCE_TYPE_FILE,
-						Value: filepath,
-					})
-				}
-
-				bom.Packages = append(bom.Packages, bomPkg)
-			}
+			bom.Packages = append(bom.Packages, languagePackages(rb.WordpressPackages, "wordpress-plugin")...)
 
 			bom.Packages = append(bom.Packages, languagePackages(rb.RubyPackages, "gem")...)
 

--- a/sbom/generator/license_test.go
+++ b/sbom/generator/license_test.go
@@ -1,0 +1,96 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.mondoo.com/mql/sbom"
+)
+
+// The whole path, from the report JSON through to the SBOM: the struct tag on
+// BomPackage, the mapping in the generator, and the model entry. A unit test on
+// the mapper alone would miss the tag, which is the half that fails silently --
+// a mistyped `json:"license"` yields a zero value, not an error.
+func TestLicenseReachesTheSbom(t *testing.T) {
+	report, err := LoadReport("testdata/licenses.json")
+	require.NoError(t, err)
+
+	boms := GenerateBom(report)
+	require.Len(t, boms, 1)
+	pkgs := boms[0].Packages
+
+	t.Run("a bare identifier lands in spdx_id", func(t *testing.T) {
+		pkg := findProtoPkg(pkgs, "busybox")
+		require.NotNil(t, pkg)
+
+		// The legacy scalar keeps being written. Nothing populates it from the
+		// list, so a consumer that has not migrated would see nothing without it.
+		assert.Equal(t, "GPL-2.0-only", pkg.License)
+
+		require.Len(t, pkg.Licenses, 1)
+		l := pkg.Licenses[0]
+		assert.Equal(t, "GPL-2.0-only", l.GetSpdxId())
+		assert.Empty(t, l.GetExpression())
+		assert.Empty(t, l.GetName())
+		assert.Equal(t, sbom.LicenseAcquisition_LICENSE_ACQUISITION_DECLARED, l.GetAcquisition())
+		assert.Equal(t, 1.0, l.GetConfidence())
+	})
+
+	// An expression in the id slot is the malformed document the three mutually
+	// exclusive fields exist to prevent, so this is the case that matters most.
+	t.Run("an expression lands in expression, not spdx_id", func(t *testing.T) {
+		pkg := findProtoPkg(pkgs, "dual-licensed")
+		require.NotNil(t, pkg)
+
+		require.Len(t, pkg.Licenses, 1)
+		l := pkg.Licenses[0]
+		assert.Equal(t, "MIT OR Apache-2.0", l.GetExpression())
+		assert.Empty(t, l.GetSpdxId())
+		assert.Empty(t, l.GetName())
+	})
+
+	t.Run("free text lands in name", func(t *testing.T) {
+		pkg := findProtoPkg(pkgs, "freetext")
+		require.NotNil(t, pkg)
+
+		require.Len(t, pkg.Licenses, 1)
+		l := pkg.Licenses[0]
+		assert.Equal(t, "see the LICENSE file", l.GetName())
+		assert.Empty(t, l.GetSpdxId())
+		assert.Empty(t, l.GetExpression())
+	})
+
+	// A package that declared nothing gets no entry at all. An entry naming no
+	// license asserts a licensing fact the producer does not have, and a
+	// consumer cannot tell it apart from a real determination.
+	t.Run("a package that declared nothing carries no entry", func(t *testing.T) {
+		pkg := findProtoPkg(pkgs, "undeclared")
+		require.NotNil(t, pkg)
+
+		assert.Empty(t, pkg.License)
+		assert.Empty(t, pkg.Licenses)
+	})
+}
+
+// languagePackages is what the ecosystems share, so a license dropped there is
+// dropped for seventeen of them at once.
+func TestLanguagePackagesCarryTheLicense(t *testing.T) {
+	out := languagePackages([]BomPackage{
+		{Name: "a", Version: "1", License: "MIT"},
+		{Name: "b", Version: "2"},
+	}, "npm")
+	require.Len(t, out, 2)
+
+	assert.Equal(t, "MIT", out[0].License)
+	require.Len(t, out[0].Licenses, 1)
+	assert.Equal(t, "MIT", out[0].Licenses[0].GetSpdxId())
+	assert.Equal(t, "npm", out[0].Type)
+
+	assert.Empty(t, out[1].License)
+	assert.Empty(t, out[1].Licenses)
+}

--- a/sbom/generator/license_test.go
+++ b/sbom/generator/license_test.go
@@ -30,7 +30,7 @@ func TestLicenseReachesTheSbom(t *testing.T) {
 
 		// The legacy scalar keeps being written. Nothing populates it from the
 		// list, so a consumer that has not migrated would see nothing without it.
-		assert.Equal(t, "GPL-2.0-only", pkg.License)
+		assert.Equal(t, "GPL-2.0-only", pkg.License) //nolint:staticcheck // SA1019: that the legacy scalar is STILL written is the assertion
 
 		require.Len(t, pkg.Licenses, 1)
 		l := pkg.Licenses[0]
@@ -72,7 +72,7 @@ func TestLicenseReachesTheSbom(t *testing.T) {
 		pkg := findProtoPkg(pkgs, "undeclared")
 		require.NotNil(t, pkg)
 
-		assert.Empty(t, pkg.License)
+		assert.Empty(t, pkg.License) //nolint:staticcheck // SA1019: that the legacy scalar is STILL written is the assertion
 		assert.Empty(t, pkg.Licenses)
 	})
 }
@@ -86,11 +86,11 @@ func TestLanguagePackagesCarryTheLicense(t *testing.T) {
 	}, "npm")
 	require.Len(t, out, 2)
 
-	assert.Equal(t, "MIT", out[0].License)
+	assert.Equal(t, "MIT", out[0].License) //nolint:staticcheck // SA1019: that the legacy scalar is STILL written is the assertion
 	require.Len(t, out[0].Licenses, 1)
 	assert.Equal(t, "MIT", out[0].Licenses[0].GetSpdxId())
 	assert.Equal(t, "npm", out[0].Type)
 
-	assert.Empty(t, out[1].License)
+	assert.Empty(t, out[1].License) //nolint:staticcheck // SA1019: that the legacy scalar is STILL written is the assertion
 	assert.Empty(t, out[1].Licenses)
 }

--- a/sbom/generator/license_test.go
+++ b/sbom/generator/license_test.go
@@ -94,3 +94,23 @@ func TestLanguagePackagesCarryTheLicense(t *testing.T) {
 	assert.Empty(t, out[1].License) //nolint:staticcheck // SA1019: that the legacy scalar is STILL written is the assertion
 	assert.Empty(t, out[1].Licenses)
 }
+
+// GithubActions, Jenkins and Wordpress packages were built by hand-written
+// loops that never mapped Cpes, so a CPE the query reported was dropped. They
+// go through the shared constructor now, which is the whole point of having
+// one: the three were identical to it apart from the field they were missing.
+func TestGithubActionPackagesCarryCpesAndLicense(t *testing.T) {
+	report, err := LoadReport("testdata/licenses.json")
+	require.NoError(t, err)
+
+	boms := GenerateBom(report)
+	require.Len(t, boms, 1)
+
+	pkg := findProtoPkg(boms[0].Packages, "actions/checkout")
+	require.NotNil(t, pkg)
+	assert.Equal(t, "github-action", pkg.Type)
+	assert.Equal(t, []string{"cpe:2.3:a:actions:checkout:4.2.2:*:*:*:*:*:*:*"}, pkg.Cpes)
+
+	require.Len(t, pkg.Licenses, 1)
+	assert.Equal(t, "MIT", pkg.Licenses[0].GetSpdxId())
+}

--- a/sbom/generator/report_collection.go
+++ b/sbom/generator/report_collection.go
@@ -33,6 +33,12 @@ type BomPackage struct {
 	Format  string   `json:"format,omitempty"`
 	Purl    string   `json:"purl,omitempty"`
 	CPEs    []string `json:"cpes.map,omitempty"`
+	// License as the package's own manifest or metadata declared it, e.g. npm
+	// package.json `license` or a Python distribution's METADATA. Empty when
+	// the query did not select it, or when the package declared none -- the
+	// two are indistinguishable here, which is why an empty value records no
+	// license entry rather than an unknown one.
+	License string `json:"license,omitempty"`
 	// used by python packages
 	// deprecated: remove once python.packages uses files
 	FilePath string `json:"file.path,omitempty"`

--- a/sbom/generator/testdata/licenses.json
+++ b/sbom/generator/testdata/licenses.json
@@ -63,6 +63,21 @@
                             }
                         ]
                     }
+                },
+                "//local.cnquery.io/run/local-execution/queries/mondoo-sbom-githubactions-packages": {
+                    "content": {
+                        "githubactions.packages.list": [
+                            {
+                                "name": "actions/checkout",
+                                "version": "4.2.2",
+                                "purl": "pkg:githubactions/actions/checkout@4.2.2",
+                                "license": "MIT",
+                                "cpes.map": [
+                                    "cpe:2.3:a:actions:checkout:4.2.2:*:*:*:*:*:*:*"
+                                ]
+                            }
+                        ]
+                    }
                 }
             }
         }

--- a/sbom/generator/testdata/licenses.json
+++ b/sbom/generator/testdata/licenses.json
@@ -1,0 +1,70 @@
+{
+    "assets": {
+        "//explorer.api.mondoo.com/assets/licensed": {
+            "mrn": "//explorer.api.mondoo.com/assets/licensed",
+            "name": "licensed:latest",
+            "trace_id": "trace-licensed"
+        }
+    },
+    "data": {
+        "//explorer.api.mondoo.com/assets/licensed": {
+            "values": {
+                "//local.cnquery.io/run/local-execution/queries/mondoo-sbom-asset": {
+                    "content": {
+                        "asset": {
+                            "version": "3.19.0",
+                            "arch": "aarch64",
+                            "platform": "alpine",
+                            "ids": [
+                                "//platformid.api.mondoo.app/runtime/docker/images/licensed"
+                            ],
+                            "name": "licensed:latest"
+                        }
+                    }
+                },
+                "//local.cnquery.io/run/local-execution/queries/mondoo-sbom-packages": {
+                    "content": {
+                        "packages.list": [
+                            {
+                                "name": "busybox",
+                                "version": "1.36.1-r15",
+                                "format": "apk",
+                                "purl": "pkg:apk/alpine/busybox@1.36.1-r15",
+                                "license": "GPL-2.0-only"
+                            }
+                        ]
+                    }
+                },
+                "//local.cnquery.io/run/local-execution/queries/mondoo-sbom-python-packages": {
+                    "content": {
+                        "python.packages": [
+                            {
+                                "name": "dual-licensed",
+                                "version": "1.0.0",
+                                "purl": "pkg:pypi/dual-licensed@1.0.0",
+                                "license": "MIT OR Apache-2.0"
+                            },
+                            {
+                                "name": "undeclared",
+                                "version": "2.0.0",
+                                "purl": "pkg:pypi/undeclared@2.0.0"
+                            }
+                        ]
+                    }
+                },
+                "//local.cnquery.io/run/local-execution/queries/mondoo-sbom-npm-packages": {
+                    "content": {
+                        "npm.packages.list": [
+                            {
+                                "name": "freetext",
+                                "version": "3.0.0",
+                                "purl": "pkg:npm/freetext@3.0.0",
+                                "license": "see the LICENSE file"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sbom/license.go
+++ b/sbom/license.go
@@ -1,0 +1,64 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sbom
+
+import "strings"
+
+// DeclaredLicense builds the License model entry for a license a package
+// DECLARED — the string its manifest or metadata stated about itself, as
+// opposed to one concluded by reading the files it ships.
+//
+// It returns nil when there is nothing to record. An entry naming no license
+// asserts a licensing fact the producer does not have, and is worse than an
+// absent one: a consumer cannot tell it apart from a real determination.
+//
+// Which of the three mutually exclusive value fields gets set is decided by
+// what the string actually is, using the same rule the CycloneDX renderer
+// applies to the legacy scalar — one decision in one place, so the model and
+// the rendering of it cannot disagree about whether "MIT OR Apache-2.0" is an
+// identifier.
+//
+// Confidence is 1.0 and not a parameter. A declared license is a statement the
+// package made about itself rather than a measurement somebody took of it, so
+// there is nothing to be less than certain about. A concluded license — which
+// carries its match score — is produced by whatever did the concluding, not
+// here.
+func DeclaredLicense(value string) *License {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+
+	l := &License{
+		Acquisition: LicenseAcquisition_LICENSE_ACQUISITION_DECLARED,
+		Confidence:  1.0,
+	}
+	switch {
+	case isSPDXExpression(value):
+		// Carried exactly as written. Re-serializing an expression means
+		// parsing and re-printing it, and that round trip drops grouping:
+		// "(MIT OR Apache-2.0) AND BSD-3-Clause" comes back as
+		// "MIT OR Apache-2.0 AND BSD-3-Clause", which is a different license,
+		// since AND binds tighter and the parentheses were carrying the meaning.
+		l.Expression = value
+	case isSPDXIdentifierShaped(value):
+		l.SpdxId = value
+	default:
+		// Neither an identifier nor an expression: free text such as
+		// "BSD-like, see LICENSE". It travels as a name, which is honest —
+		// forcing it into the id field would be a claim the source does not
+		// support, and would produce a document a consumer cannot resolve.
+		l.Name = value
+	}
+	return l
+}
+
+// DeclaredLicenses is DeclaredLicense as the repeated field wants it: a
+// one-entry list, or nil when the value states no license.
+func DeclaredLicenses(value string) []*License {
+	if l := DeclaredLicense(value); l != nil {
+		return []*License{l}
+	}
+	return nil
+}

--- a/sbom/license_test.go
+++ b/sbom/license_test.go
@@ -1,0 +1,100 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sbom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeclaredLicensePlacesTheRightField(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		value      string
+		spdxID     string
+		expression string
+		licName    string
+	}{
+		{name: "a bare identifier", value: "MIT", spdxID: "MIT"},
+		{name: "an identifier with punctuation", value: "GPL-2.0-or-later", spdxID: "GPL-2.0-or-later"},
+		{name: "an identifier with a plus", value: "Apache-2.0+", spdxID: "Apache-2.0+"},
+		// Not on the SPDX list, but identifier-shaped. Rendering it as an id is
+		// right: this package must not drop a license it cannot recognise, and a
+		// consumer validating against the list says something more useful than a
+		// producer that silently downgraded it.
+		{name: "an unlisted identifier", value: "OurInternalTerms-1.0", spdxID: "OurInternalTerms-1.0"},
+		{name: "an OR expression", value: "MIT OR Apache-2.0", expression: "MIT OR Apache-2.0"},
+		{name: "an AND expression", value: "MIT AND BSD-3-Clause", expression: "MIT AND BSD-3-Clause"},
+		{name: "a WITH exception", value: "GPL-2.0-only WITH Classpath-exception-2.0", expression: "GPL-2.0-only WITH Classpath-exception-2.0"},
+		{name: "a parenthesised expression", value: "(MIT OR Apache-2.0)", expression: "(MIT OR Apache-2.0)"},
+		{name: "free text", value: "see the LICENSE file", licName: "see the LICENSE file"},
+		// Identifier-SHAPED but not on the SPDX list. It still goes in the id
+		// field: this package deliberately does not validate against the list,
+		// so that an unlisted identifier reaches the document and a consumer
+		// that does validate can say so.
+		{name: "an identifier-shaped unlisted name", value: "BSD-like", spdxID: "BSD-like"},
+		{name: "free text naming a license", value: "BSD style, see COPYING", licName: "BSD style, see COPYING"},
+		// "and" is not an operator: SPDX keywords are case-sensitive, and
+		// several published license names contain the lowercase word.
+		{name: "a name containing the word and", value: "Sleepycat and others", licName: "Sleepycat and others"},
+		{name: "a name containing the word or", value: "Artistic or GPL", licName: "Artistic or GPL"},
+		// Parentheses alone do not make an expression. Emitting this as one
+		// produces a document no consumer can parse.
+		{name: "free text with parentheses", value: "BSD (see LICENSE)", licName: "BSD (see LICENSE)"},
+		{name: "a note in parentheses", value: "MIT (with a local amendment)", licName: "MIT (with a local amendment)"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			l := DeclaredLicense(tc.value)
+			require.NotNil(t, l)
+			assert.Equal(t, tc.spdxID, l.GetSpdxId(), "spdx_id")
+			assert.Equal(t, tc.expression, l.GetExpression(), "expression")
+			assert.Equal(t, tc.licName, l.GetName(), "name")
+
+			// Exactly one of the three, always. A document setting two is
+			// rejected by CycloneDX.
+			set := 0
+			for _, v := range []string{l.GetSpdxId(), l.GetExpression(), l.GetName()} {
+				if v != "" {
+					set++
+				}
+			}
+			assert.Equal(t, 1, set, "exactly one value field must be set")
+		})
+	}
+}
+
+// A declaration is a statement the package made about itself, not a measurement
+// somebody took of it, so it is recorded as certain and as declared.
+func TestDeclaredLicenseIsCertainAndDeclared(t *testing.T) {
+	l := DeclaredLicense("MIT")
+	require.NotNil(t, l)
+	assert.Equal(t, LicenseAcquisition_LICENSE_ACQUISITION_DECLARED, l.GetAcquisition())
+	assert.Equal(t, 1.0, l.GetConfidence())
+}
+
+// Nothing to record is recorded as nothing. An entry naming no license asserts
+// a licensing fact the producer does not have.
+func TestNoLicenseYieldsNoEntry(t *testing.T) {
+	for _, v := range []string{"", "   ", "\t\n"} {
+		assert.Nil(t, DeclaredLicense(v), "%q", v)
+		assert.Nil(t, DeclaredLicenses(v), "%q", v)
+	}
+}
+
+// Grouping carries meaning -- AND binds tighter than OR -- so an expression is
+// stored exactly as written rather than normalised.
+func TestExpressionGroupingSurvives(t *testing.T) {
+	const grouped = "(MIT OR Apache-2.0) AND BSD-3-Clause"
+	l := DeclaredLicense(grouped)
+	require.NotNil(t, l)
+	assert.Equal(t, grouped, l.GetExpression())
+}
+
+func TestDeclaredLicensesWrapsASingleEntry(t *testing.T) {
+	got := DeclaredLicenses("MIT")
+	require.Len(t, got, 1)
+	assert.Equal(t, "MIT", got[0].GetSpdxId())
+}


### PR DESCRIPTION
`GenerateBom` never set `License` on an `sbom.Package` — **not once, for any of the twenty-three package kinds it maps.** `BomPackage` had no `License` field to read either. So a generated SBOM reports no license for anything: including the npm and PHP packages #10557 just fixed at the extractor level, and the Python ones whose license `wheelegg` has always read.

xgrep never hit this because it imports the language extractors directly and builds `sbom.Package` itself — which is also why #10557 could be verified end to end through xgrep while this path stayed dark.

## What changes

`BomPackage` gains `license`, and the mapping sets both the legacy scalar **and** the repeated `Licenses` field from #10491, as a `DECLARED` entry with confidence 1.0. A declaration is a statement a package made about itself, not a measurement somebody took of it, so there is nothing to be less than certain about.

The scalar keeps being written. Nothing populates it from the list, so a consumer that has not migrated would otherwise see nothing where a license was reported.

Which of `spdx_id` / `expression` / `name` gets set is decided by the rule that **already existed** for rendering the scalar, now exported as `sbom.DeclaredLicense` — one decision in one place, so the model and the rendering of it cannot disagree about whether `MIT OR Apache-2.0` is an identifier.

## The seventeen identical mappings

Seventeen ecosystem blocks were byte-identical apart from the package type, so they now share one constructor. That is not tidiness: a field added to the mapping has to reach *every* ecosystem, and a row of hand-maintained copies is exactly the shape where it reaches all but one and the last is found later by a user whose SBOM is missing it.

Six keep their own loop (os packages carry architecture/origin, python a deprecated single file path, swift computes its type, github-action has no CPEs, plus jenkins and wordpress) and each gained the field explicitly. I reconciled the two lists afterwards: all 24 `[]BomPackage` fields in `BomFields` are mapped, and the only one without a license is `PrinterDrivers` — a Windows print driver has none to carry.

## Two defects in the shared rule, found by the tests here

Both would have been inherited by the new field, so they are fixed rather than worked around. Both also correct the **existing** CycloneDX and SPDX rendering of the scalar, which goes through the same function.

- **`isSPDXExpression` upper-cased each token before comparing**, so the ordinary English word in a license *name* — `Sleepycat and others` — was read as a conjunction and emitted as an expression. SPDX operators are case-sensitive keywords; the output is not parseable SPDX, and it is precisely the malformed document the three mutually exclusive fields exist to prevent.
- **It also returned true for any value containing a parenthesis**, so `BSD (see LICENSE)` became an expression. Grouping only ever exists to order operators, so a genuinely grouped expression contains one anyway and is still caught.

No test pinned the old behaviour; `isSPDXExpression` has three call sites (`cyclonedx.go`, `spdx.go`, and the new constructor) and all three are better for it.

## Testing

The end-to-end test loads a small report fixture and asserts the license through the whole path — struct tag, mapping, model. That matters: a unit test on the mapper alone would miss the `json:"license"` tag, and a mistyped tag yields a zero value rather than an error, which is the half that fails silently.

Covered: a bare identifier → `spdx_id`; an expression → `expression`, **not** `spdx_id`; free text → `name`; and a package declaring nothing → **no entry at all**, since an entry naming no license asserts a fact the producer does not have.

Per the "a test that cannot fail" rule, I reverted the mapping and confirmed they fail rather than assuming:

```
--- FAIL: TestLicenseReachesTheSbom/a_bare_identifier_lands_in_spdx_id
--- FAIL: TestLicenseReachesTheSbom/an_expression_lands_in_expression,_not_spdx_id
--- FAIL: TestLicenseReachesTheSbom/free_text_lands_in_name
--- FAIL: TestLanguagePackagesCarryTheLicense
```

The `DeclaredLicense` table additionally pins that exactly one of the three value fields is ever set, and that expression grouping survives — `(MIT OR Apache-2.0) AND BSD-3-Clause` must not be re-serialized, since `AND` binds tighter and the parentheses carry the meaning.

`gofmt`, `go vet`, `go build ./...` clean; `./sbom/...` and `./cli/...` green apart from `Test_probeConfigOsFs` in `cli/config`, which I verified fails identically on a clean checkout of `main` and is unrelated to this diff. `go mod tidy` leaves `go.mod`/`go.sum` unchanged. No `.lr` change, so nothing to regenerate.

## Scope — this is the producer half

The field selection lives in a **cnspec query pack** (the fixtures name `//local.cnquery.io/run/local-execution/queries/mondoo-sbom-python-packages`), and mql has no `content/`. So a license only reaches `BomPackage` once that pack asks for it. Until then this mapping is correct and carries nothing — deliberately called out rather than left to look finished. The cnspec side needs its own change; I can file it if that helps.

Independent of #10577 (the `wheelegg` PEP 639 parser fix), which is on its own branch.