### PR TITLE
🌙 mqlc: allow escaped quotes inside string literals

### DIFF
--- a/mqlc/parser/parser.go
+++ b/mqlc/parser/parser.go
@@ -33,7 +33,7 @@ const LexerRegex = `(\s+)` +
 	`|(?P<Ident>[a-zA-Z$_][a-zA-Z0-9_]*)` +
 	`|(?P<Float>[-+]?\d*\.\d+([eE][-+]?\d+)?)` +
 	`|(?P<Int>[-+]?\d+([eE][-+]?\d+)?)` +
-	`|(?P<String>'[^']*'|"[^"]*")` +
+	`|(?P<String>'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*")` +
 	`|(?P<Comment>(//|#)[^\n]*(\n|\z))` +
 	`|(?P<Regex>/([^\\/]+|\\.)+/[msi]*)` +
 	`|(?P<Op>[-+*/%,:.=<>!|&~;?])` +
@@ -280,7 +280,16 @@ func (p *parser) token2string() string {
 	vv := v[1 : len(v)-1]
 
 	if v[0] == '\'' {
-		return vv
+		// Single-quoted strings are raw: escape sequences are kept verbatim.
+		// The one exception is an escaped single quote, the only way to put a
+		// single quote inside single quotes. The lexer could not produce that
+		// pair before, so unescaping it here cannot change an existing literal.
+		return reUnescape.ReplaceAllStringFunc(vv, func(match string) string {
+			if match == `\'` {
+				return "'"
+			}
+			return match
+		})
 	}
 
 	vv = reUnescape.ReplaceAllStringFunc(vv, func(match string) string {

--- a/mqlc/parser/parser_test.go
+++ b/mqlc/parser/parser_test.go
@@ -456,3 +456,88 @@ func TestParser_OptionalChaining_trailingWithOperator(t *testing.T) {
 	require.Len(t, res.Expressions[0].Operations, 1)
 	assert.Equal(t, OpEqual, res.Expressions[0].Operations[0].Operator)
 }
+
+// TestParser_StringEscapes pins the escape handling of string literals. Before
+// the lexer learned about escape pairs, `"[^"]*"` ended the literal at the
+// backslash in `\"`, so `"a\"b"` lexed as the string `a\` followed by the
+// identifier `b` and an unterminated quote. The failure surfaced far from its
+// cause ("cannot find resource for identifier 'b'", or a truncated string with
+// no error at all), so every case below is asserted by value.
+func TestParser_StringEscapes(t *testing.T) {
+	tests := []struct {
+		code string
+		res  string
+	}{
+		// the bug: a double quote inside a double-quoted string
+		{`"a\"b"`, `a"b`},
+		{`"\""`, `"`},
+		{`"he said \"hi\""`, `he said "hi"`},
+		// ... and a single quote inside a single-quoted string
+		{`'a\'b'`, `a'b`},
+		{`'\''`, `'`},
+		// both quote styles in one literal, previously unrepresentable
+		{`"he said \"hi\" to 'me'"`, `he said "hi" to 'me'`},
+		{`'he said "hi" to \'me\''`, `he said "hi" to 'me'`},
+		// inline JSON, the shape that found this
+		{`"{\"a\": 1}"`, `{"a": 1}`},
+
+		// escapes that already worked and must keep their values
+		{`"a\nb"`, "a\nb"},
+		{`"a\tb"`, "a\tb"},
+		{`"a\\b"`, `a\b`},
+		{`"\\"`, `\`},
+		{`"tab\there"`, "tab\there"},
+		// an unknown escape still collapses to its second character, so a
+		// Windows path keeps losing its separators rather than changing shape
+		{`"C:\path"`, `C:path`},
+		{`""`, ``},
+
+		// single-quoted strings stay raw for everything but \'
+		{`'h\ni'`, `h\ni`},
+		{`'h\i'`, `h\i`},
+		{`'a\\b'`, `a\\b`},
+		{`''`, ``},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.code, func(t *testing.T) {
+			res, err := Parse(test.code)
+			require.NoError(t, err)
+			require.Len(t, res.Expressions, 1, "the literal must consume the whole source")
+
+			op := res.Expressions[0].Operand
+			require.NotNil(t, op)
+			require.Empty(t, op.Calls, "a bare literal must not pick up trailing calls")
+			require.NotNil(t, op.Value.String, "must parse as a string, not another value type")
+			assert.Equal(t, test.res, *op.Value.String)
+		})
+	}
+}
+
+// TestParser_StringEscapes_unterminated rejects a literal whose closing quote is
+// consumed by a trailing backslash. `"a\"` used to lex as the string `a\`; now
+// the backslash escapes the closing quote and the literal is unterminated,
+// which is a deliberate tightening.
+func TestParser_StringEscapes_unterminated(t *testing.T) {
+	for _, code := range []string{`"a\"`, `'a\'`, `"\"`, `'\'`} {
+		t.Run(code, func(t *testing.T) {
+			_, err := Parse(code)
+			assert.Error(t, err, "an unterminated string literal must not parse")
+		})
+	}
+}
+
+// TestParser_LexStringEscapes checks that an escaped quote stays inside one
+// String token instead of splitting the source into three.
+func TestParser_LexStringEscapes(t *testing.T) {
+	for _, code := range []string{`"a\"b"`, `'a\'b'`, `"a\\"`, `'a\\'`} {
+		t.Run(code, func(t *testing.T) {
+			res, err := Lex(code)
+			require.NoError(t, err)
+			require.Len(t, res, 1, "the whole literal must be a single token")
+			assert.Equal(t, String, res[0].Type)
+			assert.Equal(t, code, res[0].Value)
+		})
+	}
+}


### PR DESCRIPTION
## The bug

A double quote cannot appear inside an MQL double-quoted string.

```
$ mql run local -c '"a\"b".length'
FTL failed to run query error="failed to run: cannot find resource for identifier 'b'"

$ mql run local -c 'parse.json(content: "{\"a\": 1}").params'
[failed to compile: expected closing ')', got '' at <source>:0:0
```

The String token in the lexer is `'[^']*'|"[^"]*"` — no provision for an escape
pair. The literal terminates at the backslash and the remainder (`b"`) is
re-lexed as source, which is why the error names a bogus identifier rather than
a string problem. `'a\'b'` fails the same way, so a string carrying both quote
styles was unrepresentable altogether. Worst case it is silent: `Parse("\"a\\\"b\"")`
returned the truncated string `a\` plus a second expression, with no error.

`token2string` already implements the unescape, including a `return string(match[1])`
fallback that maps `\"` to `"`. That branch was simply unreachable for the quote
character, because the lexer never produced such a token.

## The fix

```diff
-	`|(?P<String>'[^']*'|"[^"]*")` +
+	`|(?P<String>'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*")` +
```

This is the shape the Regex token two lines down already uses
(`/([^\\/]+|\\.)+/`). Non-capturing groups, so the participle lexer's
"first non-nil subgroup wins" scan is unaffected.

Verified end to end with a build of this branch:

```
"a\"b".length                              length: 3
parse.json(content: "{\"a\": 1}").params   {a: 1}
"he said \"hi\" to 'me'"                   he said "hi" to 'me'
```

## Two behaviour decisions

**Single-quoted strings stay raw, except for `\'`.** `token2string` returns
single-quoted literals verbatim (`'h\ni'` is the four characters `h\ni`, pinned
by an existing test), and that is unchanged. The exception is `\'`, which now
unescapes to `'`. The lexer could not produce that pair before — an unescaped
`'` always closed the literal — so no existing single-quoted string can contain
it, and unescaping it cannot alter any existing value. The alternative, leaving
it raw, would make the newly-lexable `'a\'b'` evaluate to the surprising `a\'b`;
nobody writes that pair meaning anything but a quote.

**A literal ending in a lone backslash is now a parse error.** `"a\"` used to
lex as the two-character string `a\`. The backslash now escapes the closing
quote, leaving the literal unterminated. This is a deliberate tightening and the
only backwards-incompatible case; it is covered by
`TestParser_StringEscapes_unterminated`.

## Backwards compatibility

Every case below was run through `Parse` before and after the change:

| source | before | after |
|---|---|---|
| `"a\nb"` | `a`,LF,`b` (len 3) | same |
| `"a\tb"` | `a`,TAB,`b` (len 3) | same |
| `"a\\b"` | `a\b` (len 3) | same |
| `"\\"` | `\` (len 1) | same |
| `"tab\there"` | `tab`,TAB,`here` | same |
| `"C:\path"` | `C:path` | same |
| `'h\ni'` | `h\ni` (raw, len 4) | same |
| `'h\i'` | `h\i` (raw) | same |
| `"a\"b"` | `a\` + stray `b"` | `a"b` |
| `'a\'b'` | `a\` + stray `b'` | `a'b` |
| `"a\"` | `a\` | parse error |

`"C:\path"` keeps mapping the unknown escape `\p` to `p`, giving `C:path`. That
is unchanged, and pinned by a test so the shape cannot drift silently.

## Tests

`mqlc/parser/parser_test.go` gains three tests. Each of the new escaped-quote
cases was confirmed red against the unfixed lexer (14 failing subtests) before
the parser change was applied:

- `TestParser_StringEscapes` — value assertions for `"a\"b"`, `'a\'b'`, mixed
  quotes in one literal, inline JSON, plus the `\n` / `\t` / `\\` / `C:\path` /
  raw-single-quote cases as regression pins.
- `TestParser_StringEscapes_unterminated` — a trailing lone backslash is rejected.
- `TestParser_LexStringEscapes` — the whole literal lexes as one `String` token
  rather than splitting into three.

`go test ./mqlc/...` passes. The one failure in `./llx/`
(`TestRawDataJson_Umlauts`) is pre-existing on `main` and unrelated.
