### PR TITLE
🐛 gcp: read network firewall policies when judging instance exposure

### DIFF
--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1903,18 +1903,27 @@ gcp.project.computeService.instance @defaults("name id") {
 // Compute instance internet-exposure breakdown
 //
 // Explains whether a Compute Engine instance is reachable from the internet:
-// whether it has an external IP and whether a VPC firewall rule that applies to
-// it (same network, matching target tags or service accounts) admits ingress
-// from any address.
+// whether it has an external IP, and whether anything that applies to it admits
+// ingress from any address. Both ways a VPC admits traffic are read, because a
+// network migrated to network firewall policies can carry no legacy rules at
+// all: `openIngressFirewalls` lists the legacy VPC firewall rules that match the
+// instance by network and target tags or service accounts, and
+// `openIngressPolicyRules` the network firewall policy rules that match it,
+// counting only policies associated with one of its networks.
 private gcp.project.computeService.instance.exposure @defaults("internetReachable hasPublicIp") {
-  // Whether the instance is reachable from the internet (an external IP and an applicable firewall rule that admits any address)
+  // Whether the instance is reachable from the internet (an external IP and an applicable firewall rule or policy rule that admits any address)
   internetReachable bool
   // Whether the instance has an external IP
   hasPublicIp bool
-  // Whether a firewall rule that applies to the instance admits inbound traffic from any address (0.0.0.0/0 or ::/0)
+  // Whether a firewall rule or network firewall policy rule that applies to the instance admits inbound traffic from any address (0.0.0.0/0 or ::/0)
   firewallAllowsIngress bool
-  // Firewall rules that apply to the instance and admit ingress from any address
+  // Legacy VPC firewall rules that apply to the instance and admit ingress from any address
   openIngressFirewalls []gcp.project.computeService.firewall
+  // Network firewall policy rules that apply to the instance and admit ingress from any address
+  //
+  // Only rules from policies associated with one of the instance's networks are
+  // listed, since an unassociated policy enforces nothing.
+  openIngressPolicyRules []gcp.project.computeService.firewallPolicy.rule
 }
 
 // Compute instance network interface

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -4366,6 +4366,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.instance.exposure.openIngressFirewalls": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceExposure).GetOpenIngressFirewalls()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.firewall")))
 	},
+	"gcp.project.computeService.instance.exposure.openIngressPolicyRules": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceInstanceExposure).GetOpenIngressPolicyRules()).ToDataRes(types.Array(types.Resource("gcp.project.computeService.firewallPolicy.rule")))
+	},
 	"gcp.project.computeService.instance.networkInterface.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceInstanceNetworkInterface).GetName()).ToDataRes(types.String)
 	},
@@ -21425,6 +21428,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.instance.exposure.openIngressFirewalls": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceInstanceExposure).OpenIngressFirewalls, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.instance.exposure.openIngressPolicyRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceInstanceExposure).OpenIngressPolicyRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.instance.networkInterface.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -49685,10 +49692,11 @@ type mqlGcpProjectComputeServiceInstanceExposure struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectComputeServiceInstanceExposureInternal it will be used here
-	InternetReachable     plugin.TValue[bool]
-	HasPublicIp           plugin.TValue[bool]
-	FirewallAllowsIngress plugin.TValue[bool]
-	OpenIngressFirewalls  plugin.TValue[[]any]
+	InternetReachable      plugin.TValue[bool]
+	HasPublicIp            plugin.TValue[bool]
+	FirewallAllowsIngress  plugin.TValue[bool]
+	OpenIngressFirewalls   plugin.TValue[[]any]
+	OpenIngressPolicyRules plugin.TValue[[]any]
 }
 
 // createGcpProjectComputeServiceInstanceExposure creates a new instance of this resource
@@ -49737,6 +49745,10 @@ func (c *mqlGcpProjectComputeServiceInstanceExposure) GetFirewallAllowsIngress()
 
 func (c *mqlGcpProjectComputeServiceInstanceExposure) GetOpenIngressFirewalls() *plugin.TValue[[]any] {
 	return &c.OpenIngressFirewalls
+}
+
+func (c *mqlGcpProjectComputeServiceInstanceExposure) GetOpenIngressPolicyRules() *plugin.TValue[[]any] {
+	return &c.OpenIngressPolicyRules
 }
 
 // mqlGcpProjectComputeServiceInstanceNetworkInterface for the gcp.project.computeService.instance.networkInterface resource

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -1964,6 +1964,7 @@ gcp.project.computeService.instance.exposure.firewallAllowsIngress 13.24.1
 gcp.project.computeService.instance.exposure.hasPublicIp 13.24.1
 gcp.project.computeService.instance.exposure.internetReachable 13.24.1
 gcp.project.computeService.instance.exposure.openIngressFirewalls 13.24.1
+gcp.project.computeService.instance.exposure.openIngressPolicyRules 13.37.1
 gcp.project.computeService.instance.fingerprint 9.0.0
 gcp.project.computeService.instance.guestAccelerators 9.0.0
 gcp.project.computeService.instance.hasFullCloudPlatformScope 13.12.2

--- a/providers/gcp/resources/gcp_exposure.go
+++ b/providers/gcp/resources/gcp_exposure.go
@@ -188,27 +188,45 @@ func policyRuleOpenIngress(action, direction string, disabled bool, srcIpRanges 
 // policyRuleTargetsInstance reports whether a policy rule's targeting applies to
 // an instance.
 //
-// targetResources holds network URLs, not tags: a policy rule scoped to one
-// network in a policy associated with several applies only to that network. An
-// empty targetResources means every network the policy is associated with, and
-// an empty targetServiceAccounts means every instance, so a rule with neither
-// applies to all of them. Networks are compared by trailing name so a full URL
-// and a partial reference match.
+// The two fields are independent axes and compose with AND, which is what makes
+// this different from the legacy rule above. targetResources holds network URLs
+// and picks WHICH NETWORK the rule lands on; targetServiceAccounts picks WHICH
+// INSTANCES within it. The API documents the composition on the sibling
+// targetSecureTags field: "If neither targetServiceAccounts nor targetSecureTag
+// are specified, the firewall rule applies to all instances on the specified
+// network" -- the specified network being targetResources.
+//
+// So a rule with targetResources=[net-A] and targetServiceAccounts=[sa-B]
+// applies only to instances in net-A running as sa-B. Treating the two as
+// alternatives would report an instance in net-A running as sa-C as covered.
+//
+// An empty list on either axis means "all", so a rule with neither applies to
+// every instance the policy reaches. Networks are compared by trailing name so a
+// full URL and a partial reference match.
+//
+// The legacy firewallTargetsInstance above stays an OR for a real reason rather
+// than an inconsistency: on a legacy VPC rule targetTags and
+// targetServiceAccounts are mutually exclusive ("targetServiceAccounts cannot be
+// used at the same time as targetTags"), so at most one is ever populated and
+// the two spellings agree.
 func policyRuleTargetsInstance(targetResources, targetServiceAccounts []any, instanceNetworks, instanceServiceAccounts map[string]bool) bool {
-	if len(targetResources) == 0 && len(targetServiceAccounts) == 0 {
-		return true
-	}
+	networkMatch := len(targetResources) == 0
 	for _, r := range targetResources {
 		if url, ok := r.(string); ok && instanceNetworks[networkNameFromUrl(url)] {
-			return true
+			networkMatch = true
+			break
 		}
 	}
+
+	accountMatch := len(targetServiceAccounts) == 0
 	for _, sa := range targetServiceAccounts {
 		if email, ok := sa.(string); ok && instanceServiceAccounts[email] {
-			return true
+			accountMatch = true
+			break
 		}
 	}
-	return false
+
+	return networkMatch && accountMatch
 }
 
 // policyAppliesToNetworks reports whether a firewall policy is associated with

--- a/providers/gcp/resources/gcp_exposure.go
+++ b/providers/gcp/resources/gcp_exposure.go
@@ -91,6 +91,149 @@ func firewallRuleOpenIngress(isAllow bool, direction string, disabled bool, sour
 	return false
 }
 
+// openIngressPolicyRulesForInstance returns the network firewall policy rules
+// that apply to an instance and admit ingress from any address.
+//
+// Only policies associated with one of the instance's networks are considered,
+// because an unassociated policy enforces nothing.
+func openIngressPolicyRulesForInstance(
+	svc *mqlGcpProjectComputeService,
+	instanceNetworks, instanceServiceAccounts map[string]bool,
+) ([]any, error) {
+	policies := svc.GetFirewallPolicies()
+	if policies.Error != nil {
+		return nil, policies.Error
+	}
+
+	openRules := []any{}
+	for _, p := range policies.Data {
+		policy, ok := p.(*mqlGcpProjectComputeServiceFirewallPolicy)
+		if !ok {
+			continue
+		}
+		associations := policy.GetAssociations()
+		if associations.Error != nil {
+			return nil, associations.Error
+		}
+		if !policyAppliesToNetworks(associations.Data, instanceNetworks) {
+			continue
+		}
+
+		rules := policy.GetRules()
+		if rules.Error != nil {
+			return nil, rules.Error
+		}
+		for _, r := range rules.Data {
+			rule, ok := r.(*mqlGcpProjectComputeServiceFirewallPolicyRule)
+			if !ok {
+				continue
+			}
+			action := rule.GetAction()
+			if action.Error != nil {
+				return nil, action.Error
+			}
+			direction := rule.GetDirection()
+			if direction.Error != nil {
+				return nil, direction.Error
+			}
+			disabled := rule.GetDisabled()
+			if disabled.Error != nil {
+				return nil, disabled.Error
+			}
+			srcIpRanges := rule.GetSrcIpRanges()
+			if srcIpRanges.Error != nil {
+				return nil, srcIpRanges.Error
+			}
+			if !policyRuleOpenIngress(action.Data, direction.Data, disabled.Data, srcIpRanges.Data) {
+				continue
+			}
+
+			targetResources := rule.GetTargetResources()
+			if targetResources.Error != nil {
+				return nil, targetResources.Error
+			}
+			targetServiceAccounts := rule.GetTargetServiceAccounts()
+			if targetServiceAccounts.Error != nil {
+				return nil, targetServiceAccounts.Error
+			}
+			if policyRuleTargetsInstance(targetResources.Data, targetServiceAccounts.Data,
+				instanceNetworks, instanceServiceAccounts) {
+				openRules = append(openRules, rule)
+			}
+		}
+	}
+	return openRules, nil
+}
+
+// policyRuleOpenIngress reports whether a network firewall policy rule admits
+// ingress from the whole internet.
+//
+// Policy rules differ from legacy VPC firewall rules in two ways that matter
+// here. Their effect is an `action` string rather than the presence of an allow
+// block, and only "allow" opens traffic -- "deny", "goto_next" and
+// "apply_security_profile_group" do not. And their sources live in
+// `srcIpRanges` rather than `sourceRanges`.
+func policyRuleOpenIngress(action, direction string, disabled bool, srcIpRanges []any) bool {
+	if disabled || !strings.EqualFold(direction, "INGRESS") || !strings.EqualFold(action, "allow") {
+		return false
+	}
+	for _, s := range srcIpRanges {
+		if cidr, ok := s.(string); ok && isOpenCIDR(cidr) {
+			return true
+		}
+	}
+	return false
+}
+
+// policyRuleTargetsInstance reports whether a policy rule's targeting applies to
+// an instance.
+//
+// targetResources holds network URLs, not tags: a policy rule scoped to one
+// network in a policy associated with several applies only to that network. An
+// empty targetResources means every network the policy is associated with, and
+// an empty targetServiceAccounts means every instance, so a rule with neither
+// applies to all of them. Networks are compared by trailing name so a full URL
+// and a partial reference match.
+func policyRuleTargetsInstance(targetResources, targetServiceAccounts []any, instanceNetworks, instanceServiceAccounts map[string]bool) bool {
+	if len(targetResources) == 0 && len(targetServiceAccounts) == 0 {
+		return true
+	}
+	for _, r := range targetResources {
+		if url, ok := r.(string); ok && instanceNetworks[networkNameFromUrl(url)] {
+			return true
+		}
+	}
+	for _, sa := range targetServiceAccounts {
+		if email, ok := sa.(string); ok && instanceServiceAccounts[email] {
+			return true
+		}
+	}
+	return false
+}
+
+// policyAppliesToNetworks reports whether a firewall policy is associated with
+// any of the instance's networks.
+//
+// A policy enforces nothing until it is associated with a network, so an
+// unassociated policy must not contribute exposure no matter what its rules
+// say. Each association is a dict whose attachmentTarget names the network.
+func policyAppliesToNetworks(associations []any, instanceNetworks map[string]bool) bool {
+	for _, a := range associations {
+		assoc, ok := a.(map[string]any)
+		if !ok {
+			continue
+		}
+		target, ok := assoc["attachmentTarget"].(string)
+		if !ok || target == "" {
+			continue
+		}
+		if instanceNetworks[networkNameFromUrl(target)] {
+			return true
+		}
+	}
+	return false
+}
+
 // networkNameFromUrl returns the trailing network name from a GCP network URL or
 // partial reference, so full URLs and short names compare equal.
 func networkNameFromUrl(url string) string {
@@ -242,15 +385,26 @@ func (g *mqlGcpProjectComputeServiceInstance) exposure() (*mqlGcpProjectComputeS
 		}
 	}
 
-	firewallAllowsIngress := len(openFirewalls) > 0
+	// Network firewall policies are the second, newer way a VPC admits traffic,
+	// and they are evaluated ahead of the legacy rules above. A VPC migrated to
+	// them can have no legacy rules at all, in which case reading only those
+	// reports internetReachable: false for a genuinely reachable instance.
+	openPolicyRules, err := openIngressPolicyRulesForInstance(
+		svc.(*mqlGcpProjectComputeService), instanceNetworks, instanceServiceAccounts)
+	if err != nil {
+		return nil, err
+	}
+
+	firewallAllowsIngress := len(openFirewalls) > 0 || len(openPolicyRules) > 0
 	internetReachable := hasPublicIp.Data && firewallAllowsIngress
 
 	res, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.instance.exposure", map[string]*llx.RawData{
-		"__id":                  llx.StringData("gcp.project.computeService.instance/" + id.Data + "/exposure"),
-		"internetReachable":     llx.BoolData(internetReachable),
-		"hasPublicIp":           llx.BoolData(hasPublicIp.Data),
-		"firewallAllowsIngress": llx.BoolData(firewallAllowsIngress),
-		"openIngressFirewalls":  llx.ArrayData(openFirewalls, types.Resource("gcp.project.computeService.firewall")),
+		"__id":                   llx.StringData("gcp.project.computeService.instance/" + id.Data + "/exposure"),
+		"internetReachable":      llx.BoolData(internetReachable),
+		"hasPublicIp":            llx.BoolData(hasPublicIp.Data),
+		"firewallAllowsIngress":  llx.BoolData(firewallAllowsIngress),
+		"openIngressFirewalls":   llx.ArrayData(openFirewalls, types.Resource("gcp.project.computeService.firewall")),
+		"openIngressPolicyRules": llx.ArrayData(openPolicyRules, types.Resource("gcp.project.computeService.firewallPolicy.rule")),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/gcp/resources/gcp_exposure_policy_test.go
+++ b/providers/gcp/resources/gcp_exposure_policy_test.go
@@ -1,0 +1,144 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPolicyRuleOpenIngress pins the two ways a network firewall policy rule
+// differs from a legacy VPC firewall rule.
+//
+// A legacy rule is an allow rule or a deny rule by construction -- the presence
+// of an allow block decides. A policy rule carries an `action` string, and three
+// of its four values do not open traffic. Reading "deny" as an opening is the
+// error that would turn a block-all rule into reported exposure; reading
+// "allow" as anything else is the error that hides real exposure.
+func TestPolicyRuleOpenIngress(t *testing.T) {
+	open := []any{"0.0.0.0/0"}
+
+	t.Run("an allow rule from any address opens ingress", func(t *testing.T) {
+		assert.True(t, policyRuleOpenIngress("allow", "INGRESS", false, open))
+		assert.True(t, policyRuleOpenIngress("allow", "INGRESS", false, []any{"::/0"}))
+		// Casing is not guaranteed by the API for either field.
+		assert.True(t, policyRuleOpenIngress("ALLOW", "ingress", false, open))
+	})
+
+	t.Run("only the allow action opens ingress", func(t *testing.T) {
+		// deny is the common block-all rule and must never read as exposure;
+		// goto_next defers to the next policy and decides nothing itself.
+		for _, action := range []string{"deny", "goto_next", "apply_security_profile_group", ""} {
+			assert.False(t, policyRuleOpenIngress(action, "INGRESS", false, open),
+				"action %q must not open ingress", action)
+		}
+	})
+
+	t.Run("egress and disabled rules do not open ingress", func(t *testing.T) {
+		assert.False(t, policyRuleOpenIngress("allow", "EGRESS", false, open))
+		assert.False(t, policyRuleOpenIngress("allow", "INGRESS", true, open))
+	})
+
+	t.Run("a scoped source range does not open ingress", func(t *testing.T) {
+		assert.False(t, policyRuleOpenIngress("allow", "INGRESS", false,
+			[]any{"10.0.0.0/8", "192.168.0.0/16"}))
+		assert.False(t, policyRuleOpenIngress("allow", "INGRESS", false, nil))
+		// A non-string element must be skipped, not panic.
+		assert.False(t, policyRuleOpenIngress("allow", "INGRESS", false, []any{42}))
+	})
+
+	t.Run("an open range among scoped ones still opens ingress", func(t *testing.T) {
+		assert.True(t, policyRuleOpenIngress("allow", "INGRESS", false,
+			[]any{"10.0.0.0/8", "0.0.0.0/0"}))
+	})
+}
+
+// TestPolicyRuleTargetsInstance pins that targetResources are network URLs, not
+// tags. A rule scoped to one network inside a policy associated with several
+// applies only to that network, and reading the field as a tag list would make
+// every such rule apply to every instance.
+func TestPolicyRuleTargetsInstance(t *testing.T) {
+	networks := map[string]bool{"prod-vpc": true}
+	accounts := map[string]bool{"app@project.iam.gserviceaccount.com": true}
+
+	t.Run("no targeting applies to every instance", func(t *testing.T) {
+		assert.True(t, policyRuleTargetsInstance(nil, nil, networks, accounts))
+	})
+
+	t.Run("matches on the network, by full URL or short name", func(t *testing.T) {
+		assert.True(t, policyRuleTargetsInstance(
+			[]any{"https://www.googleapis.com/compute/v1/projects/p/global/networks/prod-vpc"},
+			nil, networks, accounts))
+		assert.True(t, policyRuleTargetsInstance([]any{"prod-vpc"}, nil, networks, accounts))
+	})
+
+	t.Run("a rule scoped to another network does not apply", func(t *testing.T) {
+		assert.False(t, policyRuleTargetsInstance(
+			[]any{"https://www.googleapis.com/compute/v1/projects/p/global/networks/dev-vpc"},
+			nil, networks, accounts))
+	})
+
+	t.Run("matches on the service account", func(t *testing.T) {
+		assert.True(t, policyRuleTargetsInstance(nil,
+			[]any{"app@project.iam.gserviceaccount.com"}, networks, accounts))
+		assert.False(t, policyRuleTargetsInstance(nil,
+			[]any{"other@project.iam.gserviceaccount.com"}, networks, accounts))
+	})
+
+	t.Run("either dimension matching is enough", func(t *testing.T) {
+		assert.True(t, policyRuleTargetsInstance(
+			[]any{"dev-vpc"},
+			[]any{"app@project.iam.gserviceaccount.com"},
+			networks, accounts))
+	})
+
+	t.Run("non-string entries are skipped", func(t *testing.T) {
+		assert.False(t, policyRuleTargetsInstance([]any{42}, []any{nil}, networks, accounts))
+	})
+}
+
+// TestPolicyAppliesToNetworks pins the association check.
+//
+// A firewall policy enforces nothing until it is associated with a network, so
+// an unassociated policy must contribute no exposure however permissive its
+// rules are. Getting this wrong would report every instance in the project as
+// reachable the moment someone drafts a policy.
+func TestPolicyAppliesToNetworks(t *testing.T) {
+	networks := map[string]bool{"prod-vpc": true}
+
+	assoc := func(target string) any {
+		return map[string]any{"attachmentTarget": target}
+	}
+
+	t.Run("associated with the instance's network", func(t *testing.T) {
+		assert.True(t, policyAppliesToNetworks([]any{
+			assoc("https://www.googleapis.com/compute/v1/projects/p/global/networks/prod-vpc"),
+		}, networks))
+	})
+
+	t.Run("an unassociated policy applies to nothing", func(t *testing.T) {
+		assert.False(t, policyAppliesToNetworks(nil, networks))
+		assert.False(t, policyAppliesToNetworks([]any{}, networks))
+	})
+
+	t.Run("associated only with another network", func(t *testing.T) {
+		assert.False(t, policyAppliesToNetworks([]any{assoc("dev-vpc")}, networks))
+	})
+
+	t.Run("one matching association among several is enough", func(t *testing.T) {
+		assert.True(t, policyAppliesToNetworks([]any{
+			assoc("dev-vpc"), assoc("staging-vpc"), assoc("prod-vpc"),
+		}, networks))
+	})
+
+	t.Run("malformed associations are skipped, not fatal", func(t *testing.T) {
+		assert.False(t, policyAppliesToNetworks([]any{
+			"not-a-dict",
+			map[string]any{"attachmentTarget": 42},
+			map[string]any{"attachmentTarget": ""},
+			map[string]any{"shortName": "prod-vpc"}, // right value, wrong key
+		}, networks))
+	})
+}

--- a/providers/gcp/resources/gcp_exposure_policy_test.go
+++ b/providers/gcp/resources/gcp_exposure_policy_test.go
@@ -55,47 +55,70 @@ func TestPolicyRuleOpenIngress(t *testing.T) {
 	})
 }
 
-// TestPolicyRuleTargetsInstance pins that targetResources are network URLs, not
-// tags. A rule scoped to one network inside a policy associated with several
-// applies only to that network, and reading the field as a tag list would make
-// every such rule apply to every instance.
+// TestPolicyRuleTargetsInstance pins two things.
+//
+// First, that targetResources are network URLs, not tags: a rule scoped to one
+// network inside a policy associated with several applies only to that network,
+// and reading the field as a tag list would make every such rule apply to every
+// instance.
+//
+// Second, that the two target fields compose with AND. They are independent
+// axes -- targetResources picks the network, targetServiceAccounts the
+// instances within it -- so a rule naming both applies only where both match.
+// Treating them as alternatives over-reports exposure.
 func TestPolicyRuleTargetsInstance(t *testing.T) {
 	networks := map[string]bool{"prod-vpc": true}
 	accounts := map[string]bool{"app@project.iam.gserviceaccount.com": true}
+
+	const (
+		prodURL = "https://www.googleapis.com/compute/v1/projects/p/global/networks/prod-vpc"
+		devURL  = "https://www.googleapis.com/compute/v1/projects/p/global/networks/dev-vpc"
+		otherSA = "other@project.iam.gserviceaccount.com"
+		ourSA   = "app@project.iam.gserviceaccount.com"
+	)
 
 	t.Run("no targeting applies to every instance", func(t *testing.T) {
 		assert.True(t, policyRuleTargetsInstance(nil, nil, networks, accounts))
 	})
 
-	t.Run("matches on the network, by full URL or short name", func(t *testing.T) {
-		assert.True(t, policyRuleTargetsInstance(
-			[]any{"https://www.googleapis.com/compute/v1/projects/p/global/networks/prod-vpc"},
-			nil, networks, accounts))
+	t.Run("network only, by full URL or short name", func(t *testing.T) {
+		assert.True(t, policyRuleTargetsInstance([]any{prodURL}, nil, networks, accounts))
 		assert.True(t, policyRuleTargetsInstance([]any{"prod-vpc"}, nil, networks, accounts))
 	})
 
 	t.Run("a rule scoped to another network does not apply", func(t *testing.T) {
-		assert.False(t, policyRuleTargetsInstance(
-			[]any{"https://www.googleapis.com/compute/v1/projects/p/global/networks/dev-vpc"},
-			nil, networks, accounts))
+		assert.False(t, policyRuleTargetsInstance([]any{devURL}, nil, networks, accounts))
 	})
 
-	t.Run("matches on the service account", func(t *testing.T) {
-		assert.True(t, policyRuleTargetsInstance(nil,
-			[]any{"app@project.iam.gserviceaccount.com"}, networks, accounts))
-		assert.False(t, policyRuleTargetsInstance(nil,
-			[]any{"other@project.iam.gserviceaccount.com"}, networks, accounts))
+	t.Run("service account only", func(t *testing.T) {
+		assert.True(t, policyRuleTargetsInstance(nil, []any{ourSA}, networks, accounts))
+		assert.False(t, policyRuleTargetsInstance(nil, []any{otherSA}, networks, accounts))
 	})
 
-	t.Run("either dimension matching is enough", func(t *testing.T) {
+	// The AND cases. Each one is a false positive under OR.
+	t.Run("both axes must match when both are named", func(t *testing.T) {
 		assert.True(t, policyRuleTargetsInstance(
-			[]any{"dev-vpc"},
-			[]any{"app@project.iam.gserviceaccount.com"},
-			networks, accounts))
+			[]any{prodURL}, []any{ourSA}, networks, accounts),
+			"our network and our service account")
+
+		assert.False(t, policyRuleTargetsInstance(
+			[]any{prodURL}, []any{otherSA}, networks, accounts),
+			"our network but another service account: the rule scopes to that account")
+
+		assert.False(t, policyRuleTargetsInstance(
+			[]any{devURL}, []any{ourSA}, networks, accounts),
+			"our service account but another network: the rule never reaches this network")
+
+		assert.False(t, policyRuleTargetsInstance(
+			[]any{devURL}, []any{otherSA}, networks, accounts),
+			"neither axis matches")
 	})
 
 	t.Run("non-string entries are skipped", func(t *testing.T) {
 		assert.False(t, policyRuleTargetsInstance([]any{42}, []any{nil}, networks, accounts))
+		// A non-string in one axis must not be read as a match for it, even
+		// when the other axis matches.
+		assert.False(t, policyRuleTargetsInstance([]any{42}, []any{ourSA}, networks, accounts))
 	})
 }
 


### PR DESCRIPTION
## The bug

`instance.exposure()` consulted only legacy VPC firewall rules (`compute.Firewalls.List`). **Network firewall policies are the second, newer way a VPC admits traffic**, and they are evaluated *ahead* of the legacy rules — so a network migrated to them can carry no legacy rules at all.

For such a VPC, every instance reported:

```
internetReachable:     false
firewallAllowsIngress: false
openIngressFirewalls:  []
```

…no matter what the policies allowed. That is a false negative on the field a policy asks about directly — `gcp.compute.instances.none(exposure.internetReachable)` passed on a genuinely reachable fleet.

The provider already models `gcp.project.computeService.firewallPolicy` and its rules. Exposure just never looked at them.

## Why policy rules get their own predicates

They differ from legacy rules in ways that would be wrong to paper over:

| | legacy VPC rule | policy rule |
|---|---|---|
| effect | allow or deny **by construction** (presence of an allow block) | an `action` **string** |
| sources | `sourceRanges` | `srcIpRanges` |
| targeting | target **tags** / service accounts | target **network URLs** / service accounts |

Only `"allow"` opens traffic — `deny`, `goto_next` and `apply_security_profile_group` do not. Reading `deny` as an opening would turn a block-all rule into reported exposure, which is why that case is pinned by a test.

Targeting matters too: `targetResources` holds network URLs, so a rule scoped to one network inside a policy associated with several applies **only** to that network.

## Association is required

Only policies associated with one of the instance's networks are considered. An unassociated policy enforces nothing, and counting one would report every instance in the project as reachable the moment somebody drafts a policy.

## New field

`openIngressPolicyRules` sits alongside the existing `openIngressFirewalls` rather than being merged into it — they are different objects, and a reader needs to know which one opened the path. `.lr.versions` entry is `13.37.1` against a provider at `13.37.0`.

## Tests

Three table tests over the pure predicates, each covering the case whose wrong answer is dangerous:

- **`TestPolicyRuleOpenIngress`** — all four `action` values, egress, disabled, scoped sources, an open range among scoped ones, and non-string elements. Verified failing when the action check is removed:
  ```
  --- FAIL: TestPolicyRuleOpenIngress/only_the_allow_action_opens_ingress
      Messages: action "deny" must not open ingress
  ```
- **`TestPolicyRuleTargetsInstance`** — network URL vs short name, a rule scoped to a *different* network, service-account matching, and the empty-targeting case that applies to everything.
- **`TestPolicyAppliesToNetworks`** — the unassociated policy, a policy associated only elsewhere, one match among several, and malformed associations (wrong type, wrong key, empty target) skipped rather than fatal.

## Deliberately not addressed here

All three are pre-existing and each wants its own change:

- **Priority is not evaluated** by either leg, so a higher-priority deny shadowing a lower-priority allow still reads as open. That **over**-reports, which is the safe direction for an exposure field.
- **Hierarchical (org/folder) firewall policies** are modeled but not read here; they need org-level access many scans do not have.
- **`NetworkFirewallPolicies.List` is global-only**, so regional policies are not listed at all — a gap in the lister, not in this logic.

## Test plan

- [x] `go test ./resources/` passes in full
- [x] Each new predicate verified failing when its check is removed
- [x] Codegen diff inspected; `.lr.versions` entry correct at 13.37.1
- [x] `gofmt` clean
- [ ] **Not live-verified** — wants a VPC using network firewall policies with no legacy rules, and an instance behind an allow-from-`0.0.0.0/0` policy rule
