### PR TITLE
🐛 sbom: render a CycloneDX document for a BOM that names no metadata

### DIFF
--- a/sbom/cyclonedx.go
+++ b/sbom/cyclonedx.go
@@ -38,26 +38,26 @@ type CycloneDX struct {
 func (ccx *CycloneDX) convertToCycloneDx(bom *Sbom) (*cyclonedx.BOM, error) {
 	sbom := cyclonedx.NewBOM()
 	sbom.SerialNumber = uuid.New().URN()
+	// The subject's name, which the root component below is required to carry.
+	// Read through the getters: a hand-built BOM need not populate Asset or
+	// Generator, and a renderer that dies on a missing metadata field reports
+	// nothing about the packages it could have listed.
+	subject := unnamedSubject
+	if name := strings.TrimSpace(bom.GetAsset().GetName()); name != "" {
+		subject = name
+	}
+
 	sbom.Metadata = &cyclonedx.Metadata{
 		Timestamp: time.Now().Format(time.RFC3339),
-		Tools: &cyclonedx.ToolsChoice{
-			Components: &[]cyclonedx.Component{
-				{
-					Type:    cyclonedx.ComponentTypeApplication,
-					Author:  bom.Generator.Vendor,
-					Name:    bom.Generator.Name,
-					Version: bom.Generator.Version,
-				},
-			},
-		},
+		Tools:     cycloneDXTools(bom.GetGenerator()),
 		Component: &cyclonedx.Component{
 			// Deterministic (was a per-render UUID) so the document's root
 			// component id is stable across renders.
-			BOMRef: "root:" + bom.Asset.Name,
+			BOMRef: "root:" + subject,
 			// TODO: understand the device type
 			// Type: cyclonedx.ComponentTypeContainer,
 			Type: cyclonedx.ComponentTypeDevice,
-			Name: bom.Asset.Name,
+			Name: subject,
 		},
 	}
 
@@ -79,19 +79,19 @@ func (ccx *CycloneDX) convertToCycloneDx(bom *Sbom) (*cyclonedx.BOM, error) {
 	// was the only renderer that dereferenced it unguarded: SPDX and the table
 	// both render a BOM without one, and cnquery_bom.go guards the same field,
 	// so the package already treats a nil platform as something that reaches it.
-	if bom.Asset.Platform != nil && bom.Asset.Platform.Name != "" {
+	if platform := bom.GetAsset().GetPlatform(); platform.GetName() != "" {
 		cpe := ""
-		if len(bom.Asset.Platform.Cpes) > 0 {
-			cpe = bom.Asset.Platform.Cpes[0]
+		if len(platform.GetCpes()) > 0 {
+			cpe = platform.GetCpes()[0]
 		}
 
-		osRef := "os:" + bom.Asset.Platform.Name
+		osRef := "os:" + platform.GetName()
 		emitted[osRef] = true
 		components = append(components, cyclonedx.Component{
 			BOMRef:  osRef,
 			Type:    cyclonedx.ComponentTypeOS,
-			Name:    bom.Asset.Platform.Name,
-			Version: bom.Asset.Platform.Version,
+			Name:    platform.GetName(),
+			Version: platform.GetVersion(),
 			CPE:     cpe,
 		})
 	}
@@ -383,6 +383,31 @@ var familyMap = map[string][]string{
 	"alpine":  {"linux", "unix", "os"},
 	"fedora":  {"linux", "unix", "os"},
 	"rhel":    {"linux", "unix", "os"},
+}
+
+// cycloneDXTools renders the tool that produced the document, or nothing when
+// no tool is named.
+//
+// A component's name is required by the schema, so a generator that names no
+// tool cannot be rendered as one: the entry would be a component called "",
+// which is the nameless-component shape a consumer has to recognise as junk and
+// filter. `tools` is optional, so leaving it out says the same thing honestly.
+// The reader already tolerates its absence.
+func cycloneDXTools(g *Generator) *cyclonedx.ToolsChoice {
+	name := strings.TrimSpace(g.GetName())
+	if name == "" {
+		return nil
+	}
+	return &cyclonedx.ToolsChoice{
+		Components: &[]cyclonedx.Component{
+			{
+				Type:    cyclonedx.ComponentTypeApplication,
+				Author:  strings.TrimSpace(g.GetVendor()),
+				Name:    name,
+				Version: strings.TrimSpace(g.GetVersion()),
+			},
+		},
+	}
 }
 
 // cycloneDXComponentLicenses renders every license the model carries onto the

--- a/sbom/cyclonedx_metadata_test.go
+++ b/sbom/cyclonedx_metadata_test.go
@@ -1,0 +1,165 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sbom
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cdxMetadataDoc is the part of a rendered document these tests read: who the
+// document says made it, and what it says it is about.
+type cdxMetadataDoc struct {
+	Metadata struct {
+		Tools *struct {
+			Components *[]struct {
+				Name    string `json:"name"`
+				Version string `json:"version"`
+				Author  string `json:"author"`
+			} `json:"components"`
+		} `json:"tools"`
+		Component *struct {
+			BOMRef string `json:"bom-ref"`
+			Name   string `json:"name"`
+			Type   string `json:"type"`
+		} `json:"component"`
+	} `json:"metadata"`
+	Components []struct {
+		Name string `json:"name"`
+	} `json:"components"`
+}
+
+func renderCdx(t *testing.T, bom *Sbom) cdxMetadataDoc {
+	t.Helper()
+	var b strings.Builder
+	require.NoError(t, New(FormatCycloneDxJSON).Render(&b, bom))
+
+	var doc cdxMetadataDoc
+	require.NoError(t, json.Unmarshal([]byte(b.String()), &doc))
+	return doc
+}
+
+// The CycloneDX renderer read Generator and Asset straight through, so a BOM
+// that did not carry them took the whole render down with a nil dereference
+// rather than producing a document missing some metadata. Every other renderer
+// in this package survives the same input, which is what made this one wrong
+// rather than merely strict.
+//
+// The two are independent -- a BOM missing one is not usually missing the other
+// -- so they get separate cases rather than one "nothing is set" case standing
+// in for both.
+func TestCycloneDXRendersABomThatNamesNoMetadata(t *testing.T) {
+	pkgs := []*Package{{Name: "p", Version: "1"}}
+
+	t.Run("no generator", func(t *testing.T) {
+		doc := renderCdx(t, &Sbom{Asset: &Asset{Name: "h"}, Packages: pkgs})
+
+		// A component's name is required by the schema, so a generator naming
+		// no tool is rendered as no tool rather than as one called "".
+		assert.Nil(t, doc.Metadata.Tools)
+		// The rest of the document is unaffected.
+		require.NotNil(t, doc.Metadata.Component)
+		assert.Equal(t, "h", doc.Metadata.Component.Name)
+		require.Len(t, doc.Components, 1)
+		assert.Equal(t, "p", doc.Components[0].Name)
+	})
+
+	t.Run("no asset", func(t *testing.T) {
+		doc := renderCdx(t, &Sbom{
+			Generator: &Generator{Name: "mql", Version: "1.2.3", Vendor: "Mondoo, Inc."},
+			Packages:  pkgs,
+		})
+
+		// The root component stays: this package's own reader rejects a
+		// document without one ("not a valid cyclone dx BOM"), so dropping it
+		// would trade a panic for a document mql cannot read back. It is named
+		// instead, since the schema requires a name.
+		require.NotNil(t, doc.Metadata.Component)
+		assert.Equal(t, unnamedSubject, doc.Metadata.Component.Name)
+		assert.Equal(t, "root:"+unnamedSubject, doc.Metadata.Component.BOMRef)
+
+		require.NotNil(t, doc.Metadata.Tools)
+		require.NotNil(t, doc.Metadata.Tools.Components)
+		require.Len(t, *doc.Metadata.Tools.Components, 1)
+		assert.Equal(t, "mql", (*doc.Metadata.Tools.Components)[0].Name)
+	})
+
+	t.Run("neither", func(t *testing.T) {
+		doc := renderCdx(t, &Sbom{Packages: pkgs})
+		assert.Nil(t, doc.Metadata.Tools)
+		require.NotNil(t, doc.Metadata.Component)
+		assert.Equal(t, unnamedSubject, doc.Metadata.Component.Name)
+		require.Len(t, doc.Components, 1)
+	})
+
+	// A BOM with no packages either: nothing to describe is still a document,
+	// not a crash.
+	t.Run("an empty bom", func(t *testing.T) {
+		doc := renderCdx(t, &Sbom{})
+		require.NotNil(t, doc.Metadata.Component)
+		assert.Equal(t, unnamedSubject, doc.Metadata.Component.Name)
+	})
+}
+
+// Whatever a BOM omits, every format has to produce something. CycloneDX was
+// the only renderer that did not, and the gap is easiest to reintroduce by
+// adding a metadata read to one of them, so the property is pinned across all
+// of them rather than only the one that was broken.
+func TestEveryRendererSurvivesAMetadatalessBom(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		bom  *Sbom
+	}{
+		{"no generator", &Sbom{Asset: &Asset{Name: "h", Platform: &Platform{Name: "linux"}}}},
+		{"no platform", &Sbom{Asset: &Asset{Name: "h"}, Generator: &Generator{Name: "mql"}}},
+		{"no asset", &Sbom{Generator: &Generator{Name: "mql"}}},
+		{"nothing at all", &Sbom{}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			for _, format := range []string{
+				FormatCycloneDxJSON,
+				FormatCycloneDxXML,
+				FormatSpdxJSON,
+				FormatSpdxTagValue,
+				FormatList,
+				FormatJson,
+			} {
+				t.Run(format, func(t *testing.T) {
+					c.bom.Packages = []*Package{{Name: "p", Version: "1"}}
+					var b strings.Builder
+					// Neither a panic nor an error: assert.NotPanics reports the
+					// panic as a failure rather than taking the test binary down.
+					require.NotPanics(t, func() {
+						require.NoError(t, New(format).Render(&b, c.bom))
+					})
+					assert.NotEmpty(t, b.String())
+				})
+			}
+		})
+	}
+}
+
+// The fallback name is shared with the SPDX renderer, so the two documents
+// describing one nameless BOM agree about what its subject is called. They
+// answer the same question from the same empty field, and a reader holding both
+// should not have to reconcile two different answers.
+func TestBothRenderersAgreeOnAnUnnamedSubject(t *testing.T) {
+	bom := &Sbom{Generator: &Generator{Name: "mql"}, Packages: []*Package{{Name: "p"}}}
+
+	cdx := renderCdx(t, bom)
+	require.NotNil(t, cdx.Metadata.Component)
+
+	var b strings.Builder
+	require.NoError(t, New(FormatSpdxJSON).Render(&b, bom))
+	var spdxDoc struct {
+		Name string `json:"name"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(b.String()), &spdxDoc))
+
+	assert.Equal(t, spdxDoc.Name, cdx.Metadata.Component.Name)
+}

--- a/sbom/formats.go
+++ b/sbom/formats.go
@@ -20,6 +20,14 @@ const (
 	FormatList          string = "table"
 )
 
+// unnamedSubject is what a BOM's subject is called when the asset does not name
+// itself. Both document formats have to put a name somewhere -- SPDX's document
+// name is mandatory, and a CycloneDX component's name is required by the schema
+// -- so the choice is between this and a nameless entry a consumer has to
+// recognise as junk. Shared so that the SPDX and CycloneDX renderings of one
+// BOM do not disagree about what its subject is called.
+const unnamedSubject = "sbom"
+
 var (
 	errConversionNotSupported = errors.New("conversion is not supported")
 	errParsingNotSupported    = errors.New("parsing is not supported")

--- a/sbom/spdx.go
+++ b/sbom/spdx.go
@@ -384,18 +384,18 @@ const spdxDataLicense = "CC0-1.0"
 // same asset distinguishable rather than colliding.
 const spdxNamespacePrefix = "https://mondoo.com/spdx/"
 
-// spdxUnnamedDocument names a document whose asset does not name itself. The
-// field is mandatory and free text, and an empty one leaves a consumer unable
-// to refer to the document at all -- NOASSERTION is not used here because it is
-// an assertion about a license or a supplier, not a stand-in for a title.
-const spdxUnnamedDocument = "sbom"
-
 // spdxDocumentName is what the document calls itself: the asset it describes.
+//
+// The fallback is shared with the CycloneDX renderer, because it answers the
+// same question from the same empty field -- what to call a subject that does
+// not name itself -- and the two documents describing one BOM should not
+// disagree about it. NOASSERTION is not used here: it is an assertion about a
+// license or a supplier, not a stand-in for a title.
 func spdxDocumentName(bom *Sbom) string {
 	if name := strings.TrimSpace(bom.GetAsset().GetName()); name != "" {
 		return name
 	}
-	return spdxUnnamedDocument
+	return unnamedSubject
 }
 
 // spdxDocumentNamespace builds the unique URI every SPDX document must carry.


### PR DESCRIPTION
`convertToCycloneDx` read `bom.Generator` and `bom.Asset` straight through, so a BOM carrying neither panicked instead of producing a document missing some metadata:

```
nil Generator  PANIC: invalid memory address or nil pointer dereference
nil Asset      PANIC: invalid memory address or nil pointer dereference
```

Both reproduce on main at `926707e7e`. `bom.Asset.Name` is read **twice** — at the root component's bom-ref and again at its name — so a guard on the first still panics on the second.

## Why this is the renderer's bug, not a caller's

It is the only renderer with the problem. The same inputs across every format mql supports:

| input | cyclonedx-json | cyclonedx-xml | spdx-json | spdx-tag-value | table | json |
|---|---|---|---|---|---|---|
| everything set | ok | ok | ok | ok | ok | ok |
| no generator | **PANIC** | **PANIC** | ok | ok | ok | ok |
| no platform | ok | ok | ok | ok | ok | ok |
| no asset | **PANIC** | **PANIC** | ok | ok | ok | ok |
| neither | **PANIC** | **PANIC** | ok | ok | ok | ok |
| empty BOM | **PANIC** | **PANIC** | ok | ok | ok | ok |

The others read through the protobuf getters, which tolerate a nil message. This one dereferenced. (`no platform` is already green — #10597 fixed that one.)

## The two nils are different questions

**A generator that names no tool renders as no tool.** A component's `name` is required by the schema, so the alternative is an entry called `""` — the nameless-component shape #10597 removed from the OS component, arriving instead through the metadata. `tools` is optional and the reader already tolerates its absence, so leaving it out states the same thing honestly.

**An asset that names nothing still gets a root component.** Dropping it would trade a panic for a document *this package cannot read back*: `convertCycloneDxToSbom` rejects a BOM whose `metadata.component` is absent with `"not a valid cyclone dx BOM"`. So it is named instead, using the fallback the SPDX renderer already applies to the same empty field — now shared rather than spelled twice, so the two documents describing one nameless BOM don't disagree about what its subject is called.

Resulting shapes:

```jsonc
// no generator            // no asset
                           "tools": { … "name": "mql" },
"bom-ref": "root:h",       "bom-ref": "root:sbom",
"type": "device",          "type": "device",
"name": "h"                "name": "sbom"
// (no "tools" key)
```

Packages still render in every case.

## Testing

The two guards were mutated **separately**, not together — a BOM missing one is not usually missing the other, and a single "nothing is set" case would let one guard's test get credited for both:

```
remove the generator guard -> fails no-generator, neither      (no-asset still passes)
remove the asset guard     -> fails no-asset, neither, empty,
                              cross-renderer agreement          (no-generator still passes)
```

The all-formats case is pinned across every renderer rather than only the one that was broken, because the way this comes back is a metadata read added to a different one.

`go test ./sbom/...` green, `go build ./...` clean, `go mod tidy` no drift. `golangci-lint run --config=.github/.golangci.yaml ./sbom/...` reports nothing beyond 3 pre-existing `SA1019` in `sbom/generator/generator.go`, which this does not touch.

## Provenance note

The protobom importer always sets `Asset` since #10597, so a nil one now reaches this only from a hand-built `Sbom` — which is exactly why it gets a test rather than only a guard.
