### PR TITLE
🐛 gcp: gate the vertexai and monitoring collections on the API being enabled

### DIFF
--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -69208,7 +69208,7 @@ func (c *mqlGcpAccessApprovalSettings) GetInvalidKeyVersion() *plugin.TValue[boo
 type mqlGcpProjectMonitoringService struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectMonitoringServiceInternal it will be used here
+	mqlGcpProjectMonitoringServiceInternal
 	ProjectId            plugin.TValue[string]
 	AlertPolicies        plugin.TValue[[]any]
 	UptimeCheckConfigs   plugin.TValue[[]any]

--- a/providers/gcp/resources/iam_roles.go
+++ b/providers/gcp/resources/iam_roles.go
@@ -19,6 +19,14 @@ import (
 )
 
 func (g *mqlGcpProjectIamService) roles() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}

--- a/providers/gcp/resources/monitoring.go
+++ b/providers/gcp/resources/monitoring.go
@@ -13,11 +13,11 @@ import (
 	"go.mondoo.com/mql/providers/gcp/connection"
 	"go.mondoo.com/mql/types"
 
-	kms "cloud.google.com/go/kms/apiv1"
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	monitoringpb "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	dashboard "cloud.google.com/go/monitoring/dashboard/apiv1"
 	"cloud.google.com/go/monitoring/dashboard/apiv1/dashboardpb"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
 	"google.golang.org/api/iterator"
 	monitoringv3 "google.golang.org/api/monitoring/v3"
@@ -73,6 +73,10 @@ func initGcpProjectMonitoringService(runtime *plugin.Runtime, args map[string]*l
 	return args, nil, nil
 }
 
+type mqlGcpProjectMonitoringServiceInternal struct {
+	serviceGate
+}
+
 func (g *mqlGcpProject) monitoring() (*mqlGcpProjectMonitoringService, error) {
 	if g.Id.Error != nil {
 		return nil, g.Id.Error
@@ -85,7 +89,24 @@ func (g *mqlGcpProject) monitoring() (*mqlGcpProjectMonitoringService, error) {
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectMonitoringService), nil
+
+	serviceEnabled, err := g.isServiceEnabled(service_monitoring)
+	if err != nil {
+		return nil, err
+	}
+
+	svc := res.(*mqlGcpProjectMonitoringService)
+	svc.recordEnabled(serviceEnabled)
+	if !serviceEnabled {
+		log.Debug().Str("service", service_monitoring).Msg("gcp service is not enabled, skipping")
+	}
+
+	return svc, nil
+}
+
+// isEnabled reports whether the API is enabled on this project.
+func (g *mqlGcpProjectMonitoringService) isEnabled() (bool, error) {
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_monitoring)
 }
 
 func (g *mqlGcpProjectMonitoringServiceAlertPolicy) id() (string, error) {
@@ -134,6 +155,14 @@ func (g *mqlGcpProjectMonitoringServiceAlertPolicy) notificationChannels() ([]an
 }
 
 func (g *mqlGcpProjectMonitoringService) alertPolicies() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -141,7 +170,7 @@ func (g *mqlGcpProjectMonitoringService) alertPolicies() ([]any, error) {
 
 	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
 
-	creds, err := conn.Credentials(kms.DefaultAuthScopes()...)
+	creds, err := conn.Credentials(monitoring.DefaultAuthScopes()...)
 	if err != nil {
 		return nil, err
 	}
@@ -282,6 +311,14 @@ func (g *mqlGcpProjectMonitoringServiceUptimeCheckConfig) id() (string, error) {
 }
 
 func (g *mqlGcpProjectMonitoringService) uptimeCheckConfigs() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -375,6 +412,14 @@ func (g *mqlGcpProjectMonitoringServiceNotificationChannel) id() (string, error)
 }
 
 func (g *mqlGcpProjectMonitoringService) notificationChannels() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -434,6 +479,14 @@ func (g *mqlGcpProjectMonitoringServiceGroup) id() (string, error) {
 }
 
 func (g *mqlGcpProjectMonitoringService) groups() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -481,6 +534,14 @@ func (g *mqlGcpProjectMonitoringService) groups() ([]any, error) {
 }
 
 func (g *mqlGcpProjectMonitoringService) dashboards() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -557,6 +618,14 @@ func (g *mqlGcpProjectMonitoringServiceDashboard) id() (string, error) {
 }
 
 func (g *mqlGcpProjectMonitoringService) services() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}

--- a/providers/gcp/resources/pubsub.go
+++ b/providers/gcp/resources/pubsub.go
@@ -908,6 +908,14 @@ func lastPathSegment(s string) string {
 }
 
 func (g *mqlGcpProjectPubsubService) schemas() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}

--- a/providers/gcp/resources/service_gate_test.go
+++ b/providers/gcp/resources/service_gate_test.go
@@ -159,3 +159,128 @@ func isResolveEnabledForwarder(fn *ast.FuncDecl) bool {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	return ok && sel.Sel.Name == "resolveEnabled"
 }
+
+// TestGatedServiceCollectionsConsultTheGate closes the gap the two tests above
+// leave open.
+//
+// They police the gate's mechanism -- that nobody grows a parallel one, that
+// isEnabled() stays a forwarder. Neither notices a service that embeds the gate
+// and then never asks it. That is not hypothetical: vertexai carried 25
+// collections and monitoring 7, none of which consulted any gate, so on a
+// project with the API switched off every one of them spent a doomed call per
+// region and returned an authoritative empty list.
+//
+// Scope is deliberately narrow. Only resources whose Internal struct embeds
+// serviceGate are checked -- those are the ones that opted in, so there is no
+// judgement call about which services ought to be gated and no false failure on
+// one that should not be.
+func TestGatedServiceCollectionsConsultTheGate(t *testing.T) {
+	paths, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob package sources: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	files := map[string]*ast.File{}
+	for _, path := range paths {
+		if strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, ".lr.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		files[path] = f
+	}
+
+	// Resource types whose Internal struct embeds serviceGate.
+	gated := map[string]bool{}
+	for _, f := range files {
+		ast.Inspect(f, func(n ast.Node) bool {
+			ts, ok := n.(*ast.TypeSpec)
+			if !ok || !strings.HasSuffix(ts.Name.Name, "Internal") {
+				return true
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok {
+				return true
+			}
+			for _, field := range st.Fields.List {
+				if len(field.Names) != 0 {
+					continue // named field, not an embed
+				}
+				if id, ok := field.Type.(*ast.Ident); ok && id.Name == "serviceGate" {
+					gated[strings.TrimSuffix(ts.Name.Name, "Internal")] = true
+				}
+			}
+			return true
+		})
+	}
+	require.NotEmpty(t, gated, "no gated services found; this test would pass vacuously")
+
+	for _, f := range files {
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || fn.Body == nil || len(fn.Recv.List) != 1 {
+				continue
+			}
+			star, ok := fn.Recv.List[0].Type.(*ast.StarExpr)
+			if !ok {
+				continue
+			}
+			recv, ok := star.X.(*ast.Ident)
+			if !ok || !gated[recv.Name] {
+				continue
+			}
+			// Only collections: func() ([]any, error).
+			if !returnsAnySliceAndError(fn) {
+				continue
+			}
+			if fn.Name.Name == "isEnabled" || callsIsEnabled(fn) {
+				continue
+			}
+			t.Errorf("%s: %s.%s() lists without consulting the service gate. "+
+				"On a project with the API disabled it spends calls that cannot "+
+				"succeed and returns an empty list as fact. Start it with "+
+				"`enabled, err := g.isEnabled()`.",
+				fset.Position(fn.Pos()), recv.Name, fn.Name.Name)
+		}
+	}
+}
+
+func returnsAnySliceAndError(fn *ast.FuncDecl) bool {
+	// Collections take no arguments. A shared helper that happens to return the
+	// same pair (vertexai listAcrossRegions) is not an accessor, and is reached
+	// only from ones that are already gated.
+	if fn.Type.Params != nil && len(fn.Type.Params.List) != 0 {
+		return false
+	}
+	if fn.Type.Results == nil || len(fn.Type.Results.List) != 2 {
+		return false
+	}
+	arr, ok := fn.Type.Results.List[0].Type.(*ast.ArrayType)
+	if !ok {
+		return false
+	}
+	elem, ok := arr.Elt.(*ast.Ident)
+	if !ok || elem.Name != "any" {
+		return false
+	}
+	errIdent, ok := fn.Type.Results.List[1].Type.(*ast.Ident)
+	return ok && errIdent.Name == "error"
+}
+
+func callsIsEnabled(fn *ast.FuncDecl) bool {
+	found := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "isEnabled" {
+			found = true
+		}
+		return true
+	})
+	return found
+}

--- a/providers/gcp/resources/services.go
+++ b/providers/gcp/resources/services.go
@@ -66,6 +66,7 @@ const (
 	service_networkconnectivity = "networkconnectivity.googleapis.com"
 	service_networkmanagement   = "networkmanagement.googleapis.com"
 	service_memcache            = "memcache.googleapis.com"
+	service_monitoring          = "monitoring.googleapis.com"
 	service_aiplatform          = "aiplatform.googleapis.com"
 	service_datastream          = "datastream.googleapis.com"
 	service_memorystore         = "memorystore.googleapis.com"

--- a/providers/gcp/resources/vertexai.go
+++ b/providers/gcp/resources/vertexai.go
@@ -73,6 +73,7 @@ func vertexaiEndpoint(region string) string {
 }
 
 type mqlGcpProjectVertexaiServiceInternal struct {
+	serviceGate
 	// skippedRegions tracks regions where the API is not available, keyed by
 	// resource kind. It MUST be per-kind: Vertex AI sub-services have very
 	// different regional footprints (the RAG data service is available in a
@@ -133,7 +134,24 @@ func (g *mqlGcpProject) vertexai() (*mqlGcpProjectVertexaiService, error) {
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectVertexaiService), nil
+
+	serviceEnabled, err := g.isServiceEnabled(service_aiplatform)
+	if err != nil {
+		return nil, err
+	}
+
+	svc := res.(*mqlGcpProjectVertexaiService)
+	svc.recordEnabled(serviceEnabled)
+	if !serviceEnabled {
+		log.Debug().Str("service", service_aiplatform).Msg("gcp service is not enabled, skipping")
+	}
+
+	return svc, nil
+}
+
+// isEnabled reports whether the API is enabled on this project.
+func (g *mqlGcpProjectVertexaiService) isEnabled() (bool, error) {
+	return g.resolveEnabled(g.MqlRuntime, g.ProjectId, service_aiplatform)
 }
 
 func initGcpProjectVertexaiService(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -215,6 +233,14 @@ func (g *mqlGcpProjectVertexaiService) listAcrossRegions(
 }
 
 func (g *mqlGcpProjectVertexaiService) models() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -329,6 +355,14 @@ func (g *mqlGcpProjectVertexaiServiceModel) id() (string, error) {
 }
 
 func (g *mqlGcpProjectVertexaiService) endpoints() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -635,6 +669,14 @@ func (d *mqlGcpProjectVertexaiServiceEndpointDeployment) serviceAccount() (*mqlG
 }
 
 func (g *mqlGcpProjectVertexaiService) pipelineJobs() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -793,6 +835,14 @@ func (g *mqlGcpProjectVertexaiServiceIndexEndpoint) networkRef() (*mqlGcpProject
 }
 
 func (g *mqlGcpProjectVertexaiService) datasets() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -872,6 +922,14 @@ func (g *mqlGcpProjectVertexaiServiceDataset) id() (string, error) {
 }
 
 func (g *mqlGcpProjectVertexaiService) featureOnlineStores() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -967,6 +1025,14 @@ func (g *mqlGcpProjectVertexaiServiceTensorboard) id() (string, error) {
 }
 
 func (g *mqlGcpProjectVertexaiService) tensorboards() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -1415,6 +1481,14 @@ func mqlVertexAICustomJobFromProto(runtime *plugin.Runtime, job *aiplatformpb.Cu
 }
 
 func (g *mqlGcpProjectVertexaiService) customJobs() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -1475,6 +1549,14 @@ func (g *mqlGcpProjectVertexaiServiceIndex) id() (string, error) {
 }
 
 func (g *mqlGcpProjectVertexaiService) indexes() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -1571,6 +1653,14 @@ func (g *mqlGcpProjectVertexaiServiceIndexEndpoint) id() (string, error) {
 }
 
 func (g *mqlGcpProjectVertexaiService) indexEndpoints() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -1659,6 +1749,14 @@ func (g *mqlGcpProjectVertexaiServiceMetadataStore) id() (string, error) {
 }
 
 func (g *mqlGcpProjectVertexaiService) metadataStores() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -1733,6 +1831,14 @@ func (g *mqlGcpProjectVertexaiService) metadataStores() ([]any, error) {
 }
 
 func (g *mqlGcpProjectVertexaiService) notebookRuntimes() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -1851,6 +1957,14 @@ func (g *mqlGcpProjectVertexaiServiceNotebookRuntime) id() (string, error) {
 }
 
 func (g *mqlGcpProjectVertexaiService) notebookRuntimeTemplates() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -1976,6 +2090,14 @@ func (g *mqlGcpProjectVertexaiServiceNotebookRuntimeTemplate) id() (string, erro
 }
 
 func (g *mqlGcpProjectVertexaiService) notebookExecutionJobs() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -2060,6 +2182,14 @@ func (g *mqlGcpProjectVertexaiServiceNotebookExecutionJob) id() (string, error) 
 }
 
 func (g *mqlGcpProjectVertexaiService) reasoningEngines() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -2160,6 +2290,14 @@ func (a *mqlGcpProjectVertexaiServiceReasoningEngine) serviceAccount() (*mqlGcpP
 }
 
 func (g *mqlGcpProjectVertexaiService) ragCorpora() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -2234,6 +2372,14 @@ func (g *mqlGcpProjectVertexaiServiceRagCorpus) id() (string, error) {
 }
 
 func (g *mqlGcpProjectVertexaiService) featureGroups() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -2303,6 +2449,14 @@ func (g *mqlGcpProjectVertexaiServiceFeatureGroup) id() (string, error) {
 }
 
 func (g *mqlGcpProjectVertexaiService) persistentResources() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -2391,6 +2545,14 @@ func (g *mqlGcpProjectVertexaiServicePersistentResource) id() (string, error) {
 }
 
 func (g *mqlGcpProjectVertexaiService) schedules() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -2537,6 +2699,14 @@ func initGcpProjectVertexaiServiceSchedule(runtime *plugin.Runtime, args map[str
 }
 
 func (g *mqlGcpProjectVertexaiService) deploymentResourcePools() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -2612,6 +2782,14 @@ func (g *mqlGcpProjectVertexaiServiceDeploymentResourcePool) id() (string, error
 }
 
 func (g *mqlGcpProjectVertexaiService) cachedContents() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -2687,6 +2865,14 @@ func (g *mqlGcpProjectVertexaiServiceCachedContent) id() (string, error) {
 }
 
 func (g *mqlGcpProjectVertexaiService) batchPredictionJobs() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -2776,6 +2962,14 @@ func (g *mqlGcpProjectVertexaiServiceBatchPredictionJob) id() (string, error) {
 }
 
 func (g *mqlGcpProjectVertexaiService) tuningJobs() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -2865,6 +3059,14 @@ func (g *mqlGcpProjectVertexaiServiceTuningJob) id() (string, error) {
 }
 
 func (g *mqlGcpProjectVertexaiService) trainingPipelines() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -2948,6 +3150,14 @@ func (g *mqlGcpProjectVertexaiServiceTrainingPipeline) id() (string, error) {
 }
 
 func (g *mqlGcpProjectVertexaiService) hyperparameterTuningJobs() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}
@@ -3039,6 +3249,14 @@ func (g *mqlGcpProjectVertexaiServiceHyperparameterTuningJob) id() (string, erro
 }
 
 func (g *mqlGcpProjectVertexaiService) modelDeploymentMonitoringJobs() ([]any, error) {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}


### PR DESCRIPTION
## The bug

`vertexai` carried **25** collections and `monitoring` **7**, none of which consulted any service gate. On a project with the API switched off, each one fanned out over its region list, got *"has not been used in project … or it is disabled"* from every region, classified that as skippable, and returned an **empty list with no error**.

An empty list is the worst available answer here. It is an authoritative "there is nothing in this project", so `gcp.project.vertexai.models.none(...)` passes vacuously rather than failing or erroring.

`servicegate.go` already says this in its own doc comment, and records the cost of the doomed calls:

> One scan of a project with Vertex AI and Memcache switched off spent 1,050 calls that way, 40% of all its API traffic, on five Get methods that could not have succeeded.

The **init** path was fixed then. The **collection** path was not.

## The fix

Both services now embed `serviceGate`, forward `isEnabled()`, and record the answer the `gcp.project.<service>()` accessor already computed — the same shape `batch`, `dataproc`, `cloudrun` and the rest use.

`monitoring` needed a `service_monitoring` constant and an Internal struct, so `gcp.lr.go` is regenerated. The diff is one line: the struct embed.

## Two more fixes fell out

**A wrong OAuth scope.** `monitoring.alertPolicies()` requested `kms.DefaultAuthScopes()`, where its six siblings request monitoring's:

```go
creds, err := conn.Credentials(kms.DefaultAuthScopes()...)   // <- Cloud KMS
```

On a credential source that honours requested scopes (a user-scoped OAuth token, a scoped service account), that one accessor asked for the Cloud KMS scope and the Monitoring API rejected the call — so `alertPolicies` errored while every sibling worked.

**Two more ungated collections.** `iam.roles()` and `pubsub.schemas()`, both on services whose other collections all gate. **The new guard test found these; neither was in the report this PR started from.**

## The guard test

`TestGatedServiceCollectionsConsultTheGate` closes the gap the existing guards leave. `TestServiceGateIsTheOnlyEnabledMechanism` and its siblings police the *mechanism* — that nobody grows a parallel one, that `isEnabled()` stays a forwarder. Neither notices a service that embeds the gate and then never asks it.

Scope is deliberately narrow: **only resources whose Internal struct embeds `serviceGate`**. Those are the ones that opted in, so there is no judgement call about which services ought to be gated, and no false failure on one that should not be.

It earned its place immediately — it is what surfaced the two extra hits above. It also caught a false positive in its own first draft (`listAcrossRegions`, a shared helper with the same return shape), which is why collections are now matched as zero-argument accessors.

## Not addressed here

`vertexai` treats a bare 403 as skippable, so a **permission gap** still degrades to an empty list even with the API enabled. That is the same failed-open class in a different place, affects roughly 50 listers provider-wide, and wants its own change.

## Test plan

- [x] `go test ./resources/` passes in full
- [x] All existing gate guards still pass
- [x] Codegen diff inspected — one line, the Internal struct embed, no schema or `.lr.versions` churn
- [x] `gofmt` clean
- [ ] Not live-verified — needs a project with Vertex AI and Cloud Monitoring disabled
