### PR TITLE
🐛 aws: init per-asset sub-resources for EMR encryption config and VPC encryption control

### DIFF
--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -1064,7 +1064,7 @@ func init() {
 			Create: createAwsVpc,
 		},
 		"aws.vpc.encryptionControl": {
-			// to override args, implement: initAwsVpcEncryptionControl(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsVpcEncryptionControl,
 			Create: createAwsVpcEncryptionControl,
 		},
 		"aws.vpc.routetable": {
@@ -2300,7 +2300,7 @@ func init() {
 			Create: createAwsEmrSecurityConfiguration,
 		},
 		"aws.emr.cluster.encryptionConfiguration": {
-			// to override args, implement: initAwsEmrClusterEncryptionConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsEmrClusterEncryptionConfiguration,
 			Create: createAwsEmrClusterEncryptionConfiguration,
 		},
 		"aws.emr.cluster.step": {

--- a/providers/aws/resources/aws_emr.go
+++ b/providers/aws/resources/aws_emr.go
@@ -685,8 +685,12 @@ func (a *mqlAwsEmrCluster) logEncryptionKmsKey() (*mqlAwsKmsKey, error) {
 // per-asset encryption checks scored fail even on correctly configured
 // clusters.
 func initAwsEmrClusterEncryptionConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if len(args) > 0 {
+	// Fully-built resources (from the accessor) always carry an __id.
+	if args["__id"] != nil {
 		return args, nil, nil
+	}
+	if len(args) > 0 {
+		return nil, nil, errors.New("aws.emr.cluster.encryptionConfiguration cannot be initialized from partial arguments; query it without arguments or through aws.emr.cluster")
 	}
 	clusterRes, err := NewResource(runtime, "aws.emr.cluster", map[string]*llx.RawData{})
 	if err != nil {

--- a/providers/aws/resources/aws_emr.go
+++ b/providers/aws/resources/aws_emr.go
@@ -678,6 +678,43 @@ func (a *mqlAwsEmrCluster) logEncryptionKmsKey() (*mqlAwsKmsKey, error) {
 	return mqlKey.(*mqlAwsKmsKey), nil
 }
 
+// initAwsEmrClusterEncryptionConfiguration resolves the encryption
+// configuration through the scanned EMR cluster asset. Without this init, the
+// static path `aws.emr.cluster.encryptionConfiguration` used by policy checks
+// instantiates the sub-resource standalone (empty id, no fields set), so
+// per-asset encryption checks scored fail even on correctly configured
+// clusters.
+func initAwsEmrClusterEncryptionConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 0 {
+		return args, nil, nil
+	}
+	clusterRes, err := NewResource(runtime, "aws.emr.cluster", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	cluster := clusterRes.(*mqlAwsEmrCluster)
+	cfg := cluster.GetEncryptionConfiguration()
+	if cfg.Error != nil {
+		return nil, nil, cfg.Error
+	}
+	if cfg.Data != nil {
+		return args, cfg.Data, nil
+	}
+	// The cluster has no security configuration: encryption is off.
+	res, err := CreateResource(runtime, "aws.emr.cluster.encryptionConfiguration",
+		map[string]*llx.RawData{
+			"__id":                   llx.StringData(cluster.Arn.Data + "/encryptionConfiguration"),
+			"atRestEnabled":          llx.BoolData(false),
+			"inTransitEnabled":       llx.BoolData(false),
+			"atRestConfiguration":    llx.NilData,
+			"inTransitConfiguration": llx.NilData,
+		})
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, res, nil
+}
+
 func (a *mqlAwsEmrCluster) encryptionConfiguration() (*mqlAwsEmrClusterEncryptionConfiguration, error) {
 	if err := a.fetchClusterDetails(); err != nil {
 		return nil, err

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -34,8 +34,12 @@ func (a *mqlAwsVpc) id() (string, error) {
 // sub-resource standalone (empty id, no fields set), so per-asset checks
 // scored fail even for VPCs with an enforce-mode encryption control.
 func initAwsVpcEncryptionControl(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if len(args) > 0 {
+	// Fully-built resources (from the accessor) always carry an __id.
+	if args["__id"] != nil {
 		return args, nil, nil
+	}
+	if len(args) > 0 {
+		return nil, nil, errors.New("aws.vpc.encryptionControl cannot be initialized from partial arguments; query it without arguments or through aws.vpc")
 	}
 	vpcRes, err := NewResource(runtime, "aws.vpc", map[string]*llx.RawData{})
 	if err != nil {
@@ -45,6 +49,11 @@ func initAwsVpcEncryptionControl(runtime *plugin.Runtime, args map[string]*llx.R
 	ec := vpc.GetEncryptionControl()
 	if ec.Error != nil {
 		return nil, nil, ec.Error
+	}
+	if vpc.encryptionControlAccessDenied {
+		// Do NOT fabricate an "absent" control here: that would score
+		// security checks as "no encryption" when the truth is unknown.
+		return nil, nil, errors.New("access denied reading the VPC encryption control")
 	}
 	if ec.Data == nil {
 		// No encryption control on this VPC: represent it explicitly so
@@ -77,6 +86,7 @@ func (a *mqlAwsVpc) encryptionControl() (*mqlAwsVpcEncryptionControl, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
+			a.encryptionControlAccessDenied = true
 			a.EncryptionControl.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
 		}
@@ -231,6 +241,9 @@ func (a *mqlAws) getVpcs(conn *connection.AwsConnection) []*jobpool.Job {
 type mqlAwsVpcInternal struct {
 	cacheCidrBlockAssociations     []vpctypes.VpcCidrBlockAssociation
 	cacheIpv6CidrBlockAssociations []vpctypes.VpcIpv6CidrBlockAssociation
+	// set when DescribeVpcEncryptionControls was denied, so callers can tell
+	// "unknown" apart from "no encryption control" (both yield a null field)
+	encryptionControlAccessDenied bool
 }
 
 func (a *mqlAwsVpc) cidrBlockAssociations() ([]any, error) {

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -28,6 +28,45 @@ func (a *mqlAwsVpc) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+// initAwsVpcEncryptionControl resolves the encryption control through the
+// scanned VPC asset. Without this init, the static path
+// `aws.vpc.encryptionControl` used by policy checks instantiates the
+// sub-resource standalone (empty id, no fields set), so per-asset checks
+// scored fail even for VPCs with an enforce-mode encryption control.
+func initAwsVpcEncryptionControl(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 0 {
+		return args, nil, nil
+	}
+	vpcRes, err := NewResource(runtime, "aws.vpc", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, nil, err
+	}
+	vpc := vpcRes.(*mqlAwsVpc)
+	ec := vpc.GetEncryptionControl()
+	if ec.Error != nil {
+		return nil, nil, ec.Error
+	}
+	if ec.Data == nil {
+		// No encryption control on this VPC: represent it explicitly so
+		// checks fail (instead of erroring) on the absent case.
+		res, err := CreateResource(runtime, "aws.vpc.encryptionControl",
+			map[string]*llx.RawData{
+				"__id":               llx.StringData(vpc.Arn.Data + "/encryptionControl"),
+				"id":                 llx.StringData(""),
+				"mode":               llx.StringData(""),
+				"state":              llx.StringData(""),
+				"stateMessage":       llx.StringData(""),
+				"resourceExclusions": llx.MapData(map[string]any{}, types.String),
+				"tags":               llx.MapData(map[string]any{}, types.String),
+			})
+		if err != nil {
+			return nil, nil, err
+		}
+		return args, res, nil
+	}
+	return args, ec.Data, nil
+}
+
 func (a *mqlAwsVpc) encryptionControl() (*mqlAwsVpcEncryptionControl, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	svc := conn.Ec2(a.Region.Data)


### PR DESCRIPTION
Policy checks reference these as static paths (aws.emr.cluster. encryptionConfiguration, aws.vpc.encryptionControl). In per-asset scans the engine instantiated them standalone — empty id, no fields set — so encryption checks scored fail even on correctly configured resources (the runtime itself warned "field was never set on the resource (provider bug)").

Both sub-resources now resolve through the scanned asset's parent resource, and represent the absent case explicitly so checks fail rather than error: an EMR cluster without a security configuration reports encryption disabled, a VPC without an encryption control reports an empty-mode control.

Verified live per-asset against a purpose-built environment: the EMR cluster with a security configuration passes and the one without fails; the VPC with an enforce-mode encryption control passes and all others fail.