### PR TITLE
🐛 os: pam.conf(path) sets a field that does not exist

### DIFF
--- a/providers/os/resources/pam.go
+++ b/providers/os/resources/pam.go
@@ -38,7 +38,7 @@ func initPamConf(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 		if err != nil {
 			return nil, nil, err
 		}
-		args["file"] = llx.ResourceData(f, "file")
+		args["files"] = llx.ArrayData([]any{f}, types.Resource("file"))
 		delete(args, "path")
 	}
 

--- a/providers/os/resources/pam_test.go
+++ b/providers/os/resources/pam_test.go
@@ -375,3 +375,95 @@ func TestIsPamControlEnabled(t *testing.T) {
 		})
 	}
 }
+
+// newPamDirRuntime builds a runtime whose /etc/pam.d directory contains a
+// single "su" service, alongside a legacy /etc/pam.conf. It mirrors the mock
+// wiring of TestPamConfPrefersPamDirOverPamConf so the path-selected and the
+// default form can be compared against the same host.
+func newPamDirRuntime(t *testing.T) *plugin.Runtime {
+	t.Helper()
+
+	findCmd := filesfind.BuildFilesFindCmd(defaultPamDir, false, "file", "", 0, "", nil, true)
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{Name: "arch", Family: []string{"arch", "linux", "unix"}},
+	}, mock.WithData(&mock.TomlData{
+		Files: map[string]*mock.MockFileData{
+			defaultPamDir:         {Path: defaultPamDir, StatData: mock.FileInfo{Mode: os.ModeDir | 0o755}},
+			defaultPamDir + "/su": {Path: defaultPamDir + "/su", Content: "auth required pam_wheel.so use_uid\n"},
+			defaultPamConf:        {Path: defaultPamConf, Content: "login auth required pam_unix.so\n"},
+		},
+		Commands: map[string]*mock.Command{
+			findCmd: {Stdout: defaultPamDir + "/su\n"},
+		},
+	}))
+	require.NoError(t, err)
+
+	return &plugin.Runtime{Connection: conn, Resources: &syncx.Map[plugin.Resource]{}}
+}
+
+func pamPaths(t *testing.T, res plugin.Resource) []string {
+	t.Helper()
+	files := res.(*mqlPamConf).GetFiles()
+	require.NoError(t, files.Error)
+	paths := make([]string, 0, len(files.Data))
+	for _, f := range files.Data {
+		paths = append(paths, f.(*mqlFile).Path.Data)
+	}
+	return paths
+}
+
+func TestPamConfPathSelectsSingleFile(t *testing.T) {
+	// pam.conf("<path>") used to set an arg named 'file', which pam.conf does
+	// not have (only files []file), so every parameterized use failed with
+	// "cannot set 'file' in resource 'pam.conf', field not found".
+	rt := newPamDirRuntime(t)
+
+	res, err := NewResource(rt, "pam.conf", map[string]*llx.RawData{
+		"path": llx.StringData(defaultPamConf),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{defaultPamConf}, pamPaths(t, res),
+		"a path-selected pam.conf reads exactly the requested file")
+
+	// The legacy single-file layout still parses: entries are keyed by the
+	// service column rather than the file path.
+	entries := res.(*mqlPamConf).GetEntries()
+	require.NoError(t, entries.Error)
+	_, hasLogin := entries.Data["login"]
+	assert.True(t, hasLogin, "the /etc/pam.conf 'login' service is parsed")
+}
+
+func TestPamConfPathDoesNotHijackDefault(t *testing.T) {
+	// The parameterized form must not change what the bare pam.conf reads,
+	// and the two must not share a cache key.
+	rt := newPamDirRuntime(t)
+
+	selected, err := NewResource(rt, "pam.conf", map[string]*llx.RawData{
+		"path": llx.StringData(defaultPamConf),
+	})
+	require.NoError(t, err)
+
+	bare, err := NewResource(rt, "pam.conf", map[string]*llx.RawData{})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{defaultPamDir + "/su"}, pamPaths(t, bare),
+		"the bare form still enumerates /etc/pam.d and ignores /etc/pam.conf")
+	assert.Equal(t, []string{defaultPamConf}, pamPaths(t, selected))
+	assert.NotEqual(t, bare.MqlID(), selected.MqlID(),
+		"a path-selected pam.conf must not collide with the default instance")
+}
+
+func TestPamConfPathMissingFile(t *testing.T) {
+	// A path that does not exist still constructs; the absence surfaces as
+	// exists == false rather than as an error, so guarded audits stay clean.
+	rt := newPamRuntime(t)
+
+	res, err := NewResource(rt, "pam.conf", map[string]*llx.RawData{
+		"path": llx.StringData("/etc/pam.d/does-not-exist"),
+	})
+	require.NoError(t, err)
+
+	exists := res.(*mqlPamConf).GetExists()
+	require.NoError(t, exists.Error)
+	assert.False(t, exists.Data)
+}


### PR DESCRIPTION
`pam.conf("<path>")` has never worked. `initPamConf` seeds `args["file"]`, but
`pam.conf` has no `file` field — only `files() []file` (`os.lr:1152`). The field
was pluralised at some point and the init's arg key was never updated alongside
it, so the runtime rejects the unknown key:

```
mql run local -c 'pam.conf("/etc/pam.conf") { files }'
-> rpc error: code = Unknown desc = [os] cannot set 'file' in resource 'pam.conf', field not found
```

Reproduced on **50 of 50 images** in a container sweep. The schema declares
`init(path string)` (`os.lr:1144`) and the doc-comment describes selecting the
legacy single-file `/etc/pam.conf`, so the documented selection path could not
work at all. The bare `pam.conf` form never runs the init, which is why this
survived unnoticed.

## Fix

```diff
-		args["file"] = llx.ResourceData(f, "file")
+		args["files"] = llx.ArrayData([]any{f}, types.Resource("file"))
```

Same idiom `initSudoers`, `initModprobe` and `initSysrc` already use for their
`files` args. No schema change: the init signature was already correct.

`mqlPamConf.id()` checksums over `Files`, so a path-selected instance and the
default instance keep distinct cache keys — asserted in the tests.

## Before / after

On `registry.access.redhat.com/ubi10/ubi` (identical on `debian:13`):

| query | before | after |
|---|---|---|
| `pam.conf("/etc/pam.conf") { exists files { path } }` | `cannot set 'file' in resource 'pam.conf'` | `exists: true, files: ["/etc/pam.conf"]` |
| `pam.conf { files { path } }` | 17 `/etc/pam.d/*` paths | byte-identical, unchanged |

## Tests

Three new tests in `pam_test.go`, all three RED before the fix with the exact
`cannot set 'file' in resource 'pam.conf', field not found` error:

- `TestPamConfPathSelectsSingleFile` — the path-selected form resolves and reads
  exactly the requested file, and its legacy single-file layout still parses.
- `TestPamConfPathDoesNotHijackDefault` — the bare form still enumerates
  `/etc/pam.d` on the same host, and the two instances do not share a cache key.
  This is the regression that matters.
- `TestPamConfPathMissingFile` — a non-existent path constructs and reports
  `exists == false` rather than erroring.
