### PR TITLE
🐛 java: tell an OSGi license list from a name that contains a comma

### DIFF
--- a/providers/os/resources/languages/java/manifestmf/license.go
+++ b/providers/os/resources/languages/java/manifestmf/license.go
@@ -90,12 +90,24 @@ func (m *manifest) license() string {
 	// The grammar makes ',' a separator between licenses, but real manifests
 	// also write an identifier that contains one: "The Apache License, Version
 	// 2.0;link=..." is a single license, and it is what Eclipse/Tycho bundles
-	// emit. Nothing distinguishes that from a genuine two-license header, so
-	// the members are rejoined into one value rather than OR-joined. Rejoining
-	// reproduces what the manifest said; OR-joining would report a bundle as
-	// dual-licensed under "The Apache License" or "Version 2.0", inventing a
-	// choice the bundle never offered.
+	// emit. The two shapes are told apart by what the pieces look like. A
+	// header whose every piece is identifier-shaped is a genuine list, and
+	// OR-joining it says what OSGi means by a list: the bundle is offered under
+	// any of them. A header with a piece that is not, like "Version 2.0", is
+	// one name that happens to contain a comma, and its pieces are rejoined.
 	//
+	// The conservative direction is deliberate. Rejoining a genuine list
+	// reproduces what the manifest said and loses only the OR; OR-joining a
+	// split name would report a bundle as dual-licensed under "The Apache
+	// License" or "Version 2.0", a choice it never offered. So anything not
+	// clearly a list is rejoined, which also leaves an operand like
+	// "GPL-2.0-only WITH Classpath-exception-2.0" alone rather than guessing.
+	if len(names) > 1 && allIdentifierShaped(names) {
+		// LicenseExpression applies the shared bounds and the parenthesisation
+		// that keeps the result valid inside a larger expression.
+		return languages.LicenseExpression(names)
+	}
+
 	// The rejoined value carries the same total bound as an OR-joined one: past
 	// it the header is not a license statement, and the whole value is dropped
 	// rather than part of it kept, which would report a bundle as licensed
@@ -105,6 +117,37 @@ func (m *manifest) license() string {
 		return ""
 	}
 	return joined
+}
+
+// allIdentifierShaped reports whether every value could be a bare license
+// identifier: one token of the characters identifiers actually use.
+//
+// It deliberately does not check against the SPDX list. This package reports
+// what a manifest stated rather than what it recognises, and an unlisted
+// identifier is still an identifier; the question here is only whether the
+// comma separated two names or split one.
+func allIdentifierShaped(names []string) bool {
+	for _, n := range names {
+		if !identifierShaped(n) {
+			return false
+		}
+	}
+	return true
+}
+
+func identifierShaped(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '-' || r == '.' || r == '+' || r == '_':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // licenseIdentifier returns the license-identifier of one entry: everything

--- a/providers/os/resources/languages/java/manifestmf/license_test.go
+++ b/providers/os/resources/languages/java/manifestmf/license_test.go
@@ -65,11 +65,12 @@ func TestManifestLicense(t *testing.T) {
 			want:   "Apache-2.0",
 		},
 		{
-			// Two licenses, both stated as identifiers. Rejoined rather than
-			// OR-joined, because a comma here is not reliably a separator.
+			// Two licenses, both stated as identifiers. Every piece is
+			// identifier-shaped, so the comma really is the separator the
+			// grammar says it is and the bundle is offering a choice.
 			name:   "two identifiers",
 			header: `Bundle-License: MIT;link="https://opensource.org/licenses/MIT",Apache-2.0;link="https://www.apache.org/licenses/LICENSE-2.0"`,
-			want:   "MIT, Apache-2.0",
+			want:   "(MIT OR Apache-2.0)",
 		},
 		{
 			// The most common real header by a wide margin, and the reason
@@ -244,5 +245,63 @@ func TestBundleLicenseDropsSchemelessURLs(t *testing.T) {
 	} {
 		m := &manifest{Headers: map[string]string{headerBundleLicense: tc.header}}
 		assert.Equal(t, tc.want, m.license(), "Bundle-License: %s", tc.header)
+	}
+}
+
+// OSGi's grammar makes ',' a separator between licenses, but manifests also
+// write a name that contains one. Which it is, is decided by what the pieces
+// look like: all identifier-shaped means the comma separated two licenses, and
+// the bundle is offering a choice, which is SPDX's OR. Anything else is treated
+// as one name that happens to contain a comma.
+//
+// The asymmetry is deliberate. Rejoining a genuine list loses only the OR;
+// OR-joining a split name would report a bundle as dual-licensed under terms it
+// never offered, so anything not clearly a list is rejoined.
+func TestBundleLicenseTellsAListFromANameWithAComma(t *testing.T) {
+	for _, tc := range []struct{ name, header, want string }{
+		{
+			"a list of identifiers is a choice",
+			"MIT,Apache-2.0",
+			"(MIT OR Apache-2.0)",
+		},
+		{
+			"three of them",
+			"MIT, Apache-2.0, BSD-3-Clause",
+			"(MIT OR Apache-2.0 OR BSD-3-Clause)",
+		},
+		{
+			// The Eclipse/Tycho shape: one license whose name carries a comma.
+			"a name containing a comma is one license",
+			"The Apache License, Version 2.0",
+			"The Apache License, Version 2.0",
+		},
+		{
+			// Not clearly a list, so left alone rather than guessed at.
+			"a piece that is not an identifier keeps the whole thing joined",
+			"MIT, GPL-2.0-only WITH Classpath-exception-2.0",
+			"MIT, GPL-2.0-only WITH Classpath-exception-2.0",
+		},
+		{
+			"a single identifier is unchanged",
+			"Apache-2.0",
+			"Apache-2.0",
+		},
+		{
+			"a single name is unchanged",
+			"Eclipse Public License v2.0",
+			"Eclipse Public License v2.0",
+		},
+		{
+			// A link beside a name leaves one entry, so there is no list to
+			// join and no parentheses to add.
+			"a dropped link leaves a single license alone",
+			"Apache-2.0, www.apache.org/licenses/LICENSE-2.0",
+			"Apache-2.0",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &manifest{Headers: map[string]string{headerBundleLicense: tc.header}}
+			assert.Equal(t, tc.want, m.license())
+		})
 	}
 }


### PR DESCRIPTION
Follow-up to #10578.

## The gap

`Bundle-License` uses `,` as the separator between licenses. #10578 rejoined the pieces into one value rather than OR-joining them, on the grounds that nothing distinguishes a genuine list from a single name carrying a comma. Its own test case shows the cost:

```
Bundle-License: MIT;link="...",Apache-2.0;link="..."   →  "MIT, Apache-2.0"
```

Two licenses reported as one, and the value is not an SPDX expression in a field documented as holding one. Now that #10579 carries the license into generated SBOMs, it reaches SPDX `licenseDeclared`, where a consumer either rejects the document or reads a license that does not exist.

## Something does distinguish them

What the pieces look like. A header whose every piece is identifier-shaped is a genuine list, and OR-joining says what OSGi means by one:

| header | before | after |
|---|---|---|
| `MIT,Apache-2.0` | `MIT, Apache-2.0` | `(MIT OR Apache-2.0)` |
| `The Apache License, Version 2.0` | unchanged | unchanged |
| `MIT, GPL-2.0-only WITH Classpath-exception-2.0` | unchanged | unchanged |
| `Apache-2.0` | unchanged | unchanged |

**The asymmetry is deliberate**, and it is why the check is shape-based rather than list-based. Rejoining a genuine list reproduces what the manifest said and loses only the `OR`. OR-joining a split name would report a bundle as dual-licensed under "The Apache License" or "Version 2.0" — a choice it never offered. So anything not clearly a list stays joined, which also leaves an operand like `GPL-2.0-only WITH Classpath-exception-2.0` alone rather than guessing at it.

Identifiers are not checked against the SPDX list: this package reports what a manifest stated rather than what it recognises, and the question here is only whether the comma separated two names or split one.

A list goes through `languages.LicenseExpression` like every other extractor, so it picks up the shared bounds and the parenthesisation that keeps the result valid inside a larger expression.

## Behaviour change

#10578's `two identifiers` case pinned the old output and is updated — that is the one behaviour change here. Every other case in that table is unchanged, the fixtures included. The new table fails when the discrimination is removed, confirmed by reverting it.
