### PR TITLE
🐛 php: expose the license and description php.package never mapped

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -9582,6 +9582,17 @@ php.package @defaults("name version purl") {
   version() string
   // Package URL (purl), a standardized identifier for the package
   purl() string
+  // Package license
+  //
+  // SPDX expression from the `license` field of composer.lock or
+  // installed.json. Composer records the field as a list, and a list means the
+  // package is offered under any one of them and the consumer chooses, so
+  // several entries render as an SPDX `OR` expression such as
+  // `(LGPL-2.1-only OR GPL-3.0-or-later)`. A single license passes through as
+  // written. Empty when the manifest declares none.
+  license() string
+  // Description of the package as its manifest states it
+  description() string
   // Common Platform Enumeration (CPE) identifiers for matching against vulnerability advisories
   cpes() []core.cpe
   // Composer files that contributed this package to the inventory

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -10829,6 +10829,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"php.package.purl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPhpPackage).GetPurl()).ToDataRes(types.String)
 	},
+	"php.package.license": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPhpPackage).GetLicense()).ToDataRes(types.String)
+	},
+	"php.package.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPhpPackage).GetDescription()).ToDataRes(types.String)
+	},
 	"php.package.cpes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPhpPackage).GetCpes()).ToDataRes(types.Array(types.Resource("cpe")))
 	},
@@ -28600,6 +28606,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"php.package.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPhpPackage).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"php.package.license": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPhpPackage).License, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"php.package.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPhpPackage).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"php.package.cpes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -72356,12 +72370,14 @@ type mqlPhpPackage struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlPhpPackageInternal it will be used here
-	Id      plugin.TValue[string]
-	Name    plugin.TValue[string]
-	Version plugin.TValue[string]
-	Purl    plugin.TValue[string]
-	Cpes    plugin.TValue[[]any]
-	Files   plugin.TValue[[]any]
+	Id          plugin.TValue[string]
+	Name        plugin.TValue[string]
+	Version     plugin.TValue[string]
+	Purl        plugin.TValue[string]
+	License     plugin.TValue[string]
+	Description plugin.TValue[string]
+	Cpes        plugin.TValue[[]any]
+	Files       plugin.TValue[[]any]
 }
 
 // createPhpPackage creates a new instance of this resource
@@ -72420,6 +72436,18 @@ func (c *mqlPhpPackage) GetVersion() *plugin.TValue[string] {
 func (c *mqlPhpPackage) GetPurl() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Purl, func() (string, error) {
 		return c.purl()
+	})
+}
+
+func (c *mqlPhpPackage) GetLicense() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.License, func() (string, error) {
+		return c.license()
+	})
+}
+
+func (c *mqlPhpPackage) GetDescription() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Description, func() (string, error) {
+		return c.description()
 	})
 }
 

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -3084,8 +3084,10 @@ parse.yaml.file 9.0.0
 parse.yaml.params 9.0.0
 php.package 13.10.1
 php.package.cpes 13.10.1
+php.package.description 13.40.10
 php.package.files 13.10.1
 php.package.id 13.10.1
+php.package.license 13.40.10
 php.package.name 13.10.1
 php.package.purl 13.10.1
 php.package.version 13.10.1

--- a/providers/os/resources/php.go
+++ b/providers/os/resources/php.go
@@ -339,8 +339,12 @@ func newPhpPackage(runtime *plugin.Runtime, pkg *languages.Package) (*mqlPhpPack
 		"name":    llx.StringData(pkg.Name),
 		"version": llx.StringData(pkg.Version),
 		"purl":    llx.StringData(pkg.Purl),
-		"cpes":    llx.ArrayData(cpes, types.Resource("cpe")),
-		"files":   llx.ArrayData(mqlFiles, types.Resource("pkgFileInfo")),
+		// composer.lock and installed.json both state these; the extractors
+		// render the license list as an SPDX expression.
+		"license":     llx.StringData(pkg.License),
+		"description": llx.StringData(pkg.Description),
+		"cpes":        llx.ArrayData(cpes, types.Resource("cpe")),
+		"files":       llx.ArrayData(mqlFiles, types.Resource("pkgFileInfo")),
 	})
 	if err != nil {
 		return nil, err
@@ -364,6 +368,14 @@ func (r *mqlPhpPackage) purl() (string, error) {
 	return "", r.populateData()
 }
 
+func (r *mqlPhpPackage) license() (string, error) {
+	return "", r.populateData()
+}
+
+func (r *mqlPhpPackage) description() (string, error) {
+	return "", r.populateData()
+}
+
 func (r *mqlPhpPackage) cpes() ([]any, error) {
 	return nil, r.populateData()
 }
@@ -379,6 +391,8 @@ func (r *mqlPhpPackage) populateData() error {
 	r.Name = plugin.TValue[string]{State: plugin.StateIsSet | plugin.StateIsNull}
 	r.Version = plugin.TValue[string]{State: plugin.StateIsSet | plugin.StateIsNull}
 	r.Purl = plugin.TValue[string]{State: plugin.StateIsSet | plugin.StateIsNull}
+	r.License = plugin.TValue[string]{State: plugin.StateIsSet | plugin.StateIsNull}
+	r.Description = plugin.TValue[string]{State: plugin.StateIsSet | plugin.StateIsNull}
 	r.Cpes = plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull}
 	r.Files = plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull}
 	return nil

--- a/providers/os/resources/php_test.go
+++ b/providers/os/resources/php_test.go
@@ -1,0 +1,60 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/resources/languages"
+	"go.mondoo.com/mql/utils/syncx"
+)
+
+// The composer.lock and installed.json extractors read a license, but until
+// php.package carried the field there was nowhere for it to land: the value was
+// set on languages.Package and the resource never mapped it, so `php.packages`
+// answered `cannot find field or resource 'license'`. This pins the mapping, so
+// the extractor work stays reachable from MQL rather than only from the Go API.
+func TestPhpPackageCarriesLicenseAndDescription(t *testing.T) {
+	runtime := &plugin.Runtime{
+		Resources: &syncx.Map[plugin.Resource]{},
+		Callback:  &providerCallbacks{},
+	}
+
+	pkg, err := newPhpPackage(runtime, &languages.Package{
+		Name:    "dual/licensed",
+		Version: "1.0.0",
+		Purl:    "pkg:composer/dual/licensed@1.0.0",
+		// What LicenseExpression renders for a composer.lock list: the package
+		// is offered under either, and the consumer chooses.
+		License:     "(LGPL-2.1-only OR GPL-3.0-or-later)",
+		Description: "Two licenses",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "(LGPL-2.1-only OR GPL-3.0-or-later)", pkg.License.Data)
+	require.Equal(t, "Two licenses", pkg.Description.Data)
+}
+
+// A package whose manifest declares neither reports empty rather than carrying
+// a value from somewhere else, and the fields are still set so a query reads ""
+// instead of failing.
+func TestPhpPackageWithoutLicenseIsEmpty(t *testing.T) {
+	runtime := &plugin.Runtime{
+		Resources: &syncx.Map[plugin.Resource]{},
+		Callback:  &providerCallbacks{},
+	}
+
+	pkg, err := newPhpPackage(runtime, &languages.Package{
+		Name:    "bare/package",
+		Version: "2.0.0",
+		Purl:    "pkg:composer/bare/package@2.0.0",
+	})
+	require.NoError(t, err)
+
+	require.Empty(t, pkg.License.Data)
+	require.Empty(t, pkg.Description.Data)
+	require.True(t, pkg.License.IsSet(), "the field must be set, so a query reads \"\" rather than erroring")
+}


### PR DESCRIPTION
Follow-up to #10557.

## The gap

#10557 made the `composer.lock` and `installed.json` extractors set `License` and `Description` on `languages.Package`. For a consumer of the Go API that is the whole story. Through MQL the values were written and dropped:

```
> php.packages(path: "...").list { name license }
failed to compile: cannot find field or resource 'license' in block for type 'php.package'
```

`php.package` declared neither field, and `newPhpPackage` mapped neither.

npm was already the other way round: `npm.package` has `license`, `description` and `author`, and `npm.go` maps all three, so the `packagelockjson` half surfaced the moment it landed while the two PHP halves surfaced nowhere. This makes php match.

The comment #10557 removed from `composerlock`'s `makePackage` said exactly this:

```go
// Note: License and Description are available in composer.lock but not yet
// exposed via the php.package MQL resource. When license support is added
// to the .lr schema, populate them here.
```

The note was accurate and its precondition was never met, so the gap outlived the record of it. This adds the schema it was waiting for.

## The change

`license()` and `description()` on `php.package`, mapped in `newPhpPackage`. They follow php.package's existing pattern: computed fields with a `populateData` fallback, since instances are always built by `newPhpPackage` with every field pre-populated. Both are marked set-and-null on the resolve-by-ID path, so a query there reads null rather than hanging.

## Verification

Against a real `composer.lock`, through a provider built from this branch:

```
php.packages.list: [
  0: { name: "dual/licensed"   license: "(LGPL-2.1-only OR GPL-3.0-or-later)"
       description: "Two licenses" }
  1: { name: "monolog/monolog" license: "MIT"
       description: "Logging for PHP" }
]
```

The `OR` expression is what `LicenseExpression` renders for a composer license list, which states a choice rather than a conjunction. npm is unchanged — still `"MIT"` and `"(MIT OR Apache-2.0)"` for the same fixtures.

`go test ./resources/...` green. Two suites (`connection/container`, `connection/tar`) fail when the whole `providers/os` tree runs in parallel and pass in isolation on both this branch and `main` — contention on Docker/tar timeouts, unrelated to this change.

## Scope

`.lr.versions` entries are `13.40.10`, the next patch after the provider's current `13.40.9`; `config.go` untouched. The mapping is pinned by a test that fails when either argument is dropped from `newPhpPackage`.

## Not addressed

`sbom/generator`'s `BomPackage` carries no license field at all, so cnspec SBOMs still report no license for **any** language package, npm included. That is a wider change touching every `*.packages.list` query and belongs on its own.
