### PR TITLE
📄 os: package.files is package-manager provenance, not installed files

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -1094,7 +1094,26 @@ package @defaults("name version") {
   // Whether a newer version than the installed one is available
   outdated() bool
 
-  // Files this package installed on the asset
+  // Package-manager records that evidence this package
+  //
+  // The file, directory, or database entry the package manager recorded this
+  // package in, usually a single record. It is provenance for the package
+  // entry, not the list of files the package installed on disk, so it does not
+  // answer which package owns a given path.
+  //
+  // The record is per-backend:
+  //
+  //   dpkg      /var/lib/dpkg/info/<name>.list
+  //   rpm       the rpm database directory, %{_dbpath}
+  //   apk       /lib/apk/db/installed
+  //   pacman    the local database entry for the package
+  //   xbps      the package's own file list, the one backend that does report
+  //             the installed paths
+  //   macOS     the application bundle path
+  //   Windows   the install location from the uninstall registry
+  //
+  // Empty on package managers with no such record, among them flatpak, snap,
+  // homebrew, nix, gentoo, and the BSD package tools.
   files() []pkgFileInfo
 
   // Package vendor
@@ -1125,9 +1144,15 @@ package @defaults("name version") {
   installDate time
 }
 
-// File installed by a package
+// File recorded for a package
+//
+// A single filesystem path a backend reported for a package entry: the
+// package-manager record that evidences an installed system package, or the
+// manifest, lockfile, or archive that declared a language dependency or a
+// plugin. It is evidence for the package entry rather than a file the package
+// installed on disk.
 private pkgFileInfo @defaults("path") {
-  // Path to the file
+  // Path to the recorded file or directory
   path string
 }
 


### PR DESCRIPTION
## Problem

`providers/os/resources/os.lr` documents `package.files` as:

```
// Files this package installed on the asset
files() []pkgFileInfo
```

It does not return the files the package installed. Every family returns a
single record that points at the package manager's own bookkeeping. Verified in
real containers:

| family | image | `package("x").files` | real file count |
|---|---|---|---|
| apk  | `docker.io/library/python:alpine` | `/lib/apk/db/installed` | `apk info -L musl` = 3 |
| rpm  | `registry.access.redhat.com/ubi10/ubi` | `/usr/lib/sysimage/rpm` | `rpm -ql bash` = 133 |
| dpkg | `docker.io/library/debian:13` | `/var/lib/dpkg/info/bash.list` | `wc -l < .../bash.list` = 166 |

So `package("openssl").files.any(path == "/usr/bin/openssl")` is always false,
with no error to say why.

## Why this is a doc fix and not a behaviour fix

The implementation is deliberate and internally consistent:

- `RpmPkgManager.Files` (`packages/rpm_packages.go`) resolves `%{_dbpath}` once
  and hands the same cached record to every package, with a comment explaining
  that this avoids an `rpm -E '%{_dbpath}'` per package (an N+1 on hosts with
  hundreds of packages).
- `DebPkgManager.Files` (`packages/dpkg_packages.go`) returns the `.list` path
  only when it stats.

That is SBOM *evidence* semantics: which file told us this package is
installed. Making it return real contents would cost an `rpm -ql` per package
and would be a breaking change for existing SBOM consumers. The schema is what
is wrong, so the schema is what this changes.

If the contents list is genuinely wanted later, it belongs in a new field, not
in this one.

## What changed

- `package.files` gets an evidence-semantics comment with the per-backend
  record for each family, and an explicit statement that it does not answer
  which package owns a path.
- `pkgFileInfo` and its `path` field lose "File installed by a package". The
  type is shared with `npm.package`, `go.package`, `python.package`,
  `wordpress.plugin` and ~40 other inventory resources whose own field comments
  already read "Files that declared the package" / "Files that contributed this
  plugin to the inventory", so evidence framing is what it has always meant
  there too.
- The comment calls out `xbps` as the one backend that does parse its file list
  into real installed paths (`ParseXbpsFileList`), so readers are not misled in
  the other direction.

## Bundled content

No bundled query content relies on the old reading. This repo has no `content/`
directory on `main`, and a repo-wide search of `.mql`, `.yaml` and `.yml` for a
`package`/`packages` expression reaching `.files` returned nothing.

## Verification

- `make providers/mqlr` + `./mqlr generate providers/os/resources/os.lr --dist providers/os/resources`
- Codegen schema-change report emits no `schema changed` line, i.e. `additive=0
  breaking=0` (docs are ignored by the report).
- `providers/os/resources/os.lr.versions` is byte-identical: a doc-only change
  does not bump a version.
- `make providers/build/os` succeeds.
- `git diff --stat` shows only `providers/os/resources/os.lr`
  (`providers/*/resources/*.resources.json` is gitignored).
