### PR TITLE
🐛 os: sudoers user specs never parse, the splitter ignores tabs

### DIFF
--- a/providers/os/resources/sudoers/sudoers.go
+++ b/providers/os/resources/sudoers/sudoers.go
@@ -249,40 +249,15 @@ func ParseDefaultsLine(line string) (string, string, string, string, string, boo
 		switch line[0] {
 		case ':': // User-specific
 			scope = "user"
-			parts := strings.SplitN(line[1:], " ", 2)
-			target = parts[0]
-			if len(parts) > 1 {
-				line = parts[1]
-			} else {
-				line = ""
-			}
 		case '@': // Host-specific
 			scope = "host"
-			parts := strings.SplitN(line[1:], " ", 2)
-			target = parts[0]
-			if len(parts) > 1 {
-				line = parts[1]
-			} else {
-				line = ""
-			}
 		case '>': // Runas-specific
 			scope = "runas"
-			parts := strings.SplitN(line[1:], " ", 2)
-			target = parts[0]
-			if len(parts) > 1 {
-				line = parts[1]
-			} else {
-				line = ""
-			}
 		case '!': // Command-specific
 			scope = "command"
-			parts := strings.SplitN(line[1:], " ", 2)
-			target = parts[0]
-			if len(parts) > 1 {
-				line = parts[1]
-			} else {
-				line = ""
-			}
+		}
+		if scope != "global" {
+			target, line = splitOnWhitespace(line[1:])
 		}
 	}
 
@@ -323,6 +298,17 @@ func ParseDefaultsLine(line string) (string, string, string, string, string, boo
 	value = strings.Trim(value, "\"")
 
 	return scope, target, parameter, value, operation, negated
+}
+
+// splitOnWhitespace splits s at the first space or tab and returns the leading
+// token plus the remainder with its leading whitespace removed. Sudoers accepts
+// either separator between a scoped Defaults target and its parameter.
+func splitOnWhitespace(s string) (string, string) {
+	idx := strings.IndexAny(s, " \t")
+	if idx == -1 {
+		return s, ""
+	}
+	return s[:idx], strings.TrimLeft(s[idx:], " \t")
 }
 
 // parsedLine represents a parsed line from a sudoers file (internal use)
@@ -478,7 +464,9 @@ func extractTagsAndCommands(result *parsedLine, remaining string) {
 	}
 }
 
-// smartSplit splits a string by whitespace but respects quoted strings
+// smartSplit splits a string on runs of spaces or tabs but respects quoted
+// strings. Distribution-shipped sudoers files separate the user, host and
+// command fields with tabs, so splitting on spaces alone drops every rule.
 func smartSplit(s string) []string {
 	var parts []string
 	var current strings.Builder
@@ -504,7 +492,7 @@ func smartSplit(s string) []string {
 			continue
 		}
 
-		if ch == ' ' && !inQuote {
+		if (ch == ' ' || ch == '\t') && !inQuote {
 			if current.Len() > 0 {
 				parts = append(parts, current.String())
 				current.Reset()

--- a/providers/os/resources/sudoers/sudoers_test.go
+++ b/providers/os/resources/sudoers/sudoers_test.go
@@ -4,6 +4,7 @@
 package sudoers_test
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -772,4 +773,185 @@ zabbix ALL=(root) NOPASSWD: /usr/sbin/dmidecode, /usr/bin/lsof
 	assert.Equal(t, []string{"zabbix"}, specs[1].Users)
 	assert.Contains(t, specs[1].Commands, "/usr/sbin/dmidecode")
 	assert.Contains(t, specs[1].Commands, "/usr/bin/lsof")
+}
+
+// Regression tests for the TAB separator bug: smartSplit only treated ' ' as a
+// field separator, so `root<TAB>ALL=(ALL) <TAB>ALL` produced a single token,
+// tripped the `len(tokens) < 2` guard in parseLine, and was dropped. Every
+// distribution ships /etc/sudoers with tab-separated fields, so userSpecs came
+// back empty on stock RHEL- and Debian-family hosts while defaults still
+// parsed (DefaultsRegex matches before smartSplit is reached).
+
+func TestParseUserSpecs_TabSeparators(t *testing.T) {
+	tests := []struct {
+		name        string
+		line        string
+		users       []string
+		hosts       []string
+		runasUsers  []string
+		runasGroups []string
+		tags        []string
+		commands    []string
+	}{
+		{
+			// verbatim from ubi10 /etc/sudoers (testdata/ubi10-etc-sudoers.txt)
+			name:       "rhel root rule",
+			line:       "root\tALL=(ALL) \tALL",
+			users:      []string{"root"},
+			hosts:      []string{"ALL"},
+			runasUsers: []string{"ALL"},
+			commands:   []string{"ALL"},
+		},
+		{
+			// verbatim from ubi10 /etc/sudoers
+			name:       "rhel wheel rule",
+			line:       "%wheel\tALL=(ALL)\tALL",
+			users:      []string{"%wheel"},
+			hosts:      []string{"ALL"},
+			runasUsers: []string{"ALL"},
+			commands:   []string{"ALL"},
+		},
+		{
+			// verbatim from debian:13 /etc/sudoers (testdata/debian13-etc-sudoers.txt)
+			name:        "debian root rule",
+			line:        "root\tALL=(ALL:ALL) ALL",
+			users:       []string{"root"},
+			hosts:       []string{"ALL"},
+			runasUsers:  []string{"ALL"},
+			runasGroups: []string{"ALL"},
+			commands:    []string{"ALL"},
+		},
+		{
+			// verbatim from debian:13 /etc/sudoers
+			name:        "debian sudo group rule",
+			line:        "%sudo\tALL=(ALL:ALL) ALL",
+			users:       []string{"%sudo"},
+			hosts:       []string{"ALL"},
+			runasUsers:  []string{"ALL"},
+			runasGroups: []string{"ALL"},
+			commands:    []string{"ALL"},
+		},
+		{
+			// guards the pre-existing space-separated behaviour against a fix
+			// that swaps ' ' for '\t' instead of accepting both
+			name:       "space separated still parses",
+			line:       "root ALL=(ALL) ALL",
+			users:      []string{"root"},
+			hosts:      []string{"ALL"},
+			runasUsers: []string{"ALL"},
+			commands:   []string{"ALL"},
+		},
+		{
+			name:       "mixed tabs and spaces with multiple users",
+			line:       "alice,\tbob\tALL=(ALL)\tNOPASSWD:\t/usr/bin/id",
+			users:      []string{"alice", "bob"},
+			hosts:      []string{"ALL"},
+			runasUsers: []string{"ALL"},
+			tags:       []string{"NOPASSWD"},
+			commands:   []string{"/usr/bin/id"},
+		},
+		{
+			// a tab inside a quoted command argument is data, not a separator
+			name:       "tab inside quoted argument is preserved",
+			line:       "bob\tALL=(root)\t/bin/grep \"foo\tbar\" /etc/hosts",
+			users:      []string{"bob"},
+			hosts:      []string{"ALL"},
+			runasUsers: []string{"root"},
+			commands:   []string{"/bin/grep \"foo\tbar\" /etc/hosts"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			specs := sudoers.ParseUserSpecs("/etc/sudoers", tt.line+"\n")
+			require.Len(t, specs, 1)
+
+			assert.Equal(t, tt.users, specs[0].Users)
+			assert.Equal(t, tt.hosts, specs[0].Hosts)
+			assert.Equal(t, tt.runasUsers, specs[0].RunasUsers)
+			assert.Equal(t, tt.runasGroups, specs[0].RunasGroups)
+			assert.Equal(t, tt.tags, specs[0].Tags)
+			assert.Equal(t, tt.commands, specs[0].Commands)
+		})
+	}
+}
+
+func TestParseUserSpecs_TabbedLineContinuation(t *testing.T) {
+	content := "john\tALL=(ALL)\tNOPASSWD: \\\n" +
+		"\t/usr/bin/systemctl restart nginx, \\\n" +
+		"\t/usr/bin/systemctl reload nginx\n"
+
+	specs := sudoers.ParseUserSpecs("/etc/sudoers", content)
+
+	require.Len(t, specs, 1)
+	assert.Equal(t, 1, specs[0].LineNumber)
+	assert.Equal(t, []string{"john"}, specs[0].Users)
+	assert.Equal(t, []string{"NOPASSWD"}, specs[0].Tags)
+	assert.Equal(t, []string{
+		"/usr/bin/systemctl restart nginx",
+		"/usr/bin/systemctl reload nginx",
+	}, specs[0].Commands)
+}
+
+func TestSmartSplit_TabSeparated(t *testing.T) {
+	assert.Equal(t, []string{"root", "ALL"}, sudoers.SmartSplit("root\tALL"))
+	assert.Equal(t, []string{"user", "host", "cmd"}, sudoers.SmartSplit("user \t host\t\tcmd"))
+}
+
+func TestSmartSplit_TabInsideQuotesDoesNotSplit(t *testing.T) {
+	assert.Equal(t, []string{"user", "host", "\"a\tb\""}, sudoers.SmartSplit("user\thost\t\"a\tb\""))
+}
+
+func TestParseDefaultsLine_TabAfterScopeTarget(t *testing.T) {
+	// A scoped Defaults target may be separated from its parameter by a tab.
+	scope, target, parameter, value, operation, negated := sudoers.ParseDefaultsLine("Defaults:john\t!requiretty")
+
+	assert.Equal(t, "user", scope)
+	assert.Equal(t, "john", target)
+	assert.Equal(t, "requiretty", parameter)
+	assert.Equal(t, "", value)
+	assert.Equal(t, "", operation)
+	assert.True(t, negated)
+}
+
+// The two files below were captured from the stock images, not hand-written,
+// so their separators are the real bytes those distributions ship.
+
+func TestParseSudoers_UBI10Fixture(t *testing.T) {
+	content := readSudoersFixture(t, "testdata/ubi10-etc-sudoers.txt")
+
+	specs := sudoers.ParseUserSpecs("/etc/sudoers", content)
+	require.Len(t, specs, 2)
+	assert.Equal(t, []string{"root"}, specs[0].Users)
+	assert.Equal(t, []string{"ALL"}, specs[0].Hosts)
+	assert.Equal(t, []string{"ALL"}, specs[0].RunasUsers)
+	assert.Equal(t, []string{"ALL"}, specs[0].Commands)
+	assert.Equal(t, []string{"%wheel"}, specs[1].Users)
+	assert.Equal(t, []string{"ALL"}, specs[1].Commands)
+
+	// defaults parsed before the fix and must keep parsing after it
+	assert.Len(t, sudoers.ParseDefaults("/etc/sudoers", content), 11)
+}
+
+func TestParseSudoers_Debian13Fixture(t *testing.T) {
+	content := readSudoersFixture(t, "testdata/debian13-etc-sudoers.txt")
+
+	specs := sudoers.ParseUserSpecs("/etc/sudoers", content)
+	require.Len(t, specs, 2)
+	assert.Equal(t, []string{"root"}, specs[0].Users)
+	assert.Equal(t, []string{"ALL"}, specs[0].RunasUsers)
+	assert.Equal(t, []string{"ALL"}, specs[0].RunasGroups)
+	assert.Equal(t, []string{"ALL"}, specs[0].Commands)
+	assert.Equal(t, []string{"%sudo"}, specs[1].Users)
+	assert.Equal(t, []string{"ALL"}, specs[1].Commands)
+
+	assert.Len(t, sudoers.ParseDefaults("/etc/sudoers", content), 4)
+}
+
+func readSudoersFixture(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), "\t", "fixture lost its tabs")
+	return string(raw)
 }

--- a/providers/os/resources/sudoers/testdata/debian13-etc-sudoers.txt
+++ b/providers/os/resources/sudoers/testdata/debian13-etc-sudoers.txt
@@ -1,0 +1,54 @@
+#
+# This file MUST be edited with the 'visudo' command as root.
+#
+# Please consider adding local content in /etc/sudoers.d/ instead of
+# directly modifying this file.
+#
+# See the man page for details on how to write a sudoers file.
+#
+Defaults	env_reset
+Defaults	mail_badpass
+Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+# This fixes CVE-2005-4890 and possibly breaks some versions of kdesu
+# (#1011624, https://bugs.kde.org/show_bug.cgi?id=452532)
+Defaults	use_pty
+
+# This preserves proxy settings from user environments of root
+# equivalent users (group sudo)
+#Defaults:%sudo env_keep += "http_proxy https_proxy ftp_proxy all_proxy no_proxy"
+
+# This allows running arbitrary commands, but so does ALL, and it means
+# different sudoers have their choice of editor respected.
+#Defaults:%sudo env_keep += "EDITOR"
+
+# Completely harmless preservation of a user preference.
+#Defaults:%sudo env_keep += "GREP_COLOR"
+
+# While you shouldn't normally run git as root, you need to with etckeeper
+#Defaults:%sudo env_keep += "GIT_AUTHOR_* GIT_COMMITTER_*"
+
+# Per-user preferences; root won't have sensible values for them.
+#Defaults:%sudo env_keep += "EMAIL DEBEMAIL DEBFULLNAME"
+
+# "sudo scp" or "sudo rsync" should be able to use your SSH agent.
+#Defaults:%sudo env_keep += "SSH_AGENT_PID SSH_AUTH_SOCK"
+
+# Ditto for GPG agent
+#Defaults:%sudo env_keep += "GPG_AGENT_INFO"
+
+# Host alias specification
+
+# User alias specification
+
+# Cmnd alias specification
+
+# User privilege specification
+root	ALL=(ALL:ALL) ALL
+
+# Allow members of group sudo to execute any command
+%sudo	ALL=(ALL:ALL) ALL
+
+# See sudoers(5) for more information on "@include" directives:
+
+@includedir /etc/sudoers.d

--- a/providers/os/resources/sudoers/testdata/ubi10-etc-sudoers.txt
+++ b/providers/os/resources/sudoers/testdata/ubi10-etc-sudoers.txt
@@ -1,0 +1,120 @@
+## Sudoers allows particular users to run various commands as
+## the root user, without needing the root password.
+##
+## Examples are provided at the bottom of the file for collections
+## of related commands, which can then be delegated out to particular
+## users or groups.
+## 
+## This file must be edited with the 'visudo' command.
+
+## Host Aliases
+## Groups of machines. You may prefer to use hostnames (perhaps using 
+## wildcards for entire domains) or IP addresses instead.
+# Host_Alias     FILESERVERS = fs1, fs2
+# Host_Alias     MAILSERVERS = smtp, smtp2
+
+## User Aliases
+## These aren't often necessary, as you can use regular groups
+## (ie, from files, LDAP, NIS, etc) in this file - just use %groupname 
+## rather than USERALIAS
+# User_Alias ADMINS = jsmith, mikem
+
+
+## Command Aliases
+## These are groups of related commands...
+
+## Networking
+# Cmnd_Alias NETWORKING = /sbin/route, /sbin/ifconfig, /bin/ping, /sbin/dhclient, /usr/bin/net, /sbin/iptables, /usr/bin/rfcomm, /usr/bin/wvdial, /sbin/iwconfig, /sbin/mii-tool
+
+## Installation and management of software
+# Cmnd_Alias SOFTWARE = /bin/rpm, /usr/bin/up2date, /usr/bin/yum
+
+## Services
+# Cmnd_Alias SERVICES = /sbin/service, /sbin/chkconfig, /usr/bin/systemctl start, /usr/bin/systemctl stop, /usr/bin/systemctl reload, /usr/bin/systemctl restart, /usr/bin/systemctl status, /usr/bin/systemctl enable, /usr/bin/systemctl disable
+
+## Updating the locate database
+# Cmnd_Alias LOCATE = /usr/bin/updatedb
+
+## Storage
+# Cmnd_Alias STORAGE = /sbin/fdisk, /sbin/sfdisk, /sbin/parted, /sbin/partprobe, /bin/mount, /bin/umount
+
+## Delegating permissions
+# Cmnd_Alias DELEGATING = /usr/sbin/visudo, /bin/chown, /bin/chmod, /bin/chgrp 
+
+## Processes
+# Cmnd_Alias PROCESSES = /bin/nice, /bin/kill, /usr/bin/kill, /usr/bin/killall
+
+## Drivers
+# Cmnd_Alias DRIVERS = /sbin/modprobe
+
+# Defaults specification
+
+#
+# Refuse to run if unable to disable echo on the tty.
+#
+Defaults   !visiblepw
+
+#
+# Preserving HOME has security implications since many programs
+# use it when searching for configuration files. Note that HOME
+# is already set when the the env_reset option is enabled, so
+# this option is only effective for configurations where either
+# env_reset is disabled or HOME is present in the env_keep list.
+#
+Defaults    always_set_home
+Defaults    match_group_by_gid
+
+# Prior to version 1.8.15, groups listed in sudoers that were not
+# found in the system group database were passed to the group
+# plugin, if any. Starting with 1.8.15, only groups of the form
+# %:group are resolved via the group plugin by default.
+# We enable always_query_group_plugin to restore old behavior.
+# Disable this option for new behavior.
+Defaults    always_query_group_plugin
+
+Defaults    env_reset
+Defaults    env_keep =  "COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS"
+Defaults    env_keep += "MAIL PS1 PS2 QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE"
+Defaults    env_keep += "LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES"
+Defaults    env_keep += "LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE"
+Defaults    env_keep += "LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY"
+
+#
+# Adding HOME to env_keep may enable a user to run unrestricted
+# commands via sudo.
+#
+# Defaults   env_keep += "HOME"
+
+Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin
+
+## Next comes the main part: which users can run what software on 
+## which machines (the sudoers file can be shared between multiple
+## systems).
+## Syntax:
+##
+## 	user	MACHINE=COMMANDS
+##
+## The COMMANDS section may have other options added to it.
+##
+## Allow root to run any commands anywhere 
+root	ALL=(ALL) 	ALL
+
+## Allows members of the 'sys' group to run networking, software, 
+## service management apps and more.
+# %sys ALL = NETWORKING, SOFTWARE, SERVICES, STORAGE, DELEGATING, PROCESSES, LOCATE, DRIVERS
+
+## Allows people in group wheel to run all commands
+%wheel	ALL=(ALL)	ALL
+
+## Same thing without a password
+# %wheel	ALL=(ALL)	NOPASSWD: ALL
+
+## Allows members of the users group to mount and unmount the 
+## cdrom as root
+# %users  ALL=/sbin/mount /mnt/cdrom, /sbin/umount /mnt/cdrom
+
+## Allows members of the users group to shutdown this system
+# %users  localhost=/sbin/shutdown -h now
+
+## Read drop-in files from /etc/sudoers.d (the # here does not mean a comment)
+#includedir /etc/sudoers.d


### PR DESCRIPTION
## Impact

`sudoers.userSpecs` returns an **empty list on every stock Linux distribution**, RHEL-family and Debian-family alike. Any policy asking "who can run what as root" evaluates against no rules and silently passes.

Verified on `registry.access.redhat.com/ubi10/ubi` with `sudo` installed, before this change:

```
sudoers.files { path }            -> [{"path":"/etc/sudoers"}]   file found
sudoers.content.length            -> 4329                        content read
sudoers.content.contains("root")  -> true                        rule is in the content
sudoers.defaults.length           -> 11                          Defaults parse fine
sudoers.userSpecs { users }       -> []                          <-- empty
```

`docker.io/library/debian:13` behaves identically: 4 defaults, zero user specs.

That partial health is what masked the bug. The file is found, the content is read, and `Defaults` entries parse — only the rules disappear, so nothing looks broken from the outside.

## Root cause

`smartSplit` treated only `' '` as a field separator:

```go
if ch == ' ' && !inQuote {
```

Distribution-shipped `/etc/sudoers` files separate the user, host and command fields with tabs:

```
root^IALL=(ALL) ^IALL        # ubi10,   ^I is a TAB
%wheel^IALL=(ALL)^IALL       # ubi10
root^IALL=(ALL:ALL) ALL      # debian:13
%sudo^IALL=(ALL:ALL) ALL     # debian:13
```

For `root\tALL=(ALL) \tALL`, `parseLine` hands `smartSplit` the pre-runas portion `root\tALL`. Space-only splitting yields one token, so the `len(tokens) < 2` guard in `parseLine` drops the line with no diagnostic. A hand-written, space-separated sudoers file was the only kind that ever parsed.

`Defaults` lines never reach `smartSplit` — `DefaultsRegex` matches earlier and returns — which is why they were unaffected.

## Fix

```diff
-		if ch == ' ' && !inQuote {
+		if (ch == ' ' || ch == '\t') && !inQuote {
```

A tab inside a quoted command argument still does not split, since the `inQuote` guard is unchanged.

### The rest of the package

Audited every place that could treat a space as *the* separator:

| Site | Verdict |
|---|---|
| `smartSplit` | **fixed** — the bug above |
| `ParseDefaultsLine` scope/target split | **fixed** — `strings.SplitN(s, " ", 2)` on a scoped `Defaults:john`, `Defaults@host`, `Defaults>root`, `Defaults!/usr/bin/su`. A tab after the target swallowed the whole parameter into the target (`Defaults:john\t!requiretty` gave `target = "john\t!requiretty"`, `parameter = ""`, `negated = false`). The four identical blocks now share one `splitOnWhitespace` helper that accepts either separator. |
| `splitAndTrim` | fine — splits on a caller-supplied separator (`","`) and `strings.TrimSpace`es each part, which already handles tabs |
| `SplitCommands` | fine — splits on `,` and trims; a tab inside a command argument is data and is deliberately preserved |
| `extractTagsAndCommands` | fine — `TagRegex` uses `\s*:\s*` |
| `AliasRegex`, `IncludeRegex`, `IncludedirRegex`, `DefaultsRegex` | fine — all use `\s` |
| line-continuation handling | fine — `strings.TrimSpace` based |

## Verification

Both containers, same binary except for this change, `sudo` installed at run time:

| | before | after |
|---|---|---|
| ubi10 `userSpecs` | `[]` | `root` and `%wheel`, each `hosts:[ALL] runasUsers:[ALL] commands:[ALL]` |
| ubi10 `defaults.length` | 11 | 11 (unchanged) |
| debian:13 `userSpecs` | `[]` | `root` and `%sudo`, each `runasUsers:[ALL] runasGroups:[ALL] commands:[ALL]` |
| debian:13 `defaults.length` | 4 | 4 (unchanged) |

## Tests

Table-driven over `ParseUserSpecs`, plus the two complete `/etc/sudoers` files captured from the images rather than typed by hand, so the separators are the real bytes those distributions ship (`testdata/ubi10-etc-sudoers.txt`, `testdata/debian13-etc-sudoers.txt`).

Every new test was run against the unfixed parser and failed:

- RHEL `root\tALL=(ALL) \tALL` and `%wheel\tALL=(ALL)\tALL` — red
- Debian `root\tALL=(ALL:ALL) ALL` and `%sudo\tALL=(ALL:ALL) ALL` — red
- mixed tabs and spaces with a comma-separated user list — red
- tab inside a quoted command argument is preserved — red
- tabbed line continuations — red
- `SmartSplit` on tabs, and on a quoted tab — red
- `ParseDefaultsLine("Defaults:john\t!requiretty")` — red
- both whole-file fixtures (user specs and the defaults count) — red

The space-separated case is green on the old parser by design, since it guards existing behaviour. It was proven able to fail by mutation: replacing the fix with a tab-only splitter (`ch == '\t'`) makes it fail while the tab cases pass. The quoted-tab assertion was proven the same way, with a mutant that splits on tab regardless of `inQuote`.
