### PR TITLE
🐛 aws: give every construction site a cache key it owns

### DIFF
--- a/providers/aws/resources/aws_eventbridge_pipes.go
+++ b/providers/aws/resources/aws_eventbridge_pipes.go
@@ -286,9 +286,22 @@ func pipeResolveArn(runtime *plugin.Runtime, arnVal string) (plugin.Resource, er
 	case strings.HasPrefix(arnVal, "arn:aws:logs:") && strings.Contains(arnVal, ":log-group:"):
 		return NewResource(runtime, "aws.cloudwatch.loggroup", map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
 	case strings.HasPrefix(arnVal, "arn:aws:events:") && strings.Contains(arnVal, ":event-bus/"):
-		return NewResource(runtime, "aws.eventbridge.eventBus", map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+		// aws.eventbridge.eventBus has neither an id() method nor an init, so
+		// without an explicit "__id" every bus reached this way lands on the
+		// empty cache key and each pipe reports the first pipe's bus. The ARN is
+		// the key the collection path stores under, so this also resolves to the
+		// fully populated bus instead of one carrying nothing but its ARN.
+		return NewResource(runtime, "aws.eventbridge.eventBus", map[string]*llx.RawData{
+			"__id": llx.StringData(arnVal),
+			"arn":  llx.StringData(arnVal),
+		})
 	case strings.HasPrefix(arnVal, "arn:aws:batch:") && strings.Contains(arnVal, ":job-queue/"):
-		return NewResource(runtime, "aws.batch.jobQueue", map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
+		// Same for aws.batch.jobQueue. aws.batch.job.jobQueue() already keys on
+		// the ARN for exactly this reason.
+		return NewResource(runtime, "aws.batch.jobQueue", map[string]*llx.RawData{
+			"__id": llx.StringData(arnVal),
+			"arn":  llx.StringData(arnVal),
+		})
 	case strings.HasPrefix(arnVal, "arn:aws:redshift:"):
 		return NewResource(runtime, "aws.redshift.cluster", map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
 	case strings.HasPrefix(arnVal, "arn:aws:ecs:") && strings.Contains(arnVal, ":task-definition/"):

--- a/providers/aws/resources/cache_key_guard_test.go
+++ b/providers/aws/resources/cache_key_guard_test.go
@@ -1,0 +1,169 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Account-level singletons: exactly one instance exists per connection, so the
+// empty cache key is both correct and desirable -- it is what makes the
+// account-wide fetch behind them happen once.
+var cacheKeySingletons = map[string]bool{
+	"aws":                    true,
+	"aws.efs":                true,
+	"aws.iam.accessAnalyzer": true,
+}
+
+// TestEveryConstructionSiteHasACacheKey fails when a resource is built without
+// anything to key it on.
+//
+// createXxx sets __id from an explicit "__id" arg and, only when that leaves it
+// empty, falls back to the resource's id() method. A resource with neither ends
+// up on the key "<name>\x00", which every instance of that resource then shares
+// -- so the first one built is handed back for all of them, carrying the first
+// one's data. Nothing errors; the wrong answer just looks like a right one.
+//
+// This is how aws.eventbridge.eventBus and aws.batch.jobQueue reached MQL from
+// aws.eventbridge.pipe: neither has an id() method, and the typed accessor
+// passed only "arn", so every pipe reported the first pipe's bus and queue.
+//
+// Only inline argument literals are checked. A site whose args come from a
+// variable or a helper is skipped rather than guessed at, so this test reports
+// no false failures -- it is a floor, not a full audit.
+func TestEveryConstructionSiteHasACacheKey(t *testing.T) {
+	fset := token.NewFileSet()
+
+	gen, err := os.ReadFile("aws.lr.go")
+	if err != nil {
+		t.Fatalf("read generated schema: %v", err)
+	}
+	genSrc := string(gen)
+
+	// Resource* constants, so a site that names the resource by constant is
+	// resolved the same as one that spells out the string.
+	constResource := map[string]string{}
+	reConst := regexp.MustCompile(`(?m)^\t(Resource[A-Za-z0-9_]+)\s+string = "([a-zA-Z0-9_.]+)"`)
+	for _, m := range reConst.FindAllStringSubmatch(genSrc, -1) {
+		constResource[m[1]] = m[2]
+	}
+
+	// A registered Init resolves the resource before createXxx is reached, and
+	// the resource it returns carries its own key -- so an init-backed resource
+	// is out of scope here. (An init that falls through on a lookup miss is a
+	// separate defect, class 4, and not what this test is for.)
+	registered := map[string]bool{}
+	hasInit := map[string]bool{}
+	reEntry := regexp.MustCompile(`(?m)^\t\t"([a-zA-Z0-9_.]+)": \{\n((?:\t\t\t.*\n)+?)\t\t\},`)
+	for _, m := range reEntry.FindAllStringSubmatch(genSrc, -1) {
+		registered[m[1]] = true
+		hasInit[m[1]] = strings.Contains(m[2], "Init:")
+	}
+
+	// A resource has an id() method exactly when its generated constructor
+	// falls back to it.
+	genFile, err := parser.ParseFile(fset, "aws.lr.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse generated schema: %v", err)
+	}
+	hasIDMethod := map[string]bool{}
+	for _, decl := range genFile.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv != nil || !strings.HasPrefix(fn.Name.Name, "create") {
+			continue
+		}
+		var resource string
+		callsID := false
+		ast.Inspect(fn, func(n ast.Node) bool {
+			if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == token.STRING && resource == "" {
+				if v, err := strconv.Unquote(lit.Value); err == nil && registered[v] {
+					resource = v
+				}
+			}
+			if sel, ok := n.(*ast.SelectorExpr); ok && sel.Sel.Name == "id" {
+				callsID = true
+			}
+			return true
+		})
+		if resource != "" {
+			hasIDMethod[resource] = callsID
+		}
+	}
+
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("list package files: %v", err)
+	}
+
+	for _, path := range files {
+		if strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, ".lr.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			fn, ok := call.Fun.(*ast.Ident)
+			if !ok || (fn.Name != "CreateResource" && fn.Name != "NewResource") || len(call.Args) < 3 {
+				return true
+			}
+
+			var resource string
+			switch arg := call.Args[1].(type) {
+			case *ast.BasicLit:
+				if arg.Kind != token.STRING {
+					return true
+				}
+				resource, _ = strconv.Unquote(arg.Value)
+			case *ast.Ident:
+				resource = constResource[arg.Name]
+			}
+			if resource == "" || !registered[resource] {
+				return true
+			}
+			if hasIDMethod[resource] || hasInit[resource] || cacheKeySingletons[resource] {
+				return true
+			}
+
+			// Only inline literals can be judged; anything else is skipped.
+			lit, ok := call.Args[2].(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			for _, elt := range lit.Elts {
+				kv, ok := elt.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				key, ok := kv.Key.(*ast.BasicLit)
+				if !ok {
+					continue
+				}
+				if name, _ := strconv.Unquote(key.Value); name == "__id" {
+					return true
+				}
+			}
+
+			pos := fset.Position(call.Pos())
+			t.Errorf("%s:%d: %s(%q) passes no \"__id\" and %s has no id() method, "+
+				"so every instance shares the cache key %q and resolves to the first one built. "+
+				"Pass an explicit \"__id\", or give the resource an id() method.",
+				path, pos.Line, fn.Name, resource, resource, resource+"\x00")
+			return true
+		})
+	}
+}


### PR DESCRIPTION
## What

`createXxx` sets `__id` from an explicit `"__id"` arg and, **only when that leaves it empty**, falls back to the resource's `id()` method. A resource with neither lands on the key `"<name>\x00"`, which every instance then shares — so the first one built is handed back for all of them, carrying the first one's data. Nothing errors; the wrong answer just looks like a right one.

`pipeResolveArn` dispatched `aws.eventbridge.eventBus` and `aws.batch.jobQueue` through `NewResource` with nothing but `"arn"`. Neither resource has an `id()` method or an `init`, so both took the empty key and every field but `arn` came back unset.

`aws.batch.job.jobQueue()` already keys on the ARN and says why in a comment — this is the same fix. It additionally makes the reference resolve to the fully populated resource the collection path stores under that key, instead of building a bare one.

**Scope, stated plainly:** `pipeResolveArn` is currently unreferenced, so this is not a live data bug today. It is one edit away from being reachable, and it is the same shape that made every GKE cluster report the first cluster's network policy (#10506) and every AWS flow log report the first one (#10497).

## The guard test

`TestEveryConstructionSiteHasACacheKey` walks the package AST and fails on any `CreateResource`/`NewResource` site whose target has no `id()` method, no `init`, and no explicit `"__id"`.

It is deliberately narrow so it reports no false failures:

- **Skips account-level singletons** (`aws`, `aws.efs`, `aws.iam.accessAnalyzer`) — one instance exists per connection, so the empty key is what makes the account-wide fetch happen once.
- **Skips init-backed resources** — a registered `Init` resolves the resource before `createXxx` is reached, and the resource it returns carries its own key. (An init that falls through on a lookup miss is a different defect and not what this test is for.)
- **Judges only inline argument literals** — a site whose args come from a variable or a helper is skipped rather than guessed at.

It resolves the generated `ResourceXxx` constants, so a site that names its resource by constant is checked the same as one that spells out the string.

Reverting either hunk in `aws_eventbridge_pipes.go` turns it red.

## Test plan

- [x] `go test ./resources/ -run TestEveryConstructionSiteHasACacheKey` passes
- [x] Verified it fails when the `"__id"` args are removed
- [x] `gofmt` clean
