### PR TITLE
🐛 pomxml: key dependencyManagement on the identity Maven keys it on

### DIFF
--- a/providers/os/resources/languages/java/pomxml/extractor.go
+++ b/providers/os/resources/languages/java/pomxml/extractor.go
@@ -111,7 +111,7 @@ func (p *pomProject) depToPackage(dep pomDependency) *languages.Package {
 		// No <version> on the dependency: the project's <dependencyManagement>
 		// is where it is declared, which is the standard way a multi-module
 		// project states a version once.
-		version = p.resolve(p.managedVersion(groupId, artifactId))
+		version = p.resolve(p.managedVersion(dep))
 	}
 
 	name := artifactId

--- a/providers/os/resources/languages/java/pomxml/extractor_test.go
+++ b/providers/os/resources/languages/java/pomxml/extractor_test.go
@@ -399,3 +399,104 @@ func TestPomXmlLicenseIsBounded(t *testing.T) {
 	assert.Equal(t, "MIT", p.Root().License,
 		"an oversized name is dropped without taking its sibling with it")
 }
+
+// Maven matches a dependency against <dependencyManagement> on groupId,
+// artifactId, type and classifier. The same groupId:artifactId is routinely
+// published as more than one artifact, and a POM versions each separately, so
+// matching on the coordinates alone returns whichever entry happens to come
+// first: a wrong version, and with it a wrong set of advisories.
+func TestPomXmlManagedMatchUsesTypeAndClassifier(t *testing.T) {
+	t.Run("a test-jar takes the test-jar's version", func(t *testing.T) {
+		p := parsePom(t, `<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.example</groupId><artifactId>app</artifactId><version>1.0</version>
+  <dependencyManagement><dependencies>
+    <dependency><groupId>g</groupId><artifactId>a</artifactId><version>1.0</version></dependency>
+    <dependency><groupId>g</groupId><artifactId>a</artifactId><type>test-jar</type><version>2.0</version></dependency>
+  </dependencies></dependencyManagement>
+  <dependencies>
+    <dependency><groupId>g</groupId><artifactId>a</artifactId><type>test-jar</type></dependency>
+  </dependencies>
+</project>`)
+		assert.Equal(t, "2.0", packagesByName(p.Transitive())["g:a"].Version)
+	})
+
+	t.Run("the plain jar still takes the plain jar's version", func(t *testing.T) {
+		p := parsePom(t, `<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.example</groupId><artifactId>app</artifactId><version>1.0</version>
+  <dependencyManagement><dependencies>
+    <dependency><groupId>g</groupId><artifactId>a</artifactId><type>test-jar</type><version>2.0</version></dependency>
+    <dependency><groupId>g</groupId><artifactId>a</artifactId><version>1.0</version></dependency>
+  </dependencies></dependencyManagement>
+  <dependencies>
+    <dependency><groupId>g</groupId><artifactId>a</artifactId></dependency>
+  </dependencies>
+</project>`)
+		assert.Equal(t, "1.0", packagesByName(p.Transitive())["g:a"].Version)
+	})
+
+	// A native library published per platform is the ordinary classifier case.
+	t.Run("a classifier selects its own entry", func(t *testing.T) {
+		p := parsePom(t, `<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.example</groupId><artifactId>app</artifactId><version>1.0</version>
+  <dependencyManagement><dependencies>
+    <dependency><groupId>g</groupId><artifactId>a</artifactId><version>1.0</version></dependency>
+    <dependency><groupId>g</groupId><artifactId>a</artifactId><classifier>linux-x86_64</classifier><version>2.0</version></dependency>
+  </dependencies></dependencyManagement>
+  <dependencies>
+    <dependency><groupId>g</groupId><artifactId>a</artifactId><classifier>linux-x86_64</classifier></dependency>
+  </dependencies>
+</project>`)
+		assert.Equal(t, "2.0", packagesByName(p.Transitive())["g:a"].Version)
+	})
+
+	// Maven assumes type jar when none is stated, so the two spellings are the
+	// same artifact and have to match each other.
+	t.Run("an explicit jar type matches an entry that states none", func(t *testing.T) {
+		p := parsePom(t, `<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.example</groupId><artifactId>app</artifactId><version>1.0</version>
+  <dependencyManagement><dependencies>
+    <dependency><groupId>g</groupId><artifactId>a</artifactId><version>1.0</version></dependency>
+  </dependencies></dependencyManagement>
+  <dependencies>
+    <dependency><groupId>g</groupId><artifactId>a</artifactId><type>jar</type></dependency>
+  </dependencies>
+</project>`)
+		assert.Equal(t, "1.0", packagesByName(p.Transitive())["g:a"].Version)
+	})
+
+	// The key is property-resolved like the coordinates, because either side
+	// may write any part of it as a reference.
+	t.Run("a property in the type still matches", func(t *testing.T) {
+		p := parsePom(t, `<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.example</groupId><artifactId>app</artifactId><version>1.0</version>
+  <properties><art.type>test-jar</art.type></properties>
+  <dependencyManagement><dependencies>
+    <dependency><groupId>g</groupId><artifactId>a</artifactId><type>test-jar</type><version>2.0</version></dependency>
+  </dependencies></dependencyManagement>
+  <dependencies>
+    <dependency><groupId>g</groupId><artifactId>a</artifactId><type>${art.type}</type></dependency>
+  </dependencies>
+</project>`)
+		assert.Equal(t, "2.0", packagesByName(p.Transitive())["g:a"].Version)
+	})
+}
+
+// The managed scope is read off the same key, so an incomplete key leaks a test
+// dependency into the production set: the test-jar below matched the plain
+// jar's entry, which states no scope, and was reported as production.
+func TestPomXmlManagedScopeUsesTheFullKey(t *testing.T) {
+	p := parsePom(t, `<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.example</groupId><artifactId>app</artifactId><version>1.0</version>
+  <dependencyManagement><dependencies>
+    <dependency><groupId>g</groupId><artifactId>a</artifactId><version>1.0</version></dependency>
+    <dependency><groupId>g</groupId><artifactId>a</artifactId><type>test-jar</type><version>2.0</version><scope>test</scope></dependency>
+  </dependencies></dependencyManagement>
+  <dependencies>
+    <dependency><groupId>g</groupId><artifactId>a</artifactId><type>test-jar</type></dependency>
+  </dependencies>
+</project>`)
+
+	assert.NotContains(t, packagesByName(p.Direct()), "g:a",
+		"a managed test scope on the test-jar must keep it out of the production set")
+	assert.Equal(t, "2.0", packagesByName(p.Transitive())["g:a"].Version)
+}

--- a/providers/os/resources/languages/java/pomxml/parser.go
+++ b/providers/os/resources/languages/java/pomxml/parser.go
@@ -23,10 +23,15 @@ type pomProject struct {
 	// the dependency's version is the literal property reference, which matches
 	// no package and no advisory.
 	Properties pomProperties `xml:"properties"`
-	// DependencyManagement holds versions declared once for the whole project
-	// (or imported from a BOM). A <dependency> under <dependencies> may then
-	// omit its <version> entirely, and the version stated here is the one that
-	// applies.
+	// DependencyManagement holds versions declared once for the whole project.
+	// A <dependency> under <dependencies> may then omit its <version> entirely,
+	// and the version stated here is the one that applies.
+	//
+	// Only entries written in this POM are read. A <scope>import</scope> entry
+	// names a BOM whose own dependencyManagement supplies the versions, and
+	// reading that needs the BOM artifact, which is not available from the file
+	// on disk. A dependency versioned only by an imported BOM therefore reports
+	// no version rather than a guessed one.
 	DependencyManagement struct {
 		Dependencies []pomDependency `xml:"dependencies>dependency"`
 	} `xml:"dependencyManagement"`
@@ -173,9 +178,10 @@ func (p *pomProject) property(name string) (string, bool) {
 // matches only when they happen to be spelled the same way, and a miss is
 // silent: the dependency simply comes out with no version, which is the outcome
 // resolving versions at all was meant to prevent.
-func (p *pomProject) managedDependency(groupId, artifactId string) (pomDependency, bool) {
+func (p *pomProject) managedDependency(dep pomDependency) (pomDependency, bool) {
+	want := p.managementKey(dep)
 	for _, m := range p.DependencyManagement.Dependencies {
-		if p.resolve(m.GroupId) == groupId && p.resolve(m.ArtifactId) == artifactId {
+		if p.managementKey(m) == want {
 			return m, true
 		}
 	}
@@ -184,8 +190,8 @@ func (p *pomProject) managedDependency(groupId, artifactId string) (pomDependenc
 
 // managedVersion returns the version <dependencyManagement> declares for a
 // dependency, which is what applies when the <dependency> states none.
-func (p *pomProject) managedVersion(groupId, artifactId string) string {
-	m, ok := p.managedDependency(groupId, artifactId)
+func (p *pomProject) managedVersion(dep pomDependency) string {
+	m, ok := p.managedDependency(dep)
 	if !ok {
 		return ""
 	}
@@ -205,7 +211,7 @@ func (p *pomProject) effectiveScope(dep pomDependency) string {
 	if scope := p.resolve(dep.Scope); scope != "" {
 		return scope
 	}
-	m, ok := p.managedDependency(p.resolve(dep.GroupId), p.resolve(dep.ArtifactId))
+	m, ok := p.managedDependency(dep)
 	if !ok {
 		return ""
 	}
@@ -256,6 +262,35 @@ type pomDependency struct {
 	Version    string `xml:"version"`
 	Scope      string `xml:"scope"`
 	Optional   string `xml:"optional"`
+	// Type and Classifier complete the identity Maven keys a dependency on.
+	// The same groupId:artifactId is routinely published as more than one
+	// artifact -- the jar and its test-jar, or a native library built per
+	// platform -- and dependencyManagement versions each of them separately.
+	// Matching without these picks whichever entry comes first.
+	Type       string `xml:"type"`
+	Classifier string `xml:"classifier"`
+}
+
+// defaultDependencyType is the type Maven assumes when a dependency states
+// none, so an entry written without <type> and one written as <type>jar</type>
+// are the same artifact and have to compare equal.
+const defaultDependencyType = "jar"
+
+// managementKey is the identity Maven matches a dependency against
+// dependencyManagement on: groupId, artifactId, type and classifier. Every part
+// is property-resolved for the same reason the coordinates are, since either
+// side may write any of them as a reference.
+func (p *pomProject) managementKey(dep pomDependency) [4]string {
+	typ := strings.TrimSpace(p.resolve(dep.Type))
+	if typ == "" {
+		typ = defaultDependencyType
+	}
+	return [4]string{
+		strings.TrimSpace(p.resolve(dep.GroupId)),
+		strings.TrimSpace(p.resolve(dep.ArtifactId)),
+		typ,
+		strings.TrimSpace(p.resolve(dep.Classifier)),
+	}
 }
 
 // effectiveGroupId returns the project's groupId, inheriting from parent if not set.


### PR DESCRIPTION
Follow-up to #10545.

## The gap

Maven matches a dependency against `<dependencyManagement>` on groupId, artifactId, **type** and **classifier**. pomxml matched on the coordinates alone, and `pomDependency` did not parse the other two at all — so a POM managing the same `groupId:artifactId` as more than one artifact got whichever entry came first.

That is not an exotic shape. A jar and its test-jar, or a native library published per platform, are the ordinary reasons a POM lists the same coordinates twice:

```xml
<dependencyManagement>
  <dependency>g:a               version 1.0</dependency>
  <dependency>g:a type=test-jar version 2.0</dependency>
</dependencyManagement>
<dependencies>
  <dependency>g:a type=test-jar</dependency>   <!-- Maven resolves 2.0 -->
</dependencies>
```

Reported `1.0`. A package reported at the wrong version is matched against the wrong advisories.

**The scope side of the same lookup fails with it, which is the worse half.** The test-jar above matched the plain jar's entry, which states no scope, so a dependency Maven scopes to `test` was reported as production — the leak #10545 closed for a dependency stating no scope of its own, reappearing through an incomplete key.

## The change

`pomDependency` carries `Type` and `Classifier`, and the lookup compares the full four-part key. An absent type is `jar`, as Maven assumes, so an entry written without `<type>` and one written as `<type>jar</type>` are the same artifact. Every part is property-resolved for the same reason the coordinates already are.

Also corrects the `DependencyManagement` doc comment, which claimed versions may come from a BOM import. They cannot: a `<scope>import</scope>` entry names a BOM whose own `dependencyManagement` supplies them, and reading it needs the BOM artifact, which is not on disk. A dependency versioned only by an imported BOM reports no version rather than a guessed one, and the comment now says so instead of implying support that was never there.

## Not changed

The purl still omits type and classifier. Adding them would change the identity of packages already reported, which is a migration rather than a fix.

## Tests

Six new assertions covering the test-jar, the plain jar picked out of a reordered management block, a classifier, the implicit-vs-explicit `jar` equivalence, a property inside the type, and the scope leak. All fail against the coordinates-only key, confirmed by reverting it. `go test ./resources/languages/java/...` green.
