### PR TITLE
🐛 os: find postgresql.conf by glob so a new major is not missed

### DIFF
--- a/providers/os/resources/postgresql.go
+++ b/providers/os/resources/postgresql.go
@@ -5,7 +5,9 @@ package resources
 
 import (
 	"errors"
+	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"sync"
 
@@ -21,28 +23,85 @@ import (
 // postgresql.conf
 // ---------------------------------------------------------------------------
 
-// postgresqlConfPaths lists well-known paths the parser will probe when no
-// explicit `path` argument is given. Postgres installations are highly
-// version- and distro-specific, so we walk this list in order and stop at
-// the first existing file. Debian/Ubuntu uses version-stamped subdirectories
-// (/etc/postgresql/<MAJOR>/main); for those we list the conventional `main`
-// cluster across the supported major versions.
-var postgresqlConfPaths = []string{
-	"/etc/postgresql/17/main/postgresql.conf",
-	"/etc/postgresql/16/main/postgresql.conf",
-	"/etc/postgresql/15/main/postgresql.conf",
-	"/etc/postgresql/14/main/postgresql.conf",
-	"/etc/postgresql/13/main/postgresql.conf",
-	"/etc/postgresql/12/main/postgresql.conf",
-	"/var/lib/postgresql/data/postgresql.conf",
-	"/var/lib/pgsql/data/postgresql.conf",
-	"/var/lib/pgsql/17/data/postgresql.conf",
-	"/var/lib/pgsql/16/data/postgresql.conf",
-	"/var/lib/pgsql/15/data/postgresql.conf",
-	"/var/lib/pgsql/14/data/postgresql.conf",
-	"/var/lib/pgsql/13/data/postgresql.conf",
-	"/usr/local/var/postgres/postgresql.conf",
-	"/usr/local/pgsql/data/postgresql.conf",
+// postgresqlConfigSearchPaths returns the ordered list of well-known locations
+// probed for one of PostgreSQL's config files (postgresql.conf, pg_hba.conf,
+// pg_ident.conf) when no explicit `path` argument is given. The caller walks
+// the list in order and stops at the first existing file.
+//
+// Distro packages stamp the major version into the directory name
+// (/etc/postgresql/<MAJOR>/main on Debian/Ubuntu, /var/lib/pgsql/<MAJOR>/data
+// on RHEL), so those two groups are resolved by glob. Enumerating the majors
+// by hand goes stale the day a new one ships: the list previously stopped at
+// 17 and therefore found nothing at all on a PostgreSQL 18 install. The
+// remaining paths (container images, initdb defaults, homebrew) carry no
+// version and stay listed literally.
+func postgresqlConfigSearchPaths(fs afero.Fs, name string) []string {
+	paths := versionedPostgresqlPaths(fs, "/etc/postgresql", "main", name)
+	paths = append(paths,
+		"/var/lib/postgresql/data/"+name,
+		"/var/lib/pgsql/data/"+name,
+	)
+	paths = append(paths, versionedPostgresqlPaths(fs, "/var/lib/pgsql", "data", name)...)
+	return append(paths,
+		"/usr/local/var/postgres/"+name,
+		"/usr/local/pgsql/data/"+name,
+	)
+}
+
+// versionedPostgresqlPaths expands <root>/*/<cluster>/<name> and returns the
+// matches ordered by major version, highest first, so a host running several
+// clusters side by side resolves to the newest the way the old descending
+// enumeration did. The sort is numeric: lexically "9" sorts above "17", and
+// /etc/postgresql/9/main still exists on long-lived hosts.
+//
+// A directory whose name is not an integer (someone's /etc/postgresql/backup)
+// is skipped rather than treated as major 0. A filesystem that cannot be
+// globbed contributes no candidates, which is what the hardcoded list did when
+// a path simply was not there.
+func versionedPostgresqlPaths(fs afero.Fs, root, cluster, name string) []string {
+	if fs == nil {
+		return nil
+	}
+	matches, err := afero.Glob(fs, root+"/*/"+cluster+"/"+name)
+	if err != nil {
+		return nil
+	}
+
+	type candidate struct {
+		major int
+		path  string
+	}
+	candidates := make([]candidate, 0, len(matches))
+	for _, match := range matches {
+		// <root>/<major>/<cluster>/<name>
+		major, err := strconv.Atoi(path.Base(path.Dir(path.Dir(match))))
+		if err != nil {
+			continue
+		}
+		candidates = append(candidates, candidate{major: major, path: match})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].major > candidates[j].major
+	})
+
+	out := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		out = append(out, c.path)
+	}
+	return out
+}
+
+// findPostgresqlConfigFile returns the first search path that exists, or "" if
+// PostgreSQL keeps its config somewhere we do not know about (or is not
+// installed at all).
+func findPostgresqlConfigFile(fs afero.Fs, name string) string {
+	afs := &afero.Afero{Fs: fs}
+	for _, p := range postgresqlConfigSearchPaths(fs, name) {
+		if ok, _ := afs.Exists(p); ok {
+			return p
+		}
+	}
+	return ""
 }
 
 type mqlPostgresqlConfInternal struct {
@@ -86,18 +145,15 @@ func (s *mqlPostgresqlConf) id() (string, error) {
 
 func (s *mqlPostgresqlConf) file() (*mqlFile, error) {
 	conn := s.MqlRuntime.Connection.(shared.Connection)
-	afs := &afero.Afero{Fs: conn.FileSystem()}
 
-	for _, path := range postgresqlConfPaths {
-		if ok, _ := afs.Exists(path); ok {
-			f, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
-				"path": llx.StringData(path),
-			})
-			if err != nil {
-				return nil, err
-			}
-			return f.(*mqlFile), nil
+	if p := findPostgresqlConfigFile(conn.FileSystem(), "postgresql.conf"); p != "" {
+		f, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
+			"path": llx.StringData(p),
+		})
+		if err != nil {
+			return nil, err
 		}
+		return f.(*mqlFile), nil
 	}
 
 	// No config file found anywhere — PostgreSQL likely isn't installed.
@@ -414,24 +470,6 @@ func (s *mqlPostgresqlConf) sharedPreloadLibraries(params map[string]any) ([]any
 // postgresql.hba
 // ---------------------------------------------------------------------------
 
-var postgresqlHbaPaths = []string{
-	"/etc/postgresql/17/main/pg_hba.conf",
-	"/etc/postgresql/16/main/pg_hba.conf",
-	"/etc/postgresql/15/main/pg_hba.conf",
-	"/etc/postgresql/14/main/pg_hba.conf",
-	"/etc/postgresql/13/main/pg_hba.conf",
-	"/etc/postgresql/12/main/pg_hba.conf",
-	"/var/lib/postgresql/data/pg_hba.conf",
-	"/var/lib/pgsql/data/pg_hba.conf",
-	"/var/lib/pgsql/17/data/pg_hba.conf",
-	"/var/lib/pgsql/16/data/pg_hba.conf",
-	"/var/lib/pgsql/15/data/pg_hba.conf",
-	"/var/lib/pgsql/14/data/pg_hba.conf",
-	"/var/lib/pgsql/13/data/pg_hba.conf",
-	"/usr/local/var/postgres/pg_hba.conf",
-	"/usr/local/pgsql/data/pg_hba.conf",
-}
-
 func initPostgresqlHba(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if x, ok := args["path"]; ok {
 		path, ok := x.Value.(string)
@@ -463,18 +501,15 @@ func (s *mqlPostgresqlHba) id() (string, error) {
 
 func (s *mqlPostgresqlHba) file() (*mqlFile, error) {
 	conn := s.MqlRuntime.Connection.(shared.Connection)
-	afs := &afero.Afero{Fs: conn.FileSystem()}
 
-	for _, path := range postgresqlHbaPaths {
-		if ok, _ := afs.Exists(path); ok {
-			f, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
-				"path": llx.StringData(path),
-			})
-			if err != nil {
-				return nil, err
-			}
-			return f.(*mqlFile), nil
+	if p := findPostgresqlConfigFile(conn.FileSystem(), "pg_hba.conf"); p != "" {
+		f, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
+			"path": llx.StringData(p),
+		})
+		if err != nil {
+			return nil, err
 		}
+		return f.(*mqlFile), nil
 	}
 	s.File.State = plugin.StateIsSet | plugin.StateIsNull
 	return nil, nil
@@ -522,24 +557,6 @@ func (s *mqlPostgresqlHbaRule) id() (string, error) {
 // postgresql.ident
 // ---------------------------------------------------------------------------
 
-var postgresqlIdentPaths = []string{
-	"/etc/postgresql/17/main/pg_ident.conf",
-	"/etc/postgresql/16/main/pg_ident.conf",
-	"/etc/postgresql/15/main/pg_ident.conf",
-	"/etc/postgresql/14/main/pg_ident.conf",
-	"/etc/postgresql/13/main/pg_ident.conf",
-	"/etc/postgresql/12/main/pg_ident.conf",
-	"/var/lib/postgresql/data/pg_ident.conf",
-	"/var/lib/pgsql/data/pg_ident.conf",
-	"/var/lib/pgsql/17/data/pg_ident.conf",
-	"/var/lib/pgsql/16/data/pg_ident.conf",
-	"/var/lib/pgsql/15/data/pg_ident.conf",
-	"/var/lib/pgsql/14/data/pg_ident.conf",
-	"/var/lib/pgsql/13/data/pg_ident.conf",
-	"/usr/local/var/postgres/pg_ident.conf",
-	"/usr/local/pgsql/data/pg_ident.conf",
-}
-
 func initPostgresqlIdent(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if x, ok := args["path"]; ok {
 		path, ok := x.Value.(string)
@@ -571,18 +588,15 @@ func (s *mqlPostgresqlIdent) id() (string, error) {
 
 func (s *mqlPostgresqlIdent) file() (*mqlFile, error) {
 	conn := s.MqlRuntime.Connection.(shared.Connection)
-	afs := &afero.Afero{Fs: conn.FileSystem()}
 
-	for _, path := range postgresqlIdentPaths {
-		if ok, _ := afs.Exists(path); ok {
-			f, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
-				"path": llx.StringData(path),
-			})
-			if err != nil {
-				return nil, err
-			}
-			return f.(*mqlFile), nil
+	if p := findPostgresqlConfigFile(conn.FileSystem(), "pg_ident.conf"); p != "" {
+		f, err := CreateResource(s.MqlRuntime, "file", map[string]*llx.RawData{
+			"path": llx.StringData(p),
+		})
+		if err != nil {
+			return nil, err
 		}
+		return f.(*mqlFile), nil
 	}
 	s.File.State = plugin.StateIsSet | plugin.StateIsNull
 	return nil, nil

--- a/providers/os/resources/postgresql_test.go
+++ b/providers/os/resources/postgresql_test.go
@@ -6,7 +6,9 @@ package resources
 import (
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 )
 
@@ -126,4 +128,138 @@ func TestPostgresqlConfPresentWithValues(t *testing.T) {
 	ssl, err := s.sslEnabled(map[string]any{"ssl": "on"})
 	assert.NoError(t, err)
 	assert.True(t, ssl)
+}
+
+// pgFs builds an in-memory filesystem holding exactly the given config files.
+func pgFs(t *testing.T, paths ...string) afero.Fs {
+	t.Helper()
+	fs := afero.NewMemMapFs()
+	for _, p := range paths {
+		require.NoError(t, afero.WriteFile(fs, p, []byte("# test\n"), 0o644))
+	}
+	return fs
+}
+
+// The search path used to enumerate majors by hand and stopped at 17, so a
+// PostgreSQL 18 host resolved no config at all and every directive read as
+// unset — with no error to say why. 19 lands around Sept 2026 and would have
+// broken it again, which is why the version-stamped groups are globbed.
+func TestPostgresqlFindsCurrentMajor(t *testing.T) {
+	t.Run("debian layout", func(t *testing.T) {
+		fs := pgFs(t, "/etc/postgresql/18/main/postgresql.conf")
+		assert.Equal(t, "/etc/postgresql/18/main/postgresql.conf",
+			findPostgresqlConfigFile(fs, "postgresql.conf"))
+	})
+
+	t.Run("rhel layout", func(t *testing.T) {
+		fs := pgFs(t, "/var/lib/pgsql/18/data/postgresql.conf")
+		assert.Equal(t, "/var/lib/pgsql/18/data/postgresql.conf",
+			findPostgresqlConfigFile(fs, "postgresql.conf"))
+	})
+
+	t.Run("hba and ident use the same search", func(t *testing.T) {
+		fs := pgFs(t,
+			"/etc/postgresql/18/main/pg_hba.conf",
+			"/etc/postgresql/18/main/pg_ident.conf",
+		)
+		assert.Equal(t, "/etc/postgresql/18/main/pg_hba.conf",
+			findPostgresqlConfigFile(fs, "pg_hba.conf"))
+		assert.Equal(t, "/etc/postgresql/18/main/pg_ident.conf",
+			findPostgresqlConfigFile(fs, "pg_ident.conf"))
+	})
+}
+
+// A host carrying several clusters resolves to the newest, the way the old
+// descending enumeration did.
+func TestPostgresqlPrefersHighestMajor(t *testing.T) {
+	fs := pgFs(t,
+		"/etc/postgresql/17/main/postgresql.conf",
+		"/etc/postgresql/18/main/postgresql.conf",
+	)
+	assert.Equal(t, "/etc/postgresql/18/main/postgresql.conf",
+		findPostgresqlConfigFile(fs, "postgresql.conf"))
+}
+
+// Glob results arrive in lexicographic order, where "9" sorts above "17".
+// /etc/postgresql/9/main still exists on long-lived hosts, so the ordering
+// must compare majors as integers. This test fails if anyone sorts strings.
+func TestPostgresqlMajorSortIsNumericNotLexical(t *testing.T) {
+	fs := pgFs(t,
+		"/etc/postgresql/9/main/postgresql.conf",
+		"/etc/postgresql/17/main/postgresql.conf",
+	)
+	assert.Equal(t, "/etc/postgresql/17/main/postgresql.conf",
+		findPostgresqlConfigFile(fs, "postgresql.conf"))
+
+	fs = pgFs(t,
+		"/var/lib/pgsql/9/data/postgresql.conf",
+		"/var/lib/pgsql/13/data/postgresql.conf",
+	)
+	assert.Equal(t, "/var/lib/pgsql/13/data/postgresql.conf",
+		findPostgresqlConfigFile(fs, "postgresql.conf"))
+}
+
+// An operator's backup copy under /etc/postgresql has no integer major.
+// It must be skipped, not parsed as major 0 and not blow up the search.
+func TestPostgresqlNonNumericDirectoryIsSkipped(t *testing.T) {
+	t.Run("skipped in favour of a real cluster", func(t *testing.T) {
+		fs := pgFs(t,
+			"/etc/postgresql/backup/main/postgresql.conf",
+			"/etc/postgresql/16/main/postgresql.conf",
+		)
+		assert.Equal(t, "/etc/postgresql/16/main/postgresql.conf",
+			findPostgresqlConfigFile(fs, "postgresql.conf"))
+	})
+
+	t.Run("never offered as a candidate", func(t *testing.T) {
+		fs := pgFs(t, "/etc/postgresql/backup/main/postgresql.conf")
+		assert.Equal(t, "", findPostgresqlConfigFile(fs, "postgresql.conf"))
+		assert.NotContains(t, postgresqlConfigSearchPaths(fs, "postgresql.conf"),
+			"/etc/postgresql/backup/main/postgresql.conf")
+	})
+}
+
+// The version-less layouts — container images, an initdb default, homebrew —
+// are what the glob does NOT cover, and they still have to resolve.
+func TestPostgresqlVersionlessPathsStillResolve(t *testing.T) {
+	for _, p := range []string{
+		"/var/lib/postgresql/data/postgresql.conf",
+		"/var/lib/pgsql/data/postgresql.conf",
+		"/usr/local/var/postgres/postgresql.conf",
+		"/usr/local/pgsql/data/postgresql.conf",
+	} {
+		t.Run(p, func(t *testing.T) {
+			assert.Equal(t, p, findPostgresqlConfigFile(pgFs(t, p), "postgresql.conf"))
+		})
+	}
+}
+
+// The version-stamped groups keep the precedence the flat list gave them:
+// /etc/postgresql beats the version-less paths, which beat /var/lib/pgsql/<N>.
+func TestPostgresqlSearchOrderIsPreserved(t *testing.T) {
+	fs := pgFs(t,
+		"/etc/postgresql/16/main/postgresql.conf",
+		"/var/lib/postgresql/data/postgresql.conf",
+		"/var/lib/pgsql/18/data/postgresql.conf",
+		"/usr/local/pgsql/data/postgresql.conf",
+	)
+	assert.Equal(t, []string{
+		"/etc/postgresql/16/main/postgresql.conf",
+		"/var/lib/postgresql/data/postgresql.conf",
+		"/var/lib/pgsql/data/postgresql.conf",
+		"/var/lib/pgsql/18/data/postgresql.conf",
+		"/usr/local/var/postgres/postgresql.conf",
+		"/usr/local/pgsql/data/postgresql.conf",
+	}, postgresqlConfigSearchPaths(fs, "postgresql.conf"))
+}
+
+// A filesystem that cannot be globbed must degrade to the version-less paths
+// rather than panicking, matching what the hardcoded list did.
+func TestPostgresqlNilFilesystemDoesNotPanic(t *testing.T) {
+	assert.Equal(t, []string{
+		"/var/lib/postgresql/data/postgresql.conf",
+		"/var/lib/pgsql/data/postgresql.conf",
+		"/usr/local/var/postgres/postgresql.conf",
+		"/usr/local/pgsql/data/postgresql.conf",
+	}, postgresqlConfigSearchPaths(nil, "postgresql.conf"))
 }


### PR DESCRIPTION
### The bug

`providers/os/resources/postgresql.go` probed for PostgreSQL's config files
using a hardcoded list of major versions that stopped at **17**:

```go
var postgresqlConfPaths = []string{
	"/etc/postgresql/17/main/postgresql.conf",
	... 16, 15, 14, 13, 12 ...
	"/var/lib/pgsql/17/data/postgresql.conf",
	... 16, 15, 14, 13 ...
}
```

PostgreSQL 18 was released 2025-09-25 and is the current stable major.
Neither `/etc/postgresql/18/main/postgresql.conf` (Debian/Ubuntu) nor
`/var/lib/pgsql/18/data/postgresql.conf` (RHEL) was in the list, so on a
current distro-packaged install `postgresql.conf` found nothing and every
directive read as unset — silently, with no error. The version-less paths
(`/var/lib/postgresql/data`, `/var/lib/pgsql/data`) cover container images and
the initdb default, which is why this was not total: it bit distro-packaged,
version-stamped installs specifically. PostgreSQL 19 lands around Sept 2026
and would have broken it again — an enumeration is stale the day a new major
ships, which is the point of moving to a glob.

`pg_hba.conf` and `pg_ident.conf` carried identical lists and are fixed the
same way.

### The fix

The two version-stamped groups are resolved by glob against
`conn.FileSystem()` (not a shell command — a shelled-out `find` returns
nothing on a host without findutils):

- `/etc/postgresql/*/main/<name>`
- `/var/lib/pgsql/*/data/<name>`

Ordering and precedence are preserved:

- matches sort by major version **numerically, descending**, so the highest
  major still wins. Glob results arrive lexicographically, where `9` sorts
  above `17`, and `/etc/postgresql/9/main` still exists on long-lived hosts.
- the three groups keep the relative order the flat list gave them:
  `/etc/postgresql/*`, then the version-less paths, then `/var/lib/pgsql/*`,
  then the homebrew/`/usr/local` paths.
- a directory whose name is not an integer (`/etc/postgresql/backup`) is
  skipped, not parsed as major 0.
- a nil/unusable filesystem contributes no candidates and does not panic,
  matching what the hardcoded list did when a path simply was not there.

### Tests

`postgresql_test.go` gains coverage for the search itself; the existing
null-state tests are untouched. Each new test was proved red by mutating the
implementation:

| test | mutation that kills it |
|---|---|
| PG 18 resolves (Debian, RHEL, hba, ident) | restore the enumerated list stopping at 17 |
| 17 vs 18 → 18 wins | restore the enumerated list |
| 9 vs 17 → 17 wins (numeric, not lexical) | sort the major as a string |
| non-numeric dir skipped | `strconv.Atoi` error ignored, dir kept as major 0 |
| version-less paths still resolve | drop them from the search list |
| group precedence preserved | swap the `/etc/postgresql` and `/var/lib/pgsql` groups |
| nil filesystem does not panic | drop the nil guard |

No schema change, so no `.lr` / `.lr.versions` edit and no provider version
bump.
