### PR TITLE
🧹 azure, oci: apply the #10585 guard review to the other two copies

### DIFF
--- a/providers/azure/resources/cache_key_guard_test.go
+++ b/providers/azure/resources/cache_key_guard_test.go
@@ -15,11 +15,133 @@ import (
 	"testing"
 )
 
-// Account-level singletons: exactly one instance exists per connection, so the
-// empty cache key is both correct and desirable -- it is what makes the
-// account-wide fetch behind them happen once.
+// generatedSchemaFile is the only provider-specific name in this file, so the
+// guards port to another provider by changing it alone.
+const generatedSchemaFile = "azure.lr.go"
+
+// cacheKeySingletons names resources for which the empty cache key is correct:
+// exactly one instance exists per connection, so sharing one key is what makes
+// the account-wide fetch behind them happen once.
+//
+// The tenant-level root is the only member: one azure resource exists per
+// connection. Anything added here has to come with a reason, so that the checks
+// below are never quietly widened to let a real collision through.
 var cacheKeySingletons = map[string]bool{
 	"azure": true,
+}
+
+// schemaFacts is everything the two guards need to know about the generated
+// schema. Both read it from the same source so they cannot disagree about what
+// counts as a resource.
+type schemaFacts struct {
+	// registered is every resource name in the generated factory registry. It
+	// is the authority on what is a resource name; nothing else is.
+	registered map[string]bool
+	// hasInit reports whether a resource has an Init in the registry.
+	hasInit map[string]bool
+	// hasIDMethod reports whether a resource's generated constructor falls back
+	// to an id() method. That fallback is emitted only when the Go method
+	// exists at codegen time, so it is the real signal, not the .lr schema.
+	hasIDMethod map[string]bool
+	// resourceOfInit maps an init function name to the resource it builds.
+	resourceOfInit map[string]string
+	// constResource maps a generated Resource* constant to its resource name,
+	// so a site naming its resource by constant is judged like a literal one.
+	constResource map[string]string
+}
+
+var (
+	reRegistryEntry = regexp.MustCompile(`(?m)^\t\t"([a-zA-Z0-9_.]+)": \{\n((?:\t\t\t.*\n)+?)\t\t\},`)
+	reRegistryInit  = regexp.MustCompile(`Init:\s+(init[A-Za-z0-9_]+)`)
+	reResourceConst = regexp.MustCompile(`(?m)^\t(Resource[A-Za-z0-9_]+)\s+string = "([a-zA-Z0-9_.]+)"`)
+)
+
+func loadSchemaFacts(t *testing.T, fset *token.FileSet) schemaFacts {
+	t.Helper()
+
+	raw, err := os.ReadFile(generatedSchemaFile)
+	if err != nil {
+		t.Fatalf("read %s: %v", generatedSchemaFile, err)
+	}
+	src := string(raw)
+
+	facts := schemaFacts{
+		registered:     map[string]bool{},
+		hasInit:        map[string]bool{},
+		hasIDMethod:    map[string]bool{},
+		resourceOfInit: map[string]string{},
+		constResource:  map[string]string{},
+	}
+
+	for _, m := range reRegistryEntry.FindAllStringSubmatch(src, -1) {
+		name, body := m[1], m[2]
+		facts.registered[name] = true
+		if init := reRegistryInit.FindStringSubmatch(body); init != nil {
+			facts.hasInit[name] = true
+			facts.resourceOfInit[init[1]] = name
+		}
+	}
+	for _, m := range reResourceConst.FindAllStringSubmatch(src, -1) {
+		facts.constResource[m[1]] = m[2]
+	}
+
+	file, err := parser.ParseFile(fset, generatedSchemaFile, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", generatedSchemaFile, err)
+	}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv != nil || !strings.HasPrefix(fn.Name.Name, "create") {
+			continue
+		}
+		var resource string
+		callsID := false
+		ast.Inspect(fn, func(n ast.Node) bool {
+			// The first string literal that is a registered resource name is
+			// the resource this constructor builds. Matching on "is registered"
+			// rather than "looks dotted" keeps an unrelated literal -- a
+			// package path, an error message -- from being mistaken for one.
+			if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == token.STRING && resource == "" {
+				if v, err := strconv.Unquote(lit.Value); err == nil && facts.registered[v] {
+					resource = v
+				}
+			}
+			if sel, ok := n.(*ast.SelectorExpr); ok && sel.Sel.Name == "id" {
+				callsID = true
+			}
+			return true
+		})
+		if resource != "" {
+			facts.hasIDMethod[resource] = callsID
+		}
+	}
+
+	return facts
+}
+
+// packageSourceFiles lists the hand-written Go in this package -- the generated
+// schema and the tests are not part of what either guard judges.
+func packageSourceFiles(t *testing.T) []string {
+	t.Helper()
+
+	all, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("list package files: %v", err)
+	}
+	out := make([]string, 0, len(all))
+	for _, path := range all {
+		if strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, ".lr.go") {
+			continue
+		}
+		out = append(out, path)
+	}
+	return out
+}
+
+// keyIsHandled reports whether a resource is exempt from both guards because
+// its identity is already settled.
+func (f schemaFacts) keyIsHandled(resource string) bool {
+	return resource == "" || !f.registered[resource] || f.hasIDMethod[resource] || cacheKeySingletons[resource]
 }
 
 // TestEveryConstructionSiteHasACacheKey fails when a resource is built without
@@ -32,81 +154,22 @@ var cacheKeySingletons = map[string]bool{
 // one's data. Nothing errors; the wrong answer just looks like a right one.
 //
 // A prior pass found twelve azure resources in exactly this state: each passed
-// a public `id` FIELD -- an ordinary declared field, which does NOT feed the
-// cache key -- with no "__id" arg and no id() method, so every instance aliased
-// to the first one built.
+// the parent-qualified value as a public `id` FIELD -- an ordinary declared
+// field, which does NOT feed the cache key -- so every instance aliased to the
+// first one built.
+//
+// A registered Init is out of scope here: it resolves the resource before
+// createXxx is reached, and the resource it returns carries its own key. An
+// init that supplies neither is the second guard's job.
 //
 // Only inline argument literals are checked. A site whose args come from a
 // variable or a helper is skipped rather than guessed at, so this test reports
 // no false failures -- it is a floor, not a full audit.
 func TestEveryConstructionSiteHasACacheKey(t *testing.T) {
 	fset := token.NewFileSet()
+	facts := loadSchemaFacts(t, fset)
 
-	gen, err := os.ReadFile("azure.lr.go")
-	if err != nil {
-		t.Fatalf("read generated schema: %v", err)
-	}
-	genSrc := string(gen)
-
-	// Resource* constants, so a site that names the resource by constant is
-	// resolved the same as one that spells out the string.
-	constResource := map[string]string{}
-	reConst := regexp.MustCompile(`(?m)^\t(Resource[A-Za-z0-9_]+)\s+string = "([a-zA-Z0-9_.]+)"`)
-	for _, m := range reConst.FindAllStringSubmatch(genSrc, -1) {
-		constResource[m[1]] = m[2]
-	}
-
-	// A registered Init resolves the resource before createXxx is reached, and
-	// the resource it returns carries its own key -- so an init-backed resource
-	// is out of scope here. (An init that falls through on a lookup miss is a
-	// separate defect, class 4, and not what this test is for.)
-	registered := map[string]bool{}
-	hasInit := map[string]bool{}
-	reEntry := regexp.MustCompile(`(?m)^\t\t"([a-zA-Z0-9_.]+)": \{\n((?:\t\t\t.*\n)+?)\t\t\},`)
-	for _, m := range reEntry.FindAllStringSubmatch(genSrc, -1) {
-		registered[m[1]] = true
-		hasInit[m[1]] = strings.Contains(m[2], "Init:")
-	}
-
-	// A resource has an id() method exactly when its generated constructor
-	// falls back to it.
-	genFile, err := parser.ParseFile(fset, "azure.lr.go", nil, 0)
-	if err != nil {
-		t.Fatalf("parse generated schema: %v", err)
-	}
-	hasIDMethod := map[string]bool{}
-	for _, decl := range genFile.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Recv != nil || !strings.HasPrefix(fn.Name.Name, "create") {
-			continue
-		}
-		var resource string
-		callsID := false
-		ast.Inspect(fn, func(n ast.Node) bool {
-			if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == token.STRING && resource == "" {
-				if v, err := strconv.Unquote(lit.Value); err == nil && registered[v] {
-					resource = v
-				}
-			}
-			if sel, ok := n.(*ast.SelectorExpr); ok && sel.Sel.Name == "id" {
-				callsID = true
-			}
-			return true
-		})
-		if resource != "" {
-			hasIDMethod[resource] = callsID
-		}
-	}
-
-	files, err := filepath.Glob("*.go")
-	if err != nil {
-		t.Fatalf("list package files: %v", err)
-	}
-
-	for _, path := range files {
-		if strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, ".lr.go") {
-			continue
-		}
+	for _, path := range packageSourceFiles(t) {
 		file, err := parser.ParseFile(fset, path, nil, 0)
 		if err != nil {
 			t.Fatalf("parse %s: %v", path, err)
@@ -129,32 +192,18 @@ func TestEveryConstructionSiteHasACacheKey(t *testing.T) {
 				}
 				resource, _ = strconv.Unquote(arg.Value)
 			case *ast.Ident:
-				resource = constResource[arg.Name]
+				resource = facts.constResource[arg.Name]
 			}
-			if resource == "" || !registered[resource] {
-				return true
-			}
-			if hasIDMethod[resource] || hasInit[resource] || cacheKeySingletons[resource] {
+			if facts.keyIsHandled(resource) || facts.hasInit[resource] {
 				return true
 			}
 
-			// Only inline literals can be judged; anything else is skipped.
 			lit, ok := call.Args[2].(*ast.CompositeLit)
 			if !ok {
 				return true
 			}
-			for _, elt := range lit.Elts {
-				kv, ok := elt.(*ast.KeyValueExpr)
-				if !ok {
-					continue
-				}
-				key, ok := kv.Key.(*ast.BasicLit)
-				if !ok {
-					continue
-				}
-				if name, _ := strconv.Unquote(key.Value); name == "__id" {
-					return true
-				}
+			if compositeLitHasKey(lit, "__id") {
+				return true
 			}
 
 			pos := fset.Position(call.Pos())
@@ -179,108 +228,26 @@ func TestEveryConstructionSiteHasACacheKey(t *testing.T) {
 // azure.subscription.advisorService was in exactly that state: its init only
 // filled in subscriptionId, so every subscription's advisor shared the key
 // "azure.subscription.advisorService\x00", and a query walking more than one
-// subscription got the first one's recommendations back for all of them. Every
-// sibling service resource keys on its subscription with an id() method.
+// subscription got the first one's recommendations back for all of them.
 func TestInitBackedResourcesCanSupplyACacheKey(t *testing.T) {
 	fset := token.NewFileSet()
+	facts := loadSchemaFacts(t, fset)
 
-	gen, err := os.ReadFile("azure.lr.go")
-	if err != nil {
-		t.Fatalf("read generated schema: %v", err)
-	}
-	genSrc := string(gen)
-
-	reEntry := regexp.MustCompile(`(?m)^\t\t"([a-zA-Z0-9_.]+)": \{\n((?:\t\t\t.*\n)+?)\t\t\},`)
-	reInitName := regexp.MustCompile(`Init:\s+(init[A-Za-z0-9_]+)`)
-	initFuncs := map[string]bool{}
-	resourceOfInit := map[string]string{}
-	for _, m := range reEntry.FindAllStringSubmatch(genSrc, -1) {
-		if n := reInitName.FindStringSubmatch(m[2]); n != nil {
-			initFuncs[n[1]] = true
-			resourceOfInit[n[1]] = m[1]
-		}
-	}
-
-	genFile, err := parser.ParseFile(fset, "azure.lr.go", nil, 0)
-	if err != nil {
-		t.Fatalf("parse generated schema: %v", err)
-	}
-	hasIDMethod := map[string]bool{}
-	for _, decl := range genFile.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Recv != nil || !strings.HasPrefix(fn.Name.Name, "create") {
-			continue
-		}
-		var resource string
-		callsID := false
-		ast.Inspect(fn, func(n ast.Node) bool {
-			if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == token.STRING && resource == "" {
-				if v, err := strconv.Unquote(lit.Value); err == nil && strings.Contains(v, ".") {
-					resource = v
-				}
-			}
-			if sel, ok := n.(*ast.SelectorExpr); ok && sel.Sel.Name == "id" {
-				callsID = true
-			}
-			return true
-		})
-		if resource != "" {
-			hasIDMethod[resource] = callsID
-		}
-	}
-
-	files, err := filepath.Glob("*.go")
-	if err != nil {
-		t.Fatalf("list package files: %v", err)
-	}
-
-	for _, path := range files {
-		if strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, ".lr.go") {
-			continue
-		}
+	for _, path := range packageSourceFiles(t) {
 		file, err := parser.ParseFile(fset, path, nil, 0)
 		if err != nil {
 			t.Fatalf("parse %s: %v", path, err)
 		}
 		for _, decl := range file.Decls {
 			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Recv != nil || !initFuncs[fn.Name.Name] {
+			if !ok || fn.Recv != nil || fn.Body == nil {
 				continue
 			}
-			resource := resourceOfInit[fn.Name.Name]
-			if resource == "" || hasIDMethod[resource] || cacheKeySingletons[resource] {
+			resource, isInit := facts.resourceOfInit[fn.Name.Name]
+			if !isInit || facts.keyIsHandled(resource) {
 				continue
 			}
-
-			// An init that just delegates (`return initFromServiceList(...)`)
-			// is out of scope: the key is supplied by the helper, which this
-			// body-only walk cannot see. Skipping them keeps the test free of
-			// false failures at the cost of not covering the delegated shape.
-			if len(fn.Body.List) == 1 {
-				if ret, ok := fn.Body.List[0].(*ast.ReturnStmt); ok && len(ret.Results) == 1 {
-					if _, ok := ret.Results[0].(*ast.CallExpr); ok {
-						continue
-					}
-				}
-			}
-
-			suppliesKey := false
-			ast.Inspect(fn, func(n ast.Node) bool {
-				if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == token.STRING {
-					if v, err := strconv.Unquote(lit.Value); err == nil && v == "__id" {
-						suppliesKey = true
-					}
-				}
-				// An init that returns an already-built resource hands back one
-				// that already carries its own key.
-				if ret, ok := n.(*ast.ReturnStmt); ok && len(ret.Results) == 3 {
-					if id, ok := ret.Results[1].(*ast.Ident); !ok || id.Name != "nil" {
-						suppliesKey = true
-					}
-				}
-				return true
-			})
-			if suppliesKey {
+			if initSuppliesCacheKey(fn) {
 				continue
 			}
 
@@ -291,4 +258,59 @@ func TestInitBackedResourcesCanSupplyACacheKey(t *testing.T) {
 				path, pos.Line, fn.Name.Name, resource, resource+"\x00")
 		}
 	}
+}
+
+// initSuppliesCacheKey reports whether an init can hand the runtime an identity.
+//
+// Three shapes count, and the third is why this is a heuristic rather than a
+// proof: an init that delegates (`return initFromServiceList(...)`) has its key
+// supplied by the callee, which an AST walk of this body cannot see. Delegation
+// is recognised wherever it appears, not only as the sole statement, so an init
+// that sets up a variable before delegating is still skipped. The cost is that
+// an init calling any single-result helper on a return path is treated as
+// delegating; the benefit is that the guard reports no false failures.
+func initSuppliesCacheKey(fn *ast.FuncDecl) bool {
+	supplies := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+			if v, err := strconv.Unquote(lit.Value); err == nil && v == "__id" {
+				supplies = true
+			}
+		}
+		ret, ok := n.(*ast.ReturnStmt)
+		if !ok {
+			return true
+		}
+		switch len(ret.Results) {
+		case 1:
+			// Delegation: `return someInit(...)`.
+			if _, ok := ret.Results[0].(*ast.CallExpr); ok {
+				supplies = true
+			}
+		case 3:
+			// An already-built resource carries its own key.
+			if id, ok := ret.Results[1].(*ast.Ident); !ok || id.Name != "nil" {
+				supplies = true
+			}
+		}
+		return true
+	})
+	return supplies
+}
+
+func compositeLitHasKey(lit *ast.CompositeLit, want string) bool {
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.BasicLit)
+		if !ok || key.Kind != token.STRING {
+			continue
+		}
+		if name, err := strconv.Unquote(key.Value); err == nil && name == want {
+			return true
+		}
+	}
+	return false
 }

--- a/providers/oci/resources/cache_key_guard_test.go
+++ b/providers/oci/resources/cache_key_guard_test.go
@@ -15,10 +15,134 @@ import (
 	"testing"
 )
 
-// Account-level singletons: exactly one instance exists per connection, so the
-// empty cache key is both correct and desirable -- it is what makes the
-// account-wide fetch behind them happen once.
+// generatedSchemaFile is the only provider-specific name in this file, so the
+// guards port to another provider by changing it alone. go/token is imported as
+// gotoken because ocipage_test.go already binds token in this package.
+const generatedSchemaFile = "oci.lr.go"
+
+// cacheKeySingletons names resources for which the empty cache key is correct:
+// exactly one instance exists per connection, so sharing one key is what makes
+// the account-wide fetch behind them happen once.
+//
+// It is intentionally empty. No resource in this provider needs the exemption
+// today -- every construction site supplies a key. It exists so that a future
+// exception has to be written down here with a reason, rather than the checks
+// below being quietly widened to let it through.
 var cacheKeySingletons = map[string]bool{}
+
+// schemaFacts is everything the two guards need to know about the generated
+// schema. Both read it from the same source so they cannot disagree about what
+// counts as a resource.
+type schemaFacts struct {
+	// registered is every resource name in the generated factory registry. It
+	// is the authority on what is a resource name; nothing else is.
+	registered map[string]bool
+	// hasInit reports whether a resource has an Init in the registry.
+	hasInit map[string]bool
+	// hasIDMethod reports whether a resource's generated constructor falls back
+	// to an id() method. That fallback is emitted only when the Go method
+	// exists at codegen time, so it is the real signal, not the .lr schema.
+	hasIDMethod map[string]bool
+	// resourceOfInit maps an init function name to the resource it builds.
+	resourceOfInit map[string]string
+	// constResource maps a generated Resource* constant to its resource name,
+	// so a site naming its resource by constant is judged like a literal one.
+	constResource map[string]string
+}
+
+var (
+	reRegistryEntry = regexp.MustCompile(`(?m)^\t\t"([a-zA-Z0-9_.]+)": \{\n((?:\t\t\t.*\n)+?)\t\t\},`)
+	reRegistryInit  = regexp.MustCompile(`Init:\s+(init[A-Za-z0-9_]+)`)
+	reResourceConst = regexp.MustCompile(`(?m)^\t(Resource[A-Za-z0-9_]+)\s+string = "([a-zA-Z0-9_.]+)"`)
+)
+
+func loadSchemaFacts(t *testing.T, fset *gotoken.FileSet) schemaFacts {
+	t.Helper()
+
+	raw, err := os.ReadFile(generatedSchemaFile)
+	if err != nil {
+		t.Fatalf("read %s: %v", generatedSchemaFile, err)
+	}
+	src := string(raw)
+
+	facts := schemaFacts{
+		registered:     map[string]bool{},
+		hasInit:        map[string]bool{},
+		hasIDMethod:    map[string]bool{},
+		resourceOfInit: map[string]string{},
+		constResource:  map[string]string{},
+	}
+
+	for _, m := range reRegistryEntry.FindAllStringSubmatch(src, -1) {
+		name, body := m[1], m[2]
+		facts.registered[name] = true
+		if init := reRegistryInit.FindStringSubmatch(body); init != nil {
+			facts.hasInit[name] = true
+			facts.resourceOfInit[init[1]] = name
+		}
+	}
+	for _, m := range reResourceConst.FindAllStringSubmatch(src, -1) {
+		facts.constResource[m[1]] = m[2]
+	}
+
+	file, err := parser.ParseFile(fset, generatedSchemaFile, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", generatedSchemaFile, err)
+	}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv != nil || !strings.HasPrefix(fn.Name.Name, "create") {
+			continue
+		}
+		var resource string
+		callsID := false
+		ast.Inspect(fn, func(n ast.Node) bool {
+			// The first string literal that is a registered resource name is
+			// the resource this constructor builds. Matching on "is registered"
+			// rather than "looks dotted" keeps an unrelated literal -- a
+			// package path, an error message -- from being mistaken for one.
+			if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == gotoken.STRING && resource == "" {
+				if v, err := strconv.Unquote(lit.Value); err == nil && facts.registered[v] {
+					resource = v
+				}
+			}
+			if sel, ok := n.(*ast.SelectorExpr); ok && sel.Sel.Name == "id" {
+				callsID = true
+			}
+			return true
+		})
+		if resource != "" {
+			facts.hasIDMethod[resource] = callsID
+		}
+	}
+
+	return facts
+}
+
+// packageSourceFiles lists the hand-written Go in this package -- the generated
+// schema and the tests are not part of what either guard judges.
+func packageSourceFiles(t *testing.T) []string {
+	t.Helper()
+
+	all, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("list package files: %v", err)
+	}
+	out := make([]string, 0, len(all))
+	for _, path := range all {
+		if strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, ".lr.go") {
+			continue
+		}
+		out = append(out, path)
+	}
+	return out
+}
+
+// keyIsHandled reports whether a resource is exempt from both guards because
+// its identity is already settled.
+func (f schemaFacts) keyIsHandled(resource string) bool {
+	return resource == "" || !f.registered[resource] || f.hasIDMethod[resource] || cacheKeySingletons[resource]
+}
 
 // TestEveryConstructionSiteHasACacheKey fails when a resource is built without
 // anything to key it on.
@@ -36,77 +160,18 @@ var cacheKeySingletons = map[string]bool{}
 // network policy (#10506), and every AWS flow log report the first one
 // (#10497).
 //
+// A registered Init is out of scope here: it resolves the resource before
+// createXxx is reached, and the resource it returns carries its own key. An
+// init that supplies neither is the second guard's job.
+//
 // Only inline argument literals are checked. A site whose args come from a
 // variable or a helper is skipped rather than guessed at, so this test reports
 // no false failures -- it is a floor, not a full audit.
 func TestEveryConstructionSiteHasACacheKey(t *testing.T) {
 	fset := gotoken.NewFileSet()
+	facts := loadSchemaFacts(t, fset)
 
-	gen, err := os.ReadFile("oci.lr.go")
-	if err != nil {
-		t.Fatalf("read generated schema: %v", err)
-	}
-	genSrc := string(gen)
-
-	// Resource* constants, so a site that names the resource by constant is
-	// resolved the same as one that spells out the string.
-	constResource := map[string]string{}
-	reConst := regexp.MustCompile(`(?m)^\t(Resource[A-Za-z0-9_]+)\s+string = "([a-zA-Z0-9_.]+)"`)
-	for _, m := range reConst.FindAllStringSubmatch(genSrc, -1) {
-		constResource[m[1]] = m[2]
-	}
-
-	// A registered Init resolves the resource before createXxx is reached, and
-	// the resource it returns carries its own key -- so an init-backed resource
-	// is out of scope here. (An init that falls through on a lookup miss is a
-	// separate defect, class 4, and not what this test is for.)
-	registered := map[string]bool{}
-	hasInit := map[string]bool{}
-	reEntry := regexp.MustCompile(`(?m)^\t\t"([a-zA-Z0-9_.]+)": \{\n((?:\t\t\t.*\n)+?)\t\t\},`)
-	for _, m := range reEntry.FindAllStringSubmatch(genSrc, -1) {
-		registered[m[1]] = true
-		hasInit[m[1]] = strings.Contains(m[2], "Init:")
-	}
-
-	// A resource has an id() method exactly when its generated constructor
-	// falls back to it.
-	genFile, err := parser.ParseFile(fset, "oci.lr.go", nil, 0)
-	if err != nil {
-		t.Fatalf("parse generated schema: %v", err)
-	}
-	hasIDMethod := map[string]bool{}
-	for _, decl := range genFile.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Recv != nil || !strings.HasPrefix(fn.Name.Name, "create") {
-			continue
-		}
-		var resource string
-		callsID := false
-		ast.Inspect(fn, func(n ast.Node) bool {
-			if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == gotoken.STRING && resource == "" {
-				if v, err := strconv.Unquote(lit.Value); err == nil && registered[v] {
-					resource = v
-				}
-			}
-			if sel, ok := n.(*ast.SelectorExpr); ok && sel.Sel.Name == "id" {
-				callsID = true
-			}
-			return true
-		})
-		if resource != "" {
-			hasIDMethod[resource] = callsID
-		}
-	}
-
-	files, err := filepath.Glob("*.go")
-	if err != nil {
-		t.Fatalf("list package files: %v", err)
-	}
-
-	for _, path := range files {
-		if strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, ".lr.go") {
-			continue
-		}
+	for _, path := range packageSourceFiles(t) {
 		file, err := parser.ParseFile(fset, path, nil, 0)
 		if err != nil {
 			t.Fatalf("parse %s: %v", path, err)
@@ -129,32 +194,18 @@ func TestEveryConstructionSiteHasACacheKey(t *testing.T) {
 				}
 				resource, _ = strconv.Unquote(arg.Value)
 			case *ast.Ident:
-				resource = constResource[arg.Name]
+				resource = facts.constResource[arg.Name]
 			}
-			if resource == "" || !registered[resource] {
-				return true
-			}
-			if hasIDMethod[resource] || hasInit[resource] || cacheKeySingletons[resource] {
+			if facts.keyIsHandled(resource) || facts.hasInit[resource] {
 				return true
 			}
 
-			// Only inline literals can be judged; anything else is skipped.
 			lit, ok := call.Args[2].(*ast.CompositeLit)
 			if !ok {
 				return true
 			}
-			for _, elt := range lit.Elts {
-				kv, ok := elt.(*ast.KeyValueExpr)
-				if !ok {
-					continue
-				}
-				key, ok := kv.Key.(*ast.BasicLit)
-				if !ok {
-					continue
-				}
-				if name, _ := strconv.Unquote(key.Value); name == "__id" {
-					return true
-				}
+			if compositeLitHasKey(lit, "__id") {
+				return true
 			}
 
 			pos := fset.Position(call.Pos())
@@ -181,104 +232,23 @@ func TestEveryConstructionSiteHasACacheKey(t *testing.T) {
 // the first. This provider is clean today; the test keeps it that way.
 func TestInitBackedResourcesCanSupplyACacheKey(t *testing.T) {
 	fset := gotoken.NewFileSet()
+	facts := loadSchemaFacts(t, fset)
 
-	gen, err := os.ReadFile("oci.lr.go")
-	if err != nil {
-		t.Fatalf("read generated schema: %v", err)
-	}
-	genSrc := string(gen)
-
-	reEntry := regexp.MustCompile(`(?m)^\t\t"([a-zA-Z0-9_.]+)": \{\n((?:\t\t\t.*\n)+?)\t\t\},`)
-	reInitName := regexp.MustCompile(`Init:\s+(init[A-Za-z0-9_]+)`)
-	initFuncs := map[string]bool{}
-	resourceOfInit := map[string]string{}
-	for _, m := range reEntry.FindAllStringSubmatch(genSrc, -1) {
-		if n := reInitName.FindStringSubmatch(m[2]); n != nil {
-			initFuncs[n[1]] = true
-			resourceOfInit[n[1]] = m[1]
-		}
-	}
-
-	genFile, err := parser.ParseFile(fset, "oci.lr.go", nil, 0)
-	if err != nil {
-		t.Fatalf("parse generated schema: %v", err)
-	}
-	hasIDMethod := map[string]bool{}
-	for _, decl := range genFile.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Recv != nil || !strings.HasPrefix(fn.Name.Name, "create") {
-			continue
-		}
-		var resource string
-		callsID := false
-		ast.Inspect(fn, func(n ast.Node) bool {
-			if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == gotoken.STRING && resource == "" {
-				if v, err := strconv.Unquote(lit.Value); err == nil && strings.Contains(v, ".") {
-					resource = v
-				}
-			}
-			if sel, ok := n.(*ast.SelectorExpr); ok && sel.Sel.Name == "id" {
-				callsID = true
-			}
-			return true
-		})
-		if resource != "" {
-			hasIDMethod[resource] = callsID
-		}
-	}
-
-	files, err := filepath.Glob("*.go")
-	if err != nil {
-		t.Fatalf("list package files: %v", err)
-	}
-
-	for _, path := range files {
-		if strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, ".lr.go") {
-			continue
-		}
+	for _, path := range packageSourceFiles(t) {
 		file, err := parser.ParseFile(fset, path, nil, 0)
 		if err != nil {
 			t.Fatalf("parse %s: %v", path, err)
 		}
 		for _, decl := range file.Decls {
 			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Recv != nil || !initFuncs[fn.Name.Name] {
+			if !ok || fn.Recv != nil || fn.Body == nil {
 				continue
 			}
-			resource := resourceOfInit[fn.Name.Name]
-			if resource == "" || hasIDMethod[resource] || cacheKeySingletons[resource] {
+			resource, isInit := facts.resourceOfInit[fn.Name.Name]
+			if !isInit || facts.keyIsHandled(resource) {
 				continue
 			}
-
-			// An init that just delegates (`return initFromServiceList(...)`)
-			// is out of scope: the key is supplied by the helper, which this
-			// body-only walk cannot see. Skipping them keeps the test free of
-			// false failures at the cost of not covering the delegated shape.
-			if len(fn.Body.List) == 1 {
-				if ret, ok := fn.Body.List[0].(*ast.ReturnStmt); ok && len(ret.Results) == 1 {
-					if _, ok := ret.Results[0].(*ast.CallExpr); ok {
-						continue
-					}
-				}
-			}
-
-			suppliesKey := false
-			ast.Inspect(fn, func(n ast.Node) bool {
-				if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == gotoken.STRING {
-					if v, err := strconv.Unquote(lit.Value); err == nil && v == "__id" {
-						suppliesKey = true
-					}
-				}
-				// An init that returns an already-built resource hands back one
-				// that already carries its own key.
-				if ret, ok := n.(*ast.ReturnStmt); ok && len(ret.Results) == 3 {
-					if id, ok := ret.Results[1].(*ast.Ident); !ok || id.Name != "nil" {
-						suppliesKey = true
-					}
-				}
-				return true
-			})
-			if suppliesKey {
+			if initSuppliesCacheKey(fn) {
 				continue
 			}
 
@@ -289,4 +259,59 @@ func TestInitBackedResourcesCanSupplyACacheKey(t *testing.T) {
 				path, pos.Line, fn.Name.Name, resource, resource+"\x00")
 		}
 	}
+}
+
+// initSuppliesCacheKey reports whether an init can hand the runtime an identity.
+//
+// Three shapes count, and the third is why this is a heuristic rather than a
+// proof: an init that delegates (`return initFromServiceList(...)`) has its key
+// supplied by the callee, which an AST walk of this body cannot see. Delegation
+// is recognised wherever it appears, not only as the sole statement, so an init
+// that sets up a variable before delegating is still skipped. The cost is that
+// an init calling any single-result helper on a return path is treated as
+// delegating; the benefit is that the guard reports no false failures.
+func initSuppliesCacheKey(fn *ast.FuncDecl) bool {
+	supplies := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == gotoken.STRING {
+			if v, err := strconv.Unquote(lit.Value); err == nil && v == "__id" {
+				supplies = true
+			}
+		}
+		ret, ok := n.(*ast.ReturnStmt)
+		if !ok {
+			return true
+		}
+		switch len(ret.Results) {
+		case 1:
+			// Delegation: `return someInit(...)`.
+			if _, ok := ret.Results[0].(*ast.CallExpr); ok {
+				supplies = true
+			}
+		case 3:
+			// An already-built resource carries its own key.
+			if id, ok := ret.Results[1].(*ast.Ident); !ok || id.Name != "nil" {
+				supplies = true
+			}
+		}
+		return true
+	})
+	return supplies
+}
+
+func compositeLitHasKey(lit *ast.CompositeLit, want string) bool {
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.BasicLit)
+		if !ok || key.Kind != gotoken.STRING {
+			continue
+		}
+		if name, err := strconv.Unquote(key.Value); err == nil && name == want {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
The three providers' cache-key guards started as the same file, so the review points raised on the gcp copy in #10585 apply verbatim to the other two. gcp was fixed before it merged; **azure and oci landed with the original**, so they are inconsistent with gcp today. One PR rather than two, because it is the same four edits applied to two copies.

## The four points

- **`cacheKeySingletons` read as an unexplained list.** It now says what the exemption is for and that anything added needs a reason, so the checks are never quietly widened to let a real collision through.
- **The two tests disagreed about what counts as a resource name.** The first checked the registry; the second matched any dotted string literal, which could pick up a package path or an error message and bind the wrong resource. Both now read the registry, through one shared `schemaFacts`. *This was a real correctness bug, not just style.*
- **Duplicated setup** — reading the generated file, parsing it, building `hasIDMethod`, globbing sources — is now `loadSchemaFacts` and `packageSourceFiles`. The two guards drifting apart is exactly how the previous point happened, so this fixes the cause rather than the symptom.
- **The delegation heuristic only recognised `return helper(...)` as the sole statement.** An init that assigned a variable before delegating would have been a **false failure**, which is the one thing these guards must never produce. It now matches a single-result call in any return position, and the comment states the trade that buys.

## Re-proven, not assumed

A refactor of a guard test is exactly where the guard quietly stops guarding, so both were re-verified after the change:

- Reverting the generated `id()` fallback for `advisorService` makes `TestInitBackedResourcesCanSupplyACacheKey` fail and name it.
- Adding a construction site for a resource with no `id()`, no init and no `"__id"` makes `TestEveryConstructionSiteHasACacheKey` fail and name it.

Both temporary edits were reverted before commit.

## Test plan

- [x] `go test ./resources/ -run CacheKey` passes in both `providers/azure` and `providers/oci`
- [x] Both guards proven to still fail on a real defect after the refactor
- [x] `gofmt` clean
- [x] oci keeps `go/token` imported as `gotoken` — `ocipage_test.go` already binds `token` in that package
