### PR TITLE
🐛 os: rpm 7 reports no packages, MODULARITYLABEL needs a lower version bound

### DIFF
--- a/providers/os/resources/packages/rpm_packages.go
+++ b/providers/os/resources/packages/rpm_packages.go
@@ -602,16 +602,21 @@ func modularitySupportedByPlatform(platform *inventory.Platform) bool {
 
 	switch platform.Name {
 	case "oraclelinux", "almalinux", "redhat", "centos", "rocky":
+		// The window is [8, 10): modularity was introduced with RHEL 8 and
+		// removed again in RHEL 10. Do not widen it. On RHEL 7 and older rpm is
+		// 4.11, which has no %{MODULARITYLABEL} tag: it writes an error per
+		// package to stderr, writes nothing to stdout, and still exits 0, so
+		// asking for the tag there returns an empty package list with no error.
 		vParser := semver.Parser{}
-		cmp, err := vParser.Compare(platform.Version, "10")
+		lower, err := vParser.Compare(platform.Version, "8")
 		if err != nil {
 			return false
 		}
-		if cmp < 0 {
-			supported = true
-		} else {
-			supported = false
+		upper, err := vParser.Compare(platform.Version, "10")
+		if err != nil {
+			return false
 		}
+		supported = lower >= 0 && upper < 0
 	}
 
 	return supported

--- a/providers/os/resources/packages/rpm_packages_test.go
+++ b/providers/os/resources/packages/rpm_packages_test.go
@@ -549,68 +549,55 @@ func TestRedHatModularParser(t *testing.T) {
 	assert.Equal(t, p.PUrl, fPkg.PUrl)
 }
 
+// TestModularitySupportedByPlatform pins the version window in which the
+// %{MODULARITYLABEL} queryformat tag may be requested: modularity arrived in
+// RHEL 8 and was removed again in RHEL 10, so only 8.x and 9.x qualify.
+//
+// The version-7 rows guard a regression that silently emptied the package
+// inventory. The guard used to carry only the upper bound, so RHEL, CentOS and
+// Oracle Linux 7 were handed the tag. Their rpm is 4.11, which does not know
+// it: rpm printed "error: incorrect format: unknown tag" per package, wrote
+// nothing at all to stdout, and still exited 0 - so `packages` came back as an
+// empty list, with no error, on a host with a fully populated rpm database.
 func TestModularitySupportedByPlatform(t *testing.T) {
-	tests := []struct {
-		name     string
-		platform *inventory.Platform
-		want     bool
+	// every distro name the modularity switch knows about
+	modularDistros := []string{"oraclelinux", "almalinux", "redhat", "centos", "rocky"}
+
+	versions := []struct {
+		version string
+		want    bool
 	}{
-		{
-			name:     "AlmaLinux",
-			platform: &inventory.Platform{Name: "almalinux", Version: "8.10", Arch: "x86_64"},
-			want:     true,
-		},
-		{
-			name:     "OracleLinux",
-			platform: &inventory.Platform{Name: "oraclelinux", Version: "9", Arch: "x86_64"},
-			want:     true,
-		},
-		{
-			name:     "AlmaLinux",
-			platform: &inventory.Platform{Name: "almalinux", Version: "10", Arch: "x86_64"},
-			want:     false,
-		},
-		{
-			name:     "OracleLinux",
-			platform: &inventory.Platform{Name: "oraclelinux", Version: "10.1", Arch: "x86_64"},
-			want:     false,
-		},
-		{
-			name:     "RHEL 8",
-			platform: &inventory.Platform{Name: "redhat", Version: "8.10", Arch: "x86_64"},
-			want:     true,
-		},
-		{
-			name:     "RHEL 9",
-			platform: &inventory.Platform{Name: "redhat", Version: "9.4", Arch: "x86_64"},
-			want:     true,
-		},
-		{
-			name:     "RHEL 10",
-			platform: &inventory.Platform{Name: "redhat", Version: "10", Arch: "x86_64"},
-			want:     false,
-		},
-		{
-			name:     "CentOS 8",
-			platform: &inventory.Platform{Name: "centos", Version: "8", Arch: "x86_64"},
-			want:     true,
-		},
-		{
-			name:     "Rocky 9",
-			platform: &inventory.Platform{Name: "rocky", Version: "9.3", Arch: "x86_64"},
-			want:     true,
-		},
-		{
-			name:     "AmazonLinux",
-			platform: &inventory.Platform{Name: "amazonlinux", Version: "2", Arch: "x86_64"},
-			want:     false,
-		},
+		{"7", false}, // rpm 4.11 has no %{MODULARITYLABEL}
+		{"7.9", false},
+		{"8", true},
+		{"8.10", true},
+		{"9", true},
+		{"9.4", true},
+		{"10", false}, // modularity removed in RHEL 10
+		{"10.1", false},
+		{"", false}, // unparseable version must not enable the tag
+		{"unknown", false},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, modularitySupportedByPlatform(tt.platform))
-		})
+	for _, distro := range modularDistros {
+		for _, v := range versions {
+			t.Run(fmt.Sprintf("%s/%q", distro, v.version), func(t *testing.T) {
+				pf := &inventory.Platform{Name: distro, Version: v.version, Arch: "x86_64"}
+				require.Equal(t, v.want, modularitySupportedByPlatform(pf))
+			})
+		}
+	}
+
+	// Names outside the switch never get the tag, at any version. Amazon Linux 2
+	// also ships rpm 4.11 and reported its packages correctly throughout,
+	// precisely because it is not listed here.
+	for _, distro := range []string{"amazonlinux", "fedora", "sles", "opensuse", "photon"} {
+		for _, version := range []string{"2", "7", "8", "9", "10", ""} {
+			t.Run(fmt.Sprintf("unlisted/%s/%q", distro, version), func(t *testing.T) {
+				pf := &inventory.Platform{Name: distro, Version: version, Arch: "x86_64"}
+				require.False(t, modularitySupportedByPlatform(pf))
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
## Impact

On RHEL, CentOS and Oracle Linux **7**, `packages` returns an **empty list with
no error** while the host has a fully populated rpm database. Every
package-based vulnerability, patch and compliance check evaluates against
nothing, and nothing anywhere reports a problem. RHEL 7 ELS runs to 2028, so
this is live.

```
# docker.io/library/centos:7, arm64, os provider 13.40.9
$ rpm -qa | wc -l
151
$ mql run local -c 'packages.length'
packages.length: 0          # no error, no warning
```

## Why it is invisible

mql asks rpm for `%{MODULARITYLABEL}`, a tag that only exists in rpm **4.14+**.
CentOS 7 ships rpm **4.11.3**:

```
$ rpm --version
RPM version 4.11.3
$ rpm -qa --queryformat '...__%{MODULARITYLABEL}\n'
error: incorrect format: unknown tag
error: incorrect format: unknown tag
...
$ echo $?
0                                    # <-- rpm EXITS 0
$ rpm -qa --queryformat '%{NAME} %{VERSION}\n' | wc -l
151                                  # <-- fine without the tag
```

rpm writes an error per package to **stderr**, writes **nothing** to stdout,
and **exits 0**. An exit-status check cannot catch this; the only signal is
empty stdout against a populated database, which parses cleanly to an empty
package list.

## Root cause

`modularitySupportedByPlatform` in `providers/os/resources/packages/rpm_packages.go`
had an **upper** bound (`< 10`, because RHEL 10 dropped modularity) but **no
lower** bound, so version 7 fell into the supported branch. Modularity arrived
in RHEL **8**; the supported window is `[8, 10)`.

`amazonlinux` is not in the switch, which is why Amazon Linux 2 (also rpm 4.11)
reports its packages correctly. That was the control that confirmed the
diagnosis.

## Verification

Built a linux/arm64 os provider and ran it in containers.

| image | rpm | `rpm -qa` | `packages.length` before | after |
|---|---|---|---|---|
| `docker.io/library/centos:7` | 4.11.3 | 151 | **0** | **151** |
| `registry.access.redhat.com/ubi8/ubi` | 4.14.3 | 185 | 185 | 185 |
| `registry.access.redhat.com/ubi9/ubi` | 4.16.1.3 | 188 | 188 | 188 |

The risk of this change is suppressing modularity where it *is* supported, so
two controls:

- The debug trace shows the tag is still requested on 8 and 9 and dropped only
  on 7:
  ```
  ubi9  : rpm -qa --queryformat '...__%{INSTALLTIME}__%{MODULARITYLABEL}\n'
  ubi8  : rpm -qa --queryformat '...__%{INSTALLTIME}__%{MODULARITYLABEL}\n'
  cos:7 : rpm -qa --queryformat '...__%{INSTALLTIME}\n'
  ```
- Installing a modular package on ubi8 (`dnf install nodejs`) shows the label
  still parses into the purl:
  ```
  rpm : nodejs nodejs:10:8030020210225164533:229f0a1c
  mql : pkg:rpm/redhat/nodejs@1:10.24.0-1.module+el8.3.0+10166+b07ac28e
        ?arch=aarch64&distro=rhel-8.10&epoch=1
        &rpmmod=nodejs:10:8030020210225164533:229f0a1c
  ```

## Tests

`TestModularitySupportedByPlatform` now walks all five distro names in the
switch across versions 7, 7.9, 8, 8.10, 9, 9.4, 10, 10.1 plus an empty and a
malformed version, and adds unlisted names (`amazonlinux`, `fedora`, `sles`,
`opensuse`, `photon`) at every version.

Against the **unpatched** function the new table fails on exactly 10 subtests,
the five distros x {`7`, `7.9`}:

```
--- FAIL: TestModularitySupportedByPlatform/oraclelinux/"7"
--- FAIL: TestModularitySupportedByPlatform/oraclelinux/"7.9"
--- FAIL: TestModularitySupportedByPlatform/almalinux/"7"
...
    Error:   Not equal: expected: false / actual: true
```

## Follow-up (not in this PR)

`ParseRpmPackages` on empty input yields an empty list, so any future
queryformat that rpm cannot render fails the same silent way (as #7818 did). A
guard that treats "empty rpm output against a non-empty database" as an error
would catch the whole class, but that is a behaviour change worth its own PR.
