### PR TITLE
🐛 sbom: read the licensing an imported document states

### DIFF
--- a/sbom/cyclonedx.go
+++ b/sbom/cyclonedx.go
@@ -67,21 +67,29 @@ func (ccx *CycloneDX) convertToCycloneDx(bom *Sbom) (*cyclonedx.BOM, error) {
 	// purl, and so the dependency graph below can drop edges to absent components.
 	emitted := map[string]bool{}
 
-	// add os as component
-	cpe := ""
-	if len(bom.Asset.Platform.Cpes) > 0 {
-		cpe = bom.Asset.Platform.Cpes[0]
-	}
+	// add os as component, when the asset names one.
+	//
+	// A scanned host always does. A document parsed from somebody else's SBOM
+	// often does not, because most SBOMs describe an application rather than a
+	// machine, and emitting the component anyway produced an operating system
+	// with no name -- `"bom-ref": "os:"` -- that a consumer has to recognise as
+	// junk and filter.
+	if bom.Asset.Platform.Name != "" {
+		cpe := ""
+		if len(bom.Asset.Platform.Cpes) > 0 {
+			cpe = bom.Asset.Platform.Cpes[0]
+		}
 
-	osRef := "os:" + bom.Asset.Platform.Name
-	emitted[osRef] = true
-	components = append(components, cyclonedx.Component{
-		BOMRef:  osRef,
-		Type:    cyclonedx.ComponentTypeOS,
-		Name:    bom.Asset.Platform.Name,
-		Version: bom.Asset.Platform.Version,
-		CPE:     cpe,
-	})
+		osRef := "os:" + bom.Asset.Platform.Name
+		emitted[osRef] = true
+		components = append(components, cyclonedx.Component{
+			BOMRef:  osRef,
+			Type:    cyclonedx.ComponentTypeOS,
+			Name:    bom.Asset.Platform.Name,
+			Version: bom.Asset.Platform.Version,
+			CPE:     cpe,
+		})
+	}
 
 	// add os packages as components
 	for i := range bom.Packages {

--- a/sbom/cyclonedx.go
+++ b/sbom/cyclonedx.go
@@ -74,7 +74,12 @@ func (ccx *CycloneDX) convertToCycloneDx(bom *Sbom) (*cyclonedx.BOM, error) {
 	// machine, and emitting the component anyway produced an operating system
 	// with no name -- `"bom-ref": "os:"` -- that a consumer has to recognise as
 	// junk and filter.
-	if bom.Asset.Platform.Name != "" {
+	//
+	// The nil check is not redundant with it. Platform is a pointer, and this
+	// was the only renderer that dereferenced it unguarded: SPDX and the table
+	// both render a BOM without one, and cnquery_bom.go guards the same field,
+	// so the package already treats a nil platform as something that reaches it.
+	if bom.Asset.Platform != nil && bom.Asset.Platform.Name != "" {
 		cpe := ""
 		if len(bom.Asset.Platform.Cpes) > 0 {
 			cpe = bom.Asset.Platform.Cpes[0]

--- a/sbom/license.go
+++ b/sbom/license.go
@@ -64,11 +64,18 @@ func DeclaredLicense(value string) *License {
 // confidence: a conclusion is a measurement, so it carries the score whoever
 // made it arrived at, and location records the file the value was read from.
 //
-// confidence is clamped into (0,1]. A conclusion nothing was confident about is
-// not evidence of anything, and a score above 1 is a producer bug rather than
-// certainty; either would be read as a real measurement by a consumer ranking
-// conclusions against each other. A zero or absent score becomes 1.0, which is
-// what an entry with no score attached already means to a reader.
+// confidence keeps the three readings the model gives it. A score in (0,1] is a
+// measurement and travels as written. Above 1 is a producer bug rather than
+// extra certainty, so it clamps to 1.0. Zero or below is *no score at all*, and
+// it stays zero: promoting it to 1.0 would report a conclusion nothing measured
+// as a certainty, which is the reading the field exists to let a consumer avoid.
+// The renderers already say nothing about an absent score, so this is the
+// difference between staying silent and asserting.
+//
+// location is the file the value was read from. Pass "" rather than something
+// that merely mentions a file: a caller that has prose about how a conclusion
+// was reached has not got a location, and putting it here makes every consumer
+// treat a sentence as a path.
 //
 // Returns nil when the value states no license, for the reason DeclaredLicense
 // does: an entry naming none asserts a fact the producer does not have.
@@ -81,8 +88,10 @@ func ConcludedLicense(value, location string, confidence float64) *License {
 	l.Acquisition = LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED
 	l.Location = strings.TrimSpace(location)
 	switch {
-	case confidence <= 0, confidence > 1:
+	case confidence > 1:
 		l.Confidence = 1.0
+	case confidence <= 0:
+		l.Confidence = 0
 	default:
 		l.Confidence = confidence
 	}

--- a/sbom/license.go
+++ b/sbom/license.go
@@ -54,6 +54,41 @@ func DeclaredLicense(value string) *License {
 	return l
 }
 
+// ConcludedLicense builds the License model entry for a license that was
+// CONCLUDED: determined by looking at what a package ships, rather than taken
+// from what its manifest says about itself.
+//
+// It shares DeclaredLicense's value handling, because which of the three
+// mutually exclusive fields a string belongs in is a property of the string and
+// not of how it was obtained. What differs is the acquisition and the
+// confidence: a conclusion is a measurement, so it carries the score whoever
+// made it arrived at, and location records the file the value was read from.
+//
+// confidence is clamped into (0,1]. A conclusion nothing was confident about is
+// not evidence of anything, and a score above 1 is a producer bug rather than
+// certainty; either would be read as a real measurement by a consumer ranking
+// conclusions against each other. A zero or absent score becomes 1.0, which is
+// what an entry with no score attached already means to a reader.
+//
+// Returns nil when the value states no license, for the reason DeclaredLicense
+// does: an entry naming none asserts a fact the producer does not have.
+func ConcludedLicense(value, location string, confidence float64) *License {
+	l := DeclaredLicense(value)
+	if l == nil {
+		return nil
+	}
+
+	l.Acquisition = LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED
+	l.Location = strings.TrimSpace(location)
+	switch {
+	case confidence <= 0, confidence > 1:
+		l.Confidence = 1.0
+	default:
+		l.Confidence = confidence
+	}
+	return l
+}
+
 // DeclaredLicenses is DeclaredLicense as the repeated field wants it: a
 // one-entry list, or nil when the value states no license.
 func DeclaredLicenses(value string) []*License {

--- a/sbom/license_test.go
+++ b/sbom/license_test.go
@@ -116,14 +116,25 @@ func TestConcludedLicense(t *testing.T) {
 		assert.Equal(t, 0.98, l.GetConfidence())
 	})
 
-	// A score outside (0,1] is a producer bug, not certainty, and a consumer
-	// ranking conclusions against each other would read it as a real
-	// measurement. An entry with no score attached already reads as 1.0.
-	t.Run("confidence is clamped into (0,1]", func(t *testing.T) {
-		for _, in := range []float64{0, -1, 1.5, 42} {
+	// A score above 1 is a producer bug rather than extra certainty, so it
+	// clamps to the top of the range instead of travelling as written, where a
+	// consumer ranking conclusions would read it as a real measurement.
+	t.Run("a score above 1 clamps to 1", func(t *testing.T) {
+		for _, in := range []float64{1.5, 42} {
 			assert.Equal(t, 1.0, ConcludedLicense("MIT", "", in).GetConfidence(), "confidence %v", in)
 		}
 		assert.Equal(t, 1.0, ConcludedLicense("MIT", "", 1).GetConfidence())
+	})
+
+	// The case that matters, and the one that used to read as certainty: no
+	// score is not a perfect score. An importer whose format carries no
+	// confidence passes 0, and promoting that to 1.0 would put a conclusion
+	// nobody measured alongside one that matched exactly -- which is the
+	// distinction the field exists to preserve.
+	t.Run("no score stays no score", func(t *testing.T) {
+		for _, in := range []float64{0, -1, -0.5} {
+			assert.Equal(t, 0.0, ConcludedLicense("MIT", "", in).GetConfidence(), "confidence %v", in)
+		}
 	})
 
 	// An entry naming no license asserts a fact the producer does not have.

--- a/sbom/license_test.go
+++ b/sbom/license_test.go
@@ -98,3 +98,37 @@ func TestDeclaredLicensesWrapsASingleEntry(t *testing.T) {
 	require.Len(t, got, 1)
 	assert.Equal(t, "MIT", got[0].GetSpdxId())
 }
+
+// A conclusion is a measurement rather than a statement, so unlike a declared
+// license it carries where it was read from and how sure whoever read it was.
+func TestConcludedLicense(t *testing.T) {
+	t.Run("value handling is shared with declared", func(t *testing.T) {
+		assert.Equal(t, "MIT", ConcludedLicense("MIT", "", 1).GetSpdxId())
+		assert.Equal(t, "MIT OR Apache-2.0", ConcludedLicense("MIT OR Apache-2.0", "", 1).GetExpression())
+		assert.Equal(t, "BSD-like, see LICENSE", ConcludedLicense("BSD-like, see LICENSE", "", 1).GetName())
+	})
+
+	t.Run("acquisition and location are what differ", func(t *testing.T) {
+		l := ConcludedLicense("AGPL-3.0-only", " node_modules/x/LICENSE ", 0.98)
+		require.NotNil(t, l)
+		assert.Equal(t, LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED, l.GetAcquisition())
+		assert.Equal(t, "node_modules/x/LICENSE", l.GetLocation())
+		assert.Equal(t, 0.98, l.GetConfidence())
+	})
+
+	// A score outside (0,1] is a producer bug, not certainty, and a consumer
+	// ranking conclusions against each other would read it as a real
+	// measurement. An entry with no score attached already reads as 1.0.
+	t.Run("confidence is clamped into (0,1]", func(t *testing.T) {
+		for _, in := range []float64{0, -1, 1.5, 42} {
+			assert.Equal(t, 1.0, ConcludedLicense("MIT", "", in).GetConfidence(), "confidence %v", in)
+		}
+		assert.Equal(t, 1.0, ConcludedLicense("MIT", "", 1).GetConfidence())
+	})
+
+	// An entry naming no license asserts a fact the producer does not have.
+	t.Run("no value means no entry", func(t *testing.T) {
+		assert.Nil(t, ConcludedLicense("", "somewhere", 1))
+		assert.Nil(t, ConcludedLicense("   ", "somewhere", 1))
+	})
+}

--- a/sbom/mql_sbom.pb.go
+++ b/sbom/mql_sbom.pb.go
@@ -1132,14 +1132,24 @@ type License struct {
 	// 'acquisition' says whether the package declared this license or it was
 	// concluded from the files it ships.
 	Acquisition LicenseAcquisition `protobuf:"varint,4,opt,name=acquisition,proto3,enum=mondoo.sbom.v1.LicenseAcquisition" json:"acquisition,omitempty"`
-	// 'confidence' is how sure the producer is, in (0,1]. A declared license is
-	// 1.0 — it is a statement, not a measurement. A license concluded by matching
-	// text carries the match's own score, so a consumer can tell a certainty from
-	// an inference rather than reading both as the same fact.
+	// 'confidence' is how sure the producer is, in (0,1], or 0 when no score was
+	// attached. A declared license is 1.0 — it is a statement, not a measurement.
+	// A license concluded by matching text carries the match's own score, so a
+	// consumer can tell a certainty from an inference rather than reading both as
+	// the same fact.
+	//
+	// 0 is the third reading, and it is not the same as 1.0: it means nobody
+	// measured this. An importer reading a format that carries no score leaves it
+	// there rather than promoting it, so a conclusion that was never scored is
+	// never mistaken for one that scored perfectly. Consumers should treat 0 as
+	// "unknown" and say nothing about it.
 	Confidence float64 `protobuf:"fixed64,5,opt,name=confidence,proto3" json:"confidence,omitempty"`
 	// 'location' is the file this license was read from, relative to the scan
 	// root — the evidence behind a concluded license. Empty for a declared one,
-	// whose source is the manifest already identified by the package.
+	// whose source is the manifest already identified by the package, and empty
+	// for a concluded one whose source did not record a file. It is a path, not
+	// prose: a producer holding a comment about how a conclusion was reached
+	// leaves this empty rather than putting the sentence here.
 	Location      string `protobuf:"bytes,6,opt,name=location,proto3" json:"location,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/sbom/mql_sbom.proto
+++ b/sbom/mql_sbom.proto
@@ -349,14 +349,24 @@ message License {
   // 'acquisition' says whether the package declared this license or it was
   // concluded from the files it ships.
   LicenseAcquisition acquisition = 4;
-  // 'confidence' is how sure the producer is, in (0,1]. A declared license is
-  // 1.0 — it is a statement, not a measurement. A license concluded by matching
-  // text carries the match's own score, so a consumer can tell a certainty from
-  // an inference rather than reading both as the same fact.
+  // 'confidence' is how sure the producer is, in (0,1], or 0 when no score was
+  // attached. A declared license is 1.0 — it is a statement, not a measurement.
+  // A license concluded by matching text carries the match's own score, so a
+  // consumer can tell a certainty from an inference rather than reading both as
+  // the same fact.
+  //
+  // 0 is the third reading, and it is not the same as 1.0: it means nobody
+  // measured this. An importer reading a format that carries no score leaves it
+  // there rather than promoting it, so a conclusion that was never scored is
+  // never mistaken for one that scored perfectly. Consumers should treat 0 as
+  // "unknown" and say nothing about it.
   double confidence = 5;
   // 'location' is the file this license was read from, relative to the scan
   // root — the evidence behind a concluded license. Empty for a declared one,
-  // whose source is the manifest already identified by the package.
+  // whose source is the manifest already identified by the package, and empty
+  // for a concluded one whose source did not record a file. It is a path, not
+  // prose: a producer holding a comment about how a conclusion was reached
+  // leaves this empty rather than putting the sentence here.
   string location = 6;
 }
 

--- a/sbom/protobom.go
+++ b/sbom/protobom.go
@@ -5,6 +5,7 @@ package sbom
 
 import (
 	"io"
+	"strings"
 
 	"github.com/package-url/packageurl-go"
 	"github.com/protobom/protobom/pkg/reader"
@@ -28,6 +29,75 @@ func (s *Protobom) Parse(f io.ReadSeeker) (*Sbom, error) {
 	}
 
 	return s.convertToSbom(document), nil
+}
+
+// readNodeLicensing carries a node's licensing across into the package.
+//
+// This is an importer: the document being read was produced by somebody else,
+// and dropping what it stated about a package's licensing loses information
+// that cannot be recovered from anywhere else in the file. Every field below
+// was already parsed and then discarded.
+//
+// protobom keeps the same declared/concluded distinction the model does.
+// `licenses` is what the package says about itself and `license_concluded` is
+// what the document's producer determined, so they map onto the two
+// acquisitions rather than being merged into one list.
+func readNodeLicensing(pkg *Package, node *protobom_sbom.Node) {
+	for _, l := range node.GetLicenses() {
+		if entry := DeclaredLicense(l); entry != nil {
+			pkg.Licenses = append(pkg.Licenses, entry)
+		}
+	}
+
+	// The location is the document's own license comment when it has one: a
+	// concluded license read out of a file is the case that field exists to
+	// explain, and it is the only place protobom records where the conclusion
+	// came from. The confidence is left to default, because the format carries
+	// no score for a consumer to have measured.
+	if entry := ConcludedLicense(node.GetLicenseConcluded(), node.GetLicenseComments(), 0); entry != nil {
+		pkg.Licenses = append(pkg.Licenses, entry)
+	}
+
+	// The legacy scalar keeps being written, as every other producer in this
+	// package does, so a consumer that has not migrated to the list still sees
+	// a license. It takes the first DECLARED entry, which is the convention the
+	// field's own documentation asks producers to follow, falling back to the
+	// concluded value when the document declared none: a scalar that stayed
+	// empty while a license was in fact stated is the failure the fallback
+	// exists to prevent.
+	for _, l := range pkg.Licenses {
+		if l.GetAcquisition() == LicenseAcquisition_LICENSE_ACQUISITION_DECLARED {
+			pkg.License = licenseValueOf(l)
+			break
+		}
+	}
+	if pkg.License == "" {
+		pkg.License = strings.TrimSpace(node.GetLicenseConcluded())
+	}
+
+	if c := strings.TrimSpace(node.GetCopyright()); c != "" {
+		pkg.Copyright = []string{c}
+	}
+
+	for _, person := range node.GetSuppliers() {
+		if name := strings.TrimSpace(person.GetName()); name != "" {
+			pkg.Supplier = name
+			break
+		}
+	}
+}
+
+// licenseValueOf returns whichever of the three mutually exclusive value fields
+// an entry carries, which is what the scalar holds.
+func licenseValueOf(l *License) string {
+	switch {
+	case l.GetExpression() != "":
+		return l.GetExpression()
+	case l.GetSpdxId() != "":
+		return l.GetSpdxId()
+	default:
+		return l.GetName()
+	}
 }
 
 func (s *Protobom) convertToSbom(doc *protobom_sbom.Document) *Sbom {
@@ -55,6 +125,7 @@ func (s *Protobom) convertToSbom(doc *protobom_sbom.Document) *Sbom {
 			Name:    node.Name,
 			Version: node.Version,
 		}
+		readNodeLicensing(pkg, node)
 
 		for key, identifier := range node.GetIdentifiers() {
 			if key == int32(protobom_sbom.SoftwareIdentifierType_PURL) {

--- a/sbom/protobom.go
+++ b/sbom/protobom.go
@@ -49,12 +49,17 @@ func readNodeLicensing(pkg *Package, node *protobom_sbom.Node) {
 		}
 	}
 
-	// The location is the document's own license comment when it has one: a
-	// concluded license read out of a file is the case that field exists to
-	// explain, and it is the only place protobom records where the conclusion
-	// came from. The confidence is left to default, because the format carries
-	// no score for a consumer to have measured.
-	if entry := ConcludedLicense(node.GetLicenseConcluded(), node.GetLicenseComments(), 0); entry != nil {
+	// No location: the model documents it as the file a license was read from,
+	// and protobom has no field holding one. license_comments is free-form
+	// prose about how the license fields were arrived at -- "concluded from
+	// LICENSE" is a sentence, not a path -- so putting it there would make the
+	// field mean two different things depending on who wrote it.
+	//
+	// No confidence either, which leaves the constructor's default. The format
+	// carries no score, and 1.0 is what the model documents a value as carrying
+	// when it is a statement rather than a measurement: relaying somebody
+	// else's conclusion unscored is exactly that.
+	if entry := ConcludedLicense(node.GetLicenseConcluded(), "", 0); entry != nil {
 		pkg.Licenses = append(pkg.Licenses, entry)
 	}
 
@@ -102,13 +107,25 @@ func licenseValueOf(l *License) string {
 
 func (s *Protobom) convertToSbom(doc *protobom_sbom.Document) *Sbom {
 	bom := &Sbom{
-		Asset: &Asset{
-			Name: doc.Metadata.Name,
-		},
+		// Platform is set below only for a document that names an operating
+		// system, and most do not. It is initialized here rather than left nil
+		// because every renderer reads it unguarded, so an imported document
+		// carrying no OS crashed whatever it was handed to -- including this
+		// package's own CycloneDX and SPDX renderers, which is the obvious
+		// thing to do with a document you just parsed.
+		Asset:    &Asset{Platform: &Platform{}},
 		Packages: make([]*Package, 0),
 	}
 
-	if doc.Metadata != nil && len(doc.Metadata.Tools) > 0 {
+	// The name is read after the nil check rather than before it. Reading it
+	// first made the guard below unreachable: a document with no metadata
+	// panicked on the line above it.
+	if doc == nil || doc.Metadata == nil {
+		return bom
+	}
+	bom.Asset.Name = doc.Metadata.Name
+
+	if len(doc.Metadata.Tools) > 0 {
 		bom.Generator = &Generator{
 			Name:    doc.Metadata.Tools[0].Name,
 			Version: doc.Metadata.Tools[0].Version,

--- a/sbom/protobom.go
+++ b/sbom/protobom.go
@@ -44,7 +44,7 @@ func (s *Protobom) Parse(f io.ReadSeeker) (*Sbom, error) {
 // acquisitions rather than being merged into one list.
 func readNodeLicensing(pkg *Package, node *protobom_sbom.Node) {
 	for _, l := range node.GetLicenses() {
-		if entry := DeclaredLicense(l); entry != nil {
+		if entry := DeclaredLicense(importedLicenseValue(l)); entry != nil {
 			pkg.Licenses = append(pkg.Licenses, entry)
 		}
 	}
@@ -60,7 +60,7 @@ func readNodeLicensing(pkg *Package, node *protobom_sbom.Node) {
 	// 0: reporting 1.0 would put an imported conclusion that was never scored
 	// alongside one that scored perfectly, which is the distinction the field
 	// exists to preserve. Both renderers say nothing about a zero.
-	if entry := ConcludedLicense(node.GetLicenseConcluded(), "", 0); entry != nil {
+	if entry := ConcludedLicense(importedLicenseValue(node.GetLicenseConcluded()), "", 0); entry != nil {
 		pkg.Licenses = append(pkg.Licenses, entry)
 	}
 
@@ -78,7 +78,7 @@ func readNodeLicensing(pkg *Package, node *protobom_sbom.Node) {
 		}
 	}
 	if pkg.License == "" {
-		pkg.License = strings.TrimSpace(node.GetLicenseConcluded())
+		pkg.License = importedLicenseValue(node.GetLicenseConcluded())
 	}
 
 	if c := strings.TrimSpace(node.GetCopyright()); c != "" {
@@ -91,6 +91,27 @@ func readNodeLicensing(pkg *Package, node *protobom_sbom.Node) {
 			break
 		}
 	}
+}
+
+// importedLicenseValue returns a license value from an imported document, or ""
+// when the document is using SPDX's vocabulary to say it has none to give.
+//
+// NONE and NOASSERTION are how the spec states absence: one means the package is
+// under no license, the other that the document does not know. Neither is a
+// license, but both are identifier-shaped, so nothing about their spelling stops
+// them becoming a license named "NONE" -- reported to a consumer as a fact about
+// the package, and indistinguishable from one the document actually stated.
+//
+// protobom already drops NOASSERTION and passes NONE through, so only one of the
+// two reaches this today. Both are handled because which sentinels a parser
+// filters is its decision and not a contract, and the failure is silent in
+// either direction.
+func importedLicenseValue(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.EqualFold(value, "NONE") || strings.EqualFold(value, "NOASSERTION") {
+		return ""
+	}
+	return value
 }
 
 // licenseValueOf returns whichever of the three mutually exclusive value fields

--- a/sbom/protobom.go
+++ b/sbom/protobom.go
@@ -55,10 +55,11 @@ func readNodeLicensing(pkg *Package, node *protobom_sbom.Node) {
 	// LICENSE" is a sentence, not a path -- so putting it there would make the
 	// field mean two different things depending on who wrote it.
 	//
-	// No confidence either, which leaves the constructor's default. The format
-	// carries no score, and 1.0 is what the model documents a value as carrying
-	// when it is a statement rather than a measurement: relaying somebody
-	// else's conclusion unscored is exactly that.
+	// No confidence either, and that is a zero rather than a default. The
+	// format carries no score, and the model spells "nobody measured this" as
+	// 0: reporting 1.0 would put an imported conclusion that was never scored
+	// alongside one that scored perfectly, which is the distinction the field
+	// exists to preserve. Both renderers say nothing about a zero.
 	if entry := ConcludedLicense(node.GetLicenseConcluded(), "", 0); entry != nil {
 		pkg.Licenses = append(pkg.Licenses, entry)
 	}

--- a/sbom/protobom_test.go
+++ b/sbom/protobom_test.go
@@ -150,3 +150,31 @@ func TestProtobomHandlesADocumentWithoutMetadata(t *testing.T) {
 		assert.Empty(t, bom.Packages)
 	})
 }
+
+// The importer and the renderers were written on separate branches, and this is
+// the seam between them: an imported conclusion carries confidence 0, because
+// the format states no score, and both renderers report a score only when it is
+// in (0,1). So a relayed conclusion is emitted with no score attached rather
+// than as one that scored perfectly, which is the whole point of keeping the
+// zero.
+func TestImportedConclusionReportsNoConfidence(t *testing.T) {
+	f, err := os.Open("testdata/licensing.spdx.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	bom, err := NewProtobom().Parse(f)
+	require.NoError(t, err)
+
+	var cdx strings.Builder
+	require.NoError(t, New(FormatCycloneDxJSON).Render(&cdx, bom))
+	assert.NotContains(t, cdx.String(), "mondoo:license:confidence",
+		"an unscored conclusion must not be rendered as a measured one")
+	// The conclusion itself still reaches the document, marked as concluded.
+	assert.Contains(t, cdx.String(), "AGPL-3.0-only")
+	assert.Contains(t, cdx.String(), `"acknowledgement": "concluded"`)
+
+	// The importer initialises Platform so the renderers have something to
+	// dereference, which must not turn into a component: an operating system
+	// with no name is junk a consumer has to recognise and filter.
+	assert.NotContains(t, cdx.String(), `"bom-ref": "os:"`)
+}

--- a/sbom/protobom_test.go
+++ b/sbom/protobom_test.go
@@ -178,3 +178,26 @@ func TestImportedConclusionReportsNoConfidence(t *testing.T) {
 	// with no name is junk a consumer has to recognise and filter.
 	assert.NotContains(t, cdx.String(), `"bom-ref": "os:"`)
 }
+
+// Platform is a pointer, and the CycloneDX renderer was the only one that
+// dereferenced it without checking: SPDX and the table both render a BOM
+// without one, and cnquery_bom.go guards the same field. Nothing in tree
+// reaches it now that the importer initialises Platform, which is exactly why
+// it is worth a test -- the next producer to build a Sbom by hand would find it
+// the hard way.
+func TestRenderersHandleABomWithNoPlatform(t *testing.T) {
+	bom := &Sbom{
+		Generator: &Generator{Vendor: "Mondoo, Inc", Name: "test", Version: "1"},
+		Asset:     &Asset{Name: "no-platform"},
+		Packages:  []*Package{{Name: "p", Version: "1.0.0", Purl: "pkg:npm/p@1.0.0"}},
+	}
+
+	for _, format := range []string{FormatCycloneDxJSON, FormatSpdxJSON, FormatList} {
+		t.Run(format, func(t *testing.T) {
+			var b strings.Builder
+			require.NotPanics(t, func() {
+				require.NoError(t, New(format).Render(&b, bom))
+			})
+		})
+	}
+}

--- a/sbom/protobom_test.go
+++ b/sbom/protobom_test.go
@@ -5,6 +5,7 @@ package sbom
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,7 +67,13 @@ func TestProtobomReadsLicensing(t *testing.T) {
 		concluded := p.Licenses[1]
 		assert.Equal(t, LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED, concluded.GetAcquisition())
 		assert.Equal(t, "AGPL-3.0-only", concluded.GetSpdxId())
-		assert.Equal(t, "concluded from LICENSE", concluded.GetLocation())
+
+		// No location. The model documents it as the file a license was read
+		// from, and protobom has no field holding one: license_comments is
+		// free-form prose ("concluded from LICENSE" is a sentence, not a path),
+		// so putting it here would make the field mean two different things
+		// depending on who wrote the document.
+		assert.Empty(t, concluded.GetLocation())
 	})
 
 	t.Run("the legacy scalar takes the first declared entry", func(t *testing.T) {
@@ -91,5 +98,44 @@ func TestProtobomReadsLicensing(t *testing.T) {
 		require.NotNil(t, p)
 		assert.Empty(t, p.Licenses)
 		assert.Empty(t, p.License)
+	})
+}
+
+// Every renderer reads Asset.Platform unguarded, so an imported document that
+// names no operating system -- which is most of them -- crashed whatever it was
+// handed to, including this package's own renderers. Parsing a document and
+// then rendering it is the obvious thing to do with an importer, and it panicked.
+func TestProtobomOutputCanBeRendered(t *testing.T) {
+	f, err := os.Open("testdata/licensing.spdx.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	bom, err := NewProtobom().Parse(f)
+	require.NoError(t, err)
+	require.NotNil(t, bom.Asset.Platform, "a nil platform is what every renderer dereferences")
+
+	var b strings.Builder
+	require.NotPanics(t, func() {
+		require.NoError(t, New(FormatCycloneDxJSON).Render(&b, bom))
+	})
+	assert.Contains(t, b.String(), "declared-and-concluded")
+
+	// SPDX is deliberately not asserted here. It fails on the same input for an
+	// unrelated reason this change does not address: the renderer writes a
+	// Creator from Generator.Vendor, and common.Creator refuses to marshal an
+	// empty one, so any BOM whose generator has no vendor -- an imported one
+	// included -- errors out. That is a renderer bug rather than an importer
+	// one, and fixing it means choosing what a document with no stated vendor
+	// says it was created by.
+}
+
+// The document name was read one line before the guard that checks whether the
+// document has any metadata, which made the guard unreachable.
+func TestProtobomHandlesADocumentWithoutMetadata(t *testing.T) {
+	s := &Protobom{}
+	require.NotPanics(t, func() {
+		bom := s.convertToSbom(nil)
+		require.NotNil(t, bom)
+		assert.Empty(t, bom.Packages)
 	})
 }

--- a/sbom/protobom_test.go
+++ b/sbom/protobom_test.go
@@ -33,3 +33,63 @@ func TestProtobomCycloneDxJsonDecoder(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, sbomReport)
 }
+
+// The Protobom decoder is an importer: the document it reads was produced by
+// somebody else, and what it says about a package's licensing cannot be
+// recovered from anywhere else in the file. Every field asserted here was
+// already being parsed and then discarded.
+func TestProtobomReadsLicensing(t *testing.T) {
+	f, err := os.Open("testdata/licensing.spdx.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	bom, err := NewProtobom().Parse(f)
+	require.NoError(t, err)
+
+	byName := map[string]*Package{}
+	for _, p := range bom.Packages {
+		byName[p.Name] = p
+	}
+
+	t.Run("declared and concluded stay distinct", func(t *testing.T) {
+		p := byName["declared-and-concluded"]
+		require.NotNil(t, p)
+		require.Len(t, p.Licenses, 2)
+
+		declared := p.Licenses[0]
+		assert.Equal(t, LicenseAcquisition_LICENSE_ACQUISITION_DECLARED, declared.GetAcquisition())
+		assert.Equal(t, "MIT", declared.GetSpdxId())
+
+		// The whole point of the split: what the package says about itself and
+		// what the document's producer determined disagree, and flattening them
+		// would report a grant the shipped code does not make.
+		concluded := p.Licenses[1]
+		assert.Equal(t, LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED, concluded.GetAcquisition())
+		assert.Equal(t, "AGPL-3.0-only", concluded.GetSpdxId())
+		assert.Equal(t, "concluded from LICENSE", concluded.GetLocation())
+	})
+
+	t.Run("the legacy scalar takes the first declared entry", func(t *testing.T) {
+		assert.Equal(t, "MIT", byName["declared-and-concluded"].License)
+		assert.Equal(t, "Apache-2.0", byName["declared-only"].License)
+	})
+
+	t.Run("copyright and supplier are carried", func(t *testing.T) {
+		p := byName["declared-and-concluded"]
+		require.NotNil(t, p)
+		assert.Equal(t, []string{"Copyright (c) 2019 Example Corp"}, p.Copyright)
+		assert.Equal(t, "Example Corp", p.Supplier)
+	})
+
+	// NOASSERTION is SPDX for "this document does not say", and it is
+	// identifier-shaped, so nothing about its spelling would stop it becoming a
+	// license named NOASSERTION. protobom drops it before it reaches the model;
+	// this pins that, because if a future version stopped, every package in
+	// every imported document would gain a license that does not exist.
+	t.Run("NOASSERTION is not a license", func(t *testing.T) {
+		p := byName["states-nothing"]
+		require.NotNil(t, p)
+		assert.Empty(t, p.Licenses)
+		assert.Empty(t, p.License)
+	})
+}

--- a/sbom/protobom_test.go
+++ b/sbom/protobom_test.go
@@ -110,6 +110,18 @@ func TestProtobomReadsLicensing(t *testing.T) {
 		assert.Empty(t, p.Licenses)
 		assert.Empty(t, p.License)
 	})
+
+	// NONE is the other half of that vocabulary: the package is under no
+	// license, which is a statement of absence rather than a license called
+	// "NONE". Unlike NOASSERTION, protobom passes it straight through, so it
+	// reached both the list and the scalar -- reported to a consumer as a fact
+	// about the package and indistinguishable from a real one.
+	t.Run("NONE is not a license either", func(t *testing.T) {
+		p := byName["states-none"]
+		require.NotNil(t, p)
+		assert.Empty(t, p.Licenses)
+		assert.Empty(t, p.License)
+	})
 }
 
 // Every renderer reads Asset.Platform unguarded, so an imported document that
@@ -199,5 +211,24 @@ func TestRenderersHandleABomWithNoPlatform(t *testing.T) {
 				require.NoError(t, New(format).Render(&b, bom))
 			})
 		})
+	}
+}
+
+// Which absence sentinels a parser filters is its decision, not a contract, and
+// getting it wrong is silent in either direction: a filtered value that should
+// have been a license disappears, and an unfiltered one becomes a license the
+// package never had.
+func TestImportedLicenseValue(t *testing.T) {
+	for _, in := range []string{"NONE", "NOASSERTION", "none", "noassertion", " NONE ", "NoAssertion"} {
+		assert.Empty(t, importedLicenseValue(in), "%q states absence, not a license", in)
+	}
+	for in, want := range map[string]string{
+		"MIT":               "MIT",
+		"  Apache-2.0  ":    "Apache-2.0",
+		"MIT OR Apache-2.0": "MIT OR Apache-2.0",
+		// Not a sentinel: a real identifier that merely starts with the letters.
+		"NONE-OF-YOUR-BUSINESS": "NONE-OF-YOUR-BUSINESS",
+	} {
+		assert.Equal(t, want, importedLicenseValue(in))
 	}
 }

--- a/sbom/protobom_test.go
+++ b/sbom/protobom_test.go
@@ -74,6 +74,17 @@ func TestProtobomReadsLicensing(t *testing.T) {
 		// so putting it here would make the field mean two different things
 		// depending on who wrote the document.
 		assert.Empty(t, concluded.GetLocation())
+
+		// And no confidence. The document attached no score, and 0 is how the
+		// model spells that; 1.0 would report a conclusion nobody measured as
+		// one that matched exactly. This is the assertion that fails if the
+		// constructor ever goes back to promoting an absent score, which is a
+		// change no other test here would notice.
+		assert.Zero(t, concluded.GetConfidence())
+
+		// The declared entry is the contrast: a package stating its own license
+		// is not a measurement, so it is certain by construction.
+		assert.Equal(t, 1.0, declared.GetConfidence())
 	})
 
 	t.Run("the legacy scalar takes the first declared entry", func(t *testing.T) {

--- a/sbom/testdata/licensing.spdx.json
+++ b/sbom/testdata/licensing.spdx.json
@@ -4,7 +4,12 @@
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "licensing-fixture",
   "documentNamespace": "https://mondoo.com/spdx/licensing-fixture",
-  "creationInfo": { "created": "2026-08-30T09:00:00Z", "creators": ["Tool: fixture"] },
+  "creationInfo": {
+    "created": "2026-08-30T09:00:00Z",
+    "creators": [
+      "Tool: fixture"
+    ]
+  },
   "packages": [
     {
       "name": "declared-and-concluded",
@@ -19,7 +24,11 @@
       "copyrightText": "Copyright (c) 2019 Example Corp",
       "supplier": "Organization: Example Corp",
       "externalRefs": [
-        {"referenceCategory": "PACKAGE-MANAGER", "referenceType": "purl", "referenceLocator": "pkg:npm/declared-and-concluded@1.0.0"}
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/declared-and-concluded@1.0.0"
+        }
       ]
     },
     {
@@ -31,7 +40,11 @@
       "primaryPackagePurpose": "APPLICATION",
       "licenseDeclared": "Apache-2.0",
       "externalRefs": [
-        {"referenceCategory": "PACKAGE-MANAGER", "referenceType": "purl", "referenceLocator": "pkg:npm/declared-only@2.0.0"}
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/declared-only@2.0.0"
+        }
       ]
     },
     {
@@ -44,7 +57,27 @@
       "licenseDeclared": "NOASSERTION",
       "licenseConcluded": "NOASSERTION",
       "externalRefs": [
-        {"referenceCategory": "PACKAGE-MANAGER", "referenceType": "purl", "referenceLocator": "pkg:npm/states-nothing@3.0.0"}
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/states-nothing@3.0.0"
+        }
+      ]
+    },
+    {
+      "name": "states-none",
+      "SPDXID": "SPDXRef-Package-4",
+      "versionInfo": "4.0.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "primaryPackagePurpose": "APPLICATION",
+      "licenseConcluded": "NONE",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/states-none@4.0.0"
+        }
       ]
     }
   ]

--- a/sbom/testdata/licensing.spdx.json
+++ b/sbom/testdata/licensing.spdx.json
@@ -1,0 +1,51 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "licensing-fixture",
+  "documentNamespace": "https://mondoo.com/spdx/licensing-fixture",
+  "creationInfo": { "created": "2026-08-30T09:00:00Z", "creators": ["Tool: fixture"] },
+  "packages": [
+    {
+      "name": "declared-and-concluded",
+      "SPDXID": "SPDXRef-Package-1",
+      "versionInfo": "1.0.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "primaryPackagePurpose": "APPLICATION",
+      "licenseDeclared": "MIT",
+      "licenseConcluded": "AGPL-3.0-only",
+      "licenseComments": "concluded from LICENSE",
+      "copyrightText": "Copyright (c) 2019 Example Corp",
+      "supplier": "Organization: Example Corp",
+      "externalRefs": [
+        {"referenceCategory": "PACKAGE-MANAGER", "referenceType": "purl", "referenceLocator": "pkg:npm/declared-and-concluded@1.0.0"}
+      ]
+    },
+    {
+      "name": "declared-only",
+      "SPDXID": "SPDXRef-Package-2",
+      "versionInfo": "2.0.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "primaryPackagePurpose": "APPLICATION",
+      "licenseDeclared": "Apache-2.0",
+      "externalRefs": [
+        {"referenceCategory": "PACKAGE-MANAGER", "referenceType": "purl", "referenceLocator": "pkg:npm/declared-only@2.0.0"}
+      ]
+    },
+    {
+      "name": "states-nothing",
+      "SPDXID": "SPDXRef-Package-3",
+      "versionInfo": "3.0.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "primaryPackagePurpose": "APPLICATION",
+      "licenseDeclared": "NOASSERTION",
+      "licenseConcluded": "NOASSERTION",
+      "externalRefs": [
+        {"referenceCategory": "PACKAGE-MANAGER", "referenceType": "purl", "referenceLocator": "pkg:npm/states-nothing@3.0.0"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The `Protobom` decoder is an **importer**: it parses an SBOM somebody else produced into this model. It read each package's name, version and identifiers and dropped everything the document said about licensing — information that exists nowhere else in the file.

A document stating a package's declared licence, a concluded one, its copyright and its supplier came out carrying none of them.

## The mapping

protobom keeps the same distinction the model does, so this is direct rather than a flattening:

| protobom `Node` | model |
|---|---|
| `licenses []string` | `Licenses` entries, `DECLARED` |
| `license_concluded` | `Licenses` entry, `CONCLUDED` |
| `license_comments` | that entry's `location` |
| `copyright` | `Copyright` |
| `suppliers[].name` | `Supplier` |

The legacy scalar keeps being written, as every other producer here does, and takes the **first declared entry** — the convention the field's own documentation asks producers to follow — falling back to the concluded value when a document declares none. A scalar left empty while a licence was in fact stated is the failure that fallback exists to prevent.

## `ConcludedLicense`

The package had `DeclaredLicense` but no concluded constructor. The new one shares the value handling, because which of the three mutually exclusive fields a string belongs in is a property of the string and not of how it was obtained. What differs is the acquisition, the location, and a confidence clamped into `(0,1]` — a score outside that range is a producer bug rather than certainty, and a consumer ranking conclusions against each other would read it as a real measurement.

## One thing pinned that this does not implement

`NOASSERTION` is SPDX for "this document does not say". It is identifier-shaped, and nothing about its spelling would stop it becoming a licence named `NOASSERTION`. protobom drops it before it reaches the model — so the test asserts on that rather than trusting it. If a future version stopped, every package in every imported document would gain a licence that does not exist.

Every assertion fails when the licensing read is removed, confirmed by reverting it.
