### PR TITLE
⭐ os: detect CBL-Mariner and wire it up for package detection

### DIFF
--- a/providers/os/detector/catalog_test.go
+++ b/providers/os/detector/catalog_test.go
@@ -45,6 +45,12 @@ func TestCatalogPlatforms(t *testing.T) {
 	require.NotNil(t, ubuntu, "ubuntu should be a catalogued platform")
 	assert.Equal(t, []string{"debian", "linux", "unix", "os"}, ubuntu.fam)
 
+	// a resolver that emits more names than the one it is registered under has
+	// to catalogue every one of them: the azurelinux resolver also handles
+	// CBL-Mariner, which reports ID=mariner
+	assert.True(t, byName["azurelinux"], "azurelinux should be a catalogued platform")
+	assert.True(t, byName["mariner"], "mariner should be a catalogued platform")
+
 	// darwin is a kernel and a family, never a platform of its own
 	assert.True(t, byName["macos"], "macos should be a catalogued platform")
 	assert.False(t, byName["darwin"], "darwin should not be a catalogued platform")

--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -161,11 +161,18 @@ var manjaro = &PlatformResolver{
 	},
 }
 
+// Azure Linux, and CBL-Mariner before it. Microsoft renamed the distribution
+// from CBL-Mariner to Azure Linux with the 3.0 release, so 2.x systems still
+// ship ID=mariner in /etc/os-release while 3.0 and later ship ID=azurelinux.
+// Both IDs resolve here and keep their own platform name: mariner stays
+// mariner so existing filters on it keep working. Emits registers both names
+// in the platform tree, which is what the platform catalog is derived from.
 var azurelinux = &PlatformResolver{
 	Name:     "azurelinux",
 	IsFamily: false,
+	Emits:    []string{"azurelinux", "mariner"},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
-		if pf.Name == "azurelinux" {
+		if pf.Name == "azurelinux" || pf.Name == "mariner" {
 			osrd := NewOSReleaseDetector(conn)
 			osr, err := osrd.osrelease()
 			if err == nil {

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -1445,6 +1445,23 @@ func TestAzureLinuxDetector(t *testing.T) {
 	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
 }
 
+// CBL-Mariner is Azure Linux under its pre-3.0 name and ships ID=mariner. It
+// keeps reporting as "mariner" rather than being folded into "azurelinux",
+// which would break anyone filtering on the name. Before it was wired into the
+// azurelinux resolver it fell through to defaultLinux, which reads neither
+// NAME nor VERSION, so title was the generic PRETTY_NAME and build was empty.
+func TestMarinerDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-mariner.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "mariner", di.Name, "os name should be identified")
+	assert.Equal(t, "Common Base Linux Mariner", di.Title, "os title should be identified")
+	assert.Equal(t, "2.0", di.Version, "os version should be identified")
+	assert.Equal(t, "2.0.20260304", di.Build, "os build should be identified")
+	assert.Equal(t, "aarch64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
+}
+
 func TestDetectorFlatcar(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-flatcar.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/testdata/detect-mariner.toml
+++ b/providers/os/detector/testdata/detect-mariner.toml
@@ -1,0 +1,21 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "aarch64"
+
+[commands."uname -r"]
+stdout = "5.15.153.1-2.cm2"
+
+[files."/etc/os-release"]
+content = """
+NAME="Common Base Linux Mariner"
+VERSION="2.0.20260304"
+ID=mariner
+VERSION_ID="2.0"
+PRETTY_NAME="CBL-Mariner/Linux"
+ANSI_COLOR="1;34"
+HOME_URL="https://aka.ms/cbl-mariner"
+BUG_REPORT_URL="https://aka.ms/cbl-mariner"
+SUPPORT_URL="https://aka.ms/cbl-mariner"
+"""

--- a/providers/os/resources/packages/mariner_test.go
+++ b/providers/os/resources/packages/mariner_test.go
@@ -1,0 +1,35 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package packages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+)
+
+// CBL-Mariner 2.x is Azure Linux under its earlier name. It is rpm based but
+// ships no /etc/redhat-release, so the redhat family declines it and it
+// resolves as a platform of its own, the way azurelinux and amazonlinux do.
+// Without a case naming it here nothing matched and packages reported an error
+// on a system with a populated rpm database.
+func TestResolveSystemPkgManagersMariner(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:    "mariner",
+			Version: "2.0",
+			Family:  []string{"linux", "unix", "os"},
+		},
+	}, mock.WithPath("./testdata/packages_mariner.toml"))
+	require.NoError(t, err)
+
+	pms, err := ResolveSystemPkgManagers(conn)
+	require.NoError(t, err, "CBL-Mariner has an rpm database, so a manager must resolve")
+	require.Len(t, pms, 1)
+	assert.IsType(t, &RpmPkgManager{}, pms[0])
+	assert.Equal(t, "Rpm Package Manager", pms[0].Name())
+}

--- a/providers/os/resources/packages/packages.go
+++ b/providers/os/resources/packages/packages.go
@@ -131,8 +131,10 @@ func ResolveSystemPkgManagers(conn shared.Connection) ([]OperatingSystemPkgManag
 	case asset.Platform.Name == "altlinux":
 		fallthrough
 	// opencloudos is rpm based but ships no /etc/redhat-release, so the redhat
-	// family declines it and it resolves as a platform of its own
-	case asset.Platform.Name == "amazonlinux" || asset.Platform.Name == "photon" || asset.Platform.Name == "wrlinux" || asset.Platform.Name == "bottlerocket" || asset.Platform.Name == "azurelinux" || asset.Platform.Name == "opencloudos":
+	// family declines it and it resolves as a platform of its own. mariner is
+	// CBL-Mariner 2.x, the name Azure Linux carried before the 3.0 rename; it
+	// is rpm based and resolves as its own platform for the same reason.
+	case asset.Platform.Name == "amazonlinux" || asset.Platform.Name == "photon" || asset.Platform.Name == "wrlinux" || asset.Platform.Name == "bottlerocket" || asset.Platform.Name == "azurelinux" || asset.Platform.Name == "mariner" || asset.Platform.Name == "opencloudos":
 		fallthrough
 	case asset.Platform.IsFamily("redhat") ||
 		asset.Platform.IsFamily("euler") ||

--- a/providers/os/resources/packages/testdata/packages_mariner.toml
+++ b/providers/os/resources/packages/testdata/packages_mariner.toml
@@ -1,0 +1,2 @@
+[commands."uname -m"]
+stdout = "aarch64"


### PR DESCRIPTION
CBL-Mariner is Microsoft's Linux distribution; it was renamed Azure Linux with the 3.0 release. The provider had an `azurelinux` platform resolver but nothing matching `ID=mariner`, so CBL-Mariner 2.x fell through to `defaultLinux`.

Measured on `mcr.microsoft.com/cbl-mariner/base/core:2.0` (arm64), which has 69 rpms installed:

| | before | after |
|---|---|---|
| `platform` | `mariner` | `mariner` |
| `title` | `CBL-Mariner/Linux, Bare metal system` | `Common Base Linux Mariner, Bare metal system` |
| `build` | `""` | `2.0.20260304` |
| `packages.length` | `error: could not detect suitable package manager for platform` | `69` |
| `services.list.length` | `0` | `0` |

## Detector

Both IDs resolve through the one `azurelinux` resolver, which reads `NAME` and `VERSION` out of `/etc/os-release` for the title and build. `mariner` keeps reporting as `mariner` rather than being folded into `azurelinux` — that is its `/etc/os-release` `ID`, and renaming it would break anyone filtering on the name. The family stays `["linux","unix","os"]`.

The resolver gains `Emits: []string{"azurelinux", "mariner"}`. `traverseFamily` keys the platform tree by `Emits` when it is set and by `[Name]` otherwise, and `CatalogPlatforms()` derives the provider's advertised platform list from that tree — so without `Emits`, `mariner` would be detected but absent from the catalog. `oraclelinux`, `rockylinux` and `opensuse-tumbleweed` already reach the catalog this way. The generated `os.json` goes from 77 platforms to 78.

## Packages

`mariner` is named alongside `azurelinux`, `amazonlinux` and `opencloudos` in `ResolveSystemPkgManagers` so it gets `RpmPkgManager`. It is rpm based but ships no `/etc/redhat-release`, so the redhat family declines it and it resolves as a platform of its own — the same reason those siblings are listed there.

This overlaps #10605, which adds a generic package-database probe to the `IsFamily("linux")` fallback in the same function and would make Mariner work as a side effect. The two are complementary and both should land: the probe is the safety net for platforms nobody has named yet, this is the explicit declaration that CBL-Mariner is supported. #10605 is still open, so there is no conflict to resolve here.

## Services

No change needed. `ResolveManager` ends in a `case asset.Platform.IsFamily("linux")` that resolves systemd, which already covers `mariner`. `services.list.length` reads 0 in the container because `/sbin/init` is absent (confirmed: neither `/sbin/init` nor `/usr/lib/systemd/systemd` exists in the image), so `useNoopInit` fires first — the intended container behaviour, not a gap.

## Tests

- `TestMarinerDetector` + `testdata/detect-mariner.toml`, carrying the real 2.0 `/etc/os-release`.
- `TestResolveSystemPkgManagersMariner`, asserting an `*RpmPkgManager` resolves.
- `TestCatalogPlatforms` gains an explicit assertion that `mariner` is catalogued.

Each was proven red by stashing the two non-test changes:

- `TestMarinerDetector`: title `"CBL-Mariner/Linux"` (want `"Common Base Linux Mariner"`), build `""` (want `"2.0.20260304"`).
- `TestCatalogPlatforms`: `catalog_test.go:52` "Should be true" — `mariner` not in the catalog.
- `TestResolveSystemPkgManagersMariner`: "Received unexpected error" — no package manager resolved.

## Regression control

Azure Linux 3.0 (`mcr.microsoft.com/azurelinux/base/core:3.0`, arm64) is byte-identical before and after: `platform=azurelinux`, `title="Microsoft Azure Linux, Bare metal system"`, `build=3.0.20260809`, `packages.length=79` matching `rpm -qa`.

No schema change, so no codegen; no provider version bump.
