### PR TITLE
🐛 os: error instead of husking when a sub-resource is named as a static path

### DIFF
--- a/providers/os/resources/implicit_subresource_init.go
+++ b/providers/os/resources/implicit_subresource_init.go
@@ -1,0 +1,154 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// Codegen synthesizes an implicit singular field for every sub-resource, so a
+// query can name `nftables.table` as a static path even though the schema only
+// declares the plural `nftables.tables` list. Naming the singular form builds
+// the sub-resource standalone: it never sees the parent that would have filled
+// it in, so its id is empty or garbage and every field stays unset. The runtime
+// then reports "provider returned no data and no error for a field" and the
+// query yields nulls, which a check reads as a real answer rather than as a
+// failure.
+//
+// The inits below refuse that instantiation, following the `logrotate.entry`
+// model of erroring out instead of handing back a husk. Each one keeps the fast
+// path for arguments that already carry the sub-resource's identity, so the
+// parent listers and the typed accessors that resolve through NewResource are
+// unaffected.
+
+// errSubResourceNeedsParent reports that a sub-resource cannot stand on its own
+// and names the parent collection to query instead.
+func errSubResourceNeedsParent(resource string, parent string) error {
+	return fmt.Errorf("%s cannot be initialized on its own, it only exists as part of %s", resource, parent)
+}
+
+// hasStringArgs reports whether every named argument is present and holds a
+// non-empty string. An argument that is absent, null, or empty cannot identify
+// a sub-resource, which is exactly the state a standalone instantiation lands in.
+func hasStringArgs(args map[string]*llx.RawData, names ...string) bool {
+	for _, name := range names {
+		raw, ok := args[name]
+		if !ok || raw == nil {
+			return false
+		}
+		s, ok := raw.Value.(string)
+		if !ok || s == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func initNftablesTable(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if hasStringArgs(args, "family", "name") {
+		return args, nil, nil
+	}
+	return nil, nil, errSubResourceNeedsParent("nftables.table", "nftables.tables")
+}
+
+func initNftablesChain(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if hasStringArgs(args, "family", "table", "name") {
+		return args, nil, nil
+	}
+	return nil, nil, errSubResourceNeedsParent("nftables.chain", "nftables.chains")
+}
+
+func initNftablesRule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if hasStringArgs(args, "family", "table", "chain") {
+		return args, nil, nil
+	}
+	return nil, nil, errSubResourceNeedsParent("nftables.rule", "nftables.rules")
+}
+
+func initNftablesSet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if hasStringArgs(args, "family", "table", "name") {
+		return args, nil, nil
+	}
+	return nil, nil, errSubResourceNeedsParent("nftables.set", "nftables.sets")
+}
+
+func initIptablesTable(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if hasStringArgs(args, "name") {
+		return args, nil, nil
+	}
+	return nil, nil, errSubResourceNeedsParent("iptables.table", "iptables.tables")
+}
+
+func initIptablesChain(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if hasStringArgs(args, "table", "name") {
+		return args, nil, nil
+	}
+	return nil, nil, errSubResourceNeedsParent("iptables.chain", "iptables.tables")
+}
+
+func initIptablesEntry(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if hasStringArgs(args, "chain") {
+		return args, nil, nil
+	}
+	return nil, nil, errSubResourceNeedsParent("iptables.entry", "iptables.input, iptables.output, iptables.forward, or iptables.tables")
+}
+
+func initLsblkEntry(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if hasStringArgs(args, "name") {
+		return args, nil, nil
+	}
+	return nil, nil, errSubResourceNeedsParent("lsblk.entry", "lsblk.list")
+}
+
+func initJournaldConfigSection(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if hasStringArgs(args, "name") {
+		return args, nil, nil
+	}
+	return nil, nil, errSubResourceNeedsParent("journald.config.section", "journald.config.sections")
+}
+
+func initModprobeBlacklist(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if hasStringArgs(args, "file") {
+		return args, nil, nil
+	}
+	return nil, nil, errSubResourceNeedsParent("modprobe.blacklist", "modprobe.blacklists")
+}
+
+func initModprobeAlias(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if hasStringArgs(args, "file") {
+		return args, nil, nil
+	}
+	return nil, nil, errSubResourceNeedsParent("modprobe.alias", "modprobe.aliases")
+}
+
+func initModprobeInstall(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if hasStringArgs(args, "file") {
+		return args, nil, nil
+	}
+	return nil, nil, errSubResourceNeedsParent("modprobe.install", "modprobe.installs")
+}
+
+func initModprobeOption(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if hasStringArgs(args, "file") {
+		return args, nil, nil
+	}
+	return nil, nil, errSubResourceNeedsParent("modprobe.option", "modprobe.options")
+}
+
+func initModprobeRemove(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if hasStringArgs(args, "file") {
+		return args, nil, nil
+	}
+	return nil, nil, errSubResourceNeedsParent("modprobe.remove", "modprobe.removes")
+}
+
+func initModprobeSoftdep(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if hasStringArgs(args, "file") {
+		return args, nil, nil
+	}
+	return nil, nil, errSubResourceNeedsParent("modprobe.softdep", "modprobe.softdeps")
+}

--- a/providers/os/resources/implicit_subresource_init_test.go
+++ b/providers/os/resources/implicit_subresource_init_test.go
@@ -1,0 +1,236 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+type subResourceInit func(*plugin.Runtime, map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+
+// subResourceInits are the sub-resources that codegen exposes as an implicit
+// singular field, which makes them nameable as a static path. Each entry pairs
+// the resource name with its init and with the arguments its parent lister
+// supplies.
+var subResourceInits = []struct {
+	name     string
+	init     subResourceInit
+	identity map[string]*llx.RawData
+	// partial carries only some of the identity fields, which is still not
+	// enough to resolve the sub-resource.
+	partial map[string]*llx.RawData
+}{
+	{
+		name: "nftables.table",
+		init: initNftablesTable,
+		identity: map[string]*llx.RawData{
+			"family": llx.StringData("inet"),
+			"name":   llx.StringData("filter"),
+		},
+		partial: map[string]*llx.RawData{"family": llx.StringData("inet")},
+	},
+	{
+		name: "nftables.chain",
+		init: initNftablesChain,
+		identity: map[string]*llx.RawData{
+			"family": llx.StringData("inet"),
+			"table":  llx.StringData("filter"),
+			"name":   llx.StringData("input"),
+		},
+		partial: map[string]*llx.RawData{
+			"family": llx.StringData("inet"),
+			"table":  llx.StringData("filter"),
+		},
+	},
+	{
+		name: "nftables.rule",
+		init: initNftablesRule,
+		identity: map[string]*llx.RawData{
+			"family": llx.StringData("inet"),
+			"table":  llx.StringData("filter"),
+			"chain":  llx.StringData("input"),
+		},
+		partial: map[string]*llx.RawData{"family": llx.StringData("inet")},
+	},
+	{
+		name: "nftables.set",
+		init: initNftablesSet,
+		identity: map[string]*llx.RawData{
+			"family": llx.StringData("inet"),
+			"table":  llx.StringData("filter"),
+			"name":   llx.StringData("blocklist"),
+		},
+		partial: map[string]*llx.RawData{"table": llx.StringData("filter")},
+	},
+	{
+		name:     "iptables.table",
+		init:     initIptablesTable,
+		identity: map[string]*llx.RawData{"name": llx.StringData("filter")},
+		partial:  map[string]*llx.RawData{"name": llx.StringData("")},
+	},
+	{
+		name: "iptables.chain",
+		init: initIptablesChain,
+		identity: map[string]*llx.RawData{
+			"table": llx.StringData("filter"),
+			"name":  llx.StringData("INPUT"),
+		},
+		partial: map[string]*llx.RawData{"name": llx.StringData("INPUT")},
+	},
+	{
+		name: "iptables.entry",
+		init: initIptablesEntry,
+		identity: map[string]*llx.RawData{
+			"chain":      llx.StringData("filter/INPUT"),
+			"lineNumber": llx.IntData(1),
+		},
+		partial: map[string]*llx.RawData{"lineNumber": llx.IntData(1)},
+	},
+	{
+		name:     "lsblk.entry",
+		init:     initLsblkEntry,
+		identity: map[string]*llx.RawData{"name": llx.StringData("nvme0n1p1")},
+		partial:  map[string]*llx.RawData{"fstype": llx.StringData("ext4")},
+	},
+	{
+		name:     "journald.config.section",
+		init:     initJournaldConfigSection,
+		identity: map[string]*llx.RawData{"name": llx.StringData("Journal")},
+		partial:  map[string]*llx.RawData{"params": llx.NilData},
+	},
+	{
+		name: "modprobe.blacklist",
+		init: initModprobeBlacklist,
+		identity: map[string]*llx.RawData{
+			"file":       llx.StringData("/etc/modprobe.d/blacklist.conf"),
+			"lineNumber": llx.IntData(3),
+		},
+		partial: map[string]*llx.RawData{"module": llx.StringData("cramfs")},
+	},
+	{
+		name: "modprobe.alias",
+		init: initModprobeAlias,
+		identity: map[string]*llx.RawData{
+			"file":       llx.StringData("/etc/modprobe.d/aliases.conf"),
+			"lineNumber": llx.IntData(1),
+		},
+		partial: map[string]*llx.RawData{"alias": llx.StringData("net-pf-10")},
+	},
+	{
+		name: "modprobe.install",
+		init: initModprobeInstall,
+		identity: map[string]*llx.RawData{
+			"file":       llx.StringData("/etc/modprobe.d/install.conf"),
+			"lineNumber": llx.IntData(1),
+		},
+		partial: map[string]*llx.RawData{"module": llx.StringData("usb-storage")},
+	},
+	{
+		name: "modprobe.option",
+		init: initModprobeOption,
+		identity: map[string]*llx.RawData{
+			"file":       llx.StringData("/etc/modprobe.d/options.conf"),
+			"lineNumber": llx.IntData(1),
+		},
+		partial: map[string]*llx.RawData{"parameters": llx.StringData("nomodeset")},
+	},
+	{
+		name: "modprobe.remove",
+		init: initModprobeRemove,
+		identity: map[string]*llx.RawData{
+			"file":       llx.StringData("/etc/modprobe.d/remove.conf"),
+			"lineNumber": llx.IntData(1),
+		},
+		partial: map[string]*llx.RawData{"command": llx.StringData("/bin/true")},
+	},
+	{
+		name: "modprobe.softdep",
+		init: initModprobeSoftdep,
+		identity: map[string]*llx.RawData{
+			"file":       llx.StringData("/etc/modprobe.d/softdep.conf"),
+			"lineNumber": llx.IntData(1),
+		},
+		partial: map[string]*llx.RawData{"module": llx.StringData("snd")},
+	},
+}
+
+// A sub-resource named as a static path arrives at its init with no arguments.
+// Falling through with (args, nil, nil) there is what builds the husk the
+// runtime then reports as "provider returned no data and no error for a field",
+// so the init has to refuse.
+func TestSubResourceInitRefusesEmptyArgs(t *testing.T) {
+	for _, tc := range subResourceInits {
+		t.Run(tc.name, func(t *testing.T) {
+			args, res, err := tc.init(nil, map[string]*llx.RawData{})
+			require.Error(t, err)
+			assert.Nil(t, args, "must not hand back args for blank-resource creation")
+			assert.Nil(t, res)
+			assert.Contains(t, err.Error(), tc.name)
+		})
+	}
+}
+
+// Identity fields that are present but empty are exactly what a standalone
+// instantiation produces, so they must not open the fast path either.
+func TestSubResourceInitRefusesPartialArgs(t *testing.T) {
+	for _, tc := range subResourceInits {
+		t.Run(tc.name, func(t *testing.T) {
+			args, res, err := tc.init(nil, tc.partial)
+			require.Error(t, err)
+			assert.Nil(t, args)
+			assert.Nil(t, res)
+		})
+	}
+}
+
+// The parent listers and the typed accessors that resolve through NewResource
+// supply the identity fields, and they have to keep working untouched.
+func TestSubResourceInitAcceptsIdentityArgs(t *testing.T) {
+	for _, tc := range subResourceInits {
+		t.Run(tc.name, func(t *testing.T) {
+			args, res, err := tc.init(nil, tc.identity)
+			require.NoError(t, err)
+			assert.Nil(t, res, "init resolves through Create, it does not build the resource itself")
+			assert.Equal(t, tc.identity, args)
+		})
+	}
+}
+
+// NewResource is the path a static-path lookup takes (plugin service GetData
+// with no resource id and no field). Before the inits were wired it returned a
+// husk here; it must return an error.
+func TestNewResourceRefusesStandaloneSubResource(t *testing.T) {
+	for _, tc := range subResourceInits {
+		t.Run(tc.name, func(t *testing.T) {
+			runtime := plugin.NewRuntime(nil, nil, false, CreateResource, NewResource, GetData, SetData, nil)
+			res, err := NewResource(runtime, tc.name, map[string]*llx.RawData{})
+			require.Error(t, err)
+			assert.Nil(t, res)
+		})
+	}
+}
+
+func TestHasStringArgs(t *testing.T) {
+	args := map[string]*llx.RawData{
+		"name":   llx.StringData("filter"),
+		"empty":  llx.StringData(""),
+		"null":   llx.NilData,
+		"number": llx.IntData(7),
+		"absent": nil,
+	}
+
+	assert.True(t, hasStringArgs(args, "name"))
+	assert.True(t, hasStringArgs(args), "no requirements is vacuously satisfied")
+	assert.False(t, hasStringArgs(args, "empty"), "an empty string does not identify anything")
+	assert.False(t, hasStringArgs(args, "null"))
+	assert.False(t, hasStringArgs(args, "number"), "a non-string value is not an identity string")
+	assert.False(t, hasStringArgs(args, "absent"))
+	assert.False(t, hasStringArgs(args, "missing"))
+	assert.False(t, hasStringArgs(args, "name", "empty"), "every named arg has to be present")
+}

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -1336,7 +1336,7 @@ func init() {
 			Create: createJournaldConfig,
 		},
 		"journald.config.section": {
-			// to override args, implement: initJournaldConfigSection(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initJournaldConfigSection,
 			Create: createJournaldConfigSection,
 		},
 		"journald.config.section.param": {
@@ -1552,15 +1552,15 @@ func init() {
 			Create: createIp6tables,
 		},
 		"iptables.table": {
-			// to override args, implement: initIptablesTable(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initIptablesTable,
 			Create: createIptablesTable,
 		},
 		"iptables.chain": {
-			// to override args, implement: initIptablesChain(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initIptablesChain,
 			Create: createIptablesChain,
 		},
 		"iptables.entry": {
-			// to override args, implement: initIptablesEntry(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initIptablesEntry,
 			Create: createIptablesEntry,
 		},
 		"nftables": {
@@ -1568,19 +1568,19 @@ func init() {
 			Create: createNftables,
 		},
 		"nftables.table": {
-			// to override args, implement: initNftablesTable(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initNftablesTable,
 			Create: createNftablesTable,
 		},
 		"nftables.chain": {
-			// to override args, implement: initNftablesChain(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initNftablesChain,
 			Create: createNftablesChain,
 		},
 		"nftables.rule": {
-			// to override args, implement: initNftablesRule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initNftablesRule,
 			Create: createNftablesRule,
 		},
 		"nftables.set": {
-			// to override args, implement: initNftablesSet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initNftablesSet,
 			Create: createNftablesSet,
 		},
 		"ufw": {
@@ -1748,7 +1748,7 @@ func init() {
 			Create: createLsblk,
 		},
 		"lsblk.entry": {
-			// to override args, implement: initLsblkEntry(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initLsblkEntry,
 			Create: createLsblkEntry,
 		},
 		"luks": {
@@ -1820,27 +1820,27 @@ func init() {
 			Create: createModprobe,
 		},
 		"modprobe.install": {
-			// to override args, implement: initModprobeInstall(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initModprobeInstall,
 			Create: createModprobeInstall,
 		},
 		"modprobe.remove": {
-			// to override args, implement: initModprobeRemove(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initModprobeRemove,
 			Create: createModprobeRemove,
 		},
 		"modprobe.blacklist": {
-			// to override args, implement: initModprobeBlacklist(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initModprobeBlacklist,
 			Create: createModprobeBlacklist,
 		},
 		"modprobe.option": {
-			// to override args, implement: initModprobeOption(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initModprobeOption,
 			Create: createModprobeOption,
 		},
 		"modprobe.alias": {
-			// to override args, implement: initModprobeAlias(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initModprobeAlias,
 			Create: createModprobeAlias,
 		},
 		"modprobe.softdep": {
-			// to override args, implement: initModprobeSoftdep(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initModprobeSoftdep,
 			Create: createModprobeSoftdep,
 		},
 		"mount": {


### PR DESCRIPTION
## The bug

Codegen synthesizes an **implicit singular field** for every sub-resource (`"is_implicit_resource": true` in `os.resources.json`), so a query can name `nftables.table` as a static path even though the schema only declares the plural `nftables.tables` list.

When the target resource has no init, naming it that way instantiates it standalone. It never sees the parent that would have filled it in, so its id is empty or garbage and every field stays unset. The runtime logs a provider bug and the query yields nulls — and a check reads those nulls as a real answer rather than as a failure. That is the dangerous part: the resource looks answered.

Reproduced on `debian:13` against a provider built from `main`:

```
$ mql run local -j -c 'nftables.table { * }'
x provider returned no data and no error for a field; the field was never set on the
  resource (provider bug) field=flags id=/ provider=os resource=nftables.table
x llx: encountered a primitive with no type information, coercing to null
{"nftables.table":{"chains":null,"family":null,"sets":null,"flags":null,"handle":null,"rules":null,"name":null}}
```

All fifteen resources touched here behave the same way. `nftables.chain` is worse still — it hands back a nested `tableRef` husk, `{"family":"","name":""}`, which looks like a resolved reference.

## The fix

`logrotate.entry` already gets this right: it errors out rather than handing back a husk. These inits follow that model.

```
$ mql run local -j -c 'nftables.table { * }'
{"nftables.table":{"error":"nftables.table cannot be initialized on its own,
                            it only exists as part of nftables.tables"}}
```

Each init keeps the fast path for arguments that already carry the sub-resource's identity, so nothing that constructs the resource properly changes behavior:

- The parent listers go through `CreateResource`, which skips init entirely.
- The nftables typed accessors `tableRef` / `chainRef` resolve through `NewResource`, which does run init — they pass the full identity and take the fast path.

## Resources covered

`nftables.table`, `nftables.chain`, `nftables.rule`, `nftables.set`, `iptables.table`, `iptables.chain`, `iptables.entry`, `lsblk.entry`, `journald.config.section`, `modprobe.blacklist`, `modprobe.alias`, `modprobe.install`, `modprobe.option`, `modprobe.remove`, `modprobe.softdep`.

## Verification

Built `linux/arm64` and ran a before/after against a container carrying real nftables tables/chains/rules/sets, iptables rules, `/etc/modprobe.d` directives and `/etc/systemd/journald.conf`.

Every singular static path flipped from a husk to a clear error. Every plural path and every typed accessor produced **byte-identical output** before and after:

```
nftables.tables { name family flags }
  BASE: [{"family":"inet","flags":[],"name":"mondoo"},{"family":"ip","flags":[],"name":"filter"}]
  FIX : [{"family":"inet","flags":[],"name":"mondoo"},{"family":"ip","flags":[],"name":"filter"}]

nftables.rules { chain handle chainRef { name } tableRef { name } }
  BASE: [{"chainRef":{"name":"input"},"tableRef":{"name":"mondoo"},"chain":"input","handle":2}, ...]
  FIX : [{"chainRef":{"name":"input"},"tableRef":{"name":"mondoo"},"chain":"input","handle":2}, ...]
```

Also checked identical: `nftables.chains` (with `tableRef`), `nftables.sets`, `iptables.output`, `iptables.tables { chains }`, `journald.config.sections { params }`, `modprobe.blacklists`, `modprobe.softdeps`, `lsblk.list`.

## Tests

`providers/os/resources/implicit_subresource_init_test.go` covers the init functions directly and through the generated `NewResource`. Both failure modes were confirmed red before the fix:

- Unwiring `Init:` in the generated factory (reverting only `os.lr.go`) makes all 15 subtests of `TestNewResourceRefusesStandaloneSubResource` fail — that test asserts the exact runtime path a static-path lookup takes.
- Replacing each init body with the buggy `return args, nil, nil` fall-through makes all 30 subtests of `TestSubResourceInitRefusesEmptyArgs` and `TestSubResourceInitRefusesPartialArgs` fail.

`TestSubResourceInitAcceptsIdentityArgs` pins the fast path so an over-eager init cannot break the plural listers, and `TestHasStringArgs` covers absent / null / empty / wrong-type arguments.

## Scope

This is a targeted fix, not the general one. The os provider has **378** implicit fields whose target has no init, and the same shape repeats across aws, gcp, azure and oci (previously measured at 1,762).

`mqlc/builtin.go` already refuses to glob-expand an implicit resource whose target lacks an empty init:

```go
if v.IsImplicitResource {
    child := c.Schema.Lookup(types.Type(v.Type).ResourceName())
    if !child.HasEmptyInit() {
        continue
    }
```

The same rule is not applied to static-path resolution, which is exactly why `nftables.table` compiles and then husks. Applying that gate there would turn the whole class into compile errors — a strictly better failure mode with no per-resource work. That is an architectural, cross-provider change and is deliberately out of scope here.

No schema change, so no `.lr.versions` entries and no provider version bump. The only generated diff is 15 `Init:` lines in `os.lr.go`.
