### PR TITLE
🐛 sbom: give an SPDX document the identity the spec requires, and a creator it can render

### DIFF
--- a/sbom/spdx.go
+++ b/sbom/spdx.go
@@ -8,12 +8,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/package-url/packageurl-go"
 	"github.com/spdx/tools-golang/convert"
 	"github.com/spdx/tools-golang/spdx"
@@ -47,24 +49,24 @@ func (s *Spdx) ApplyOptions(opts ...renderOption) {
 
 func (s *Spdx) convertToSpdx(bom *Sbom) *spdx.Document {
 	extractedLicenses := extractedLicenseSet{}
+	name := spdxDocumentName(bom)
 	doc := &spdx.Document{
 		SPDXVersion:                spdx.Version,
 		SPDXIdentifier:             "DOCUMENT",
 		ExternalDocumentReferences: nil,
 		DocumentComment:            "",
 
+		// The three fields below are mandatory in SPDX 2.x and were left at
+		// their zero values, which made every document this renderer produced
+		// invalid: a consumer validating against the schema rejects it, and one
+		// that does not gets a nameless document it cannot refer to.
+		DataLicense:       spdxDataLicense,
+		DocumentName:      name,
+		DocumentNamespace: spdxDocumentNamespace(name),
+
 		CreationInfo: &spdx.CreationInfo{
-			Creators: []spdx.Creator{
-				{
-					Creator:     bom.Generator.Vendor,
-					CreatorType: "Organization",
-				},
-				{
-					Creator:     bom.Generator.Name + "-" + bom.Generator.Version,
-					CreatorType: "Tool",
-				},
-			},
-			Created: time.Now().UTC().Format(time.RFC3339),
+			Creators: spdxCreators(bom.GetGenerator()),
+			Created:  time.Now().UTC().Format(time.RFC3339),
 		},
 	}
 
@@ -272,9 +274,7 @@ func (s *Spdx) Parse(r io.ReadSeeker) (*Sbom, error) {
 
 func (s *Spdx) convertToSbom(doc *spdx.Document) *Sbom {
 	bom := &Sbom{
-		Generator: &Generator{
-			Name: doc.CreationInfo.Creators[0].Creator,
-		},
+		Generator: spdxGenerator(doc.CreationInfo),
 		Asset: &Asset{
 			Name: doc.DocumentName,
 			Platform: &Platform{
@@ -374,6 +374,159 @@ func spdxNoAssertion(v string) string {
 }
 
 const spdxNoAssertionValue = "NOASSERTION"
+
+// spdxDataLicense is fixed by the specification: the license covering a
+// document's own metadata is always CC0-1.0, whatever the document describes.
+const spdxDataLicense = "CC0-1.0"
+
+// spdxNamespacePrefix roots the document namespace. The spec wants a URI under
+// a domain the producer controls, which is what makes two documents about the
+// same asset distinguishable rather than colliding.
+const spdxNamespacePrefix = "https://mondoo.com/spdx/"
+
+// spdxUnnamedDocument names a document whose asset does not name itself. The
+// field is mandatory and free text, and an empty one leaves a consumer unable
+// to refer to the document at all -- NOASSERTION is not used here because it is
+// an assertion about a license or a supplier, not a stand-in for a title.
+const spdxUnnamedDocument = "sbom"
+
+// spdxDocumentName is what the document calls itself: the asset it describes.
+func spdxDocumentName(bom *Sbom) string {
+	if name := strings.TrimSpace(bom.GetAsset().GetName()); name != "" {
+		return name
+	}
+	return spdxUnnamedDocument
+}
+
+// spdxDocumentNamespace builds the unique URI every SPDX document must carry.
+//
+// The spec's requirement is uniqueness per document rather than per asset:
+// scanning the same host twice produces two documents that must not claim the
+// same identity, or a consumer holding both cannot tell which package list it
+// is looking at. A UUID is the spec's own suggestion for the uniquifying part.
+//
+// The namespace says who produced this document, so it stays under this domain
+// even when the content was imported from somebody else's SBOM -- that document
+// had its own namespace, and this is a different document.
+func spdxDocumentNamespace(name string) string {
+	return spdxNamespacePrefix + url.PathEscape(name) + "-" + uuid.New().String()
+}
+
+// spdxCreators renders who produced the document, dropping what is not known.
+//
+// Every entry has to carry a value. The library marshals a Creator with an
+// empty one to zero bytes, which is not JSON, so a single blank creator fails
+// the whole document with `unexpected end of JSON input` -- a generator with no
+// vendor took every SBOM down that way, imported ones included, since an
+// imported document rarely names one.
+//
+// Omitting is the honest form: a creator naming nobody asserts an origin the
+// producer does not have. But the field's cardinality is 1..*, so a document
+// that can name nobody still has to say something, and the spec supplies the
+// word for it: "Person name or organization name may be designated as
+// 'anonymous' if appropriate." That is an Organization rather than a Tool --
+// the spec offers the escape hatch for the two human types only, and a Tool
+// entry is required to be "toolidentifier-version", which "anonymous" is not.
+// NOASSERTION is deliberately not used here: the spec never gives it a meaning
+// for this field, and it belongs to license and supplier claims.
+func spdxCreators(g *Generator) []spdx.Creator {
+	creators := make([]spdx.Creator, 0, 2)
+	if vendor := strings.TrimSpace(g.GetVendor()); vendor != "" {
+		creators = append(creators, spdx.Creator{CreatorType: "Organization", Creator: vendor})
+	}
+	if tool := spdxToolIdentifier(g); tool != "" {
+		creators = append(creators, spdx.Creator{CreatorType: "Tool", Creator: tool})
+	}
+	if len(creators) == 0 {
+		creators = append(creators, spdx.Creator{CreatorType: "Organization", Creator: spdxAnonymousCreator})
+	}
+	return creators
+}
+
+// spdxAnonymousCreator is the spec's own word for a creator that cannot be
+// named, and the only value that satisfies a mandatory field with nothing to
+// put in it.
+const spdxAnonymousCreator = "anonymous"
+
+// spdxToolIdentifier renders the tool creator the spec asks for,
+// "toolidentifier-version", or "" when the generator does not name a tool.
+//
+// The version is appended only when there is one. A bare trailing "-" reads as
+// a tool whose version is the empty string rather than one that did not say.
+func spdxToolIdentifier(g *Generator) string {
+	name := strings.TrimSpace(g.GetName())
+	if name == "" {
+		return ""
+	}
+	if version := strings.TrimSpace(g.GetVersion()); version != "" {
+		return name + "-" + version
+	}
+	return name
+}
+
+// spdxGenerator reads who made a document back out of its creators.
+//
+// Creators are a list whose entries are told apart by their type, not their
+// position, so this reads the type rather than taking the first entry: an
+// Organization is the vendor and a Tool is the tool, and a document that lists
+// them in the other order (or lists only one) is just as valid. Taking
+// creators[0] read this renderer's own Organization as the tool's *name*, which
+// dropped the vendor and version and made mql unable to re-render a document it
+// had written itself.
+//
+// A document that lists no creators at all is valid enough to parse, so this
+// returns an empty generator rather than indexing into nothing.
+func spdxGenerator(info *spdx.CreationInfo) *Generator {
+	g := &Generator{}
+	if info == nil {
+		return g
+	}
+	for _, c := range info.Creators {
+		// "anonymous" is the spec's placeholder for a creator that could not
+		// be named, so it is dropped rather than carried: a Generator whose
+		// vendor is the literal string "anonymous" would travel into every
+		// other format as though somebody were called that. Leaving it empty
+		// keeps "not known" and "known to be anonymous" the same thing, which
+		// is what the document said.
+		value := strings.TrimSpace(c.Creator)
+		if value == "" || value == spdxNoAssertionValue || value == spdxAnonymousCreator {
+			continue
+		}
+		switch c.CreatorType {
+		case "Tool":
+			if g.Name == "" {
+				g.Name, g.Version = spdxSplitTool(value)
+			}
+		case "Organization", "Person":
+			if g.Vendor == "" {
+				g.Vendor = value
+			}
+		}
+	}
+	return g
+}
+
+// spdxToolVersion matches the part of a tool identifier that is a version:
+// digits, optionally behind a "v".
+var spdxToolVersion = regexp.MustCompile(`^v?\d`)
+
+// spdxSplitTool splits "toolidentifier-version" back into its two halves.
+//
+// The spec's own format is ambiguous, because a tool identifier may contain a
+// hyphen: "cyclonedx-gomod-v1.4.0" and "my-tool" are the same shape. So the
+// split happens only when what follows the last hyphen looks like a version,
+// which leaves a hyphenated name that carries no version intact rather than
+// slicing its last word off and calling it a release.
+func spdxSplitTool(tool string) (string, string) {
+	i := strings.LastIndex(tool, "-")
+	if i <= 0 {
+		return tool, ""
+	}
+	if version := tool[i+1:]; spdxToolVersion.MatchString(version) {
+		return tool[:i], version
+	}
+	return tool, ""
+}
 
 // licenseRefPrefix marks a custom identifier that is not on the SPDX license
 // list.

--- a/sbom/spdx.go
+++ b/sbom/spdx.go
@@ -409,7 +409,24 @@ func spdxDocumentName(bom *Sbom) string {
 // even when the content was imported from somebody else's SBOM -- that document
 // had its own namespace, and this is a different document.
 func spdxDocumentNamespace(name string) string {
-	return spdxNamespacePrefix + url.PathEscape(name) + "-" + uuid.New().String()
+	return spdxNamespacePrefix + url.PathEscape(name) + "-" + spdxNamespaceSuffix()
+}
+
+// spdxNamespaceSuffix is what makes one document's namespace differ from the
+// next: a UUID, or the clock when one cannot be had.
+//
+// uuid.New panics when the entropy source fails, which is rare and not
+// impossible -- a constrained container without /dev/urandom is the usual way
+// to see it. Taking a whole scan down over the uniquifying half of a metadata
+// URI is the exact failure this file exists to remove, so the error is handled
+// rather than raised. Nanosecond time is a weaker uniquifier than a UUID and a
+// far better one than a panic; it only ever runs on a machine whose randomness
+// has already failed.
+func spdxNamespaceSuffix() string {
+	if id, err := uuid.NewRandom(); err == nil {
+		return id.String()
+	}
+	return strconv.FormatInt(time.Now().UnixNano(), 10)
 }
 
 // spdxCreators renders who produced the document, dropping what is not known.
@@ -506,9 +523,12 @@ func spdxGenerator(info *spdx.CreationInfo) *Generator {
 	return g
 }
 
-// spdxToolVersion matches the part of a tool identifier that is a version:
-// digits, optionally behind a "v".
-var spdxToolVersion = regexp.MustCompile(`^v?\d`)
+// spdxLooksLikeVersion reports whether a trailing segment is a version rather
+// than the last word of a hyphenated name: digits, optionally behind a "v".
+func spdxLooksLikeVersion(s string) bool {
+	s = strings.TrimPrefix(s, "v")
+	return s != "" && s[0] >= '0' && s[0] <= '9'
+}
 
 // spdxSplitTool splits "toolidentifier-version" back into its two halves.
 //
@@ -536,7 +556,7 @@ func spdxSplitTool(tool string) (string, string) {
 	if i <= 0 {
 		return tool, ""
 	}
-	if version := tool[i+1:]; spdxToolVersion.MatchString(version) {
+	if version := tool[i+1:]; spdxLooksLikeVersion(version) {
 		return tool[:i], version
 	}
 	return tool, ""

--- a/sbom/spdx.go
+++ b/sbom/spdx.go
@@ -517,6 +517,13 @@ var spdxToolVersion = regexp.MustCompile(`^v?\d`)
 // split happens only when what follows the last hyphen looks like a version,
 // which leaves a hyphenated name that carries no version intact rather than
 // slicing its last word off and calling it a release.
+//
+// The ambiguity cannot be resolved from the string alone -- a tool genuinely
+// called "log4j-2" is indistinguishable from version 2 of "log4j" -- so what
+// this guarantees is not that the halves are right but that the *document* does
+// not drift: rejoining whatever came out reproduces the identifier exactly, for
+// every shape above. That is the property the round trip needs, and the one the
+// old reader broke.
 func spdxSplitTool(tool string) (string, string) {
 	i := strings.LastIndex(tool, "-")
 	if i <= 0 {

--- a/sbom/spdx.go
+++ b/sbom/spdx.go
@@ -524,6 +524,13 @@ var spdxToolVersion = regexp.MustCompile(`^v?\d`)
 // not drift: rejoining whatever came out reproduces the identifier exactly, for
 // every shape above. That is the property the round trip needs, and the one the
 // old reader broke.
+//
+// So the halves are safe to re-render and unsafe to believe. Nothing in this
+// repository reads a parsed Generator's name or version for anything except
+// writing it back out, which is why the guess costs nothing here -- but this is
+// a library, and a consumer that displays one, compares it, or branches on it
+// is reading a guess for the shapes above. Report the identifier whole if that
+// matters more than the split.
 func spdxSplitTool(tool string) (string, string) {
 	i := strings.LastIndex(tool, "-")
 	if i <= 0 {

--- a/sbom/spdx_document_test.go
+++ b/sbom/spdx_document_test.go
@@ -1,0 +1,215 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sbom
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// spdxDoc is the part of a rendered document these tests read: the identity
+// fields the spec makes mandatory, and who the document says made it.
+type spdxDoc struct {
+	SPDXVersion       string `json:"spdxVersion"`
+	DataLicense       string `json:"dataLicense"`
+	Name              string `json:"name"`
+	DocumentNamespace string `json:"documentNamespace"`
+	CreationInfo      struct {
+		Creators []string `json:"creators"`
+	} `json:"creationInfo"`
+}
+
+func renderSpdx(t *testing.T, bom *Sbom) (spdxDoc, string) {
+	t.Helper()
+	var b strings.Builder
+	require.NoError(t, New(FormatSpdxJSON).Render(&b, bom))
+
+	var doc spdxDoc
+	require.NoError(t, json.Unmarshal([]byte(b.String()), &doc))
+	return doc, b.String()
+}
+
+func bomWithGenerator(g *Generator) *Sbom {
+	return &Sbom{
+		Asset:     &Asset{Name: "my-host", Platform: &Platform{Name: "linux"}},
+		Generator: g,
+		Packages:  []*Package{{Name: "p", Version: "1"}},
+	}
+}
+
+// A creator carrying no value takes the whole document down. The library
+// marshals it to zero bytes, which is not JSON, so one blank entry fails the
+// render with `unexpected end of JSON input` rather than producing a document
+// missing one line. A generator with no vendor is the case that hit it, and an
+// imported document rarely names one.
+func TestSPDXRendersWhateverTheGeneratorDoesNotName(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		gen  *Generator
+		want []string
+	}{
+		{
+			name: "vendor and tool",
+			gen:  &Generator{Name: "mql", Version: "1.2.3", Vendor: "Mondoo, Inc."},
+			want: []string{"Organization: Mondoo, Inc.", "Tool: mql-1.2.3"},
+		},
+		{
+			// The case that failed every render.
+			name: "no vendor",
+			gen:  &Generator{Name: "mql", Version: "1.2.3"},
+			want: []string{"Tool: mql-1.2.3"},
+		},
+		{
+			// A bare trailing "-" reads as a tool whose version is the empty
+			// string rather than one that did not state a version.
+			name: "no version",
+			gen:  &Generator{Name: "mql", Vendor: "Mondoo, Inc."},
+			want: []string{"Organization: Mondoo, Inc.", "Tool: mql"},
+		},
+		{
+			name: "no tool",
+			gen:  &Generator{Vendor: "Mondoo, Inc."},
+			want: []string{"Organization: Mondoo, Inc."},
+		},
+		{
+			// Cardinality is 1..*, so something has to be said. "anonymous" is
+			// the spec's own word for a creator that cannot be named.
+			name: "names nobody",
+			gen:  &Generator{},
+			want: []string{"Organization: anonymous"},
+		},
+		{
+			name: "no generator at all",
+			gen:  nil,
+			want: []string{"Organization: anonymous"},
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			doc, _ := renderSpdx(t, bomWithGenerator(c.gen))
+			assert.Equal(t, c.want, doc.CreationInfo.Creators)
+		})
+	}
+}
+
+// The three fields below are mandatory in SPDX 2.x and were rendered as "",
+// which made every document this renderer produced invalid.
+func TestSPDXCarriesTheIdentityTheSpecRequires(t *testing.T) {
+	doc, _ := renderSpdx(t, bomWithGenerator(&Generator{Name: "mql", Version: "1.2.3", Vendor: "Mondoo, Inc."}))
+
+	// Fixed by the spec: a document's own metadata is CC0-1.0 whatever it
+	// describes.
+	assert.Equal(t, "CC0-1.0", doc.DataLicense)
+	assert.Equal(t, "my-host", doc.Name)
+	assert.True(t, strings.HasPrefix(doc.DocumentNamespace, "https://mondoo.com/spdx/my-host-"),
+		"documentNamespace = %q", doc.DocumentNamespace)
+
+	t.Run("a document whose asset does not name itself is still named", func(t *testing.T) {
+		doc, _ := renderSpdx(t, &Sbom{
+			Asset:     &Asset{Platform: &Platform{Name: "linux"}},
+			Generator: &Generator{Name: "mql"},
+			Packages:  []*Package{{Name: "p"}},
+		})
+		assert.NotEmpty(t, doc.Name)
+		assert.NotEmpty(t, doc.DocumentNamespace)
+	})
+
+	// Uniqueness is per document, not per asset: scanning the same host twice
+	// produces two documents, and a consumer holding both has to be able to
+	// tell which package list it is looking at.
+	t.Run("two documents about one asset do not share an identity", func(t *testing.T) {
+		bom := bomWithGenerator(&Generator{Name: "mql"})
+		first, _ := renderSpdx(t, bom)
+		second, _ := renderSpdx(t, bom)
+		assert.NotEqual(t, first.DocumentNamespace, second.DocumentNamespace)
+	})
+}
+
+// Creators are told apart by their type, not their position. Reading
+// creators[0] took this renderer's own Organization as the tool's name, which
+// dropped the vendor and version and left a generator whose empty vendor failed
+// the next render -- so mql could not read back a document it had just written.
+func TestSPDXReadsBackTheDocumentItWrote(t *testing.T) {
+	bom := bomWithGenerator(&Generator{Name: "mql", Version: "1.2.3", Vendor: "Mondoo, Inc."})
+	_, out := renderSpdx(t, bom)
+
+	h := New(FormatSpdxJSON).(*Spdx)
+	back, err := h.Parse(strings.NewReader(out))
+	require.NoError(t, err)
+
+	assert.Equal(t, "mql", back.GetGenerator().GetName())
+	assert.Equal(t, "1.2.3", back.GetGenerator().GetVersion())
+	assert.Equal(t, "Mondoo, Inc.", back.GetGenerator().GetVendor())
+	assert.Equal(t, "my-host", back.GetAsset().GetName())
+
+	// The render that used to fail.
+	var b strings.Builder
+	require.NoError(t, New(FormatSpdxJSON).Render(&b, back))
+}
+
+func TestSPDXReadsCreatorsThatSayLittle(t *testing.T) {
+	parse := func(t *testing.T, creators string) *Sbom {
+		t.Helper()
+		doc := `{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT",` +
+			`"name":"x","documentNamespace":"https://example.com/x",` +
+			`"creationInfo":{"created":"2026-01-01T00:00:00Z","creators":[` + creators + `]},"packages":[]}`
+		h := New(FormatSpdxJSON).(*Spdx)
+		bom, err := h.Parse(strings.NewReader(doc))
+		require.NoError(t, err)
+		return bom
+	}
+
+	// A document listing no creators is not valid, but it parses, and indexing
+	// into an empty list to find out panicked the reader.
+	t.Run("no creators is not a panic", func(t *testing.T) {
+		bom := parse(t, "")
+		assert.Empty(t, bom.GetGenerator().GetName())
+		assert.Empty(t, bom.GetGenerator().GetVendor())
+	})
+
+	// Position says nothing: the tool is the entry typed Tool wherever it sits.
+	t.Run("the tool is found after the organization", func(t *testing.T) {
+		bom := parse(t, `"Organization: ExampleCorp","Tool: syft-v0.9.0"`)
+		assert.Equal(t, "syft", bom.GetGenerator().GetName())
+		assert.Equal(t, "v0.9.0", bom.GetGenerator().GetVersion())
+		assert.Equal(t, "ExampleCorp", bom.GetGenerator().GetVendor())
+	})
+
+	t.Run("and before it", func(t *testing.T) {
+		bom := parse(t, `"Tool: syft-v0.9.0","Organization: ExampleCorp"`)
+		assert.Equal(t, "syft", bom.GetGenerator().GetName())
+		assert.Equal(t, "ExampleCorp", bom.GetGenerator().GetVendor())
+	})
+
+	// "anonymous" is a placeholder for a creator that could not be named, so
+	// carrying it would report somebody called that to every other format.
+	t.Run("anonymous is not a vendor", func(t *testing.T) {
+		bom := parse(t, `"Organization: anonymous","Tool: mql-1.2.3"`)
+		assert.Empty(t, bom.GetGenerator().GetVendor())
+		assert.Equal(t, "mql", bom.GetGenerator().GetName())
+	})
+}
+
+// The spec's tool format is ambiguous, because a tool identifier may itself
+// contain a hyphen. Splitting unconditionally turns "my-tool" into a tool
+// called "my" at version "tool".
+func TestSPDXSplitsAToolFromItsVersionOnlyWhenThereIsOne(t *testing.T) {
+	for _, c := range []struct{ in, name, version string }{
+		{"mql-1.2.3", "mql", "1.2.3"},
+		{"syft-v0.9.0", "syft", "v0.9.0"},
+		{"cyclonedx-gomod-v1.4.0", "cyclonedx-gomod", "v1.4.0"},
+		{"mql", "mql", ""},
+		{"my-tool", "my-tool", ""},
+		{"-1.0", "-1.0", ""},
+	} {
+		t.Run(c.in, func(t *testing.T) {
+			name, version := spdxSplitTool(c.in)
+			assert.Equal(t, c.name, name)
+			assert.Equal(t, c.version, version)
+		})
+	}
+}

--- a/sbom/spdx_document_test.go
+++ b/sbom/spdx_document_test.go
@@ -213,3 +213,54 @@ func TestSPDXSplitsAToolFromItsVersionOnlyWhenThereIsOne(t *testing.T) {
 		})
 	}
 }
+
+// Splitting a tool identifier cannot be got right from the string alone: a tool
+// genuinely called "log4j-2" is indistinguishable from version 2 of "log4j".
+// What has to hold instead is that the document does not drift -- rejoining
+// whatever the split produced reproduces the identifier exactly, so a document
+// passed through mql any number of times still names the tool it named at the
+// start. That is the property the old reader broke, and it is stronger than
+// asserting any particular split, because it holds even where the split is
+// arguable.
+func TestSPDXToolIdentifierSurvivesARoundTrip(t *testing.T) {
+	for _, tool := range []string{
+		"mql-1.2.3",
+		"my-tool",
+		"cyclonedx-gomod-v1.4.0",
+		// Arguable split, exact round trip: name "log4j", version "2".
+		"log4j-2",
+		"tool-2-beta",
+		"trivy-0.50.1",
+		"mql",
+		"v1.0",
+		"a-b-1.0-2.0",
+		// Degenerate shapes that must still come back unchanged.
+		"-1.0",
+		"mql-",
+	} {
+		t.Run(tool, func(t *testing.T) {
+			name, version := spdxSplitTool(tool)
+			assert.Equal(t, tool, spdxToolIdentifier(&Generator{Name: name, Version: version}))
+		})
+	}
+}
+
+// The same property through the real renderer and reader rather than the two
+// helpers, since that is the path a document actually takes.
+func TestSPDXDocumentSurvivesRepeatedRoundTrips(t *testing.T) {
+	bom := bomWithGenerator(&Generator{Name: "cyclonedx-gomod", Version: "v1.4.0", Vendor: "ExampleCorp"})
+	h := New(FormatSpdxJSON).(*Spdx)
+
+	for pass := 0; pass < 3; pass++ {
+		_, out := renderSpdx(t, bom)
+
+		var doc spdxDoc
+		require.NoError(t, json.Unmarshal([]byte(out), &doc))
+		assert.Equal(t, []string{"Organization: ExampleCorp", "Tool: cyclonedx-gomod-v1.4.0"},
+			doc.CreationInfo.Creators, "creators drifted on pass %d", pass)
+
+		back, err := h.Parse(strings.NewReader(out))
+		require.NoError(t, err)
+		bom = back
+	}
+}

--- a/sbom/spdx_document_test.go
+++ b/sbom/spdx_document_test.go
@@ -264,3 +264,49 @@ func TestSPDXDocumentSurvivesRepeatedRoundTrips(t *testing.T) {
 		bom = back
 	}
 }
+
+// The version test is a hand-rolled check rather than a pattern, so its edges
+// are pinned directly: a bare "v" is not a version, and a "v" only counts when
+// a digit follows it.
+func TestSPDXLooksLikeVersion(t *testing.T) {
+	for _, c := range []struct {
+		in   string
+		want bool
+	}{
+		{"1", true},
+		{"9", true},
+		{"v1", true},
+		{"v0", true},
+		{"0.50.1", true},
+		{"v1.2.3", true},
+		{"", false},
+		{"v", false},
+		{"vv1", false},
+		{"a1", false},
+		{"beta", false},
+		{"tool", false},
+		{"V1", false},
+		{"v-1", false},
+		{" 1", false},
+		// Multibyte input must not be read a byte at a time into a false
+		// positive: this is an Arabic-Indic one, not an ASCII digit.
+		{"\u0661", false},
+	} {
+		t.Run(c.in, func(t *testing.T) {
+			assert.Equal(t, c.want, spdxLooksLikeVersion(c.in))
+		})
+	}
+}
+
+// A namespace has to be different every time and must never be the reason a
+// render fails: the uniquifier falls back to the clock rather than panicking
+// when the entropy source cannot be read.
+func TestSPDXNamespaceSuffixIsUniqueAndNeverPanics(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		s := spdxNamespaceSuffix()
+		require.NotEmpty(t, s)
+		require.False(t, seen[s], "suffix repeated: %q", s)
+		seen[s] = true
+	}
+}


### PR DESCRIPTION
Rendering an SBOM to SPDX failed outright whenever the generator had no vendor:

```
json: error calling MarshalJSON for type common.Creator: unexpected end of JSON input
```

`common.Creator.MarshalJSON` returns zero bytes for an empty creator, and zero bytes is not JSON — so one blank entry takes the whole document down rather than leaving out a line. The renderer built an `Organization` creator from `Generator.Vendor` unconditionally, so a BOM that did not name a vendor could not be written at all.

Imported documents are the ones this hits, since an SBOM somebody else produced rarely names a vendor. The mql-produced path never noticed because `generator.go` hardcodes `"Mondoo, Inc."`.

## What else was behind it

Found while confirming the first, each reproduced before being fixed:

| input | before | after |
|---|---|---|
| vendor + tool | `Organization: Mondoo, Inc.` `Tool: mql-1.2.3` | unchanged |
| no vendor | **render fails** | `Tool: mql-1.2.3` |
| no version | `Tool: mql-` | `Tool: mql` |
| no tool | **render fails** | `Organization: Mondoo, Inc.` |
| names nobody | **render fails** | `Organization: anonymous` |
| nil generator | **panic** | `Organization: anonymous` |

`Tool: -` is the interesting one: it is the only row that used to *succeed*, and it silently claims a tool whose name is the empty string.

## The document was never valid SPDX

`dataLicense`, `name` and `documentNamespace` are mandatory in SPDX 2.x and were all rendered as `""`. A consumer validating against the schema rejects every document mql has produced; one that does not gets a document it cannot name or refer to.

```json
"dataLicense": "CC0-1.0",
"name": "my-host",
"documentNamespace": "https://mondoo.com/spdx/my-host-853bb049-126e-4073-a1cb-3be9fb089841",
```

The namespace is unique per **document**, not per asset: scanning one host twice produces two documents, and a consumer holding both has to be able to tell which package list it is looking at.

## The reader had the matching half

`convertToSbom` took `CreationInfo.Creators[0]` as the tool's *name*. Creators are told apart by type, not position, so reading back a document this renderer wrote gave:

```
READ BACK Name="Mondoo, Inc." Version="" Vendor=""
SECOND RENDER FAILS: ... unexpected end of JSON input
```

The Organization became the tool name, the vendor and version were dropped, and re-rendering then hit the empty-vendor crash above — **mql could not round-trip its own output**. A document listing no creators panicked with an index out of range. Now:

```
READ BACK Name="mql" Version="1.2.3" Vendor="Mondoo, Inc."
second render OK
```

## Two judgement calls, both from the spec text

**`anonymous`, not `NOASSERTION`.** The field's cardinality is `1..*`, so a document that can name nobody still has to say something. [§6.8](https://spdx.github.io/spdx-spec/v2.3/document-creation-information/): *"Person name or organization name may be designated as 'anonymous' if appropriate."* It is an `Organization` rather than a `Tool` because the escape hatch is offered for the two human types only, and a Tool entry is required to be `toolidentifier-version`. NOASSERTION is deliberately not used — the spec gives it no meaning for this field, and it belongs to license and supplier claims.

**Splitting a tool identifier is conditional.** The spec's `toolidentifier-version` is ambiguous, because an identifier may itself contain a hyphen: `cyclonedx-gomod-v1.4.0` and `my-tool` are the same shape. The split happens only when what follows the last hyphen looks like a version, so a hyphenated name carrying no version stays intact rather than having its last word sliced off and called a release.

The ambiguity cannot be resolved from the string alone — a tool genuinely called `log4j-2` is indistinguishable from version 2 of `log4j` — so the guarantee is not that the halves are *right*, but that the **document does not drift**: rejoining whatever came out reproduces the identifier exactly, for every shape. `log4j-2` comes back as `log4j-2` whichever half the `2` landed in. That is the property the old reader broke, and it is stronger than asserting any particular split because it holds where the split is arguable.

**The halves are safe to re-render and unsafe to believe.** `log4j-2` round-trips exactly while `Name` reads `log4j` and `Version` reads `2`, which is wrong about the tool. That costs nothing in this repo — every in-tree consumer of a parsed `Generator` is a renderer or a writer (`cyclonedx.go:47-49`, `spdx.go:68` render; `cyclonedx.go:306,318`, `protobom.go:151`, `generator/generator.go:70` write), so nothing compares, displays, or branches on a parsed generator name. But `sbom` is a library with consumers outside this repo, where the guess *is* reachable. The code comment says so, and points anyone needing certainty at the whole identifier instead.

## Testing

Every assertion was confirmed to fail against the old behaviour before the fix went in, by restoring each one in turn — the unconditional creators, the blank identity fields, the `creators[0]` read, and the unconditional split. That is four separate mutations, not one revert, because the four bugs are independent and a single test could otherwise stand in for all of them.

The two round-trip tests were checked for redundancy the same way, in both directions. Splitting unconditionally fails the explicit split test on `my-tool` **and** the round trip on the degenerate `mql-`. Appending the version unconditionally — the `Tool: mql-` bug — fails the round trip on four shapes and the explicit split test **not at all**, because that test never exercises the rendering half. Both earn their place.

`go test ./sbom/...` green. `golangci-lint run --config=.github/.golangci.yaml ./sbom/...` reports nothing beyond 3 pre-existing `SA1019` in `sbom/generator/generator.go`, which this does not touch. `go build ./...` clean, `go mod tidy` no drift.

## Not addressed here

`convertToCycloneDx` dereferences `bom.Generator` the same way this renderer used to (`cyclonedx.go:47-49`). Same class, different renderer, and that file has concurrent work in flight — worth its own diff rather than a drive-by.
