### PR TITLE
🐛 sbom: read licensing in the SPDX decoder consumers actually reach

### DIFF
--- a/sbom/spdx.go
+++ b/sbom/spdx.go
@@ -302,6 +302,8 @@ func (s *Spdx) convertToSbom(doc *spdx.Document) *Sbom {
 			Cpes:        []string{},
 		}
 
+		readSpdxPackageLicensing(bomPkg, pkg)
+
 		for _, ref := range pkg.PackageExternalReferences {
 			if ref.RefType == spdx.PackageManagerPURL {
 				bomPkg.Purl = ref.Locator
@@ -779,4 +781,57 @@ func spdxSupplier(supplier string) *common.Supplier {
 		return &common.Supplier{Supplier: spdxNoAssertionValue}
 	}
 	return &common.Supplier{Supplier: supplier, SupplierType: "Organization"}
+}
+
+// readSpdxPackageLicensing carries what an imported SPDX document states about a
+// package's licensing into the model.
+//
+// This decoder read a package's name, version, identifiers and file evidence and
+// dropped everything else the document said, which is information that exists
+// nowhere else in the file: a document stating a declared license, a concluded
+// one, a copyright and a supplier came out carrying none of them. #10597 fixed
+// the same gap in the Protobom decoder, but DefaultMultiDecoder routes SPDX
+// here, so no consumer of that entry point saw the difference.
+//
+// SPDX separates the two acquisitions by field, which is exactly the distinction
+// the model draws: PackageLicenseDeclared is what the package says about itself,
+// PackageLicenseConcluded is what the document's producer determined. Both are
+// single expressions rather than lists, so there is at most one entry of each.
+func readSpdxPackageLicensing(bomPkg *Package, pkg *v2_3.Package) {
+	if entry := DeclaredLicense(importedLicenseValue(pkg.PackageLicenseDeclared)); entry != nil {
+		bomPkg.Licenses = append(bomPkg.Licenses, entry)
+	}
+
+	// No location and no confidence, for the reasons the Protobom decoder
+	// records: SPDX carries neither for a concluded license, and the model
+	// spells "nobody measured this" as 0. Reporting 1.0 would rank an imported
+	// conclusion that was never scored alongside one that scored perfectly.
+	if entry := ConcludedLicense(importedLicenseValue(pkg.PackageLicenseConcluded), "", 0); entry != nil {
+		bomPkg.Licenses = append(bomPkg.Licenses, entry)
+	}
+
+	// The legacy scalar keeps being written, as every other producer in this
+	// package does, so a consumer that has not migrated to the list still sees a
+	// license. It takes the DECLARED entry, falling back to the concluded value
+	// when the document declared none: a scalar left empty while the document
+	// did state a license is the failure the fallback exists to prevent.
+	for _, l := range bomPkg.Licenses {
+		if l.GetAcquisition() == LicenseAcquisition_LICENSE_ACQUISITION_DECLARED {
+			bomPkg.License = licenseValueOf(l)
+			break
+		}
+	}
+	if bomPkg.License == "" {
+		bomPkg.License = importedLicenseValue(pkg.PackageLicenseConcluded)
+	}
+
+	if c := importedLicenseValue(pkg.PackageCopyrightText); c != "" {
+		bomPkg.Copyright = []string{c}
+	}
+
+	if pkg.PackageSupplier != nil {
+		if name := importedLicenseValue(pkg.PackageSupplier.Supplier); name != "" {
+			bomPkg.Supplier = name
+		}
+	}
 }

--- a/sbom/spdx.go
+++ b/sbom/spdx.go
@@ -134,9 +134,25 @@ func (s *Spdx) convertToSpdx(bom *Sbom) *spdx.Document {
 		declared := spdxNoAssertion(spdxLicense(declaredLicenses(pkg), pkg.License, extractedLicenses))
 		concluded := spdxNoAssertion(spdxLicense(concludedLicenses(pkg), "", extractedLicenses))
 		if concluded == spdxNoAssertionValue {
-			// Nothing was concluded. Echoing the declared value is the honest
-			// reading: it is what the document has to go on, and asserting more
-			// than was determined is what NOASSERTION exists to avoid.
+			// Nothing was concluded, so this repeats the declared value.
+			//
+			// The comment that stood here called that "the honest reading",
+			// which had the argument backwards: echoing IS asserting more than
+			// was determined, and NOASSERTION is the thing that avoids it. The
+			// echo is a deliberate overstatement, not a modest one.
+			//
+			// It stays because the strictly accurate value is the more
+			// misleading one in practice. A consumer reading licenseConcluded
+			// as the package's license -- and many read it first -- sees
+			// NOASSERTION and takes a package that plainly declares MIT for one
+			// whose license is unknown. Repeating the declaration is wrong in a
+			// direction a reader can recover from; NOASSERTION is wrong in a
+			// direction they cannot.
+			//
+			// What makes the overstatement safe to keep is that it no longer
+			// survives a round trip: readSpdxPackageLicensing recognises a
+			// concluded value equal to the declared one as this echo and does
+			// not import it as a determination.
 			concluded = declared
 		}
 		doc.Packages = append(doc.Packages, &spdx.Package{
@@ -810,12 +826,19 @@ func readSpdxPackageLicensing(bomPkg *Package, pkg *v2_3.Package) {
 	// nothing into one asserting somebody concluded MIT -- a claim that the
 	// license was verified, invented by a round trip.
 	//
-	// The two are indistinguishable in the document, so the question is which
-	// way to be wrong. Dropping a conclusion that merely agrees with the
-	// declaration costs nothing: the license is still reported, as declared, and
-	// only the unverifiable claim that someone checked it goes. Keeping it
-	// manufactures that claim. A conclusion that DISAGREES is the case the split
-	// exists for and is always kept.
+	// The two are indistinguishable in the document, so this is a choice about
+	// which way to be wrong, and it is not free either way. A third-party tool
+	// that genuinely concluded MIT for a package declaring MIT wrote the same
+	// two fields as our echo, and its real conclusion is dropped here with the
+	// echoes. What is lost is the acquisition signal, not the license: the
+	// package is still reported as licensed MIT, on its own declaration.
+	//
+	// It goes this way on frequency and on direction. This renderer echoes for
+	// every unconcluded package, so keeping the entry over-asserts across most
+	// of every document it produces, against a minority of genuine agreements;
+	// and inventing a verification nobody performed is worse than omitting one
+	// that happened. A conclusion that DISAGREES is the case the split exists
+	// for and is never touched.
 	if concluded == declared {
 		concluded = ""
 	}

--- a/sbom/spdx.go
+++ b/sbom/spdx.go
@@ -798,7 +798,29 @@ func spdxSupplier(supplier string) *common.Supplier {
 // PackageLicenseConcluded is what the document's producer determined. Both are
 // single expressions rather than lists, so there is at most one entry of each.
 func readSpdxPackageLicensing(bomPkg *Package, pkg *v2_3.Package) {
-	if entry := DeclaredLicense(importedLicenseValue(pkg.PackageLicenseDeclared)); entry != nil {
+	declared := importedLicenseValue(pkg.PackageLicenseDeclared)
+	concluded := importedLicenseValue(pkg.PackageLicenseConcluded)
+
+	// A concluded value equal to the declared one is an echo, not a conclusion.
+	//
+	// This renderer writes one: where nothing was concluded it repeats the
+	// declared value rather than NOASSERTION, on the grounds that it is what the
+	// document has to go on, and other SPDX producers do the same. Reading it
+	// back as a determination turns a package that declared MIT and concluded
+	// nothing into one asserting somebody concluded MIT -- a claim that the
+	// license was verified, invented by a round trip.
+	//
+	// The two are indistinguishable in the document, so the question is which
+	// way to be wrong. Dropping a conclusion that merely agrees with the
+	// declaration costs nothing: the license is still reported, as declared, and
+	// only the unverifiable claim that someone checked it goes. Keeping it
+	// manufactures that claim. A conclusion that DISAGREES is the case the split
+	// exists for and is always kept.
+	if concluded == declared {
+		concluded = ""
+	}
+
+	if entry := DeclaredLicense(declared); entry != nil {
 		bomPkg.Licenses = append(bomPkg.Licenses, entry)
 	}
 
@@ -806,7 +828,7 @@ func readSpdxPackageLicensing(bomPkg *Package, pkg *v2_3.Package) {
 	// records: SPDX carries neither for a concluded license, and the model
 	// spells "nobody measured this" as 0. Reporting 1.0 would rank an imported
 	// conclusion that was never scored alongside one that scored perfectly.
-	if entry := ConcludedLicense(importedLicenseValue(pkg.PackageLicenseConcluded), "", 0); entry != nil {
+	if entry := ConcludedLicense(concluded, "", 0); entry != nil {
 		bomPkg.Licenses = append(bomPkg.Licenses, entry)
 	}
 
@@ -822,7 +844,7 @@ func readSpdxPackageLicensing(bomPkg *Package, pkg *v2_3.Package) {
 		}
 	}
 	if bomPkg.License == "" {
-		bomPkg.License = importedLicenseValue(pkg.PackageLicenseConcluded)
+		bomPkg.License = concluded
 	}
 
 	if c := importedLicenseValue(pkg.PackageCopyrightText); c != "" {

--- a/sbom/spdx_licensing_test.go
+++ b/sbom/spdx_licensing_test.go
@@ -5,6 +5,7 @@ package sbom
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -78,4 +79,94 @@ func TestSpdxDecoderReadsLicensing(t *testing.T) {
 			assert.Empty(t, p.License)
 		})
 	}
+}
+
+// This renderer writes a concluded value equal to the declared one where nothing
+// was concluded, rather than NOASSERTION, and other SPDX producers do the same.
+// Reading that back as a determination is how a round trip through our own
+// output invents a claim the model never made: a package that declared MIT and
+// concluded nothing returns asserting somebody concluded MIT.
+func TestSPDXDecoderDoesNotReadAnEchoAsAConclusion(t *testing.T) {
+	orig := &Sbom{
+		Generator: &Generator{Vendor: "Mondoo, Inc", Name: "test", Version: "1"},
+		Asset:     &Asset{Name: "a", Platform: &Platform{Name: "linux", Version: "1"}},
+		Packages: []*Package{{
+			Name: "declares-only", Version: "1.0.0", Purl: "pkg:npm/declares-only@1.0.0",
+			Licenses: []*License{DeclaredLicense("MIT")},
+			License:  "MIT",
+		}},
+	}
+
+	var rendered strings.Builder
+	require.NoError(t, New(FormatSpdxJSON).Render(&rendered, orig))
+	// The echo is in the document: this is what the decoder has to interpret.
+	assert.Contains(t, rendered.String(), `"licenseConcluded": "MIT"`)
+
+	back, err := NewSPDX(FormatSpdxJSON).Parse(strings.NewReader(rendered.String()))
+	require.NoError(t, err)
+
+	var got *Package
+	for _, p := range back.Packages {
+		if p.Name == "declares-only" {
+			got = p
+		}
+	}
+	require.NotNil(t, got)
+
+	require.Len(t, got.Licenses, 1, "the echoed conclusion must not become a second entry")
+	assert.Equal(t, LicenseAcquisition_LICENSE_ACQUISITION_DECLARED, got.Licenses[0].GetAcquisition())
+	assert.Equal(t, "MIT", got.Licenses[0].GetSpdxId())
+	assert.Equal(t, "MIT", got.License)
+}
+
+// A conclusion that DISAGREES with the declaration is the case the split exists
+// for, and must survive the echo check.
+func TestSPDXDecoderKeepsAConclusionThatDisagrees(t *testing.T) {
+	doc := `{
+  "spdxVersion": "SPDX-2.3", "dataLicense": "CC0-1.0", "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "disagreeing", "documentNamespace": "https://mondoo.com/spdx/d",
+  "creationInfo": { "created": "2026-08-30T09:00:00Z", "creators": ["Tool: fixture-1"] },
+  "packages": [{
+    "name": "disagrees", "SPDXID": "SPDXRef-P1", "versionInfo": "1.0.0",
+    "downloadLocation": "NOASSERTION", "filesAnalyzed": false,
+    "licenseDeclared": "MIT", "licenseConcluded": "AGPL-3.0-only"
+  }]
+}`
+	back, err := NewSPDX(FormatSpdxJSON).Parse(strings.NewReader(doc))
+	require.NoError(t, err)
+	require.Len(t, back.Packages, 1)
+
+	licenses := back.Packages[0].Licenses
+	require.Len(t, licenses, 2)
+	assert.Equal(t, LicenseAcquisition_LICENSE_ACQUISITION_DECLARED, licenses[0].GetAcquisition())
+	assert.Equal(t, "MIT", licenses[0].GetSpdxId())
+	assert.Equal(t, LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED, licenses[1].GetAcquisition())
+	assert.Equal(t, "AGPL-3.0-only", licenses[1].GetSpdxId())
+
+	// The scalar still takes the declared entry.
+	assert.Equal(t, "MIT", back.Packages[0].License)
+}
+
+// A document that concludes without declaring is not an echo: the conclusion is
+// the only thing it states, and dropping it would lose the license entirely.
+func TestSPDXDecoderKeepsAConclusionWithNoDeclaration(t *testing.T) {
+	doc := `{
+  "spdxVersion": "SPDX-2.3", "dataLicense": "CC0-1.0", "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "concluded-only", "documentNamespace": "https://mondoo.com/spdx/c",
+  "creationInfo": { "created": "2026-08-30T09:00:00Z", "creators": ["Tool: fixture-1"] },
+  "packages": [{
+    "name": "concluded-only", "SPDXID": "SPDXRef-P1", "versionInfo": "1.0.0",
+    "downloadLocation": "NOASSERTION", "filesAnalyzed": false,
+    "licenseDeclared": "NOASSERTION", "licenseConcluded": "Apache-2.0"
+  }]
+}`
+	back, err := NewSPDX(FormatSpdxJSON).Parse(strings.NewReader(doc))
+	require.NoError(t, err)
+	require.Len(t, back.Packages, 1)
+
+	licenses := back.Packages[0].Licenses
+	require.Len(t, licenses, 1)
+	assert.Equal(t, LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED, licenses[0].GetAcquisition())
+	assert.Equal(t, "Apache-2.0", licenses[0].GetSpdxId())
+	assert.Equal(t, "Apache-2.0", back.Packages[0].License, "the scalar falls back to the conclusion")
 }

--- a/sbom/spdx_licensing_test.go
+++ b/sbom/spdx_licensing_test.go
@@ -1,0 +1,81 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sbom
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The SPDX decoder is an importer: the document it reads was produced by
+// somebody else, and what it says about licensing cannot be recovered from
+// anywhere else in the file. It read each package's name, version, identifiers
+// and file evidence and dropped the rest.
+//
+// #10597 fixed this for the Protobom decoder. This asserts through
+// DefaultMultiDecoder, which is what consumers call and which routes SPDX to
+// *this* decoder -- so the earlier fix reached none of them, and a test calling
+// only the Protobom decoder would not have noticed.
+func TestSpdxDecoderReadsLicensing(t *testing.T) {
+	f, err := os.Open("testdata/licensing.spdx.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	bom, err := DefaultMultiDecoder().Parse(f)
+	require.NoError(t, err)
+
+	byName := map[string]*Package{}
+	for _, p := range bom.Packages {
+		byName[p.Name] = p
+	}
+
+	t.Run("declared and concluded are told apart by the field they came from", func(t *testing.T) {
+		p := byName["declared-and-concluded"]
+		require.NotNil(t, p)
+		require.Len(t, p.Licenses, 2)
+
+		assert.Equal(t, LicenseAcquisition_LICENSE_ACQUISITION_DECLARED, p.Licenses[0].GetAcquisition())
+		assert.Equal(t, "MIT", p.Licenses[0].GetSpdxId())
+
+		assert.Equal(t, LicenseAcquisition_LICENSE_ACQUISITION_CONCLUDED, p.Licenses[1].GetAcquisition())
+		assert.Equal(t, "AGPL-3.0-only", p.Licenses[1].GetSpdxId())
+
+		// Zero, not 1.0: SPDX carries no score, and the model spells "nobody
+		// measured this" as 0. Reporting full confidence would rank an imported
+		// conclusion nobody scored alongside one that scored perfectly.
+		assert.Zero(t, p.Licenses[1].GetConfidence())
+
+		// The declared entry wins the legacy scalar, so a consumer that has not
+		// migrated to the list still sees a license.
+		assert.Equal(t, "MIT", p.License)
+
+		assert.Equal(t, []string{"Copyright (c) 2019 Example Corp"}, p.Copyright)
+		assert.Equal(t, "Example Corp", p.Supplier)
+	})
+
+	t.Run("a declaration alone is enough", func(t *testing.T) {
+		p := byName["declared-only"]
+		require.NotNil(t, p)
+		require.Len(t, p.Licenses, 1)
+		assert.Equal(t, LicenseAcquisition_LICENSE_ACQUISITION_DECLARED, p.Licenses[0].GetAcquisition())
+		assert.Equal(t, "Apache-2.0", p.Licenses[0].GetSpdxId())
+		assert.Equal(t, "Apache-2.0", p.License)
+	})
+
+	// NOASSERTION and NONE are SPDX's two ways of saying it is not telling you.
+	// Carrying either through as a license name would report a package as
+	// licensed under the string "NOASSERTION", which matches nothing and reads
+	// as a statement where the document made none.
+	for _, name := range []string{"states-nothing", "states-none"} {
+		t.Run(name+" reports no license", func(t *testing.T) {
+			p := byName[name]
+			require.NotNil(t, p)
+			assert.Empty(t, p.Licenses)
+			assert.Empty(t, p.License)
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #10597, which fixed this for a decoder nothing routes to.

## The gap

#10597 taught the Protobom decoder to read the licensing an imported document states, and it does. But `DefaultMultiDecoder` — the entry point consumers call — wires `NewCycloneDX`, `NewSPDX` and `New(FormatJson)`, **not `NewProtobom`**. So an SPDX document goes to the decoder in `spdx.go`, which was never taught, and the fix reached nobody through that path.

Measured on `main` against #10597's own fixture:

```text
DefaultMultiDecoder    packages=4  license entries=0
NewSPDX(json)          packages=4  license entries=0
NewProtobom            packages=4  license entries=3
```

The test added with #10597 passes because it calls `NewProtobom().Parse` directly. It pins the decoder rather than the behaviour a consumer gets, so it could not see this.

Downstream, xgrep's `deps license --sbom` reports `APPROVE unknown (undetermined)` for a document whose package plainly declares `GPL-3.0-only` — a GPL policy does not fire on a vendor SBOM that states GPL.

## The change

`convertToSbom` read each package's name, version, identifiers and file evidence and dropped the rest — declared license, concluded license, copyright and supplier, none of which exist anywhere else in the file. It now reads them the same way and with the same reasoning as the Protobom decoder, sharing its helpers rather than restating the rules:

- SPDX separates the two acquisitions **by field**, which is the distinction the model draws: `PackageLicenseDeclared` becomes a `DECLARED` entry, `PackageLicenseConcluded` a `CONCLUDED` one. Both are single expressions, so at most one of each.
- The concluded entry carries **confidence 0, not 1.0**. SPDX has no score, and the model spells "nobody measured this" as 0; full confidence would rank an imported conclusion nobody scored alongside one that scored perfectly.
- `NOASSERTION` and `NONE` are SPDX saying it is not telling you, and `importedLicenseValue` already drops both. Carrying either through would report a package licensed under the string `NOASSERTION`, which matches nothing and reads as a statement where the document made none.
- The legacy scalar keeps being written, taking the declared entry and falling back to the concluded value, so a consumer that has not migrated to the list still sees a license.

## Why not just route SPDX to NewProtobom

That would fix the symptom while changing which implementation handles **every** SPDX import. This decoder is also the SPDX *renderer* — #10599 has just been working on its document identity — and it carries purl, CPE and distro extraction the other does not. Swapping it out to gain one field trades a known-good path for an unmeasured one. Adding the missing mapping keeps that behaviour and closes the gap.

## Testing

The new test asserts through `DefaultMultiDecoder`, deliberately: a test calling `NewSPDX` directly would repeat exactly the mistake that let this survive. It covers the declared/concluded split, the confidence-0 rule, the scalar fallback, copyright and supplier, and both `NOASSERTION` and `NONE`.

All three decoders now agree at 3 entries on the shared fixture. Verified to fail without the change rather than assumed:

```
--- FAIL: TestSpdxDecoderReadsLicensing/declared_and_concluded_are_told_apart_by_the_field_they_came_from
    Error: "[]" should have 2 item(s), but has 0
```

`go test ./sbom/...` green; `golangci-lint run --config=.github/.golangci.yaml ./sbom/...` reports 0 issues. Additive — no existing behaviour changes, and no new dependency.

## Follow-up

xgrep needs a matching change to benefit: its `spdxComponents` reads the deprecated scalar `p.License` rather than `p.Licenses`, so it would still flatten the declared/concluded split even once this lands. That is a separate diff in that repo.