### PR TITLE
🐛 sbom: say on the license how it was arrived at, instead of by where it sits

### DIFF
--- a/sbom/cyclonedx.go
+++ b/sbom/cyclonedx.go
@@ -511,9 +511,16 @@ func cycloneDXAcknowledgement(a LicenseAcquisition) cyclonedx.LicenseAcknowledge
 // not a measurement -- so emitting it would be noise on every license in every
 // document. It is written only for a conclusion, where it is the difference
 // between a certainty and an inference.
+//
+// Full confidence is left out for the same reason, and on the same rule the
+// SPDX renderer applies. The model documents 1.0 as the value a license carries
+// when it is a statement rather than a measurement, so a conclusion at 1.0 is
+// asserting no measurement, which is what an entry with no score attached
+// already says. A property that states nothing would still be read by a
+// consumer ranking conclusions as a score somebody took.
 func cycloneDXLicenseProperties(l *License) *[]cyclonedx.Property {
 	props := []cyclonedx.Property{}
-	if l.GetAcquisition() == LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED && l.GetConfidence() > 0 {
+	if c := l.GetConfidence(); l.GetAcquisition() == LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED && c > 0 && c < 1 {
 		props = append(props, cyclonedx.Property{
 			Name:  "mondoo:license:confidence",
 			Value: strconv.FormatFloat(l.GetConfidence(), 'g', -1, 64),

--- a/sbom/cyclonedx.go
+++ b/sbom/cyclonedx.go
@@ -389,18 +389,6 @@ func cycloneDXComponentLicenses(pkg *Package) *cyclonedx.Licenses {
 	return cycloneDXLicenses(pkg.License)
 }
 
-// cycloneDXDeclared renders the licenses a package declares, preferring the
-// structured list and falling back to the legacy scalar.
-//
-// The fallback is what lets consumers migrate without a flag day: a producer
-// that has not yet populated Licenses still renders exactly as it did before.
-func cycloneDXDeclared(pkg *Package) *cyclonedx.Licenses {
-	if l := cycloneDXLicenseList(declaredLicenses(pkg)); l != nil {
-		return l
-	}
-	return cycloneDXLicenses(pkg.License)
-}
-
 // declaredLicenses returns the package's declared entries. An entry whose
 // acquisition the producer did not set counts as declared: it is what the
 // scalar always meant, so an unset value keeps the old reading rather than

--- a/sbom/cyclonedx.go
+++ b/sbom/cyclonedx.go
@@ -6,6 +6,7 @@ package sbom
 import (
 	"errors"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -125,24 +126,29 @@ func (ccx *CycloneDX) convertToCycloneDx(bom *Sbom) (*cyclonedx.BOM, error) {
 		}
 		emitted[ref] = true
 
-		// Concluded licenses and copyright are evidence, not assertion: they were
-		// read out of the files the package ships rather than stated by it, and
-		// CycloneDX has a place that says exactly that.
-		if concluded := cycloneDXLicenseList(concludedLicenses(pkg)); concluded != nil {
-			if evidence == nil {
-				evidence = &cyclonedx.Evidence{}
+		// Concluded licenses and copyright are also stated as evidence, which is
+		// what CycloneDX's evidence block is for: they were read out of the
+		// files the package ships rather than asserted by it. It is a second
+		// view of what component.licenses already carries, not the only home
+		// for it, so it follows the same opt-in as the occurrences above rather
+		// than being the one part of the block that appears unasked.
+		if ccx.opts.IncludeEvidence {
+			if concluded := cycloneDXLicenseList(concludedLicenses(pkg)); concluded != nil {
+				if evidence == nil {
+					evidence = &cyclonedx.Evidence{}
+				}
+				evidence.Licenses = concluded
 			}
-			evidence.Licenses = concluded
-		}
-		if len(pkg.Copyright) > 0 {
-			if evidence == nil {
-				evidence = &cyclonedx.Evidence{}
+			if len(pkg.Copyright) > 0 {
+				if evidence == nil {
+					evidence = &cyclonedx.Evidence{}
+				}
+				copyrights := make([]cyclonedx.Copyright, 0, len(pkg.Copyright))
+				for _, c := range pkg.Copyright {
+					copyrights = append(copyrights, cyclonedx.Copyright{Text: c})
+				}
+				evidence.Copyright = &copyrights
 			}
-			copyrights := make([]cyclonedx.Copyright, 0, len(pkg.Copyright))
-			for _, c := range pkg.Copyright {
-				copyrights = append(copyrights, cyclonedx.Copyright{Text: c})
-			}
-			evidence.Copyright = &copyrights
 		}
 
 		bomPkg := cyclonedx.Component{
@@ -154,7 +160,7 @@ func (ccx *CycloneDX) convertToCycloneDx(bom *Sbom) (*cyclonedx.BOM, error) {
 			CPE:         cpe,
 			Evidence:    evidence,
 			Description: pkg.Description,
-			Licenses:    cycloneDXDeclared(pkg),
+			Licenses:    cycloneDXComponentLicenses(pkg),
 			Copyright:   strings.Join(pkg.Copyright, "\n"),
 		}
 		if pkg.Supplier != "" {
@@ -366,6 +372,23 @@ var familyMap = map[string][]string{
 	"rhel":    {"linux", "unix", "os"},
 }
 
+// cycloneDXComponentLicenses renders every license the model carries onto the
+// component, each saying how it was arrived at.
+//
+// Declared and concluded live in one list because `acknowledgement` tells them
+// apart, which is what the attribute is for. Putting the concluded ones only
+// under evidence would make a consumer reading component.licenses believe the
+// package is licensed as it claims, in exactly the case the two disagree and
+// the shipped text is the grant.
+func cycloneDXComponentLicenses(pkg *Package) *cyclonedx.Licenses {
+	if l := cycloneDXLicenseList(pkg.Licenses); l != nil {
+		return l
+	}
+	// No structured list: the legacy scalar is all there is, and it renders as
+	// it always did.
+	return cycloneDXLicenses(pkg.License)
+}
+
 // cycloneDXDeclared renders the licenses a package declares, preferring the
 // structured list and falling back to the legacy scalar.
 //
@@ -409,26 +432,103 @@ func concludedLicenses(pkg *Package) []*License {
 // The three shapes are mutually exclusive in the schema, which is why the
 // producer says which kind it has rather than the renderer guessing: a value
 // already known to be an expression must not be emitted as an id.
+//
+// How a license was arrived at travels with it, as CycloneDX 1.6's
+// `acknowledgement`. Saying it on the license is what lets a declared and a
+// concluded one sit in the same list: the alternative is to encode the
+// difference in *where* they are placed, which needs somewhere to put the
+// concluded ones and says nothing to a consumer reading a single entry.
+//
+// A conclusion's confidence and the file it was read from become license
+// properties, the schema's own extension point. Neither has a first-class field
+// in 1.6, and both are the difference between a certainty and an inference, so
+// dropping them loses the reason a consumer would trust one conclusion over
+// another.
 func cycloneDXLicenseList(licenses []*License) *cyclonedx.Licenses {
 	out := make(cyclonedx.Licenses, 0, len(licenses))
 	for _, l := range licenses {
+		var choice cyclonedx.LicenseChoice
 		switch {
 		case strings.TrimSpace(l.GetExpression()) != "":
-			out = append(out, cyclonedx.LicenseChoice{Expression: strings.TrimSpace(l.GetExpression())})
+			choice = cyclonedx.LicenseChoice{Expression: strings.TrimSpace(l.GetExpression())}
 		case strings.TrimSpace(l.GetSpdxId()) != "":
-			out = append(out, cyclonedx.LicenseChoice{
+			choice = cyclonedx.LicenseChoice{
 				License: &cyclonedx.License{ID: strings.TrimSpace(l.GetSpdxId())},
-			})
+			}
 		case strings.TrimSpace(l.GetName()) != "":
-			out = append(out, cyclonedx.LicenseChoice{
+			choice = cyclonedx.LicenseChoice{
 				License: &cyclonedx.License{Name: strings.TrimSpace(l.GetName())},
-			})
+			}
+		default:
+			continue
 		}
+
+		if ack := cycloneDXAcknowledgement(l.GetAcquisition()); ack != "" {
+			// An expression carries it on the choice, an id or a name on the
+			// license itself: the schema puts the attribute in both places and
+			// only one of the two is populated for any given entry.
+			if choice.License != nil {
+				choice.License.Acknowledgement = ack
+			} else {
+				choice.Acknowledgement = &ack
+			}
+		}
+		if props := cycloneDXLicenseProperties(l); props != nil {
+			if choice.License != nil {
+				choice.License.Properties = props
+			} else {
+				choice.Properties = props
+			}
+		}
+
+		out = append(out, choice)
 	}
 	if len(out) == 0 {
 		return nil
 	}
 	return &out
+}
+
+// cycloneDXAcknowledgement maps the model's acquisition onto the schema's
+// vocabulary, which uses the same two words. An unspecified acquisition renders
+// nothing rather than guessing at "declared": the producer did not say, and an
+// omitted attribute is how the schema spells that.
+func cycloneDXAcknowledgement(a LicenseAcquisition) cyclonedx.LicenseAcknowledgement {
+	switch a {
+	case LicenseAcquisition_LICENSE_ACQUISITION_DECLARED:
+		return cyclonedx.LicenseAcknowledgementDeclared
+	case LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED:
+		return cyclonedx.LicenseAcknowledgementConcluded
+	default:
+		return ""
+	}
+}
+
+// cycloneDXLicenseProperties carries the parts of a conclusion the schema has no
+// field for, and only when they say something.
+//
+// A declared license's confidence is 1.0 by construction -- it is a statement,
+// not a measurement -- so emitting it would be noise on every license in every
+// document. It is written only for a conclusion, where it is the difference
+// between a certainty and an inference.
+func cycloneDXLicenseProperties(l *License) *[]cyclonedx.Property {
+	props := []cyclonedx.Property{}
+	if l.GetAcquisition() == LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED && l.GetConfidence() > 0 {
+		props = append(props, cyclonedx.Property{
+			Name:  "mondoo:license:confidence",
+			Value: strconv.FormatFloat(l.GetConfidence(), 'g', -1, 64),
+		})
+	}
+	if loc := strings.TrimSpace(l.GetLocation()); loc != "" {
+		props = append(props, cyclonedx.Property{
+			Name:  "mondoo:license:location",
+			Value: loc,
+		})
+	}
+	if len(props) == 0 {
+		return nil
+	}
+	return &props
 }
 
 // cycloneDXLicenses renders a package's declared license as a CycloneDX license

--- a/sbom/license_render_test.go
+++ b/sbom/license_render_test.go
@@ -7,6 +7,9 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // The renderers dropped every package license for as long as they existed,
@@ -250,61 +253,121 @@ func renderBom(t *testing.T, format string, bom *Sbom) string {
 }
 
 func TestCycloneDXSeparatesDeclaredFromConcluded(t *testing.T) {
-	var doc struct {
-		Components []struct {
-			Name     string `json:"name"`
-			Licenses []struct {
-				License    *struct{ ID, Name string } `json:"license"`
-				Expression string                     `json:"expression"`
-			} `json:"licenses"`
-			Copyright string `json:"copyright"`
-			Supplier  *struct {
-				Name string `json:"name"`
-			} `json:"supplier"`
-			Evidence *struct {
-				Licenses []struct {
-					License *struct{ ID, Name string } `json:"license"`
-				} `json:"licenses"`
-				Copyright []struct {
-					Text string `json:"text"`
-				} `json:"copyright"`
-			} `json:"evidence"`
-		} `json:"components"`
+	c := cdxComponent(t, renderBom(t, "cyclonedx-json", splitLicenseBom()), "disagrees")
+
+	// Both licenses sit on the component, because acknowledgement tells them
+	// apart. Carrying the concluded one only under evidence would leave a
+	// consumer reading component.licenses believing the package is licensed as
+	// it claims, in exactly the case the two disagree and the shipped text is
+	// the grant.
+	require.Len(t, c.Licenses, 2)
+
+	declared := c.Licenses[0]
+	require.NotNil(t, declared.License)
+	assert.Equal(t, "MIT", declared.License.ID)
+	assert.Equal(t, "declared", declared.License.Acknowledgement)
+
+	concluded := c.Licenses[1]
+	require.NotNil(t, concluded.License)
+	assert.Equal(t, "AGPL-3.0-only", concluded.License.ID)
+	assert.Equal(t, "concluded", concluded.License.Acknowledgement)
+
+	// The confidence and the file it was read from are what separate a
+	// certainty from an inference, and 1.6 has no field for either.
+	props := map[string]string{}
+	require.NotNil(t, concluded.License.Properties)
+	for _, pr := range *concluded.License.Properties {
+		props[pr.Name] = pr.Value
 	}
-	if err := json.Unmarshal([]byte(renderBom(t, "cyclonedx-json", splitLicenseBom())), &doc); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	// The document also carries the asset's platform component; the package is
-	// the one under test.
-	var c = doc.Components[0]
-	found := false
-	for _, comp := range doc.Components {
-		if comp.Name == "disagrees" {
-			c, found = comp, true
+	assert.Equal(t, "0.98", props["mondoo:license:confidence"])
+	assert.Equal(t, "node_modules/disagrees/LICENSE", props["mondoo:license:location"])
+
+	// A declared license is a statement rather than a measurement, so its
+	// confidence is 1.0 by construction and saying so on every license in every
+	// document would be noise.
+	if declared.License.Properties != nil {
+		for _, pr := range *declared.License.Properties {
+			assert.NotEqual(t, "mondoo:license:confidence", pr.Name)
 		}
 	}
-	if !found {
-		t.Fatalf("no component named disagrees in %d components", len(doc.Components))
-	}
 
-	// Declared is an assertion the package makes about itself.
-	if len(c.Licenses) != 1 || c.Licenses[0].License == nil || c.Licenses[0].License.ID != "MIT" {
-		t.Errorf("licenses = %+v, want the declared MIT", c.Licenses)
+	assert.Equal(t, "Copyright (c) 2019 Example Corp", c.Copyright)
+	require.NotNil(t, c.Supplier)
+	assert.Equal(t, "Example Corp", c.Supplier.Name)
+}
+
+// The evidence block is a second view of what component.licenses already
+// carries, so it follows the same opt-in as evidence.occurrences rather than
+// being the one part of the block that appears unasked.
+func TestCycloneDXEvidenceFollowsTheEvidenceOption(t *testing.T) {
+	t.Run("absent by default", func(t *testing.T) {
+		c := cdxComponent(t, renderBom(t, "cyclonedx-json", splitLicenseBom()), "disagrees")
+		if c.Evidence != nil {
+			assert.Empty(t, c.Evidence.Licenses, "evidence.licenses without WithEvidence()")
+			assert.Empty(t, c.Evidence.Copyright, "evidence.copyright without WithEvidence()")
+		}
+		// The licensing itself is still reported; only the second view is gone.
+		assert.Len(t, c.Licenses, 2)
+	})
+
+	t.Run("present when asked for", func(t *testing.T) {
+		var b strings.Builder
+		h := New(FormatCycloneDxJSON)
+		h.ApplyOptions(WithEvidence())
+		require.NoError(t, h.Render(&b, splitLicenseBom()))
+
+		c := cdxComponent(t, b.String(), "disagrees")
+		require.NotNil(t, c.Evidence)
+		require.Len(t, c.Evidence.Licenses, 1)
+		require.NotNil(t, c.Evidence.Licenses[0].License)
+		assert.Equal(t, "AGPL-3.0-only", c.Evidence.Licenses[0].License.ID)
+		require.Len(t, c.Evidence.Copyright, 1)
+	})
+}
+
+type cdxLicenseChoice struct {
+	License *struct {
+		ID              string `json:"id"`
+		Name            string `json:"name"`
+		Acknowledgement string `json:"acknowledgement"`
+		Properties      *[]struct {
+			Name  string `json:"name"`
+			Value string `json:"value"`
+		} `json:"properties"`
+	} `json:"license"`
+	Expression      string `json:"expression"`
+	Acknowledgement string `json:"acknowledgement"`
+}
+
+type cdxComponentDoc struct {
+	Name      string             `json:"name"`
+	Licenses  []cdxLicenseChoice `json:"licenses"`
+	Copyright string             `json:"copyright"`
+	Supplier  *struct {
+		Name string `json:"name"`
+	} `json:"supplier"`
+	Evidence *struct {
+		Licenses  []cdxLicenseChoice `json:"licenses"`
+		Copyright []struct {
+			Text string `json:"text"`
+		} `json:"copyright"`
+	} `json:"evidence"`
+}
+
+// cdxComponent decodes one named component out of a rendered CycloneDX document.
+func cdxComponent(t *testing.T, out, name string) cdxComponentDoc {
+	t.Helper()
+	var doc struct {
+		Components []cdxComponentDoc `json:"components"`
 	}
-	// Concluded is evidence: it was read out of a file rather than stated.
-	if c.Evidence == nil || len(c.Evidence.Licenses) != 1 ||
-		c.Evidence.Licenses[0].License == nil || c.Evidence.Licenses[0].License.ID != "AGPL-3.0-only" {
-		t.Errorf("evidence.licenses = %+v, want the concluded AGPL-3.0-only", c.Evidence)
+	require.NoError(t, json.Unmarshal([]byte(out), &doc))
+	for _, c := range doc.Components {
+		if c.Name == name {
+			return c
+		}
 	}
-	if c.Copyright != "Copyright (c) 2019 Example Corp" {
-		t.Errorf("copyright = %q", c.Copyright)
-	}
-	if c.Evidence == nil || len(c.Evidence.Copyright) != 1 {
-		t.Errorf("evidence.copyright = %+v, want the statement that was found", c.Evidence)
-	}
-	if c.Supplier == nil || c.Supplier.Name != "Example Corp" {
-		t.Errorf("supplier = %+v", c.Supplier)
-	}
+	t.Fatalf("no component named %q in %d components", name, len(doc.Components))
+	return cdxComponentDoc{}
 }
 
 func TestSPDXConcludedIsNotAnEchoOfDeclared(t *testing.T) {
@@ -545,4 +608,61 @@ func TestSPDXUnreferenceableNameIsDropped(t *testing.T) {
 			t.Errorf("emitted a bare LicenseRef prefix: %q", id)
 		}
 	}
+}
+
+// SPDX has no field for a conclusion's confidence or the file it was read from,
+// and PackageLicenseComments is the one place the spec puts prose about how the
+// license fields were arrived at. Free text, so this is for a human reading the
+// document; the alternative was dropping the difference between a certainty and
+// an inference entirely.
+func TestSPDXRecordsWhatAConclusionWasBasedOn(t *testing.T) {
+	var doc struct {
+		Packages []struct {
+			Name            string `json:"name"`
+			LicenseComments string `json:"licenseComments"`
+		} `json:"packages"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(renderBom(t, FormatSpdxJSON, splitLicenseBom())), &doc))
+	require.Len(t, doc.Packages, 1)
+
+	got := doc.Packages[0].LicenseComments
+	assert.Contains(t, got, "AGPL-3.0-only")
+	assert.Contains(t, got, "node_modules/disagrees/LICENSE")
+	assert.Contains(t, got, "0.98")
+}
+
+// A comment saying nothing is worse than none: a reader takes its presence as a
+// sign there was something to say.
+func TestSPDXLicenseCommentsAreEmptyWithNothingToSay(t *testing.T) {
+	t.Run("nothing concluded", func(t *testing.T) {
+		assert.Empty(t, spdxLicenseComments(nil))
+	})
+
+	t.Run("a conclusion carrying neither detail", func(t *testing.T) {
+		assert.Empty(t, spdxLicenseComments([]*License{{
+			SpdxId:      "MIT",
+			Acquisition: LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED,
+			Confidence:  1,
+		}}))
+	})
+
+	// Full confidence says the same thing as no score attached, so it is not
+	// worth a note on its own.
+	t.Run("full confidence alone is not a note", func(t *testing.T) {
+		assert.Empty(t, spdxLicenseComments([]*License{{
+			SpdxId:      "MIT",
+			Acquisition: LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED,
+			Confidence:  1.0,
+		}}))
+	})
+
+	t.Run("a location alone is", func(t *testing.T) {
+		got := spdxLicenseComments([]*License{{
+			SpdxId:      "MIT",
+			Acquisition: LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED,
+			Location:    "LICENSE",
+			Confidence:  1,
+		}})
+		assert.Equal(t, "Concluded MIT: read from LICENSE.", got)
+	})
 }

--- a/sbom/license_render_test.go
+++ b/sbom/license_render_test.go
@@ -666,3 +666,50 @@ func TestSPDXLicenseCommentsAreEmptyWithNothingToSay(t *testing.T) {
 		assert.Equal(t, "Concluded MIT: read from LICENSE.", got)
 	})
 }
+
+// Both renderers apply the same rule to a conclusion's confidence, and the rule
+// is that full confidence says nothing. The model documents 1.0 as what a value
+// carries when it is a statement rather than a measurement, so a conclusion at
+// 1.0 is asserting no measurement -- the same thing an entry with no score
+// attached says. Reporting it would read as a score somebody took.
+func TestFullConfidenceIsNotReportedByEitherRenderer(t *testing.T) {
+	bom := &Sbom{
+		Generator: &Generator{Vendor: "Mondoo, Inc", Name: "test", Version: "1"},
+		Asset:     &Asset{Name: "test-asset", Platform: &Platform{Name: "linux", Version: "1"}},
+		Packages: []*Package{{
+			Name: "certain", Version: "1.0.0", Purl: "pkg:npm/certain@1.0.0",
+			Licenses: []*License{{
+				SpdxId:      "MIT",
+				Acquisition: LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED,
+				Confidence:  1.0,
+				Location:    "LICENSE",
+			}},
+		}},
+	}
+
+	t.Run("cyclonedx omits the confidence property but keeps the location", func(t *testing.T) {
+		c := cdxComponent(t, renderBom(t, FormatCycloneDxJSON, bom), "certain")
+		require.Len(t, c.Licenses, 1)
+		require.NotNil(t, c.Licenses[0].License)
+		require.NotNil(t, c.Licenses[0].License.Properties)
+
+		names := map[string]string{}
+		for _, pr := range *c.Licenses[0].License.Properties {
+			names[pr.Name] = pr.Value
+		}
+		assert.NotContains(t, names, "mondoo:license:confidence")
+		assert.Equal(t, "LICENSE", names["mondoo:license:location"])
+	})
+
+	t.Run("spdx says the same", func(t *testing.T) {
+		var doc struct {
+			Packages []struct {
+				LicenseComments string `json:"licenseComments"`
+			} `json:"packages"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(renderBom(t, FormatSpdxJSON, bom)), &doc))
+		require.Len(t, doc.Packages, 1)
+		assert.Equal(t, "Concluded MIT: read from LICENSE.", doc.Packages[0].LicenseComments)
+		assert.NotContains(t, doc.Packages[0].LicenseComments, "confidence")
+	})
+}

--- a/sbom/spdx.go
+++ b/sbom/spdx.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -143,6 +144,7 @@ func (s *Spdx) convertToSpdx(bom *Sbom) *spdx.Document {
 			PackageLicenseDeclared:    declared,
 			PackageLicenseConcluded:   concluded,
 			PackageCopyrightText:      spdxNoAssertion(strings.Join(pkg.Copyright, "\n")),
+			PackageLicenseComments:    spdxLicenseComments(concludedLicenses(pkg)),
 			PackageSupplier:           spdxSupplier(pkg.Supplier),
 			PackageDescription:        pkg.Description,
 			PackageExternalReferences: refs,
@@ -535,6 +537,46 @@ func spdxLicenseRef(name string) string {
 		return ""
 	}
 	return licenseRefPrefix + id
+}
+
+// spdxLicenseComments records what a conclusion was based on: the file it was
+// read from and how sure whoever read it was.
+//
+// SPDX has no field for either, and PackageLicenseComments is the one place the
+// spec puts prose about how the license fields were arrived at. It is free text,
+// so this is for a human reading the document rather than a consumer parsing it
+// -- but the alternative is dropping the difference between a certainty and an
+// inference entirely, which is what the renderer did before.
+//
+// Empty when nothing was concluded, or when a conclusion carries neither
+// detail: a comment saying nothing is worse than none, since a reader takes its
+// presence as a sign there was something to say.
+func spdxLicenseComments(licenses []*License) string {
+	notes := make([]string, 0, len(licenses))
+	for _, l := range licenses {
+		value := strings.TrimSpace(spdxLicense([]*License{l}, "", extractedLicenseSet{}))
+		if value == "" {
+			continue
+		}
+
+		var detail []string
+		if loc := strings.TrimSpace(l.GetLocation()); loc != "" {
+			detail = append(detail, "read from "+loc)
+		}
+		// A conclusion at full confidence is not worth a note: it says the same
+		// thing as a conclusion with no score attached.
+		if c := l.GetConfidence(); c > 0 && c < 1 {
+			detail = append(detail, "confidence "+strconv.FormatFloat(c, 'g', -1, 64))
+		}
+		if len(detail) == 0 {
+			continue
+		}
+		notes = append(notes, value+": "+strings.Join(detail, ", "))
+	}
+	if len(notes) == 0 {
+		return ""
+	}
+	return "Concluded " + strings.Join(notes, "; ") + "."
 }
 
 // spdxSupplier renders a supplier as the spec's Originator/Supplier shape, or


### PR DESCRIPTION
Fixes two things #10491 left open, which turn out to be the same problem.

## The cause

#10491 encoded the declared/concluded split **positionally**: declared → `component.licenses`, concluded → `component.evidence.licenses`. That forced both defects.

- Concluded licences had to appear **whether or not the caller asked for evidence**, because gating them the way `evidence.occurrences` is gated would have dropped real licensing rather than provenance detail.
- `evidence.licenses` is a plain licence array, so `License.confidence` and `License.location` — the fields separating a certainty from an inference — reached no renderer at all. Modelled, populated, never emitted.

## CycloneDX already has the field

1.6 has `acknowledgement` (`declared` | `concluded`), said on the licence itself. `cyclonedx-go v0.11.0` carries it in JSON and — via the custom `Licenses` marshaller, not the struct tags — as an XML attribute for **both** the licence and the expression shape. So:

- **Every licence renders on the component**, each stating its acknowledgement. Carrying the concluded one only under evidence left a consumer reading `component.licenses` believing a package is licensed as it claims, in exactly the case the two disagree and the shipped text is the grant.
- **`confidence` and `location` become licence properties**, the schema's own extension point, and only for a conclusion — a declared licence's confidence is 1.0 by construction, so emitting it would be noise on every licence in every document.
- **`evidence.licenses` / `evidence.copyright` now follow `WithEvidence()`**, like `evidence.occurrences` beside them. They are a second view of what the component already carries, so there is no longer a reason for one part of the block to appear unasked.

```json
"licenses": [
  {"license": {"id": "MIT", "acknowledgement": "declared"}},
  {"license": {"id": "AGPL-3.0-only", "acknowledgement": "concluded",
    "properties": [
      {"name": "mondoo:license:confidence", "value": "0.98"},
      {"name": "mondoo:license:location", "value": "node_modules/disagrees/LICENSE"}
    ]}}
]
```

## SPDX

No field for either detail. `PackageLicenseComments` is where the spec puts prose about how the licence fields were arrived at, so a conclusion records what it was read from and how sure it was:

```
Concluded AGPL-3.0-only: read from node_modules/disagrees/LICENSE, confidence 0.98.
```

Free text, so it is for a human rather than a parser — but the alternative is what shipped, which was dropping the distinction entirely. A conclusion carrying neither detail writes nothing, because a comment saying nothing reads as a sign there was something to say.

## Behaviour change

#10491's `TestCycloneDXSeparatesDeclaredFromConcluded` pinned the positional encoding and is rewritten against the new contract. That is the one behaviour change, and it is visible to anyone reading `evidence.licenses` today — the data is still there, on the component, and now under `WithEvidence()` in evidence too. The legacy scalar path is untouched.

All four parts were confirmed to fail when reverted individually: acknowledgement, the properties, the evidence gate, and the SPDX comments.
