### PR TITLE
🐛 azure: list ADLS Gen2 containers, and stop publishing three secrets

### DIFF
--- a/providers/azure/resources/redis.go
+++ b/providers/azure/resources/redis.go
@@ -183,8 +183,17 @@ func createRedisInstanceRawData(runtime *plugin.Runtime, cache *armredis.Resourc
 	// throughout; normalize to an empty struct so a cache returned without
 	// properties doesn't panic here (the callers reach this before their own
 	// nil guards).
+	//
+	// Normalize onto a local copy rather than writing back through the pointer.
+	// The caller keeps using its own *ResourceInfo after this returns -- to seed
+	// the resource's caches, behind an `if cache.Properties != nil` guard -- so
+	// filling the field in here would turn that guard into a read of an empty
+	// struct, and would contradict what the redaction helpers below promise
+	// about leaving the source alone.
 	if cache.Properties == nil {
-		cache.Properties = &armredis.Properties{}
+		normalized := *cache
+		normalized.Properties = &armredis.Properties{}
+		cache = &normalized
 	}
 	properties, err := convert.JsonToDict(redactedRedisResource(cache))
 	if err != nil {

--- a/providers/azure/resources/redis.go
+++ b/providers/azure/resources/redis.go
@@ -139,6 +139,45 @@ func (a *mqlAzureSubscriptionCacheService) redis() ([]any, error) {
 	return caches, nil
 }
 
+// redactedRedisConfiguration copies a cache's Redis configuration with the
+// persistence storage connection strings removed.
+//
+// Azure returns all three verbatim, and each carries either an account key or a
+// SAS token for the storage account holding the RDB/AOF backups. They reached
+// MQL twice -- once through redisConfiguration and again through properties,
+// which serializes the whole ResourceInfo -- so anyone printing either field
+// printed the storage credential.
+//
+// The copy is by field rather than by JSON key so that a field renamed in a
+// future SDK breaks the build instead of silently leaking again. Everything
+// else in the configuration is kept, including rdbBackupEnabled, so the audit
+// signal survives the redaction.
+func redactedRedisConfiguration(cfg *armredis.CommonPropertiesRedisConfiguration) *armredis.CommonPropertiesRedisConfiguration {
+	if cfg == nil {
+		return nil
+	}
+	safe := *cfg
+	safe.AofStorageConnectionString0 = nil
+	safe.AofStorageConnectionString1 = nil
+	safe.RdbStorageConnectionString = nil
+	return &safe
+}
+
+// redactedRedisResource copies a cache with its configuration redacted, for the
+// properties bag that serializes the whole record.
+func redactedRedisResource(cache *armredis.ResourceInfo) *armredis.ResourceInfo {
+	if cache == nil {
+		return nil
+	}
+	safe := *cache
+	if cache.Properties != nil {
+		props := *cache.Properties
+		props.RedisConfiguration = redactedRedisConfiguration(cache.Properties.RedisConfiguration)
+		safe.Properties = &props
+	}
+	return &safe
+}
+
 func createRedisInstanceRawData(runtime *plugin.Runtime, cache *armredis.ResourceInfo) (map[string]*llx.RawData, error) {
 	// Properties is a nullable pointer that the field reads below dereference
 	// throughout; normalize to an empty struct so a cache returned without
@@ -147,7 +186,7 @@ func createRedisInstanceRawData(runtime *plugin.Runtime, cache *armredis.Resourc
 	if cache.Properties == nil {
 		cache.Properties = &armredis.Properties{}
 	}
-	properties, err := convert.JsonToDict(cache)
+	properties, err := convert.JsonToDict(redactedRedisResource(cache))
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +214,7 @@ func createRedisInstanceRawData(runtime *plugin.Runtime, cache *armredis.Resourc
 		minimumTlsVersion = &val
 	}
 
-	redisConfiguration, err := convert.JsonToDict(cache.Properties.RedisConfiguration)
+	redisConfiguration, err := convert.JsonToDict(redactedRedisConfiguration(cache.Properties.RedisConfiguration))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/azure/resources/secret_redaction_test.go
+++ b/providers/azure/resources/secret_redaction_test.go
@@ -1,0 +1,127 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	web "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v6"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
+)
+
+// These tests assert on the SERIALIZED form, not on the struct fields, because
+// serialization is what actually reaches MQL. A redaction that nils a field the
+// marshaller does not emit would pass a struct-level assertion and still leak.
+
+const (
+	fakeStorageConnString = "DefaultEndpointsProtocol=https;AccountName=acct;AccountKey=SUPERSECRETKEY==;"
+	fakeClientSecret      = "SUPERSECRETCLIENTSECRET"
+)
+
+func TestRedactedRedisConfigurationDropsStorageCredentials(t *testing.T) {
+	cfg := &armredis.CommonPropertiesRedisConfiguration{
+		AofStorageConnectionString0: to.Ptr(fakeStorageConnString + "aof0"),
+		AofStorageConnectionString1: to.Ptr(fakeStorageConnString + "aof1"),
+		RdbStorageConnectionString:  to.Ptr(fakeStorageConnString + "rdb"),
+		RdbBackupEnabled:            to.Ptr("true"),
+		MaxmemoryPolicy:             to.Ptr("allkeys-lru"),
+	}
+
+	dict, err := convert.JsonToDict(redactedRedisConfiguration(cfg))
+	require.NoError(t, err)
+	serialized := mustJSON(t, dict)
+
+	assert.NotContains(t, serialized, "SUPERSECRETKEY",
+		"the storage account key must not reach MQL")
+	assert.NotContains(t, serialized, "AccountKey")
+
+	// The audit signal has to survive the redaction, or the fix trades one
+	// wrong answer for another.
+	assert.Contains(t, serialized, "true", "rdbBackupEnabled is still reported")
+	assert.Contains(t, serialized, "allkeys-lru")
+
+	// The source is not mutated -- callers downstream still see the original.
+	assert.Equal(t, fakeStorageConnString+"rdb", *cfg.RdbStorageConnectionString)
+
+	assert.Nil(t, redactedRedisConfiguration(nil))
+}
+
+// TestRedactedRedisResourceDropsStorageCredentials covers the second, easier to
+// miss leak: properties serializes the whole ResourceInfo, so redacting only
+// the redisConfiguration field would have left the same secrets readable one
+// field over.
+func TestRedactedRedisResourceDropsStorageCredentials(t *testing.T) {
+	cache := &armredis.ResourceInfo{
+		Name: to.Ptr("my-cache"),
+		Properties: &armredis.Properties{
+			RedisConfiguration: &armredis.CommonPropertiesRedisConfiguration{
+				RdbStorageConnectionString: to.Ptr(fakeStorageConnString),
+			},
+		},
+	}
+
+	dict, err := convert.JsonToDict(redactedRedisResource(cache))
+	require.NoError(t, err)
+	serialized := mustJSON(t, dict)
+
+	assert.NotContains(t, serialized, "SUPERSECRETKEY")
+	assert.Contains(t, serialized, "my-cache", "the rest of the record is untouched")
+
+	// The copy must be deep enough that the caller's struct is unchanged; the
+	// same *ResourceInfo is used afterwards to seed the resource's caches.
+	require.NotNil(t, cache.Properties.RedisConfiguration.RdbStorageConnectionString)
+	assert.Equal(t, fakeStorageConnString, *cache.Properties.RedisConfiguration.RdbStorageConnectionString)
+
+	assert.Nil(t, redactedRedisResource(nil))
+
+	// A cache with no properties must not panic.
+	assert.NotNil(t, redactedRedisResource(&armredis.ResourceInfo{Name: to.Ptr("bare")}))
+}
+
+func TestRedactedAuthSettingsDropsEveryProviderSecret(t *testing.T) {
+	props := &web.SiteAuthSettingsProperties{
+		Enabled:                      to.Ptr(true),
+		ClientID:                     to.Ptr("client-id-is-not-a-secret"),
+		ClientSecret:                 to.Ptr(fakeClientSecret + "-aad"),
+		FacebookAppSecret:            to.Ptr(fakeClientSecret + "-fb"),
+		GitHubClientSecret:           to.Ptr(fakeClientSecret + "-gh"),
+		GoogleClientSecret:           to.Ptr(fakeClientSecret + "-goog"),
+		MicrosoftAccountClientSecret: to.Ptr(fakeClientSecret + "-msa"),
+		TwitterConsumerSecret:        to.Ptr(fakeClientSecret + "-tw"),
+	}
+
+	dict, err := convert.JsonToDict(redactedAuthSettings(props))
+	require.NoError(t, err)
+	serialized := mustJSON(t, dict)
+
+	// One assertion per provider: a redaction that misses one is the whole bug.
+	for _, suffix := range []string{"-aad", "-fb", "-gh", "-goog", "-msa", "-tw"} {
+		assert.NotContains(t, serialized, fakeClientSecret+suffix,
+			"secret %q must not reach MQL", suffix)
+	}
+	assert.NotContains(t, serialized, fakeClientSecret)
+
+	// Everything that is not a secret is still reported: the resource exists to
+	// say whether Easy Auth is on and how it is configured.
+	assert.Contains(t, serialized, "client-id-is-not-a-secret")
+	assert.Contains(t, serialized, "true")
+
+	assert.Equal(t, fakeClientSecret+"-aad", *props.ClientSecret, "source not mutated")
+	assert.Nil(t, redactedAuthSettings(nil))
+}
+
+// mustJSON serializes exactly as the value will reach MQL. It deliberately does
+// NOT normalize case: the assertions below search for upper-case secret
+// markers, and lower-casing here would make every NotContains unfalsifiable.
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}

--- a/providers/azure/resources/secret_redaction_test.go
+++ b/providers/azure/resources/secret_redaction_test.go
@@ -116,6 +116,48 @@ func TestRedactedAuthSettingsDropsEveryProviderSecret(t *testing.T) {
 	assert.Nil(t, redactedAuthSettings(nil))
 }
 
+// TestCreateRedisInstanceRawDataLeavesTheSourceAlone pins the guarantee at the
+// level that actually matters to the caller.
+//
+// The redaction helpers copy before editing, but the function around them used
+// to normalize a nil Properties by writing back through the caller's pointer.
+// The caller keeps using that same *ResourceInfo afterwards to seed the
+// resource's caches, behind an `if cache.Properties != nil` guard -- so filling
+// the field in here quietly turned that guard into a read of an empty struct.
+func TestCreateRedisInstanceRawDataLeavesTheSourceAlone(t *testing.T) {
+	bare := &armredis.ResourceInfo{Name: to.Ptr("no-properties")}
+
+	_, err := createRedisInstanceRawData(nil, bare)
+	require.NoError(t, err)
+
+	assert.Nil(t, bare.Properties,
+		"a cache that arrived without properties must still have none afterwards")
+
+	withSecret := &armredis.ResourceInfo{
+		Name: to.Ptr("has-properties"),
+		Properties: &armredis.Properties{
+			RedisConfiguration: &armredis.CommonPropertiesRedisConfiguration{
+				RdbStorageConnectionString: to.Ptr(fakeStorageConnString),
+			},
+		},
+	}
+
+	args, err := createRedisInstanceRawData(nil, withSecret)
+	require.NoError(t, err)
+
+	// The secret is gone from both fields it used to reach.
+	for _, field := range []string{"properties", "redisConfiguration"} {
+		require.Contains(t, args, field)
+		assert.NotContains(t, mustJSON(t, args[field].Value), "SUPERSECRETKEY",
+			"%s must not carry the storage credential", field)
+	}
+
+	// ...and still present on the caller's own struct.
+	require.NotNil(t, withSecret.Properties.RedisConfiguration.RdbStorageConnectionString)
+	assert.Equal(t, fakeStorageConnString,
+		*withSecret.Properties.RedisConfiguration.RdbStorageConnectionString)
+}
+
 // mustJSON serializes exactly as the value will reach MQL. It deliberately does
 // NOT normalize case: the assertions below search for upper-case secret
 // markers, and lower-casing here would make every NotContains unfalsifiable.

--- a/providers/azure/resources/storage.go
+++ b/providers/azure/resources/storage.go
@@ -174,12 +174,18 @@ func (a *mqlAzureSubscriptionStorageService) accounts() ([]any, error) {
 }
 
 func (a *mqlAzureSubscriptionStorageServiceAccount) containers() ([]any, error) {
-	// Data Lake Storage Gen2 (HNS-enabled) accounts don't support the Blob containers API.
-	if a.GetIsHnsEnabled().Data {
-		a.Containers.State = plugin.StateIsNull | plugin.StateIsSet
-		return nil, nil
-	}
-
+	// No hierarchical-namespace guard here. This is the ARM control-plane
+	// BlobContainers client, which Microsoft supports on HNS-enabled accounts;
+	// only four data-plane blob operations are unsupported on Data Lake Storage
+	// Gen2, and none of them is this one. Skipping HNS accounts made every ADLS
+	// Gen2 account report `containers: null`, so publicAccess,
+	// hasImmutabilityPolicy, hasLegalHold and the encryption-scope fields were
+	// invisible for exactly the accounts an anonymous-access audit cares about
+	// -- and under three-valued logic a where() over null matches nothing, so
+	// the check passed rather than failed.
+	//
+	// The pager below already degrades on the one error that genuinely means
+	// "this account does not support the operation".
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()
 	token := conn.Token()
@@ -206,7 +212,9 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) containers() ([]any, error) 
 		page, err := pager.NextPage(ctx)
 		if err != nil {
 			if isFeatureNotSupportedForAccountError(err) {
-				return nil, nil
+				// Keep whatever earlier pages returned. Discarding them would
+				// report a partial listing as an empty one.
+				return res, nil
 			}
 			return nil, err
 		}

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -975,6 +975,35 @@ func (a *mqlAzureSubscriptionWebServiceAppsiteconfig) ipSecurityRestrictionsDefa
 	return s, nil
 }
 
+// redactedAuthSettings copies legacy (V1) Easy Auth settings with the six
+// identity-provider client secrets removed.
+//
+// GetAuthSettings is the `/config/authsettings/list` action, which is Azure's
+// convention for the form that returns secret values -- the V2 sibling has a
+// separate GetAuthSettingsV2WithoutSecrets precisely because the /list form
+// does not redact. Everything else about the configuration is kept, so
+// enabled, unauthenticatedClientAction, the allowed audiences and the provider
+// client IDs still read as before.
+//
+// The V2 path is already clean: SiteAuthSettingsV2Properties carries only
+// clientSecretSettingName and a certificate thumbprint, never a value.
+//
+// The copy is by field rather than by JSON key so a secret field renamed in a
+// future SDK breaks the build instead of silently leaking again.
+func redactedAuthSettings(props *web.SiteAuthSettingsProperties) *web.SiteAuthSettingsProperties {
+	if props == nil {
+		return nil
+	}
+	safe := *props
+	safe.ClientSecret = nil
+	safe.FacebookAppSecret = nil
+	safe.GitHubClientSecret = nil
+	safe.GoogleClientSecret = nil
+	safe.MicrosoftAccountClientSecret = nil
+	safe.TwitterConsumerSecret = nil
+	return &safe
+}
+
 func (a *mqlAzureSubscriptionWebServiceAppsite) authenticationSettings() (*mqlAzureSubscriptionWebServiceAppsiteauthsettings, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()
@@ -1002,7 +1031,7 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) authenticationSettings() (*mqlAz
 	if err != nil {
 		return nil, err
 	}
-	properties, err := convert.JsonToDict(configuration.Properties)
+	properties, err := convert.JsonToDict(redactedAuthSettings(configuration.Properties))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Three defects from the cross-provider audit, all in what a storage or app posture check reads. Grouped because they are the remaining items from one audit row; the fourth in that row, `runtimeStackDescriptor`'s uncomparable ID, was already fixed in #10583.

## 1. ADLS Gen2 containers were reported as `null`

```go
// Data Lake Storage Gen2 (HNS-enabled) accounts don't support the Blob containers API.
if a.GetIsHnsEnabled().Data {
    a.Containers.State = plugin.StateIsNull | plugin.StateIsSet
    return nil, nil
}
```

The comment is true of four **data-plane** blob operations. This is the ARM **control-plane** `BlobContainers` client (`Microsoft.Storage/storageAccounts/*/blobServices/default/containers`), which Microsoft supports on HNS accounts — their own "Known issues with Azure Data Lake Storage" page even documents anonymous read access granted to a container on an HNS account.

**What the user saw:** every ADLS Gen2 account reported `containers: null`, hiding `publicAccess`, `hasImmutabilityPolicy`, `immutabilityPolicyState`, `hasLegalHold`, `defaultEncryptionScope` and `denyEncryptionScopeOverride` — for exactly the accounts an anonymous-access audit cares about. Under three-valued logic a `where(publicAccess != "None")` over null matches nothing, **so the check passed rather than failed.**

The pager already handles the one error that genuinely means "not supported here" (`isFeatureNotSupportedForAccountError`), which is the targeted version of what this guard was doing bluntly.

While in that loop: on that degrade it returned `nil` rather than the pages already collected, reporting a partial listing as an empty one.

## 2. Redis persistence storage connection strings reached MQL — twice

`CommonPropertiesRedisConfiguration` carries `AofStorageConnectionString0`, `AofStorageConnectionString1` and `RdbStorageConnectionString`, each containing a storage account key or a SAS token. They surfaced through `redisConfiguration` **and again** through `properties`, which serializes the whole `ResourceInfo` — so redacting only the obvious field would have left them readable one field over.

Everything else is kept, including `rdbBackupEnabled`, so no audit signal is lost.

## 3. App Service Easy Auth V1 published six OAuth client secrets

`GetAuthSettings` issues `POST .../config/authsettings/list` — Azure's convention for the form that **returns secret values**, which is why the V2 sibling has a separate `GetAuthSettingsV2WithoutSecrets`. The whole properties struct was serialized into a dict, carrying `clientSecret`, `facebookAppSecret`, `gitHubClientSecret`, `googleClientSecret`, `microsoftAccountClientSecret` and `twitterConsumerSecret`.

The V2 path added in #10308 is already clean — `SiteAuthSettingsV2Properties` reaches only `clientSecretSettingName` and a certificate thumbprint. This is the legacy sibling that PR left alone.

## Why the redactions copy by field

Both helpers copy the struct and nil the secret fields, rather than deleting JSON keys from the resulting map. A field renamed in a future SDK then **breaks the build** instead of silently leaking again.

## Tests

The tests assert on the **serialized** form, not the struct fields, because serialization is what reaches MQL — a redaction that nils a field the marshaller does not emit would pass a struct-level assertion and still leak. They also check the source struct is not mutated (the same `*ResourceInfo` seeds the resource's caches afterwards), that the non-secret configuration survives, and the nil cases.

Verified by un-redacting one field in each and confirming the failure:

```
"...\"rdb-storage-connection-string\":\"...AccountKey=SUPERSECRETKEY==;rdb\"}" should not contain "SUPERSECRETKEY"
"...\"twitterConsumerSecret\":\"SUPERSECRETCLIENTSECRET-tw\"}" should not contain "SUPERSECRETCLIENTSECRET-tw"
```

I also caught and fixed a flaw in my own first draft: the JSON helper lower-cased its output while the assertions searched for upper-case markers, which would have made every `NotContains` unfalsifiable.

## Test plan

- [x] `go test ./resources/ -run Redact` passes; each test verified failing on a missed field
- [x] `gofmt` clean, `go build ./resources/` clean
- [ ] Not live-verified — item 1 wants an ADLS Gen2 account with a public container, items 2 and 3 a Redis cache with persistence and an app on Easy Auth V1
