### PR TITLE
🐛 azure: read the App Service runtime stacks Azure actually returns

### DIFF
--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -298,23 +298,18 @@ func runtimeStackDescriptorFromResource(runtime *mqlAzureSubscriptionWebServiceA
 	if runtime == nil {
 		return descriptor
 	}
-	var runtimeName string
 	if name, ok := stringFromTValue(&runtime.Name); ok {
-		runtimeName = name
 		descriptor.Name = strings.ToLower(name)
 	}
 	if minor, ok := stringFromTValue(&runtime.MinorVersion); ok {
 		descriptor.MinorVersion = strings.ToLower(minor)
 	}
-	subscriptionID := ""
-	if runtime.MqlRuntime != nil {
-		if conn, ok := runtime.MqlRuntime.Connection.(*connection.AzureConnection); ok {
-			subscriptionID = conn.SubId()
-		}
-	}
-	if subscriptionID != "" && runtimeName != "" {
-		descriptor.ID = fmt.Sprintf("%s/%s", subscriptionID, runtimeName)
-	} else if id, ok := stringFromTValue(&runtime.RuntimeVersion); ok {
+	// The ID is compared against the app's own runtime identifier, which is
+	// either its LinuxFxVersion or "<STACK>|<version>" -- so it has to be the
+	// stack's runtimeVersion ("NODE|18-lts"), not the resource's cache key. A
+	// subscription-qualified key can never equal either shape, which left the
+	// comparison dead and the whole match resting on name plus minor version.
+	if id, ok := stringFromTValue(&runtime.RuntimeVersion); ok {
 		descriptor.ID = id
 	}
 	if autoUpdate, ok := boolFromTValue(&runtime.AutoUpdate); ok {
@@ -616,6 +611,26 @@ func (a *mqlAzureSubscriptionWebService) apps() ([]any, error) {
 	return res, nil
 }
 
+// runtimeSettingsForPreferredOs picks the runtime settings matching a stack's
+// preferred OS, and names that OS.
+//
+// The wire values are capitalized -- StackPreferredOsLinux is "Linux", not
+// "linux" -- so comparing against lowercase literals matched neither arm, left
+// the settings nil, and skipped every minor version of every stack. Comparing
+// against the SDK constants is what keeps that from silently recurring.
+func runtimeSettingsForPreferredOs(preferred *web.StackPreferredOs, settings *web.WebAppRuntimes) (*web.WebAppRuntimeSettings, string) {
+	if preferred == nil || settings == nil {
+		return nil, ""
+	}
+	switch *preferred {
+	case web.StackPreferredOsLinux:
+		return settings.LinuxRuntimeSettings, "linux"
+	case web.StackPreferredOsWindows:
+		return settings.WindowsRuntimeSettings, "windows"
+	}
+	return nil, ""
+}
+
 func (a *mqlAzureSubscriptionWebService) availableRuntimes() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()
@@ -657,16 +672,7 @@ func (a *mqlAzureSubscriptionWebService) availableRuntimes() ([]any, error) {
 						continue
 					}
 
-					var os string
-					var settings *web.WebAppRuntimeSettings
-					switch convert.ToValue(entry.Properties.PreferredOs) {
-					case "linux":
-						settings = minor.StackSettings.LinuxRuntimeSettings
-						os = "linux"
-					case "windows":
-						settings = minor.StackSettings.WindowsRuntimeSettings
-						os = "windows"
-					}
+					settings, os := runtimeSettingsForPreferredOs(entry.Properties.PreferredOs, minor.StackSettings)
 
 					if settings == nil {
 						log.Debug().

--- a/providers/azure/resources/web_runtime_stack_test.go
+++ b/providers/azure/resources/web_runtime_stack_test.go
@@ -1,0 +1,119 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	web "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v6"
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// TestRuntimeSettingsForPreferredOs pins the capitalization of the wire values.
+//
+// StackPreferredOs is "Linux" / "Windows". The switch used to compare against
+// the lowercase literals "linux" / "windows", which are valid StackPreferredOs
+// values and so compiled, but matched neither arm — so the settings stayed nil,
+// every minor version of every stack was skipped, and availableRuntimes
+// returned an empty list on every subscription.
+func TestRuntimeSettingsForPreferredOs(t *testing.T) {
+	linux := &web.WebAppRuntimeSettings{RuntimeVersion: strPtr("NODE|18-lts")}
+	windows := &web.WebAppRuntimeSettings{RuntimeVersion: strPtr("ASPNET|v4.8")}
+	settings := &web.WebAppRuntimes{LinuxRuntimeSettings: linux, WindowsRuntimeSettings: windows}
+
+	got, os := runtimeSettingsForPreferredOs(webOsPtr(web.StackPreferredOsLinux), settings)
+	assert.Same(t, linux, got)
+	assert.Equal(t, "linux", os)
+
+	got, os = runtimeSettingsForPreferredOs(webOsPtr(web.StackPreferredOsWindows), settings)
+	assert.Same(t, windows, got)
+	assert.Equal(t, "windows", os)
+
+	// The lowercase spellings are what the bug compared against. They are not
+	// values the API emits, and they must not resolve to settings.
+	got, os = runtimeSettingsForPreferredOs(webOsPtr(web.StackPreferredOs("linux")), settings)
+	assert.Nil(t, got)
+	assert.Equal(t, "", os)
+
+	// Absent preferred OS, absent settings, and an OS the SDK does not define
+	// all resolve to nothing rather than guessing at one of the two.
+	got, _ = runtimeSettingsForPreferredOs(nil, settings)
+	assert.Nil(t, got)
+	got, _ = runtimeSettingsForPreferredOs(webOsPtr(web.StackPreferredOsLinux), nil)
+	assert.Nil(t, got)
+	got, _ = runtimeSettingsForPreferredOs(webOsPtr(web.StackPreferredOs("Solaris")), settings)
+	assert.Nil(t, got)
+
+	// A stack that only publishes settings for the other OS yields nil, not the
+	// wrong OS's settings.
+	linuxOnly := &web.WebAppRuntimes{LinuxRuntimeSettings: linux}
+	got, _ = runtimeSettingsForPreferredOs(webOsPtr(web.StackPreferredOsWindows), linuxOnly)
+	assert.Nil(t, got)
+}
+
+// TestRuntimeStackDescriptorIDIsTheRuntimeVersion pins what the descriptor's ID
+// is compared against.
+//
+// computeWebAppStack matches an app's runtime identifier -- its LinuxFxVersion
+// ("NODE|18-lts") or "<STACK>|<version>" -- against descriptor.ID. The ID used
+// to be built as "<subscriptionId>/<stackName>", which can never equal either
+// shape, so the comparison was dead and matching rested entirely on name plus
+// minor version.
+//
+// Note what this test does and does not buy: it pins the ID as unconditionally
+// the runtime version, and fails on any edit that derives it from something
+// else. It would NOT have caught the original bug, whose wrong branch was
+// reachable only when a live Azure connection supplied a subscription id. What
+// closes that gap is the fix itself -- the function no longer reads the
+// connection, so there is no longer a branch a test cannot reach.
+func TestRuntimeStackDescriptorIDIsTheRuntimeVersion(t *testing.T) {
+	stack := &mqlAzureSubscriptionWebServiceAppRuntimeStack{
+		Name:           setString("node"),
+		MinorVersion:   setString("18-lts"),
+		RuntimeVersion: setString("NODE|18-lts"),
+		AutoUpdate:     setBool(true),
+		Deprecated:     setBool(false),
+	}
+
+	got := runtimeStackDescriptorFromResource(stack)
+	assert.Equal(t, "NODE|18-lts", got.ID,
+		"the ID has to be comparable to an app's LinuxFxVersion")
+	assert.Equal(t, "node", got.Name)
+	assert.Equal(t, "18-lts", got.MinorVersion)
+	assert.True(t, got.AutoUpdate)
+	assert.False(t, got.IsDeprecated)
+
+	// Name and minor version are lowercased for the case-insensitive match; the
+	// ID is not, because it is compared with EqualFold anyway and the wire form
+	// is what a reader expects to see.
+	upper := &mqlAzureSubscriptionWebServiceAppRuntimeStack{
+		Name:           setString("DOTNET"),
+		MinorVersion:   setString("V4.8"),
+		RuntimeVersion: setString("ASPNET|v4.8"),
+	}
+	got = runtimeStackDescriptorFromResource(upper)
+	assert.Equal(t, "dotnet", got.Name)
+	assert.Equal(t, "v4.8", got.MinorVersion)
+	assert.Equal(t, "ASPNET|v4.8", got.ID)
+
+	// A stack with no runtime version leaves the ID empty, which the match loop
+	// requires so that an empty ID never counts as a match.
+	got = runtimeStackDescriptorFromResource(&mqlAzureSubscriptionWebServiceAppRuntimeStack{
+		Name: setString("node"),
+	})
+	assert.Equal(t, "", got.ID)
+
+	assert.NotNil(t, runtimeStackDescriptorFromResource(nil))
+}
+
+func webOsPtr(v web.StackPreferredOs) *web.StackPreferredOs { return &v }
+
+func setString(v string) plugin.TValue[string] {
+	return plugin.TValue[string]{Data: v, State: plugin.StateIsSet}
+}
+
+func setBool(v bool) plugin.TValue[bool] {
+	return plugin.TValue[bool]{Data: v, State: plugin.StateIsSet}
+}


### PR DESCRIPTION
## The bug

`availableRuntimes` switched on the stack's preferred OS against the literals `"linux"` / `"windows"`. The wire values are capitalized:

```go
// armappservice/v6@v6.0.0/constants.go:1885
StackPreferredOsLinux   StackPreferredOs = "Linux"
StackPreferredOsWindows StackPreferredOs = "Windows"
```

Because both lowercase literals are themselves valid `StackPreferredOs` values, the comparison **compiled** while matching neither arm. `settings` stayed nil, every minor version of every stack hit the `continue`, and `azure.subscription.webService.availableRuntimes` came back **empty on every subscription**.

## Why that isn't confined to one resource

`computeWebAppStack` looks each app's runtime up in that list. With the list empty, `match` is always nil and it falls to:

```go
} else {
    if len(runtimeInfo.MinorVersion) > 0 {
        runtimeInfo.IsDeprecated = true
    }
}
```

So **every App Service app on a fully supported runtime reported `stack.isDeprecated: true`** and `stack.autoUpdate: false`. A "no App Service on a deprecated runtime" control fails across a whole healthy fleet.

## The second dead comparison

Fixing the lookup alone would have left the matching still broken. `runtimeStackDescriptorFromResource` built the descriptor ID as `"<subscriptionId>/<stackName>"`, which is compared against the app's own runtime identifier — its `LinuxFxVersion` (`"NODE|18-lts"`) or `"<STACK>|<version>"`. Those shapes can never be equal, so `sameID` was always false and matching rested entirely on name + minor version.

The ID is now the stack's `runtimeVersion` — the value it is actually compared against.

## Tests

`TestRuntimeSettingsForPreferredOs` covers `"Linux"` / `"Windows"`, the lowercase spellings the bug compared against, a nil preferred OS, nil settings, an OS the SDK doesn't define, and a stack publishing settings for only the other OS. **It fails on the old code.**

`TestRuntimeStackDescriptorIDIsTheRuntimeVersion` pins the ID as unconditionally the runtime version. Stated plainly in the test: it would *not* have caught the original bug, because the wrong branch was reachable only when a live connection supplied a subscription id. What closes that gap is the fix — the function no longer reads the connection, so there is no longer a branch a test cannot reach.

## Known follow-up, deliberately not in this PR

`computeWebAppStack` remaps `CURRENT_STACK == "dotnet"` to `stack = "aspnet"` before matching on name. Whether that still matches now that the list is populated depends on what the stack list actually names .NET on Windows, which I can't settle from the SDK alone. Worth one live check against a Windows .NET app.

## Test plan

- [x] `go test ./resources/ -run 'TestRuntimeSettingsForPreferredOs|TestRuntimeStackDescriptorIDIsTheRuntimeVersion'` passes
- [x] `go build ./resources/` clean, `gofmt` clean
- [ ] Not live-verified — needs a subscription with App Service apps
