### PR TITLE
🐛 os: add nginx returnDirective, the return field collides with an MQL keyword

### DIFF
--- a/providers/os/resources/nginx.go
+++ b/providers/os/resources/nginx.go
@@ -950,15 +950,18 @@ func nginxLocations2Resources(locations []nginxLocation, runtime *plugin.Runtime
 	res := make([]any, len(locations))
 	for i, loc := range locations {
 		obj, err := CreateResource(runtime, "nginx.conf.location", map[string]*llx.RawData{
-			"__id":        llx.StringData(fmt.Sprintf("%s/location/%d-%s", ownerID, i, loc.Path)),
-			"path":        llx.StringData(loc.Path),
-			"modifier":    llx.StringData(loc.Modifier),
-			"proxyPass":   llx.StringData(loc.ProxyPass),
-			"root":        llx.StringData(loc.Root),
-			"tryFiles":    llx.StringData(loc.TryFiles),
-			"return":      llx.StringData(loc.Return),
-			"fastcgiPass": llx.StringData(loc.FastcgiPass),
-			"params":      llx.MapData(loc.Params, types.String),
+			"__id":      llx.StringData(fmt.Sprintf("%s/location/%d-%s", ownerID, i, loc.Path)),
+			"path":      llx.StringData(loc.Path),
+			"modifier":  llx.StringData(loc.Modifier),
+			"proxyPass": llx.StringData(loc.ProxyPass),
+			"root":      llx.StringData(loc.Root),
+			"tryFiles":  llx.StringData(loc.TryFiles),
+			"return":    llx.StringData(loc.Return),
+			// returnDirective duplicates return: the field name `return` is an
+			// MQL keyword and gets eaten by the parser inside a block.
+			"returnDirective": llx.StringData(loc.Return),
+			"fastcgiPass":     llx.StringData(loc.FastcgiPass),
+			"params":          llx.MapData(loc.Params, types.String),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/os/resources/nginx_test.go
+++ b/providers/os/resources/nginx_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers/os/resources/nginx"
+	"go.mondoo.com/mql/utils/syncx"
 )
 
 func TestParseNginxServerBlock(t *testing.T) {
@@ -593,4 +595,33 @@ func TestParseNginxLocationDetail(t *testing.T) {
 	assert.Equal(t, "$uri $uri/ =404", loc.TryFiles)
 	assert.Equal(t, "301 https://example.com$request_uri", loc.Return)
 	assert.Equal(t, "unix:/var/run/php-fpm.sock", loc.FastcgiPass)
+}
+
+// The `return` field cannot be read from inside an MQL block: the compiler
+// treats a bare `return` identifier as a return statement, so
+// `nginx.conf.servers { locations { return } }` compiles and silently reads
+// nothing. returnDirective carries the same value under a name the parser
+// does not claim, so it has to be populated wherever `return` is.
+func TestNginxLocationReturnDirective(t *testing.T) {
+	loc := parseNginxLocationBlock("/old", []nginx.Directive{
+		{Name: "return", Args: []string{"301", "https://example.com$request_uri"}},
+	})
+	empty := parseNginxLocationBlock("/plain", []nginx.Directive{
+		{Name: "root", Args: []string{"/var/www/html"}},
+	})
+
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	res, err := nginxLocations2Resources([]nginxLocation{loc, empty}, runtime, "nginx.conf/etc/nginx/nginx.conf")
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+
+	redirect := res[0].(*mqlNginxConfLocation)
+	assert.Equal(t, "301 https://example.com$request_uri", redirect.ReturnDirective.Data)
+	assert.Equal(t, redirect.Return.Data, redirect.ReturnDirective.Data)
+
+	// a location without a return directive reads as the empty string on both
+	// fields, never as a stale value from the previous location
+	plain := res[1].(*mqlNginxConfLocation)
+	assert.Equal(t, "", plain.ReturnDirective.Data)
+	assert.Equal(t, plain.Return.Data, plain.ReturnDirective.Data)
 }

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -2039,8 +2039,21 @@ private nginx.conf.location @defaults("path") {
   root string
   // try_files directive value
   tryFiles string
-  // return directive value (status + URI/text)
-  return string
+  // return directive value
+  //
+  // Deprecated in favor of returnDirective, which carries the same value.
+  // The name return collides with an MQL keyword, so this field cannot be
+  // read from inside a block: a query such as
+  // `nginx.conf.servers { locations { return } }` compiles but never reads
+  // it. Only dotted access still works.
+  return @maturity("deprecated") string
+  // return directive value
+  //
+  // Status code plus the redirect URI or response text, as written in the
+  // location block. For example "301 https://example.com$request_uri" for a
+  // permanent redirect, or "444" for a connection that is closed without a
+  // response. Empty when the location block has no return directive.
+  returnDirective string
   // fastcgi_pass directive value
   fastcgiPass string
   // All directives within this location block

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -4610,6 +4610,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"nginx.conf.location.return": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNginxConfLocation).GetReturn()).ToDataRes(types.String)
 	},
+	"nginx.conf.location.returnDirective": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNginxConfLocation).GetReturnDirective()).ToDataRes(types.String)
+	},
 	"nginx.conf.location.fastcgiPass": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNginxConfLocation).GetFastcgiPass()).ToDataRes(types.String)
 	},
@@ -19321,6 +19324,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"nginx.conf.location.return": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlNginxConfLocation).Return, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"nginx.conf.location.returnDirective": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNginxConfLocation).ReturnDirective, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"nginx.conf.location.fastcgiPass": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -45821,14 +45828,15 @@ type mqlNginxConfLocation struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlNginxConfLocationInternal it will be used here
-	Path        plugin.TValue[string]
-	Modifier    plugin.TValue[string]
-	ProxyPass   plugin.TValue[string]
-	Root        plugin.TValue[string]
-	TryFiles    plugin.TValue[string]
-	Return      plugin.TValue[string]
-	FastcgiPass plugin.TValue[string]
-	Params      plugin.TValue[map[string]any]
+	Path            plugin.TValue[string]
+	Modifier        plugin.TValue[string]
+	ProxyPass       plugin.TValue[string]
+	Root            plugin.TValue[string]
+	TryFiles        plugin.TValue[string]
+	Return          plugin.TValue[string]
+	ReturnDirective plugin.TValue[string]
+	FastcgiPass     plugin.TValue[string]
+	Params          plugin.TValue[map[string]any]
 }
 
 // createNginxConfLocation creates a new instance of this resource
@@ -45885,6 +45893,10 @@ func (c *mqlNginxConfLocation) GetTryFiles() *plugin.TValue[string] {
 
 func (c *mqlNginxConfLocation) GetReturn() *plugin.TValue[string] {
 	return &c.Return
+}
+
+func (c *mqlNginxConfLocation) GetReturnDirective() *plugin.TValue[string] {
+	return &c.ReturnDirective
 }
 
 func (c *mqlNginxConfLocation) GetFastcgiPass() *plugin.TValue[string] {

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -2677,6 +2677,7 @@ nginx.conf.location.params 13.14.1
 nginx.conf.location.path 13.14.1
 nginx.conf.location.proxyPass 13.14.1
 nginx.conf.location.return 13.16.10
+nginx.conf.location.returnDirective 13.40.10
 nginx.conf.location.root 13.14.1
 nginx.conf.location.tryFiles 13.16.10
 nginx.conf.params 13.14.1


### PR DESCRIPTION
## Problem

`nginx.conf.location.return` is named after an MQL keyword. `mqlc/parser/parser.go` treats a bare `return` identifier at operand position as a return *statement*, unconditionally. Inside a block, the field name is eaten by the parser:

| query | result |
|---|---|
| `nginx.conf.servers { locations { return } }` | **compiles, `return` is never read** — no error, no value |
| `nginx.conf.servers { locations { return root tryFiles } }` | `return statement is followed by too many expressions` |
| `nginx.conf.servers[0].locations[0].return` | works (dotted access) |

The first row is the dangerous one: a policy asking for `return` gets a clean result set with the field silently absent, not an error.

nginx's `location ... { return 301 https://... }` is the redirect directive, so any audit of open redirects or HTTP-to-HTTPS enforcement that reads it in block form reads nothing.

Confirmed with the offline compile gate against the built provider:

```
$ mql run local --info -c 'nginx.conf.servers { locations { return } }'
Resources and Fields used:
- nginx.conf
  - servers  type=[]nginx.conf.server
- nginx.conf.server
  - locations  type=[]nginx.conf.location      <-- no `return`

$ mql run local --info -c 'nginx.conf.servers { locations { returnDirective } }'
...
- nginx.conf.location
  - returnDirective  type=string
```

## Fix

The field is shipped, so it cannot be renamed in place (CLAUDE.md §6). Following the deprecate-and-add rule:

- adds `returnDirective string` to `nginx.conf.location`, carrying exactly the same value
- marks the existing `return` field `@maturity("deprecated")` with a description pointing at the replacement and stating the keyword clash
- `.lr.versions` entry for `returnDirective` at `13.40.10`, the next patch after the provider's current `13.40.9`. The `return` entry stays at `13.16.10` — deprecation does not bump a version.

No provider version bump in `config.go`.

## Scope check

Scanned every `*.resources.json` in the repo for public fields named after MQL keywords. `default` appears 13 times but is only reserved inside `switch` and compiles fine as a field name. `nginx.conf.location.return` is the only genuine collision.

## Test

`TestNginxLocationReturnDirective` runs `nginxLocations2Resources` over a location with `return 301 https://example.com$request_uri;` and one without, and asserts `returnDirective` carries the value on the first and the empty string on the second, matching `return` in both cases.

Verified it fails without the Go change: removing the `"returnDirective"` line from `nginxLocations2Resources` and re-running gives

```
Error: Not equal:
expected: "301 https://example.com$request_uri"
actual  : ""
```
