### PR TITLE
🧹 manifestmf: export the Bundle-License parsing so it has one implementation

### DIFF
--- a/providers/os/resources/languages/java/manifestmf/license.go
+++ b/providers/os/resources/languages/java/manifestmf/license.go
@@ -53,7 +53,25 @@ var urlPattern = regexp.MustCompile(`^([a-zA-Z][a-zA-Z0-9+.\-]*://|[a-zA-Z0-9\-]
 // The value is returned as the manifest wrote it. Normalizing a name to a
 // canonical SPDX identifier is a consumer's decision, not a parser's.
 func (m *manifest) license() string {
-	raw := strings.TrimSpace(m.Headers[headerBundleLicense])
+	return ParseBundleLicense(m.Headers[headerBundleLicense])
+}
+
+// ParseBundleLicense returns the license an OSGi Bundle-License header states,
+// or "" when it states none this can name.
+//
+// Exported because a MANIFEST.MF is read by more than the inventory path. A
+// scanner that has already opened a jar's manifest for its own reasons needs
+// the same answer this gives, and the alternative — a second reader of the
+// same header somewhere else — is a reader that will not know about the
+// external marker, or schemeless URLs, or a comma inside a quoted attribute,
+// and will report a different license for the same jar than mql does.
+//
+// The header value is the whole input, so nothing else about the manifest has
+// to be shared. Unfolding continuation lines and looking the header up
+// case-insensitively stay with the caller's manifest reader; this names only
+// the value.
+func ParseBundleLicense(header string) string {
+	raw := strings.TrimSpace(header)
 	if raw == "" {
 		return ""
 	}

--- a/providers/os/resources/languages/java/manifestmf/license_test.go
+++ b/providers/os/resources/languages/java/manifestmf/license_test.go
@@ -305,3 +305,38 @@ func TestBundleLicenseTellsAListFromANameWithAComma(t *testing.T) {
 		})
 	}
 }
+
+// TestParseBundleLicenseIsTheSameAnswerAsTheManifestPath pins what exporting
+// the function is for: one implementation, so a caller that reads the header
+// itself cannot report a different license for a jar than the inventory does.
+//
+// The first five cases are the shapes a second reader of this header gets
+// wrong: the external marker, a schemeless URL, quoting, a comma list read as
+// a single name, and a comma inside a quoted attribute. The sixth is the
+// control that keeps the list rule from swallowing a name that genuinely
+// contains a comma. The test fails if either side is ever reimplemented rather
+// than shared, which is the drift this export exists to prevent.
+func TestParseBundleLicenseIsTheSameAnswerAsTheManifestPath(t *testing.T) {
+	for _, c := range []struct{ header, want string }{
+		{"<<EXTERNAL>>", ""},
+		{"www.apache.org/licenses/LICENSE-2.0", ""},
+		{`'Apache-2.0';link="http://x"`, "Apache-2.0"},
+		{"GPL-3.0-only,Apache-2.0", "(GPL-3.0-only OR Apache-2.0)"},
+		{`Apache-2.0;description="The Apache License, Version 2.0"`, "Apache-2.0"},
+		{"The Apache License, Version 2.0", "The Apache License, Version 2.0"},
+	} {
+		t.Run(c.header, func(t *testing.T) {
+			assert.Equal(t, c.want, ParseBundleLicense(c.header))
+
+			// The same header through a whole manifest must agree, which is the
+			// property that makes the export safe to depend on.
+			mf := "Manifest-Version: 1.0\nBundle-SymbolicName: com.example\n" +
+				"Bundle-License: " + c.header + "\n"
+			info, err := (&Extractor{}).Parse(strings.NewReader(mf), "META-INF/MANIFEST.MF")
+			require.NoError(t, err)
+			root := info.Root()
+			require.NotNil(t, root)
+			assert.Equal(t, c.want, root.License, "manifest path disagrees with ParseBundleLicense")
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #10595, and the thing that lets its fix actually reach a consumer.

## The gap

A `MANIFEST.MF` is read by more than the inventory path. The Bundle-License parsing here is unexported and reachable only through `Root()` — which needs a `Bundle-SymbolicName` — so anything that already has a jar's manifest open for its own reasons cannot reach it, and reads the header itself instead.

A second reader of this header misses five things this one handles. Each is a jar reported under a license it does not have:

```text
header                                              second reader      this one
--------------------------------------------------------------------------------
EXTERNAL-marker  (see note)                         the marker itself  ""
www.apache.org/licenses/LICENSE-2.0                 the URL            ""
'Apache-2.0';link="http://x"                        "'Apache-2.0'"     Apache-2.0
GPL-3.0-only,Apache-2.0                             "GPL-3.0-only"     (GPL-3.0-only OR Apache-2.0)
Apache-2.0;description="The Apache License, V 2.0"  "The Apache Lic…"  Apache-2.0
```

Note: row 1 is OSGi's reserved value `EXTERNAL` wrapped in doubled angle brackets — GitHub eats the literal here, so see `bundleLicenseExternal` in the diff for the exact spelling. It means *no license is stated in this header*, and a second reader reports it as if it were a license name.

Row 2 is a link that happens to omit its scheme, so it is still a link. Row 4 is the one with teeth: a comma list is a **choice**, so reporting only its first arm fails a policy the bundle offered an `Apache-2.0` way around. Row 5 truncates at a comma inside a quoted attribute *and* overrides the correct identifier sitting in the field before it.

None of this is a criticism of any second reader in particular — it is simply what a second implementation of a grammar costs. The external marker, the schemeless-URL shape, quoting rules and the list/name asymmetry are each a place where two readers of one header drift, and every one of them was got right here already, most recently in #10595.

## The change

The header value is the whole input, so nothing else about the manifest has to be shared:

```go
func ParseBundleLicense(header string) string
```

`license()` becomes a call to it. **Purely additive — no behaviour change**, and no new dependency in either direction. Unfolding continuation lines and looking the header up case-insensitively stay with the caller's own manifest reader; this names only the value.

## Testing

The new table asserts that `ParseBundleLicense` and the manifest path give the same answer for the five rows above, plus a control that keeps the list rule from swallowing a name that genuinely contains a comma. That agreement is the property that makes the export safe to depend on, and it fails if either side is ever reimplemented rather than shared — which is the drift this PR exists to prevent, so it is the one worth pinning.

`go test ./providers/os/resources/languages/...` green; `golangci-lint run --config=.github/.golangci.yaml ./providers/os/resources/languages/java/...` reports 0 issues.

## Follow-up

Two adjacent gaps found while checking whether other root manifests could move the same way, **not** addressed here — they are extractor field mapping rather than this seam, and each deserves its own diff:

- `composerjson` does not map the `license` field at all (its sibling lockfile readers do, since #10557), and returns no root without a `name`.
- `cargotoml` does not map `[package] license` either.

Both verified by probing the extractors directly, not inferred from reading.
