### PR TITLE
🐛 azure: detect Defender vulnerability management on the field ARM sets

### DIFF
--- a/providers/azure/resources/armsecurity.go
+++ b/providers/azure/resources/armsecurity.go
@@ -70,6 +70,38 @@ func getPolicyAssignments(ctx context.Context, conn armSecurityConn) (PolicyAssi
 	return result, nil
 }
 
+// mdvmSelectedProvider is the value ARM reports when a subscription's server
+// vulnerability assessment is Microsoft Defender Vulnerability Management.
+const mdvmSelectedProvider = "MdeTvm"
+
+// azureServersSetting identifies the subscription-wide server VA setting.
+//
+// ARM spells it two ways on the same record, differing only in the leading
+// capital: "AzureServersSetting" is the kind (the discriminator) and
+// "azureServersSetting" is the resource name. The SDK models them as two
+// separate enums for that reason.
+const azureServersSetting = "azureServersSetting"
+
+// mdvmVulnerabilityAssessmentEnabled reports whether any server VA setting
+// selects Microsoft Defender Vulnerability Management.
+//
+// It matches either field, case-insensitively, rather than picking one: the
+// call behind these records is pinned to an older api-version whose casing we
+// cannot assume, and matching the wrong one is silent -- the loop simply never
+// fires and the subscription reports no vulnerability management tool.
+func mdvmVulnerabilityAssessmentEnabled(settings []ServerVulnerabilityAssessmentsSettings) bool {
+	for _, sett := range settings {
+		if !strings.EqualFold(sett.Properties.SelectedProvider, mdvmSelectedProvider) {
+			continue
+		}
+		if strings.EqualFold(sett.Kind, azureServersSetting) ||
+			strings.EqualFold(sett.Name, azureServersSetting) {
+			return true
+		}
+	}
+	return false
+}
+
 func getServerVulnAssessmentSettings(ctx context.Context, conn armSecurityConn) (ServerVulnerabilityAssessmentsSettingsList, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Security/serverVulnerabilityAssessmentsSettings"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(conn.subscriptionId))

--- a/providers/azure/resources/armsecurity_mdvm_test.go
+++ b/providers/azure/resources/armsecurity_mdvm_test.go
@@ -1,0 +1,109 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// documentedServerVASettingsBody is shaped like the response ARM returns, taken
+// from the SDK's own recorded example for
+// ServerVulnerabilityAssessmentsSettingsClient (armsecurity@v0.15.0,
+// servervulnerabilityassessmentssettings_client_example_test.go).
+//
+// The casing is the whole point of the fixture: "kind" carries the capitalized
+// discriminator, "name" the lower-cased resource name.
+const documentedServerVASettingsBody = `{
+  "value": [
+    {
+      "properties": { "selectedProvider": "MdeTvm" },
+      "kind": "AzureServersSetting",
+      "name": "azureServersSetting",
+      "type": "Microsoft.Security/serverVulnerabilityAssessmentsSettings",
+      "id": "/subscriptions/0000/providers/Microsoft.Security/serverVulnerabilityAssessmentsSettings/azureServersSetting"
+    }
+  ]
+}`
+
+// TestMdvmDetectedInDocumentedResponse pins the bug this function exists to
+// prevent: the match used to compare the resource NAME against the KIND value
+// ("AzureServersSetting"), which Go compares case-sensitively, so the branch was
+// dead. A subscription using Microsoft Defender Vulnerability Management -- the
+// only provider since the Qualys scanner was retired -- reported no
+// vulnerability management tool at all.
+func TestMdvmDetectedInDocumentedResponse(t *testing.T) {
+	var list ServerVulnerabilityAssessmentsSettingsList
+	require.NoError(t, json.Unmarshal([]byte(documentedServerVASettingsBody), &list))
+	require.Len(t, list.Settings, 1)
+
+	// The decode itself is worth asserting: these two fields differ only by a
+	// leading capital, so a struct-tag slip is invisible without it.
+	assert.Equal(t, "AzureServersSetting", list.Settings[0].Kind)
+	assert.Equal(t, "azureServersSetting", list.Settings[0].Name)
+	assert.Equal(t, "MdeTvm", list.Settings[0].Properties.SelectedProvider)
+
+	assert.True(t, mdvmVulnerabilityAssessmentEnabled(list.Settings))
+}
+
+func TestMdvmVulnerabilityAssessmentEnabled(t *testing.T) {
+	setting := func(provider, kind, name string) ServerVulnerabilityAssessmentsSettings {
+		s := ServerVulnerabilityAssessmentsSettings{Kind: kind, Name: name}
+		s.Properties.SelectedProvider = provider
+		return s
+	}
+
+	t.Run("matches on the kind", func(t *testing.T) {
+		assert.True(t, mdvmVulnerabilityAssessmentEnabled([]ServerVulnerabilityAssessmentsSettings{
+			setting("MdeTvm", "AzureServersSetting", ""),
+		}))
+	})
+
+	t.Run("matches on the name", func(t *testing.T) {
+		assert.True(t, mdvmVulnerabilityAssessmentEnabled([]ServerVulnerabilityAssessmentsSettings{
+			setting("MdeTvm", "", "azureServersSetting"),
+		}))
+	})
+
+	t.Run("matches either casing on either field", func(t *testing.T) {
+		// The hand-rolled call is pinned to an older api-version, so neither
+		// spelling can be assumed away.
+		for _, s := range []ServerVulnerabilityAssessmentsSettings{
+			setting("MdeTvm", "azureServersSetting", ""),
+			setting("MdeTvm", "", "AzureServersSetting"),
+			setting("mdetvm", "AzureServersSetting", ""),
+		} {
+			assert.True(t, mdvmVulnerabilityAssessmentEnabled([]ServerVulnerabilityAssessmentsSettings{s}))
+		}
+	})
+
+	t.Run("a different provider does not count", func(t *testing.T) {
+		// Qualys is the retired provider and has its own detection path; it must
+		// not be reported as Defender Vulnerability Management.
+		assert.False(t, mdvmVulnerabilityAssessmentEnabled([]ServerVulnerabilityAssessmentsSettings{
+			setting("Qualys", "AzureServersSetting", "azureServersSetting"),
+		}))
+	})
+
+	t.Run("a different setting does not count", func(t *testing.T) {
+		assert.False(t, mdvmVulnerabilityAssessmentEnabled([]ServerVulnerabilityAssessmentsSettings{
+			setting("MdeTvm", "SomeOtherSetting", "someOtherSetting"),
+		}))
+	})
+
+	t.Run("no settings", func(t *testing.T) {
+		assert.False(t, mdvmVulnerabilityAssessmentEnabled(nil))
+		assert.False(t, mdvmVulnerabilityAssessmentEnabled([]ServerVulnerabilityAssessmentsSettings{}))
+	})
+
+	t.Run("finds a match past a non-matching entry", func(t *testing.T) {
+		assert.True(t, mdvmVulnerabilityAssessmentEnabled([]ServerVulnerabilityAssessmentsSettings{
+			setting("Qualys", "SomeOtherSetting", "someOtherSetting"),
+			setting("MdeTvm", "AzureServersSetting", "azureServersSetting"),
+		}))
+	})
+}

--- a/providers/azure/resources/cloud_defender.go
+++ b/providers/azure/resources/cloud_defender.go
@@ -235,11 +235,9 @@ func (a *mqlAzureSubscriptionCloudDefenderService) forServers() (*mqlAzureSubscr
 			vulnToolName = "Microsoft Defender for Cloud integrated Qualys scanner"
 		}
 	}
-	for _, sett := range serverVASetings.Settings {
-		if sett.Properties.SelectedProvider == "MdeTvm" && sett.Name == "AzureServersSetting" {
-			args["enabled"] = llx.BoolData(true)
-			vulnToolName = "Microsoft Defender vulnerability management"
-		}
+	if mdvmVulnerabilityAssessmentEnabled(serverVASetings.Settings) {
+		args["enabled"] = llx.BoolData(true)
+		vulnToolName = "Microsoft Defender vulnerability management"
 	}
 	args["vulnerabilityManagementToolName"] = llx.StringData(vulnToolName)
 


### PR DESCRIPTION
## The bug

The MDVM check compared the setting's resource **name** against the **kind** value:

```go
if sett.Properties.SelectedProvider == "MdeTvm" && sett.Name == "AzureServersSetting" {
```

ARM spells the two differently on the same record, by one leading capital. The SDK models them as separate enums for exactly that reason:

```go
// armsecurity@v0.15.0/constants.go
ServerVulnerabilityAssessmentsSettingKindAzureServersSetting     = "AzureServersSetting"  // kind
ServerVulnerabilityAssessmentsSettingKindNameAzureServersSetting = "azureServersSetting"  // name
```

and the SDK's own recorded example response confirms the wire shape:

```
Name: to.Ptr("azureServersSetting"),
Kind: to.Ptr(armsecurity.ServerVulnerabilityAssessmentsSettingKindAzureServersSetting),
```

Go compares strings case-sensitively, so **the condition was never true**. The tell was already in the file: the local model decodes a `Kind` field that nothing reads.

## What the user saw

Microsoft Defender Vulnerability Management is the only server VA provider since the integrated Qualys scanner was retired. On a subscription that uses it:

- `defenderForServers.vulnerabilityManagementToolName` was `""`
- the VA half of `enabled` never fired

A check asserting that vulnerability assessment is configured **failed on a correctly configured subscription**.

## The fix

The match now reads either field, case-insensitively, rather than picking one. The hand-rolled call behind these records is pinned to api-version `2022-01-01-preview`, whose casing cannot be assumed — and getting it wrong is silent, because the loop simply never fires.

Extracted as `mdvmVulnerabilityAssessmentEnabled` so it can be tested at all; it was previously inline in a function that needs a live ARM connection.

## Tests

`TestMdvmDetectedInDocumentedResponse` decodes a body shaped like the SDK's recorded response and asserts the two near-identical fields survive the decode — which is where a struct-tag slip would otherwise hide — before asserting the match. **It fails on the old comparison.**

`TestMdvmVulnerabilityAssessmentEnabled` covers kind-only, name-only, both casings on both fields, a different provider (Qualys, which has its own detection path and must not be reported as MDVM), a different setting, the empty case, and a match found past a non-matching entry.

## Follow-up, not in this PR

`getServerVulnAssessmentSettings` is a hand-rolled ARM walk pinned to `2022-01-01-preview`, while `armsecurity@v0.15.0` now ships `ServerVulnerabilityAssessmentsSettingsClient.NewListBySubscriptionPager` at GA `2023-05-01`. Moving to the SDK client would delete the local model, the api-version pin, and this whole class of name-vs-kind ambiguity. Worth doing as its own change, with a live check.

## Test plan

- [x] `go test ./resources/ -run Mdvm` passes; verified failing against the old comparison
- [x] `gofmt` clean
- [ ] Not live-verified — needs a subscription with Defender for Servers using MDVM
