### PR TITLE
🐛 os: probe for a package database when no case names the platform

### DIFF
--- a/providers/os/resources/packages/packages.go
+++ b/providers/os/resources/packages/packages.go
@@ -171,14 +171,41 @@ func ResolveSystemPkgManagers(conn shared.Connection) ([]OperatingSystemPkgManag
 	case asset.Platform.Name == "gentoo":
 		pms = append(pms, &GentooPkgManager{conn: conn, platform: asset.Platform})
 	case asset.Platform.IsFamily("linux"):
-		// no clear package manager for linux platform found
-		// most likely we land here if we have a yocto-based system
+		// No case above claimed this platform, so nothing above it knows which
+		// package manager it uses. Every distro named above had to be named
+		// because it carries neither a family nor a name any earlier case
+		// matches, and a distro nobody has added yet is indistinguishable from
+		// one nobody ever will: it lands here and, without a probe, reports no
+		// package manager at all. CBL-Mariner 2.0 (ID=mariner) was one such
+		// case, with a populated rpm database and no package inventory.
+		//
+		// So ask the filesystem instead of the name. A package database on
+		// disk is the same evidence the named cases stand on, and it is
+		// evidence the distro provides itself.
 		opkgPaths := []string{"/bin/opkg", "/usr/bin/opkg"}
 		for i := range opkgPaths {
 			if _, err := conn.FileSystem().Stat(opkgPaths[i]); err == nil {
 				pms = append(pms, &OpkgPkgManager{conn: conn})
 				break
 			}
+		}
+
+		// rpm keeps its database under /var/lib/rpm, or under
+		// /usr/lib/sysimage/rpm on systems that moved it for /var immutability.
+		rpmPaths := []string{"/var/lib/rpm", "/usr/lib/sysimage/rpm"}
+		for i := range rpmPaths {
+			if _, err := conn.FileSystem().Stat(rpmPaths[i]); err == nil {
+				pms = append(pms, &RpmPkgManager{conn: conn, platform: asset.Platform})
+				break
+			}
+		}
+
+		if _, err := conn.FileSystem().Stat("/var/lib/dpkg/status"); err == nil {
+			pms = append(pms, &DebPkgManager{conn: conn, platform: asset.Platform})
+		}
+
+		if _, err := conn.FileSystem().Stat("/lib/apk/db/installed"); err == nil {
+			pms = append(pms, &AlpinePkgManager{conn: conn, platform: asset.Platform})
 		}
 	}
 

--- a/providers/os/resources/packages/resolve_pkg_managers_test.go
+++ b/providers/os/resources/packages/resolve_pkg_managers_test.go
@@ -1,0 +1,163 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package packages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+)
+
+// newProbeConn builds a mock connection for a platform whose name matches no
+// case in ResolveSystemPkgManagers, so resolution reaches the plain-linux
+// branch and has nothing but the given filesystem entries to go on.
+func newProbeConn(t *testing.T, platform *inventory.Platform, paths ...string) *mock.Connection {
+	t.Helper()
+
+	files := map[string]*mock.MockFileData{}
+	for _, p := range paths {
+		files[p] = &mock.MockFileData{Path: p}
+	}
+
+	conn, err := mock.New(0, &inventory.Asset{Platform: platform}, mock.WithData(&mock.TomlData{Files: files}))
+	require.NoError(t, err)
+	return conn
+}
+
+func managerNames(pms []OperatingSystemPkgManager) []string {
+	names := make([]string, 0, len(pms))
+	for _, pm := range pms {
+		names = append(names, pm.Name())
+	}
+	return names
+}
+
+// CBL-Mariner 2.0 reports ID=mariner with family ["linux","unix","os"]. It is
+// not in the redhat family and no case names it, so before the filesystem
+// probe it matched nothing and packages errored on a host with 69 rpms in a
+// healthy /var/lib/rpm.
+func TestResolveSystemPkgManagersMariner(t *testing.T) {
+	conn := newProbeConn(t, &inventory.Platform{
+		Name:    "mariner",
+		Version: "2.0",
+		Family:  []string{"linux", "unix", "os"},
+	}, "/var/lib/rpm")
+
+	pms, err := ResolveSystemPkgManagers(conn)
+	require.NoError(t, err, "an rpm database is present, so a manager must resolve")
+	require.Len(t, pms, 1)
+	assert.IsType(t, &RpmPkgManager{}, pms[0])
+}
+
+// Some rpm distros moved the database off /var so /var can stay mutable state.
+func TestResolveSystemPkgManagersRpmSysimagePath(t *testing.T) {
+	conn := newProbeConn(t, &inventory.Platform{
+		Name:   "somenewrpmdistro",
+		Family: []string{"linux", "unix", "os"},
+	}, "/usr/lib/sysimage/rpm")
+
+	pms, err := ResolveSystemPkgManagers(conn)
+	require.NoError(t, err)
+	require.Len(t, pms, 1)
+	assert.IsType(t, &RpmPkgManager{}, pms[0])
+}
+
+func TestResolveSystemPkgManagersUnknownDpkg(t *testing.T) {
+	conn := newProbeConn(t, &inventory.Platform{
+		Name:   "somenewdebiandistro",
+		Family: []string{"linux", "unix", "os"},
+	}, "/var/lib/dpkg/status")
+
+	pms, err := ResolveSystemPkgManagers(conn)
+	require.NoError(t, err)
+	require.Len(t, pms, 1)
+	assert.IsType(t, &DebPkgManager{}, pms[0])
+}
+
+func TestResolveSystemPkgManagersUnknownApk(t *testing.T) {
+	conn := newProbeConn(t, &inventory.Platform{
+		Name:   "somenewapkdistro",
+		Family: []string{"linux", "unix", "os"},
+	}, "/lib/apk/db/installed")
+
+	pms, err := ResolveSystemPkgManagers(conn)
+	require.NoError(t, err)
+	require.Len(t, pms, 1)
+	assert.IsType(t, &AlpinePkgManager{}, pms[0])
+}
+
+// The probe must stay evidence-driven: a linux platform with no package
+// database on disk still resolves nothing, and still says so.
+func TestResolveSystemPkgManagersUnknownLinuxNoDatabase(t *testing.T) {
+	conn := newProbeConn(t, &inventory.Platform{
+		Name:   "somedistrowithoutpackages",
+		Family: []string{"linux", "unix", "os"},
+	}, "/etc/os-release")
+
+	_, err := ResolveSystemPkgManagers(conn)
+	require.Error(t, err)
+}
+
+// The probe lives in the plain-linux branch, which a distro that already
+// matched an earlier case never reaches. If it ever leaked out of that branch,
+// every rpm and dpkg host would resolve a second manager and packages would
+// count each package twice.
+func TestResolveSystemPkgManagersNoDoubleCountOnKnownPlatforms(t *testing.T) {
+	tests := []struct {
+		name     string
+		platform *inventory.Platform
+		files    []string
+		expected []string
+	}{
+		{
+			name: "redhat family with an rpm database",
+			platform: &inventory.Platform{
+				Name:   "redhat",
+				Family: []string{"redhat", "linux", "unix", "os"},
+			},
+			files:    []string{"/var/lib/rpm"},
+			expected: []string{"Rpm Package Manager"},
+		},
+		{
+			name: "azurelinux with an rpm database",
+			platform: &inventory.Platform{
+				Name:   "azurelinux",
+				Family: []string{"linux", "unix", "os"},
+			},
+			files:    []string{"/var/lib/rpm"},
+			expected: []string{"Rpm Package Manager"},
+		},
+		{
+			name: "debian family with a dpkg status file",
+			platform: &inventory.Platform{
+				Name:   "debian",
+				Family: []string{"debian", "linux", "unix", "os"},
+			},
+			files:    []string{"/var/lib/dpkg/status"},
+			expected: []string{"Debian Package Manager", "Snap Package Manager"},
+		},
+		{
+			name: "alpine with an apk database",
+			platform: &inventory.Platform{
+				Name:   "alpine",
+				Family: []string{"linux", "unix", "os"},
+			},
+			files:    []string{"/lib/apk/db/installed"},
+			expected: []string{"apk Package Manager"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			conn := newProbeConn(t, test.platform, test.files...)
+
+			pms, err := ResolveSystemPkgManagers(conn)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, managerNames(pms))
+		})
+	}
+}


### PR DESCRIPTION
## The bug

On CBL-Mariner 2.0 (`mcr.microsoft.com/cbl-mariner/base/core:2.0`), `packages` returns an error and the asset has no package inventory at all, so every package-based vulnerability and compliance check silently has nothing to evaluate.

```
$ mql run local -c 'asset { platform version family }'
{"asset":{"platform":"mariner","version":"2.0","family":["linux","unix","os"]}}

$ mql run local -c 'packages.length'
packages: error: could not detect suitable package manager for platform

$ rpm -qa | wc -l
69
$ ls /var/lib/rpm/
rpmdb.sqlite  rpmdb.sqlite-shm  rpmdb.sqlite-wal
```

69 rpms in a healthy sqlite rpmdb; mql reports none.

## Root cause

`ResolveSystemPkgManagers` matches on platform family first, then on a list of platform names. `mariner` is in neither: it is not in the `redhat` family, and the name case that carries the rpm-based outliers lists `azurelinux` (the name Microsoft moved to at 3.0) but not `mariner` (the name 2.0 still reports). Resolution falls through to the plain-linux branch, which probed only for opkg, and then to `len(pms) == 0`.

**Mariner is the instance, not the class.** Every distro named in that switch had to be named because it carries neither a family nor a name any earlier case matches — `altlinux`, `opencloudos`, `photon`, `bottlerocket` and the rest each arrived as a bug report of exactly this shape. A distro nobody has added yet is indistinguishable from one nobody ever will: it lands in the same branch and reports no packages.

## The fix

The plain-linux branch now asks the filesystem instead of the name, extending what it already did for opkg:

| evidence on disk | manager |
|---|---|
| `/var/lib/rpm` or `/usr/lib/sysimage/rpm` | `RpmPkgManager` |
| `/var/lib/dpkg/status` | `DebPkgManager` |
| `/lib/apk/db/installed` | `AlpinePkgManager` |

A package database on disk is the same evidence the named cases stand on, and it is evidence the distro provides itself rather than evidence we have to keep adding by hand.

**The reported platform name is unchanged.** `mariner` stays `mariner`. Renaming it to `azurelinux` in the detector would fix this one distro and break anyone already filtering on the reported name, and it would leave the class untouched. No detector change is included here.

## Verification (linux/arm64, real images)

Mariner 2.0, before and after, against the native count:

| | `packages.length` |
|---|---|
| before | `error: could not detect suitable package manager for platform` |
| after | **69** |
| `rpm -qa \| wc -l` | **69** |

The probe lives in a branch a distro that matched an earlier case never reaches, so nothing that already worked changes — a wrongly-appended second manager would double-count every package. Control images, before build vs. after build vs. native count:

| image | before | after | native |
|---|---|---|---|
| `mcr.microsoft.com/azurelinux/base/core:3.0` (rpm) | 79 | 79 | 79 |
| `registry.access.redhat.com/ubi10/ubi` (rpm) | 175 | 175 | 175 |
| `docker.io/library/debian:13` (dpkg) | 78 | 78 | 78 |
| `docker.io/library/python:alpine` (apk) | 30 | 30 | 30 |

## Tests

`providers/os/resources/packages/resolve_pkg_managers_test.go` resolves managers through a mock connection whose filesystem holds only the package database under test.

Confirmed red before the change: with `packages.go` stashed, the four probe cases (mariner, the `/usr/lib/sysimage/rpm` path, unknown-dpkg, unknown-apk) fail with `could not detect suitable package manager for platform`; with the change applied all pass.

Two of the tests pass in both states by design, because they pin what must *not* change:

- `TestResolveSystemPkgManagersUnknownLinuxNoDatabase` — a linux platform with no package database still resolves nothing and still errors. It fails if a probe is ever made unconditional.
- `TestResolveSystemPkgManagersNoDoubleCountOnKnownPlatforms` — redhat, azurelinux, debian and alpine each resolve exactly the managers they resolved before. It fails if the probe ever leaks out of the plain-linux branch, which is the regression that would double-count packages on every host.
