### PR TITLE
🐛 os: files.find reports no matches when the find command fails

### DIFF
--- a/providers/os/resources/files.go
+++ b/providers/os/resources/files.go
@@ -159,15 +159,60 @@ func (l *mqlFilesFind) unixFilesFindCmd() ([]string, error) {
 	if out.Error != nil {
 		return nil, out.Error
 	}
+	exit := cmd.GetExitcode()
+	if exit.Error != nil {
+		return nil, exit.Error
+	}
+
+	lines := strings.TrimSpace(out.Data)
+	if err := checkFindExit("find", callCmd, exit.Data, lines, cmd.GetStderr().Data); err != nil {
+		return nil, err
+	}
 
 	var foundFiles []string
-	lines := strings.TrimSpace(out.Data)
 	if lines == "" {
 		foundFiles = []string{}
 	} else {
 		foundFiles = strings.Split(lines, "\n")
 	}
 	return foundFiles, nil
+}
+
+// checkFindExit decides what a non-zero exit from the search command means.
+//
+// A search tool fails for two very different reasons. It can fail to run at
+// all: `find` is absent (exit 127, common on minimal amazonlinux, opencloudos
+// and openEuler images, which ship no findutils), is not executable (126), or
+// was handed a start path that does not exist. It can also run fine and still
+// report a failure because it could not descend into some subdirectory, which
+// GNU find signals with exit 1 while printing every path it did reach. That
+// second case is routine for an unprivileged scan of /etc or / and its results
+// are valid.
+//
+// Output separates the two. No results plus a failure means nothing was
+// searched, and returning an empty list there is indistinguishable from "the
+// directory is empty" for every caller. Results plus a failure is a partial
+// traversal: keep what was found and warn.
+func checkFindExit(tool string, cmdline string, exitcode int64, stdout string, stderr string) error {
+	if exitcode == 0 {
+		return nil
+	}
+
+	stderr = strings.TrimSpace(stderr)
+	if stdout == "" {
+		msg := tool + " failed with exit code " + strconv.FormatInt(exitcode, 10)
+		if stderr != "" {
+			msg += ": " + stderr
+		}
+		return errors.New(msg)
+	}
+
+	log.Warn().
+		Int64("exitcode", exitcode).
+		Str("stderr", stderr).
+		Str("command", cmdline).
+		Msg("file search reported errors, results may be incomplete")
+	return nil
 }
 
 func (l *mqlFilesFind) windowsPowershellCmd() ([]string, error) {
@@ -189,9 +234,17 @@ func (l *mqlFilesFind) windowsPowershellCmd() ([]string, error) {
 	if out.Error != nil {
 		return nil, out.Error
 	}
+	exit := ps.GetExitcode()
+	if exit.Error != nil {
+		return nil, exit.Error
+	}
+
+	lines := strings.TrimSpace(out.Data)
+	if err := checkFindExit("Get-ChildItem", pwshScript, exit.Data, lines, ps.GetStderr().Data); err != nil {
+		return nil, err
+	}
 
 	var foundFiles []string
-	lines := strings.TrimSpace(out.Data)
 	if lines == "" {
 		foundFiles = []string{}
 	} else {

--- a/providers/os/resources/files_test.go
+++ b/providers/os/resources/files_test.go
@@ -1,0 +1,128 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+	"go.mondoo.com/mql/providers/os/resources/filesfind"
+	"go.mondoo.com/mql/providers/os/resources/powershell"
+	"go.mondoo.com/mql/utils/syncx"
+)
+
+// filesFindWithCmdResult wires a files.find resource to a mock connection that
+// answers the exact `find` invocation the resource builds with the given
+// stdout / stderr / exit status.
+func filesFindWithCmdResult(t *testing.T, from string, fileType string, stdout string, stderr string, exitStatus int) *mqlFilesFind {
+	t.Helper()
+
+	cmdline := filesfind.BuildFilesFindCmd(from, false, fileType, "", 0o777, "", nil, true)
+
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:   "arch",
+			Family: []string{"linux", "unix"},
+		},
+	}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			cmdline: {
+				Command:    cmdline,
+				Stdout:     stdout,
+				Stderr:     stderr,
+				ExitStatus: exitStatus,
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	res := &mqlFilesFind{}
+	res.MqlRuntime = &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+	res.From = plugin.TValue[string]{Data: from, State: plugin.StateIsSet}
+	res.Type = plugin.TValue[string]{Data: fileType, State: plugin.StateIsSet}
+	res.Permissions = plugin.TValue[int64]{Data: 0o777, State: plugin.StateIsSet}
+	return res
+}
+
+// A host without findutils (amazonlinux 2023, opencloudos, openEuler) exits
+// 127 with nothing on stdout. Reporting that as "no files matched" makes every
+// resource built on files.find — logrotate, sudoers, limits, modprobe, apt and
+// the rest — silently under-report.
+func TestFilesFind_UnixCmd_FailedCommandIsAnError(t *testing.T) {
+	res := filesFindWithCmdResult(t, "/etc", "file", "", "sh: find: command not found", 127)
+
+	found, err := res.unixFilesFindCmd()
+	require.Error(t, err)
+	assert.Empty(t, found)
+	assert.Contains(t, err.Error(), "127")
+	assert.Contains(t, err.Error(), "find: command not found")
+}
+
+// GNU find exits 1 when it cannot descend into a subdirectory while still
+// printing every path it did reach. That is routine for an unprivileged scan
+// of /etc and must keep returning results.
+func TestFilesFind_UnixCmd_PartialTraversalKeepsResults(t *testing.T) {
+	res := filesFindWithCmdResult(t, "/etc", "file",
+		"/etc/hosts\n/etc/passwd\n",
+		"find: '/etc/ssl/private': Permission denied", 1)
+
+	found, err := res.unixFilesFindCmd()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/etc/hosts", "/etc/passwd"}, found)
+}
+
+// An empty directory is not a failure: exit 0 with no output is an honest
+// "nothing matched".
+func TestFilesFind_UnixCmd_EmptyResultIsNotAnError(t *testing.T) {
+	res := filesFindWithCmdResult(t, "/etc", "file", "", "", 0)
+
+	found, err := res.unixFilesFindCmd()
+	require.NoError(t, err)
+	assert.Empty(t, found)
+}
+
+// The Windows path has the same shape: a PowerShell run that never produced a
+// listing must not read as an empty directory.
+func TestFilesFind_Powershell_FailedScriptIsAnError(t *testing.T) {
+	script := filesfind.BuildPowershellCmd("C:\\Windows", false, "file", "", 0o777, "", nil)
+	// the powershell resource base64-encodes the script before running it
+	encoded := powershell.Encode(script)
+
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:   "windows",
+			Family: []string{"windows"},
+		},
+	}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			encoded: {
+				Command:    encoded,
+				Stderr:     "The system cannot find the path specified.",
+				ExitStatus: 1,
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	res := &mqlFilesFind{}
+	res.MqlRuntime = &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+	res.From = plugin.TValue[string]{Data: "C:\\Windows", State: plugin.StateIsSet}
+	res.Type = plugin.TValue[string]{Data: "file", State: plugin.StateIsSet}
+	res.Permissions = plugin.TValue[int64]{Data: 0o777, State: plugin.StateIsSet}
+
+	found, err := res.windowsPowershellCmd()
+	require.Error(t, err)
+	assert.Empty(t, found)
+	assert.Contains(t, err.Error(), "cannot find the path")
+}


### PR DESCRIPTION
## The bug

`unixFilesFindCmd` (`providers/os/resources/files.go`) reads the `command` resource's stdout and never consults its exit code:

```go
cmd := rawCmd.(*mqlCommand)
out := cmd.GetStdout()
if out.Error != nil { return nil, out.Error }
lines := strings.TrimSpace(out.Data)
if lines == "" {
	foundFiles = []string{}   // indistinguishable from "the command failed"
}
```

A host with no `findutils` runs `find` and gets exit 127 with empty stdout, so `files.find` reports **no files matched** rather than an error. 6 of 50 images in a container sweep ship no `find`: amazonlinux 2018.03 and 2023, opencloudos 8 and 9, openEuler 22.03-LTS and 24.03-LTS.

Same class as #10527 (`systemctl show` exit status unchecked).

## Blast radius

Twelve resources build on `files.find` internally and all of them silently under-report on such a host:

`apt.go`, `chrome.go`, `firefox.go`, `kernel_modprobe.go`, `limits.go`, `logrotate.go`, `modprobe.go`, `rsyslog.go`, `sudoers.go`, `sysrc.go`, `utils.go`.

`logrotate` is the instructive case, and the reason this is more than an error-handling tidy-up: it reads `/etc/logrotate.conf` through the `file` resource, which works, but enumerates the `/etc/logrotate.d` drop-ins through `files.find`. On a find-less host it therefore returns a **partial configuration that looks complete** — a policy asserting on rotation settings passes on a config it never fully read.

## The fix, and the trap in it

Erroring on any non-zero exit would be a worse regression than the bug. GNU `find` exits **1** when it cannot descend into a subdirectory *while still printing every path it did reach* — routine for an unprivileged scan of `/etc` or `/`, or over mounts with restricted permissions.

Output is what separates the two failures, so `checkFindExit` keys on it:

| exit | stdout | behavior |
|---|---|---|
| 0 | anything | unchanged, including the legitimate empty-directory case |
| != 0 | empty | error carrying the exit code and stderr (127 not-found, 126 not-executable, a bad start path) |
| != 0 | non-empty | results preserved, no error, `log.Warn()` — today's partial-traversal behavior, unchanged |

`windowsPowershellCmd` immediately below had the identical shape (stdout read, `Exitcode` never consulted) and gets the same treatment.

Out of scope, flagged separately: `fsFilesFind` (the native filesystem path) is untouched, and making local connections advertise `Capability_FindFile` — which would remove the `find` dependency for these twelve resources outright — is a larger change.

## Tests

`providers/os/resources/files_test.go`, driven through the mock connection so each case exercises the real resource:

1. exit 127 + empty stdout -> error. **Red before the fix** ("An error is expected but got nil").
2. exit 1 + non-empty stdout -> results preserved, no error. Green before the fix by design; it is the guard on the trap. Verified it can fail by mutating `checkFindExit` to the naive "any non-zero exit is an error" — the test goes red.
3. exit 0 + empty stdout -> empty list, no error. Verified it can fail by mutating `checkFindExit` to treat an empty result as a failure — the test goes red.
4. PowerShell exit 1 + empty stdout -> error. **Red before the fix.**

## Verification against containers

Provider built for linux/arm64 and run inside the image via `PROVIDERS_PATH`, base vs fix in the same container.

**Bug image** `docker.io/library/amazonlinux:2023` (`command -v find` -> MISSING), `files.find(from: "/etc", type: "file").length`:

```
base: files.find.length: 0
fix:  find failed with exit code 127: sh: line 1: find: command not found
      files.find.length: no data available
```

**Regression control** `docker.io/library/debian:13`, same query: `121` before, `121` after.

**Partial traversal**, live rather than mocked: on debian:13, a directory with a `chmod 000` subdirectory scanned as a non-root user, where `find` exits 1 after printing two of three files:

```
base: files.find.list: [ /data/t/ok.txt, /data/t/two.txt ]
fix:  ! file search reported errors, results may be incomplete
        command="find -L \"/data/t\" -xdev -type f" exitcode=1
        stderr="find: '/data/t/secret': Permission denied"
      files.find.list: [ /data/t/ok.txt, /data/t/two.txt ]
```

Results identical, warning added.

No schema change, no provider version bump.
