### PR TITLE
🐛 os: read the cgroup tree from the filesystem, not through find

### DIFF
--- a/providers/os/resources/cgroups.go
+++ b/providers/os/resources/cgroups.go
@@ -4,45 +4,55 @@
 package resources
 
 import (
-	"bufio"
+	"fmt"
+	"path"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 
+	"github.com/spf13/afero"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/connection/shared"
 	"go.mondoo.com/mql/types"
 )
 
-// cgroupV2Probe determines what cgroup mode the host is running in by
-// looking for the v2 unified-hierarchy marker file and falling back to
-// v1's per-controller directories. The output is one of `V2`, `V1`, or
-// `NONE`.
-const cgroupV2Probe = `if [ -r /sys/fs/cgroup/cgroup.controllers ]; then echo V2; elif [ -d /sys/fs/cgroup/memory ]; then echo V1; else echo NONE; fi`
+const (
+	cgroupRoot = "/sys/fs/cgroup"
 
-// cgroupV2Walk dumps the entire v2 cgroup tree in a single shell call.
-// Each cgroup directory is separated by a `===CGROUP===<path>` line,
-// followed by `key=value` pairs for the interesting attribute files.
-// `-maxdepth 4` bounds traversal on busy hosts (e.g., K8s nodes with
-// thousands of pod cgroups); the typical layout is
-// `slice/sub-slice/unit`, which fits comfortably within four levels.
-// The `tr '\n' ' '` collapses multi-line values (notably cgroup.procs,
-// which is one PID per line) into a single space-separated string; the
-// parser trims the trailing space that `tr` leaves behind.
-const cgroupV2Walk = `find /sys/fs/cgroup -maxdepth 4 -name cgroup.controllers 2>/dev/null | while read f; do
-  d="${f%/cgroup.controllers}"
-  echo "===CGROUP===$d"
-  for n in cgroup.controllers cgroup.type memory.max memory.current memory.high memory.swap.max cpu.max cpu.weight pids.max pids.current cgroup.procs; do
-    if [ -r "$d/$n" ]; then
-      printf '%s=' "$n"
-      tr '\n' ' ' < "$d/$n" 2>/dev/null
-      echo
-    fi
-  done
-done`
+	// cgroupControllersFile marks a directory as a cgroup v2 node. Its
+	// presence at the mount point also identifies the unified hierarchy.
+	cgroupControllersFile = "cgroup.controllers"
 
-const cgroupRoot = "/sys/fs/cgroup"
+	// cgroupV1MemoryDir is the per-controller hierarchy that only exists
+	// under cgroup v1.
+	cgroupV1MemoryDir = "memory"
+
+	// cgroupWalkMaxDepth bounds how far below the cgroup root the walk
+	// descends. Busy hosts (e.g. K8s nodes with thousands of pod
+	// cgroups) would otherwise cost one directory listing per pod
+	// container; the typical layout is `slice/sub-slice/unit`, which
+	// fits comfortably within three levels below the root.
+	cgroupWalkMaxDepth = 3
+)
+
+// cgroupAttrFiles are the v2 attribute files read for every cgroup, in
+// addition to cgroupControllersFile. Files that are absent (the
+// controller is not enabled on that cgroup) are skipped, and the
+// builder falls back to the documented default for the field.
+var cgroupAttrFiles = []string{
+	"cgroup.type",
+	"memory.max",
+	"memory.current",
+	"memory.high",
+	"memory.swap.max",
+	"cpu.max",
+	"cpu.weight",
+	"pids.max",
+	"pids.current",
+	"cgroup.procs",
+}
 
 type mqlCgroupsInternal struct {
 	lock     sync.Mutex
@@ -83,37 +93,22 @@ func (c *mqlCgroups) probe() (*cgroupDetection, error) {
 func (c *mqlCgroups) doProbe() (*cgroupDetection, error) {
 	det := &cgroupDetection{controllers: []string{}, flat: []*mqlCgroup{}}
 
-	probe, ok, err := runShellCmd(c.MqlRuntime, cgroupV2Probe)
+	conn, ok := c.MqlRuntime.Connection.(shared.Connection)
+	if !ok {
+		return det, fmt.Errorf("cgroups requires a filesystem connection, got %T", c.MqlRuntime.Connection)
+	}
+	fs := conn.FileSystem()
+
+	det.version = detectCgroupVersion(fs)
+	if det.version != 2 {
+		// v1's per-controller hierarchies are intentionally unmodeled,
+		// and version 0 means there is no cgroup mount to walk.
+		return det, nil
+	}
+
+	parsed, err := walkCgroupFS(fs)
 	if err != nil {
 		return det, err
-	}
-	if !ok {
-		return det, nil
-	}
-
-	switch strings.TrimSpace(probe) {
-	case "V2":
-		det.version = 2
-	case "V1":
-		det.version = 1
-		// v1's per-controller hierarchies are intentionally unmodeled.
-		return det, nil
-	default:
-		det.version = 0
-		return det, nil
-	}
-
-	stdout, ok, err := runShellCmd(c.MqlRuntime, cgroupV2Walk)
-	if err != nil {
-		return det, err
-	}
-	if !ok {
-		return det, nil
-	}
-
-	parsed := parseCgroupWalk(stdout)
-	if len(parsed) == 0 {
-		return det, nil
 	}
 
 	byPath := make(map[string]*mqlCgroup, len(parsed))
@@ -128,9 +123,9 @@ func (c *mqlCgroups) doProbe() (*cgroupDetection, error) {
 	}
 
 	// Link parents -> children. Root's parent is itself; skip self-links.
-	for path, cg := range byPath {
-		parent := parentCgroupPath(path)
-		if parent == path {
+	for cgPath, cg := range byPath {
+		parent := parentCgroupPath(cgPath)
+		if parent == cgPath {
 			continue
 		}
 		if p, ok := byPath[parent]; ok {
@@ -159,6 +154,100 @@ func (c *mqlCgroups) doProbe() (*cgroupDetection, error) {
 		det.version = 0
 	}
 	return det, nil
+}
+
+// detectCgroupVersion reports what cgroup mode the target is running in
+// by looking for the v2 unified-hierarchy marker file and falling back
+// to v1's per-controller directories. It returns 2, 1, or 0.
+func detectCgroupVersion(fs afero.Fs) int64 {
+	// Open rather than Stat: an unreadable marker file is not a usable
+	// unified hierarchy, and the v1 fallback may still apply.
+	if f, err := fs.Open(path.Join(cgroupRoot, cgroupControllersFile)); err == nil {
+		f.Close()
+		return 2
+	}
+	if fi, err := fs.Stat(path.Join(cgroupRoot, cgroupV1MemoryDir)); err == nil && fi.IsDir() {
+		return 1
+	}
+	return 0
+}
+
+// walkCgroupFS collects every cgroup v2 node under the cgroup root,
+// depth-first and in directory order, starting with the root itself.
+// A root that cannot be read is an error rather than an empty result:
+// reporting "v2 with no controllers" would assert something false about
+// the target.
+func walkCgroupFS(fs afero.Fs) ([]parsedCgroup, error) {
+	root, ok := readCgroupDir(fs, cgroupRoot)
+	if !ok {
+		return nil, fmt.Errorf("cannot read the cgroup v2 root at %s", cgroupRoot)
+	}
+	out := []parsedCgroup{root}
+
+	entries, err := afero.ReadDir(fs, cgroupRoot)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list the cgroup v2 root at %s: %w", cgroupRoot, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			walkCgroupDir(fs, path.Join(cgroupRoot, entry.Name()), 1, &out)
+		}
+	}
+	return out, nil
+}
+
+// walkCgroupDir appends dir (when it is a cgroup) and recurses into its
+// subdirectories up to cgroupWalkMaxDepth. Unreadable subtrees are
+// skipped: a single delegated cgroup the scanner cannot enter must not
+// discard the rest of the tree.
+func walkCgroupDir(fs afero.Fs, dir string, depth int, out *[]parsedCgroup) {
+	cg, ok := readCgroupDir(fs, dir)
+	if ok {
+		*out = append(*out, cg)
+	}
+	if depth >= cgroupWalkMaxDepth {
+		return
+	}
+	entries, err := afero.ReadDir(fs, dir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			walkCgroupDir(fs, path.Join(dir, entry.Name()), depth+1, out)
+		}
+	}
+}
+
+// readCgroupDir reads one cgroup directory's attribute files. A
+// directory without a readable cgroup.controllers is not a cgroup node
+// and reports false.
+func readCgroupDir(fs afero.Fs, dir string) (parsedCgroup, bool) {
+	controllers, err := afero.ReadFile(fs, path.Join(dir, cgroupControllersFile))
+	if err != nil {
+		return parsedCgroup{}, false
+	}
+
+	cg := parsedCgroup{
+		rawPath: dir,
+		attrs:   map[string]string{cgroupControllersFile: flattenCgroupAttr(controllers)},
+	}
+	for _, name := range cgroupAttrFiles {
+		data, err := afero.ReadFile(fs, path.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		cg.attrs[name] = flattenCgroupAttr(data)
+	}
+	return cg, true
+}
+
+// flattenCgroupAttr collapses a cgroup attribute file into the
+// single-line form the resource builder expects. cgroup.procs is one
+// PID per line and callers split it on whitespace, so newlines become
+// spaces and the surrounding whitespace is trimmed.
+func flattenCgroupAttr(data []byte) string {
+	return strings.TrimSpace(strings.ReplaceAll(string(data), "\n", " "))
 }
 
 func (c *mqlCgroups) version() (int64, error) {
@@ -216,45 +305,12 @@ func (cg *mqlCgroup) children() ([]any, error) {
 	return cg.childResources, nil
 }
 
-// parsedCgroup is the raw key/value capture from one cgroup directory's
-// section of the walk output. Conversion to numeric fields happens in
-// buildCgroupResource so the parser stays a flat string-to-string map.
+// parsedCgroup is the raw key/value capture from one cgroup directory.
+// Conversion to numeric fields happens in buildCgroupResource so the
+// walk stays a flat string-to-string map.
 type parsedCgroup struct {
 	rawPath string
 	attrs   map[string]string
-}
-
-func parseCgroupWalk(stdout string) []parsedCgroup {
-	var out []parsedCgroup
-	var cur *parsedCgroup
-
-	scanner := bufio.NewScanner(strings.NewReader(stdout))
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "===CGROUP===") {
-			if cur != nil {
-				out = append(out, *cur)
-			}
-			cur = &parsedCgroup{
-				rawPath: strings.TrimPrefix(line, "===CGROUP==="),
-				attrs:   map[string]string{},
-			}
-			continue
-		}
-		if cur == nil {
-			continue
-		}
-		idx := strings.IndexByte(line, '=')
-		if idx <= 0 {
-			continue
-		}
-		cur.attrs[line[:idx]] = strings.TrimSpace(line[idx+1:])
-	}
-	if cur != nil {
-		out = append(out, *cur)
-	}
-	return out
 }
 
 func buildCgroupResource(runtime *plugin.Runtime, relPath string, p parsedCgroup) (*mqlCgroup, error) {

--- a/providers/os/resources/cgroups_test.go
+++ b/providers/os/resources/cgroups_test.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -83,70 +84,9 @@ func TestParseCpuMax(t *testing.T) {
 	assert.Equal(t, int64(100000), p)
 }
 
-func TestParseCgroupWalk(t *testing.T) {
-	input := `===CGROUP===/sys/fs/cgroup
-cgroup.controllers=cpuset cpu io memory hugetlb pids rdma misc
-memory.max=max
-memory.current=104857600
-memory.high=max
-memory.swap.max=max
-cpu.max=max 100000
-cpu.weight=100
-pids.max=max
-pids.current=42
-cgroup.procs=1
-===CGROUP===/sys/fs/cgroup/system.slice
-cgroup.controllers=cpuset cpu io memory pids
-memory.max=8589934592
-memory.current=536870912
-memory.high=max
-memory.swap.max=max
-cpu.max=200000 100000
-cpu.weight=100
-pids.max=4096
-pids.current=85
-cgroup.procs=
-===CGROUP===/sys/fs/cgroup/system.slice/nginx.service
-cgroup.controllers=
-memory.max=104857600
-memory.current=83886080
-memory.swap.max=0
-cpu.max=50000 100000
-cpu.weight=50
-pids.max=512
-pids.current=4
-cgroup.procs=1234 1235 1236 1237
-`
-	parsed := parseCgroupWalk(input)
-	require.Len(t, parsed, 3)
-
-	// Root
-	assert.Equal(t, "/sys/fs/cgroup", parsed[0].rawPath)
-	assert.Equal(t, "cpuset cpu io memory hugetlb pids rdma misc", parsed[0].attrs["cgroup.controllers"])
-	assert.Equal(t, "max", parsed[0].attrs["memory.max"])
-	assert.Equal(t, "104857600", parsed[0].attrs["memory.current"])
-	assert.Equal(t, "42", parsed[0].attrs["pids.current"])
-	assert.Equal(t, "1", parsed[0].attrs["cgroup.procs"])
-
-	// system.slice with concrete memory cap
-	assert.Equal(t, "/sys/fs/cgroup/system.slice", parsed[1].rawPath)
-	assert.Equal(t, "8589934592", parsed[1].attrs["memory.max"])
-	assert.Equal(t, "200000 100000", parsed[1].attrs["cpu.max"])
-	assert.Equal(t, "", parsed[1].attrs["cgroup.procs"], "empty cgroup.procs file becomes empty string")
-
-	// Service with explicit limits and a multi-pid procs file
-	require.Equal(t, "/sys/fs/cgroup/system.slice/nginx.service", parsed[2].rawPath)
-	assert.Equal(t, "104857600", parsed[2].attrs["memory.max"])
-	assert.Equal(t, "1234 1235 1236 1237", parsed[2].attrs["cgroup.procs"])
-}
-
-func TestParseCgroupWalkEmpty(t *testing.T) {
-	assert.Empty(t, parseCgroupWalk(""))
-}
-
 func TestPidsAsAny(t *testing.T) {
 	// Numeric strings parse to int64; non-numeric tokens are dropped so
-	// stray output from `tr` collapsing an empty file can't crash MQL.
+	// junk in a cgroup.procs file can't crash MQL.
 	out := pidsAsAny([]string{"1234", "1235", "abc", "1236"})
 	require.Len(t, out, 3)
 	assert.Equal(t, int64(1234), out[0])
@@ -163,4 +103,118 @@ func TestStringsAsAny(t *testing.T) {
 	assert.Equal(t, "memory", out[0])
 	assert.Equal(t, "io", out[2])
 	assert.Empty(t, stringsAsAny(nil))
+}
+
+// writeCgroupDir lays down one cgroup v2 node in a fake filesystem.
+func writeCgroupDir(t *testing.T, fs afero.Fs, dir string, attrs map[string]string) {
+	t.Helper()
+	require.NoError(t, fs.MkdirAll(dir, 0o755))
+	for name, content := range attrs {
+		require.NoError(t, afero.WriteFile(fs, dir+"/"+name, []byte(content), 0o444))
+	}
+}
+
+func TestDetectCgroupVersion(t *testing.T) {
+	// Unified hierarchy: the marker file at the mount point.
+	v2 := afero.NewMemMapFs()
+	writeCgroupDir(t, v2, "/sys/fs/cgroup", map[string]string{"cgroup.controllers": "cpu memory\n"})
+	assert.Equal(t, int64(2), detectCgroupVersion(v2))
+
+	// v1 ships per-controller directories and no marker file.
+	v1 := afero.NewMemMapFs()
+	require.NoError(t, v1.MkdirAll("/sys/fs/cgroup/memory", 0o755))
+	require.NoError(t, v1.MkdirAll("/sys/fs/cgroup/cpu", 0o755))
+	assert.Equal(t, int64(1), detectCgroupVersion(v1))
+
+	// Image/tar scans have no /sys at all.
+	assert.Equal(t, int64(0), detectCgroupVersion(afero.NewMemMapFs()))
+}
+
+func TestWalkCgroupFS(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	// Root. cgroup.procs is one PID per line on a real system.
+	writeCgroupDir(t, fs, "/sys/fs/cgroup", map[string]string{
+		"cgroup.controllers": "cpuset cpu io memory hugetlb pids rdma misc\n",
+		"cgroup.type":        "domain\n",
+		"memory.max":         "max\n",
+		"memory.current":     "104857600\n",
+		"cpu.max":            "max 100000\n",
+		"cpu.weight":         "100\n",
+		"pids.current":       "42\n",
+		"cgroup.procs":       "1\n",
+	})
+	writeCgroupDir(t, fs, "/sys/fs/cgroup/system.slice", map[string]string{
+		"cgroup.controllers": "cpuset cpu io memory pids\n",
+		"memory.max":         "8589934592\n",
+		"cpu.max":            "200000 100000\n",
+		"cgroup.procs":       "",
+	})
+	writeCgroupDir(t, fs, "/sys/fs/cgroup/system.slice/nginx.service", map[string]string{
+		"cgroup.controllers": "\n",
+		"memory.max":         "104857600\n",
+		"cgroup.procs":       "1234\n1235\n1236\n1237\n",
+	})
+	// A plain directory that is not a cgroup must not become a node.
+	require.NoError(t, fs.MkdirAll("/sys/fs/cgroup/system.slice/not-a-cgroup", 0o755))
+
+	parsed, err := walkCgroupFS(fs)
+	require.NoError(t, err)
+	require.Len(t, parsed, 3)
+
+	// Depth-first from the root, root first.
+	assert.Equal(t, "/sys/fs/cgroup", parsed[0].rawPath)
+	assert.Equal(t, "/sys/fs/cgroup/system.slice", parsed[1].rawPath)
+	assert.Equal(t, "/sys/fs/cgroup/system.slice/nginx.service", parsed[2].rawPath)
+
+	assert.Equal(t, "cpuset cpu io memory hugetlb pids rdma misc", parsed[0].attrs["cgroup.controllers"])
+	assert.Equal(t, "domain", parsed[0].attrs["cgroup.type"])
+	assert.Equal(t, "104857600", parsed[0].attrs["memory.current"])
+	assert.Equal(t, "max 100000", parsed[0].attrs["cpu.max"])
+
+	// Absent attribute files stay absent rather than becoming "".
+	_, ok := parsed[1].attrs["cgroup.type"]
+	assert.False(t, ok, "an attribute file that does not exist must not be recorded")
+	assert.Equal(t, "", parsed[1].attrs["cgroup.procs"], "an empty cgroup.procs file reads as empty")
+
+	// The multi-line cgroup.procs file collapses to the space-separated
+	// form buildCgroupResource splits on.
+	assert.Equal(t, "1234 1235 1236 1237", parsed[2].attrs["cgroup.procs"])
+}
+
+func TestWalkCgroupFSDepthBound(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	dir := "/sys/fs/cgroup"
+	for i := 0; i <= cgroupWalkMaxDepth+1; i++ {
+		writeCgroupDir(t, fs, dir, map[string]string{"cgroup.controllers": "memory\n"})
+		dir += "/level"
+	}
+
+	parsed, err := walkCgroupFS(fs)
+	require.NoError(t, err)
+
+	// Root plus cgroupWalkMaxDepth levels below it; the level past the
+	// bound is not collected.
+	require.Len(t, parsed, cgroupWalkMaxDepth+1)
+	assert.Equal(t,
+		"/sys/fs/cgroup/level/level/level",
+		parsed[cgroupWalkMaxDepth].rawPath)
+}
+
+func TestWalkCgroupFSUnreadableRoot(t *testing.T) {
+	// The regression this guards: a target where the cgroup root cannot
+	// be read used to report version 2 with zero controllers, asserting
+	// as fact that a cgroup v2 host has no controllers. It must be an
+	// error instead.
+	_, err := walkCgroupFS(afero.NewMemMapFs())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), cgroupRoot)
+}
+
+func TestFlattenCgroupAttr(t *testing.T) {
+	// cgroup.procs is one PID per line; callers split on whitespace.
+	assert.Equal(t, "1234 1235 1236", flattenCgroupAttr([]byte("1234\n1235\n1236\n")))
+	assert.Equal(t, "max", flattenCgroupAttr([]byte("max\n")))
+	assert.Equal(t, "", flattenCgroupAttr([]byte("")))
+	assert.Equal(t, "", flattenCgroupAttr([]byte("\n")))
+	assert.Equal(t, "50000 100000", flattenCgroupAttr([]byte("50000 100000\n")))
 }


### PR DESCRIPTION
## The bug

`cgroups` enumerated the v2 tree by shelling out to
`find /sys/fs/cgroup -maxdepth 4 -name cgroup.controllers`. `runShellCmd` maps a
non-zero exit to `("", false, nil)` and `doProbe` turned that into an empty
detection **with no error**, so on any target without `findutils` the resource
reported `version: 2` with `controllers: []`, `root: null`, `list: []`. That is
not empty-but-honest: it asserts that a cgroup v2 host has no controllers.

`docker.io/library/amazonlinux:2023` (arm64), before:

```
$ cat /sys/fs/cgroup/cgroup.controllers   -> cpu io memory pids
$ command -v find                         -> MISSING (findutils not installed)
$ mql run local -c 'cgroups { version controllers root }'
{"cgroups":{"controllers":[],"root":null,"version":2,"list":[]}}
```

Hit on 6 of 50 images in a container sweep (amazonlinux 2018.03 / 2023,
opencloudos 8 / 9, openeuler 22.03 / 24.03). Minimal base images increasingly
ship without findutils.

## The fix

Both the version probe and the tree walk now go through `conn.FileSystem()`,
the idiom the rest of the provider uses to read `/proc` and `/sys`:

- no findutils dependency
- works on connection types that cannot run commands at all (tar / image scans),
  where the shell walk could never return anything
- a cgroup root that cannot be read is now an **error**, not a silent empty
  detection
- `list` ordering is deterministic (root first, then depth-first in directory
  order). The `find` walk's order was already unstable between two runs against
  the same host, so nothing was relying on it.

The walk descends three levels below the root, the equivalent of the
`-maxdepth 4` bound it replaces, and for the same reason the old comment gave: a
K8s node with thousands of pod cgroups would otherwise cost one directory
listing per pod container.

`parseCgroupWalk` and its tests are removed — nothing emits that text format any
more.

### Second defect fixed on the way

The shell pipeline's `while read f` had no `-r`, so it ate the backslashes in
systemd's escaped unit names. `system-serial\x2dgetty.slice` was reported at the
non-existent path `system-serialx2dgetty.slice`, and because every subsequent
`[ -r "$d/$n" ]` then failed, the cgroup came back with all attributes defaulted:

```
BASE /system.slice/system-serialx2dgetty.slice    controllers=[]  type=""      memoryCurrent=0
FIX  /system.slice/system-serial\x2dgetty.slice   controllers=[cpuset cpu io memory pids] type=domain memoryCurrent=1421312
```

## Verification

Provider built `GOOS=linux GOARCH=arm64` and run inside each container
(`mql run local`, `PROVIDERS_PATH` pointed at the built provider).

**1. The bug image** — `docker.io/library/amazonlinux:2023`, ground truth
`cpu io memory pids`:

| | `controllers` |
|---|---|
| before | `[]` |
| after | `["cpu","io","memory","pids"]` |

**2. Regression, identical output on images that already worked.** `base -> fix -> base`
run in the *same* container, full `cgroups { version controllers root { * } list { * } }`,
JSON canonicalized with sorted keys. `pids` / `pidsCurrent` / `memoryCurrent` are
live counters that differ between any two runs, so they are masked — and the
base-vs-base control below shows they are the *only* fields that move:

```
$ diff -u debian13.base1.masked debian13.fix.masked   # -> empty
$ diff -u debian13.base1.masked debian13.base2.masked # -> empty (control)
$ diff -u ubi10.base1.masked    ubi10.fix.masked      # -> empty
$ diff -u ubi10.base1.masked    ubi10.base2.masked    # -> empty (control)
```

**3. Regression on a real 59-cgroup tree** (`debian:13` with `--cgroupns=host`,
so the walk sees the VM host's full systemd hierarchy). Same cgroup count (59)
before and after; over the 52 cgroups present in both runs, zero differences in
any non-volatile field and zero differences in child counts. The 7 that differ
are the `\x2d` names the old code mangled, plus one ssh session scope that also
churns between the two base runs.

**4. Unit tests.** Four new tests, each proved red by mutating the
implementation:

| mutation | test that failed |
|---|---|
| drop the v1 fallback in `detectCgroupVersion` | `TestDetectCgroupVersion` |
| unreadable root returns an empty detection instead of an error (the shipped bug) | `TestWalkCgroupFSUnreadableRoot` |
| `cgroupWalkMaxDepth = 99` | `TestWalkCgroupFSDepthBound` |
| stop collapsing newlines in attribute files | `TestWalkCgroupFS`, `TestFlattenCgroupAttr` |

`go test ./resources/...` in `providers/os` passes.
`connection/device/linux` fails to build its tests on `main` already
(`undefined: snapshot.MockVolumeMounter`) — pre-existing and untouched here.

No schema change, no provider version bump.
