### PR TITLE
🐛 os: an errored command must not read as exit code 0

### DIFF
--- a/providers/os/resources/command.go
+++ b/providers/os/resources/command.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"errors"
 	"io"
 	"sync"
 
@@ -65,4 +66,58 @@ func (c *mqlCommand) stderr(cmd string) (string, error) {
 func (c *mqlCommand) exitcode(cmd string) (int64, error) {
 	// note: we ignore the return value because everything is set in execute
 	return 0, c.execute(cmd)
+}
+
+// commandRun is the settled result of a `command` resource: the exit code and
+// both output streams, read only once every underlying TValue is known to be
+// error free.
+type commandRun struct {
+	exitcode int64
+	stdout   string
+	stderr   string
+}
+
+// commandResult reads an already-created `command` resource and reports an
+// error whenever the command could not run at all.
+//
+// This check is not optional. A connection without command execution answers
+// every field of the resource with an error and leaves Data at its zero value,
+// so `exitcode` reads as 0 and stdout reads as "". Code that trusts Data
+// without consulting Error therefore sees a command that succeeded and printed
+// nothing, and goes on to report the parse of an empty string as a measured
+// fact. On a container image scan that is how `macos.filevault.enabled` came
+// back as a confident `false`.
+//
+// A non-zero exit code is deliberately not an error here: callers that branch
+// on a specific code (lvm's 127 for "not installed", softwareupdate's exit 1
+// for "no updates available") need to see it. Callers that only want stdout
+// from a command that must succeed should use commandOutput instead.
+func commandResult(cmd *mqlCommand) (commandRun, error) {
+	exit := cmd.GetExitcode()
+	if exit.Error != nil {
+		return commandRun{}, exit.Error
+	}
+	stdout := cmd.GetStdout()
+	if stdout.Error != nil {
+		return commandRun{}, stdout.Error
+	}
+	return commandRun{
+		exitcode: exit.Data,
+		stdout:   stdout.Data,
+		stderr:   cmd.GetStderr().Data,
+	}, nil
+}
+
+// commandOutput returns the stdout of an already-created `command` resource,
+// or an error if the command could not run or exited non-zero. `what` names
+// the command in the error message.
+func commandOutput(cmd *mqlCommand, what string) (string, error) {
+	run, err := commandResult(cmd)
+	if err != nil {
+		return "", err
+	}
+	if run.exitcode != 0 {
+		return "", errors.New(what + " failed: " + run.stderr)
+	}
+	return run.stdout, nil
 }

--- a/providers/os/resources/command_result_test.go
+++ b/providers/os/resources/command_result_test.go
@@ -1,0 +1,263 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/connection/fs"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+)
+
+func testRuntime(t *testing.T, conn plugin.Connection) *plugin.Runtime {
+	t.Helper()
+	return plugin.NewRuntime(conn, nil, false, CreateResource, NewResource, GetData, SetData, nil)
+}
+
+// noCommandRuntime builds a runtime on a filesystem connection: it can read
+// files but has no command execution, exactly like a container-image or
+// mounted-volume scan. Every field of the `command` resource then carries
+// plugin.ErrRunCommandNotImplemented with Data left at its zero value.
+func noCommandRuntime(t *testing.T) *plugin.Runtime {
+	t.Helper()
+	asset := &inventory.Asset{}
+	conn, err := fs.NewFileSystemConnectionWithFs(1, &inventory.Config{}, asset, "/", nil, afero.NewMemMapFs())
+	require.NoError(t, err)
+	return testRuntime(t, conn)
+}
+
+// commandRuntime builds a runtime whose commands answer from the given table.
+func commandRuntime(t *testing.T, cmds map[string]*mock.Command) *plugin.Runtime {
+	t.Helper()
+	for k, v := range cmds {
+		v.Command = k
+	}
+	conn, err := mock.New(1, &inventory.Asset{}, mock.WithData(&mock.TomlData{Commands: cmds}))
+	require.NoError(t, err)
+	return testRuntime(t, conn)
+}
+
+func mustResource(t *testing.T, runtime *plugin.Runtime, name string) plugin.Resource {
+	t.Helper()
+	res, err := CreateResource(runtime, name, map[string]*llx.RawData{})
+	require.NoError(t, err)
+	return res
+}
+
+// TestCommandCannotRun_Errors pins the core contract: on a connection with no
+// command execution, a resource that shells out must report an error. Before
+// this was fixed every one of these read `exitcode` as 0 -- the zero value that
+// accompanies the error -- parsed empty stdout, and answered with a confident
+// zero value. macos.filevault/sip/gatekeeper each reported `enabled: false` on
+// a Debian container image, which is a false-positive security finding on three
+// of macOS's load-bearing controls.
+func TestCommandCannotRun_Errors(t *testing.T) {
+	t.Run("macos.filevault.enabled", func(t *testing.T) {
+		r := mustResource(t, noCommandRuntime(t), "macos.filevault").(*mqlMacosFilevault)
+		v := r.GetEnabled()
+		require.Error(t, v.Error)
+		assert.False(t, v.Data, "must not answer `false` when nothing was measured")
+	})
+
+	t.Run("macos.sip.enabled", func(t *testing.T) {
+		r := mustResource(t, noCommandRuntime(t), "macos.sip").(*mqlMacosSip)
+		v := r.GetEnabled()
+		require.Error(t, v.Error)
+		assert.False(t, v.Data)
+	})
+
+	t.Run("macos.gatekeeper.enabled", func(t *testing.T) {
+		r := mustResource(t, noCommandRuntime(t), "macos.gatekeeper").(*mqlMacosGatekeeper)
+		v := r.GetEnabled()
+		require.Error(t, v.Error)
+		assert.False(t, v.Data)
+	})
+
+	t.Run("macos.sharing", func(t *testing.T) {
+		// A non-zero exit legitimately means "this release has no Sharing
+		// panel" and yields an empty map; a command that never ran must not
+		// take that path.
+		r := mustResource(t, noCommandRuntime(t), "macos.sharing").(*mqlMacosSharing)
+		_, err := r.fetchState()
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, errSharingPanelUnavailable)
+	})
+
+	t.Run("zfs.pools", func(t *testing.T) {
+		r := mustResource(t, noCommandRuntime(t), "zfs").(*mqlZfs)
+		v := r.GetPools()
+		require.Error(t, v.Error)
+		assert.Empty(t, v.Data)
+	})
+
+	t.Run("mdadm.arrays", func(t *testing.T) {
+		// This one used to return an empty list on any failure, so an image
+		// scan reported "no RAID arrays" as a measured fact.
+		r := mustResource(t, noCommandRuntime(t), "mdadm").(*mqlMdadm)
+		require.Error(t, r.GetArrays().Error)
+	})
+
+	// lsblk and lvm already surfaced a failure before the fix, but only by
+	// accident: they fed the empty stdout to a JSON parser that rejected it.
+	// These pin the error to the command, so a parser that grows tolerant of
+	// empty input cannot turn them into silent empty lists.
+	t.Run("lsblk.list", func(t *testing.T) {
+		r := mustResource(t, noCommandRuntime(t), "lsblk").(*mqlLsblk)
+		err := r.GetList().Error
+		require.Error(t, err)
+		assert.ErrorIs(t, err, plugin.ErrRunCommandNotImplemented)
+	})
+
+	t.Run("lvm.volumeGroups", func(t *testing.T) {
+		r := mustResource(t, noCommandRuntime(t), "lvm").(*mqlLvm)
+		err := r.GetVolumeGroups().Error
+		require.Error(t, err)
+		assert.ErrorIs(t, err, plugin.ErrRunCommandNotImplemented)
+	})
+
+	t.Run("mount df entries", func(t *testing.T) {
+		// mount.point size/used/available come from `df`, which used to fall
+		// back to an empty table whenever the command "failed".
+		r := mustResource(t, noCommandRuntime(t), "mount").(*mqlMount)
+		_, err := r.fetchDfEntries()
+		require.Error(t, err)
+	})
+}
+
+// TestCommandExitsNonZero_Unchanged pins that a command which really ran and
+// really failed keeps its old behaviour: an error naming the command and
+// carrying its stderr.
+func TestCommandExitsNonZero_Unchanged(t *testing.T) {
+	t.Run("macos.filevault.enabled", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"fdesetup status": {Stderr: "not permitted", ExitStatus: 1},
+		})
+		v := mustResource(t, rt, "macos.filevault").(*mqlMacosFilevault).GetEnabled()
+		require.Error(t, v.Error)
+		assert.Contains(t, v.Error.Error(), "fdesetup status failed: not permitted")
+	})
+
+	t.Run("zfs.pools", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"zpool get -jp all": {Stderr: "zpool: not found", ExitStatus: 127},
+		})
+		v := mustResource(t, rt, "zfs").(*mqlZfs).GetPools()
+		require.Error(t, v.Error)
+		assert.Contains(t, v.Error.Error(), "zpool: not found")
+	})
+}
+
+// TestCommandSucceeds_Unchanged pins that a command which ran and exited zero
+// still produces the value it always did.
+func TestCommandSucceeds_Unchanged(t *testing.T) {
+	t.Run("filevault on", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"fdesetup status": {Stdout: "FileVault is On.\n"},
+		})
+		r := mustResource(t, rt, "macos.filevault").(*mqlMacosFilevault)
+		v := r.GetEnabled()
+		require.NoError(t, v.Error)
+		assert.True(t, v.Data)
+		assert.Equal(t, "FileVault is On.", r.GetStatus().Data)
+	})
+
+	t.Run("filevault off", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"fdesetup status": {Stdout: "FileVault is Off.\n"},
+		})
+		v := mustResource(t, rt, "macos.filevault").(*mqlMacosFilevault).GetEnabled()
+		require.NoError(t, v.Error)
+		assert.False(t, v.Data, "a measured `false` is still a measured `false`")
+	})
+
+	t.Run("gatekeeper enabled", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"spctl --status": {Stdout: "assessments enabled\n"},
+		})
+		v := mustResource(t, rt, "macos.gatekeeper").(*mqlMacosGatekeeper).GetEnabled()
+		require.NoError(t, v.Error)
+		assert.True(t, v.Data)
+	})
+
+	t.Run("sip enabled", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"csrutil status": {Stdout: "System Integrity Protection status: enabled.\n"},
+		})
+		v := mustResource(t, rt, "macos.sip").(*mqlMacosSip).GetEnabled()
+		require.NoError(t, v.Error)
+		assert.True(t, v.Data)
+	})
+}
+
+// TestDeliberateNonZeroExitBranchesSurvive guards the branches that act on a
+// specific non-zero exit code. Routing every site through a "non-zero means
+// error" helper would have flattened these.
+func TestDeliberateNonZeroExitBranchesSurvive(t *testing.T) {
+	t.Run("lvm exit 127 means not installed, not an error", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{})
+		lvm := mustResource(t, rt, "lvm").(*mqlLvm)
+		// the mock answers an unknown command with exit 1 + "command not
+		// found: ...", which isLvmNotInstalled also accepts; pin the 127 path
+		// through the helper directly so the exit code itself is the input.
+		out, ok, err := lvm.runLvmReport("vgs --reportformat json")
+		require.NoError(t, err)
+		assert.False(t, ok)
+		assert.Empty(t, out)
+
+		rt = commandRuntime(t, map[string]*mock.Command{
+			"vgs --reportformat json": {ExitStatus: 127},
+		})
+		lvm = mustResource(t, rt, "lvm").(*mqlLvm)
+		out, ok, err = lvm.runLvmReport("vgs --reportformat json")
+		require.NoError(t, err)
+		assert.False(t, ok)
+		assert.Empty(t, out)
+	})
+
+	t.Run("lvm other non-zero exit is still an error", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"vgs --reportformat json": {ExitStatus: 5, Stderr: "broken metadata"},
+		})
+		lvm := mustResource(t, rt, "lvm").(*mqlLvm)
+		_, _, err := lvm.runLvmReport("vgs --reportformat json")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exit 5")
+	})
+
+	t.Run("mdadm non-zero exit means no arrays", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"mdadm --detail --scan": {ExitStatus: 1, Stderr: "mdadm: not found"},
+		})
+		v := mustResource(t, rt, "mdadm").(*mqlMdadm).GetArrays()
+		require.NoError(t, v.Error)
+		assert.Empty(t, v.Data)
+	})
+
+	t.Run("macos.sharing non-zero exit yields an empty panel", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			systemProfilerSharingCmd: {ExitStatus: 1},
+		})
+		r := mustResource(t, rt, "macos.sharing").(*mqlMacosSharing)
+		state, err := r.fetchState()
+		require.NoError(t, err)
+		assert.Empty(t, state)
+		// and an empty panel is still reported as "not measured", not "off"
+		assert.ErrorIs(t, r.GetFileSharing().Error, errSharingPanelUnavailable)
+	})
+
+	t.Run("systemctl non-zero exit means inactive, not an error", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"systemctl is-active -- systemd-resolved.service": {ExitStatus: 3, Stdout: "inactive\n"},
+		})
+		active, err := isSystemdUnitActive(rt, "systemd-resolved.service")
+		require.NoError(t, err)
+		assert.False(t, active)
+	})
+}

--- a/providers/os/resources/command_result_test.go
+++ b/providers/os/resources/command_result_test.go
@@ -231,15 +231,6 @@ func TestDeliberateNonZeroExitBranchesSurvive(t *testing.T) {
 		assert.Contains(t, err.Error(), "exit 5")
 	})
 
-	t.Run("mdadm non-zero exit means no arrays", func(t *testing.T) {
-		rt := commandRuntime(t, map[string]*mock.Command{
-			"mdadm --detail --scan": {ExitStatus: 1, Stderr: "mdadm: not found"},
-		})
-		v := mustResource(t, rt, "mdadm").(*mqlMdadm).GetArrays()
-		require.NoError(t, v.Error)
-		assert.Empty(t, v.Data)
-	})
-
 	t.Run("macos.sharing non-zero exit yields an empty panel", func(t *testing.T) {
 		rt := commandRuntime(t, map[string]*mock.Command{
 			systemProfilerSharingCmd: {ExitStatus: 1},

--- a/providers/os/resources/containerd.go
+++ b/providers/os/resources/containerd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kballard/go-shellquote"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/types"
 )
 
@@ -100,7 +101,10 @@ func (p *mqlContainerd) containers() ([]any, error) {
 	}
 
 	namespaces := parseNamespaceList(stdout)
-	var containers []any
+	containers := []any{}
+	// incomplete records that at least one namespace or container could not be
+	// read. Combined with an empty result it means "unknown", not "none".
+	incomplete := false
 
 	for _, ns := range namespaces {
 		if ns == "" {
@@ -113,6 +117,7 @@ func (p *mqlContainerd) containers() ([]any, error) {
 		})
 		if err != nil {
 			log.Debug().Str("namespace", ns).Err(err).Msg("skipping namespace, failed to create command")
+			incomplete = true
 			continue
 		}
 		cmd := o.(*mqlCommand)
@@ -122,6 +127,7 @@ func (p *mqlContainerd) containers() ([]any, error) {
 		}
 		if nsRun.exitcode != 0 {
 			log.Debug().Str("namespace", ns).Str("stderr", nsRun.stderr).Msg("skipping namespace, failed to list containers")
+			incomplete = true
 			continue
 		}
 
@@ -153,6 +159,7 @@ func (p *mqlContainerd) containers() ([]any, error) {
 			})
 			if err != nil {
 				log.Debug().Str("namespace", ns).Str("container", containerID).Err(err).Msg("skipping container, failed to create command")
+				incomplete = true
 				continue
 			}
 			cmd := o.(*mqlCommand)
@@ -162,6 +169,7 @@ func (p *mqlContainerd) containers() ([]any, error) {
 			}
 			if infoRun.exitcode != 0 {
 				log.Debug().Str("namespace", ns).Str("container", containerID).Str("stderr", infoRun.stderr).Msg("skipping container, failed to get info")
+				incomplete = true
 				continue
 			}
 
@@ -169,6 +177,7 @@ func (p *mqlContainerd) containers() ([]any, error) {
 			info, err := parseContainerInfo([]byte(infoRun.stdout))
 			if err != nil {
 				log.Debug().Str("namespace", ns).Str("container", containerID).Err(err).Msg("skipping container, failed to parse info")
+				incomplete = true
 				continue
 			}
 
@@ -206,6 +215,15 @@ func (p *mqlContainerd) containers() ([]any, error) {
 
 			containers = append(containers, containerRes.(*mqlContainerdContainer))
 		}
+	}
+
+	if len(containers) == 0 && incomplete {
+		// Every namespace or container we tried to read was skipped, so we
+		// measured nothing. An empty list would pass
+		// `containerd.containers.none(...)` on a host we never managed to
+		// inspect.
+		p.Containers.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
 	}
 
 	return containers, nil

--- a/providers/os/resources/containerd.go
+++ b/providers/os/resources/containerd.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -95,11 +94,12 @@ func (p *mqlContainerd) containers() ([]any, error) {
 		return nil, err
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return nil, errors.New("failed to list namespaces: " + cmd.Stderr.Data)
+	stdout, err := commandOutput(cmd, "ctr namespaces list")
+	if err != nil {
+		return nil, err
 	}
 
-	namespaces := parseNamespaceList(cmd.Stdout.Data)
+	namespaces := parseNamespaceList(stdout)
 	var containers []any
 
 	for _, ns := range namespaces {
@@ -116,12 +116,16 @@ func (p *mqlContainerd) containers() ([]any, error) {
 			continue
 		}
 		cmd := o.(*mqlCommand)
-		if exit := cmd.GetExitcode(); exit.Data != 0 {
-			log.Debug().Str("namespace", ns).Str("stderr", cmd.Stderr.Data).Msg("skipping namespace, failed to list containers")
+		nsRun, err := commandResult(cmd)
+		if err != nil {
+			return nil, err
+		}
+		if nsRun.exitcode != 0 {
+			log.Debug().Str("namespace", ns).Str("stderr", nsRun.stderr).Msg("skipping namespace, failed to list containers")
 			continue
 		}
 
-		containerIDs := parseContainerIDList(cmd.Stdout.Data)
+		containerIDs := parseContainerIDList(nsRun.stdout)
 
 		// Get tasks info for this namespace to map PIDs and status
 		var taskInfo map[string]taskData
@@ -131,8 +135,10 @@ func (p *mqlContainerd) containers() ([]any, error) {
 		})
 		if err == nil {
 			cmd := o.(*mqlCommand)
-			if exit := cmd.GetExitcode(); exit.Data == 0 {
-				taskInfo = parseTaskList(cmd.Stdout.Data)
+			// exitcode reads as 0 on a command that never ran; parsing that
+			// would report every container as taskless.
+			if taskRun, taskErr := commandResult(cmd); taskErr == nil && taskRun.exitcode == 0 {
+				taskInfo = parseTaskList(taskRun.stdout)
 			}
 		}
 
@@ -150,13 +156,17 @@ func (p *mqlContainerd) containers() ([]any, error) {
 				continue
 			}
 			cmd := o.(*mqlCommand)
-			if exit := cmd.GetExitcode(); exit.Data != 0 {
-				log.Debug().Str("namespace", ns).Str("container", containerID).Str("stderr", cmd.Stderr.Data).Msg("skipping container, failed to get info")
+			infoRun, err := commandResult(cmd)
+			if err != nil {
+				return nil, err
+			}
+			if infoRun.exitcode != 0 {
+				log.Debug().Str("namespace", ns).Str("container", containerID).Str("stderr", infoRun.stderr).Msg("skipping container, failed to get info")
 				continue
 			}
 
 			// Parse JSON output from ctr
-			info, err := parseContainerInfo([]byte(cmd.Stdout.Data))
+			info, err := parseContainerInfo([]byte(infoRun.stdout))
 			if err != nil {
 				log.Debug().Str("namespace", ns).Str("container", containerID).Err(err).Msg("skipping container, failed to parse info")
 				continue

--- a/providers/os/resources/firewalld.go
+++ b/providers/os/resources/firewalld.go
@@ -190,6 +190,11 @@ func (f *mqlFirewalld) zones() ([]any, error) {
 		return nil, err
 	}
 	if f.cacheStatus != "running" {
+		// firewall-cmd can only enumerate zones through a running daemon, so a
+		// stopped firewalld leaves the zone set unread. Returning an empty list
+		// would make `firewalld.zones.all(...)` and `.none(...)` pass
+		// vacuously on exactly the host whose firewall is off.
+		f.Zones.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 

--- a/providers/os/resources/firewalld.go
+++ b/providers/os/resources/firewalld.go
@@ -101,9 +101,13 @@ func (f *mqlFirewalld) fetchStatus() error {
 		return nil
 	}
 	cmd := o.(*mqlCommand)
-	exitcode := cmd.GetExitcode().Data
-	state := strings.TrimSpace(cmd.GetStdout().Data)
-	if exitcode != 0 {
+	run, err := commandResult(cmd)
+	if err != nil {
+		// A command that never ran is not evidence that firewalld is absent.
+		return fmt.Errorf("cannot determine firewalld state: %w", err)
+	}
+	state := strings.TrimSpace(run.stdout)
+	if run.exitcode != 0 {
 		// A refused question is not an answer. firewall-cmd exits non-zero both
 		// when the firewall is genuinely stopped and when polkit declines to
 		// answer an unprivileged caller. Recording the second as "not running"
@@ -111,7 +115,7 @@ func (f *mqlFirewalld) fetchStatus() error {
 		// returns nothing whenever the status is not "running", so every zone
 		// and every rule silently disappears from the scan and an exposure
 		// check finds nothing to object to.
-		if stderr := strings.TrimSpace(cmd.GetStderr().Data); isFirewalldAuthzError(stderr) {
+		if stderr := strings.TrimSpace(run.stderr); isFirewalldAuthzError(stderr) {
 			return fmt.Errorf("cannot determine firewalld state: %s", stderr)
 		}
 		f.cacheStatus = "not running"
@@ -133,10 +137,11 @@ func (f *mqlFirewalld) fetchStatus() error {
 		return err
 	}
 	cmd = o.(*mqlCommand)
-	if cmd.GetExitcode().Data != 0 {
-		return fmt.Errorf("firewall-cmd --get-default-zone failed: %s", cmd.Stderr.Data)
+	defaultZone, err := commandOutput(cmd, "firewall-cmd --get-default-zone")
+	if err != nil {
+		return err
 	}
-	f.cacheDefault = strings.TrimSpace(cmd.Stdout.Data)
+	f.cacheDefault = strings.TrimSpace(defaultZone)
 
 	f.fetched = true
 	return nil
@@ -195,11 +200,12 @@ func (f *mqlFirewalld) zones() ([]any, error) {
 		return nil, err
 	}
 	cmd := o.(*mqlCommand)
-	if cmd.GetExitcode().Data != 0 {
-		return nil, fmt.Errorf("firewall-cmd --list-all-zones failed: %s", cmd.Stderr.Data)
+	stdout, err := commandOutput(cmd, "firewall-cmd --list-all-zones")
+	if err != nil {
+		return nil, err
 	}
 
-	zones := parseFirewalldZones(cmd.Stdout.Data)
+	zones := parseFirewalldZones(stdout)
 
 	var res []any
 	for _, z := range zones {

--- a/providers/os/resources/list_unread_test.go
+++ b/providers/os/resources/list_unread_test.go
@@ -1,0 +1,176 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+)
+
+// A list accessor cannot express "unknown" by returning a nil slice: the
+// runtime writes StateIsSet with no StateIsNull, and TValue.ToDataRes then
+// serializes the nil slice as an empty array. Both `return nil, nil` and
+// `return []any{}, nil` reach the client as `[]`.
+//
+// That matters because for list assertions EMPTY is the unsafe state, not null.
+// `.none(...)` and `.all(...)` over an empty list are vacuously TRUE, so a host
+// where `semodule -l` or `mdadm --detail --scan` could not run used to PASS
+// every assertion over data nobody read. A null list fails those same
+// assertions.
+//
+// So each accessor below has to separate two cases that look identical in the
+// return value:
+//
+//   - we could not read      -> StateIsSet|StateIsNull, fails closed
+//   - we read, found nothing -> an empty list, a measured fact
+//
+// These tests pin both directions. Getting either one backwards is a bug.
+
+func TestUnreadListIsNull(t *testing.T) {
+	t.Run("mdadm.arrays: scan could not run", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"mdadm --detail --scan": {ExitStatus: 1, Stderr: "mdadm: not found"},
+		})
+		v := mustResource(t, rt, "mdadm").(*mqlMdadm).GetArrays()
+		require.NoError(t, v.Error)
+		assert.True(t, v.IsNull(), "a failed scan must not read as `no arrays`")
+	})
+
+	t.Run("mdadm.arrays: scan listed arrays but none could be read", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"mdadm --detail --scan":     {Stdout: "ARRAY /dev/md0 metadata=1.2 UUID=abc\n"},
+			`mdadm --detail "/dev/md0"`: {ExitStatus: 1, Stderr: "permission denied"},
+		})
+		v := mustResource(t, rt, "mdadm").(*mqlMdadm).GetArrays()
+		require.NoError(t, v.Error)
+		assert.True(t, v.IsNull(), "the scan found an array, so `no arrays` is false")
+	})
+
+	t.Run("selinux.modules: semodule could not run", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"semodule -l": {ExitStatus: 127, Stderr: "semodule: command not found"},
+		})
+		v := mustResource(t, rt, "selinux").(*mqlSelinux).GetModules()
+		require.NoError(t, v.Error)
+		assert.True(t, v.IsNull())
+	})
+
+	t.Run("selinux.modules: no command execution", func(t *testing.T) {
+		v := mustResource(t, noCommandRuntime(t), "selinux").(*mqlSelinux).GetModules()
+		require.NoError(t, v.Error)
+		assert.True(t, v.IsNull(), "an image scan never ran semodule")
+	})
+
+	t.Run("selinux.booleans: no source answered", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"getsebool -a": {ExitStatus: 127, Stderr: "getsebool: command not found"},
+		})
+		v := mustResource(t, rt, "selinux").(*mqlSelinux).GetBooleans()
+		require.NoError(t, v.Error)
+		assert.True(t, v.IsNull())
+	})
+
+	t.Run("firewalld.zones: daemon not running", func(t *testing.T) {
+		// firewall-cmd can only enumerate zones through a running daemon, so a
+		// stopped firewalld leaves the zone set unread rather than empty.
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"firewall-cmd --state": {ExitStatus: 252, Stderr: "not running"},
+		})
+		f := mustResource(t, rt, "firewalld").(*mqlFirewalld)
+		require.Equal(t, "not running", f.GetStatus().Data)
+		v := f.GetZones()
+		require.NoError(t, v.Error)
+		assert.True(t, v.IsNull())
+	})
+
+	t.Run("containerd.containers: every namespace refused", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"ctr namespaces list -q":            {Stdout: "default\n"},
+			"ctr -n default containers list -q": {ExitStatus: 1, Stderr: "permission denied"},
+		})
+		v := mustResource(t, rt, "containerd").(*mqlContainerd).GetContainers()
+		require.NoError(t, v.Error)
+		assert.True(t, v.IsNull(), "we listed no containers because we were refused, not because there are none")
+	})
+}
+
+func TestMeasuredEmptyListStaysEmpty(t *testing.T) {
+	t.Run("mdadm.arrays: scan ran and listed nothing", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"mdadm --detail --scan": {Stdout: ""},
+		})
+		v := mustResource(t, rt, "mdadm").(*mqlMdadm).GetArrays()
+		require.NoError(t, v.Error)
+		assert.False(t, v.IsNull(), "exit 0 with no ARRAY lines is a measured `no arrays`")
+		assert.Empty(t, v.Data)
+	})
+
+	t.Run("selinux.modules: semodule ran and listed nothing", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"semodule -l": {Stdout: "\n"},
+		})
+		v := mustResource(t, rt, "selinux").(*mqlSelinux).GetModules()
+		require.NoError(t, v.Error)
+		assert.False(t, v.IsNull())
+		assert.Empty(t, v.Data)
+	})
+
+	t.Run("containerd.containers: no namespaces", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"ctr namespaces list -q": {Stdout: ""},
+		})
+		v := mustResource(t, rt, "containerd").(*mqlContainerd).GetContainers()
+		require.NoError(t, v.Error)
+		assert.False(t, v.IsNull())
+		assert.Empty(t, v.Data)
+	})
+}
+
+func TestReadListIsPopulated(t *testing.T) {
+	t.Run("mdadm.arrays", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"mdadm --detail --scan": {Stdout: "ARRAY /dev/md0 metadata=1.2 UUID=abc\n"},
+			`mdadm --detail "/dev/md0"`: {Stdout: "" +
+				"/dev/md0:\n" +
+				"     Raid Level : raid1\n" +
+				"          State : clean\n" +
+				" Active Devices : 2\n"},
+		})
+		v := mustResource(t, rt, "mdadm").(*mqlMdadm).GetArrays()
+		require.NoError(t, v.Error)
+		require.False(t, v.IsNull())
+		require.Len(t, v.Data, 1)
+		arr := v.Data[0].(*mqlMdadmArray)
+		assert.Equal(t, "/dev/md0", arr.Name.Data)
+		assert.Equal(t, "raid1", arr.Level.Data)
+		assert.Equal(t, "clean", arr.State.Data)
+	})
+
+	t.Run("selinux.modules", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"semodule -l": {Stdout: "100 zebra enabled\n200 apache disabled\n"},
+		})
+		v := mustResource(t, rt, "selinux").(*mqlSelinux).GetModules()
+		require.NoError(t, v.Error)
+		require.False(t, v.IsNull())
+		require.Len(t, v.Data, 2)
+		assert.Equal(t, "zebra", v.Data[0].(*mqlSelinuxModule).Name.Data)
+		assert.Equal(t, "disabled", v.Data[1].(*mqlSelinuxModule).Status.Data)
+	})
+
+	t.Run("selinux.booleans", func(t *testing.T) {
+		rt := commandRuntime(t, map[string]*mock.Command{
+			"getsebool -a": {Stdout: "httpd_can_network_connect --> on\nhttpd_enable_cgi --> off\n"},
+		})
+		v := mustResource(t, rt, "selinux").(*mqlSelinux).GetBooleans()
+		require.NoError(t, v.Error)
+		require.False(t, v.IsNull())
+		require.Len(t, v.Data, 2)
+		assert.True(t, v.Data[0].(*mqlSelinuxBoolean).Value.Data)
+		assert.False(t, v.Data[1].(*mqlSelinuxBoolean).Value.Data)
+	})
+}

--- a/providers/os/resources/lsblk.go
+++ b/providers/os/resources/lsblk.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"encoding/json"
-	"errors"
 	"slices"
 
 	"go.mondoo.com/mql/llx"
@@ -24,11 +23,12 @@ func (l *mqlLsblk) list() ([]any, error) {
 		return nil, err
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return nil, errors.New("could not retrieve lsblk: " + cmd.Stderr.Data)
+	stdout, err := commandOutput(cmd, "lsblk")
+	if err != nil {
+		return nil, err
 	}
 
-	blockEntries, err := parseBlockEntries([]byte(cmd.Stdout.Data))
+	blockEntries, err := parseBlockEntries([]byte(stdout))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/resources/luks.go
+++ b/providers/os/resources/luks.go
@@ -44,11 +44,12 @@ func (l *mqlLuks) volumes() ([]any, error) {
 		return nil, err
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return nil, errors.New("lsblk failed: " + cmd.Stderr.Data)
+	stdout, err := commandOutput(cmd, "lsblk")
+	if err != nil {
+		return nil, err
 	}
 
-	parsed, err := parseBlockEntries([]byte(cmd.Stdout.Data))
+	parsed, err := parseBlockEntries([]byte(stdout))
 	if err != nil {
 		return nil, err
 	}
@@ -107,10 +108,11 @@ func runLuksDump(runtime *plugin.Runtime, device string) (luksDump, error) {
 		return luksDump{}, err
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return luksDump{}, errors.New("cryptsetup luksDump failed: " + cmd.Stderr.Data)
+	stdout, err := commandOutput(cmd, "cryptsetup luksDump")
+	if err != nil {
+		return luksDump{}, err
 	}
-	return parseLuksDump(cmd.Stdout.Data)
+	return parseLuksDump(stdout)
 }
 
 func newLuksVolume(runtime *plugin.Runtime, device string, dump luksDump) (*mqlLuksVolume, error) {

--- a/providers/os/resources/lvm.go
+++ b/providers/os/resources/lvm.go
@@ -132,16 +132,18 @@ func (l *mqlLvm) runLvmReport(cmdline string) (string, bool, error) {
 		return "", false, err
 	}
 	cmd := o.(*mqlCommand)
-	exit := cmd.GetExitcode()
-	if exit.Data == 0 {
-		return cmd.Stdout.Data, true, nil
+	run, err := commandResult(cmd)
+	if err != nil {
+		return "", false, err
+	}
+	if run.exitcode == 0 {
+		return run.stdout, true, nil
 	}
 
-	stderr := cmd.Stderr.Data
-	if isLvmNotInstalled(exit.Data, stderr) {
+	if isLvmNotInstalled(run.exitcode, run.stderr) {
 		return "", false, nil
 	}
-	return "", false, fmt.Errorf("lvm command failed (exit %d): %s", exit.Data, strings.TrimSpace(stderr))
+	return "", false, fmt.Errorf("lvm command failed (exit %d): %s", run.exitcode, strings.TrimSpace(run.stderr))
 }
 
 // isLvmNotInstalled reports whether the failure of an lvm reporting command

--- a/providers/os/resources/macos_filevault.go
+++ b/providers/os/resources/macos_filevault.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"errors"
 	"strings"
 	"sync"
 
@@ -34,11 +33,12 @@ func (m *mqlMacosFilevault) fetchStatus() (string, error) {
 		return "", err
 	}
 	cmd := res.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return "", errors.New("fdesetup status failed: " + cmd.GetStderr().Data)
+	stdout, err := commandOutput(cmd, "fdesetup status")
+	if err != nil {
+		return "", err
 	}
 
-	m.output = parseFdesetupStatus(cmd.GetStdout().Data)
+	m.output = parseFdesetupStatus(stdout)
 	m.fetched = true
 	return m.output, nil
 }
@@ -111,10 +111,11 @@ func (m *mqlMacosFilevault) runFdesetup(subcmd string) (string, error) {
 		return "", err
 	}
 	cmd := res.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return "", errors.New("fdesetup " + subcmd + " failed: " + cmd.GetStderr().Data)
+	stdout, err := commandOutput(cmd, "fdesetup "+subcmd)
+	if err != nil {
+		return "", err
 	}
-	return strings.TrimSpace(cmd.GetStdout().Data), nil
+	return strings.TrimSpace(stdout), nil
 }
 
 func (m *mqlMacosFilevault) hasPersonalRecoveryKey() (bool, error) {

--- a/providers/os/resources/macos_firewall_live.go
+++ b/providers/os/resources/macos_firewall_live.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"errors"
-	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -41,10 +40,7 @@ func (m *mqlMacosFirewall) runSocketfilterfw(flag string) (string, error) {
 		return "", err
 	}
 	cmd := res.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return "", fmt.Errorf("socketfilterfw %s failed: %s", flag, cmd.GetStderr().Data)
-	}
-	return cmd.GetStdout().Data, nil
+	return commandOutput(cmd, "socketfilterfw "+flag)
 }
 
 // parseGlobalState reads the numeric state out of --getglobalstate output.

--- a/providers/os/resources/macos_gatekeeper.go
+++ b/providers/os/resources/macos_gatekeeper.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"errors"
 	"strings"
 	"sync"
 
@@ -34,11 +33,12 @@ func (m *mqlMacosGatekeeper) fetchStatus() (string, error) {
 		return "", err
 	}
 	cmd := res.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return "", errors.New("spctl --status failed: " + cmd.GetStderr().Data)
+	stdout, err := commandOutput(cmd, "spctl --status")
+	if err != nil {
+		return "", err
 	}
 
-	m.output = parseSpctlStatus(cmd.GetStdout().Data)
+	m.output = parseSpctlStatus(stdout)
 	m.fetched = true
 	return m.output, nil
 }

--- a/providers/os/resources/macos_mdm.go
+++ b/providers/os/resources/macos_mdm.go
@@ -72,11 +72,12 @@ func (m *mqlMacosMdm) fetchEnrollment() (mdmEnrollment, error) {
 		return mdmEnrollment{}, err
 	}
 	cmd := res.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return mdmEnrollment{}, errors.New("profiles status failed: " + cmd.GetStderr().Data)
+	stdout, err := commandOutput(cmd, "profiles status")
+	if err != nil {
+		return mdmEnrollment{}, err
 	}
 
-	m.state = parseMdmEnrollment(cmd.GetStdout().Data)
+	m.state = parseMdmEnrollment(stdout)
 	m.fetched = true
 	return m.state, nil
 }
@@ -170,13 +171,17 @@ func (p *mqlMacosProfiles) list() ([]any, error) {
 		return nil, err
 	}
 	cmd := res.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
+	run, err := commandResult(cmd)
+	if err != nil {
+		return nil, err
+	}
+	if run.exitcode != 0 {
 		// `profiles list` exits non-zero on argument errors (missing
 		// action, unknown flag) — surface those as real errors so
 		// authors notice when the command shape changes upstream.
-		stderr := strings.TrimSpace(cmd.GetStderr().Data)
+		stderr := strings.TrimSpace(run.stderr)
 		if stderr == "" {
-			stderr = strings.TrimSpace(cmd.GetStdout().Data)
+			stderr = strings.TrimSpace(run.stdout)
 		}
 		return nil, errors.New("profiles list failed: " + stderr)
 	}
@@ -186,7 +191,7 @@ func (p *mqlMacosProfiles) list() ([]any, error) {
 	// "profiles: this command requires root privileges" to stdout
 	// instead of failing. Detect that diagnostic up front so callers
 	// don't see a misleading XML parse error.
-	stdout := cmd.GetStdout().Data
+	stdout := run.stdout
 	trimmed := strings.TrimSpace(stdout)
 	if strings.HasPrefix(trimmed, "profiles:") {
 		return nil, errors.New("profiles list failed: " + trimmed)

--- a/providers/os/resources/macos_sharing.go
+++ b/providers/os/resources/macos_sharing.go
@@ -53,13 +53,20 @@ func (s *mqlMacosSharing) fetchState() (map[string]bool, error) {
 		return nil, err
 	}
 	cmd := res.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
+	run, err := commandResult(cmd)
+	if err != nil {
+		return nil, err
+	}
+	if run.exitcode != 0 {
+		// system_profiler exits non-zero on releases that dropped
+		// SPSharingDataType; that is a genuine "no sharing services
+		// reported", unlike a command that never ran.
 		s.state = map[string]bool{}
 		s.fetched = true
 		return s.state, nil
 	}
 
-	s.state = parseSharingOutput(cmd.GetStdout().Data)
+	s.state = parseSharingOutput(run.stdout)
 	s.fetched = true
 	return s.state, nil
 }

--- a/providers/os/resources/macos_sip.go
+++ b/providers/os/resources/macos_sip.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"errors"
 	"strings"
 	"sync"
 
@@ -34,15 +33,16 @@ func (m *mqlMacosSip) fetchStatus() (string, error) {
 		return "", err
 	}
 	cmd := res.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return "", errors.New("csrutil status failed: " + cmd.GetStderr().Data)
+	stdout, err := commandOutput(cmd, "csrutil status")
+	if err != nil {
+		return "", err
 	}
 
 	// csrutil status outputs:
 	// "System Integrity Protection status: enabled."
 	// "System Integrity Protection status: disabled."
 	// May also include individual configuration flags on separate lines
-	output := strings.TrimSpace(cmd.GetStdout().Data)
+	output := strings.TrimSpace(stdout)
 	lines := strings.SplitN(output, "\n", 2)
 
 	m.output = strings.TrimSpace(lines[0])

--- a/providers/os/resources/macos_softwareupdate.go
+++ b/providers/os/resources/macos_softwareupdate.go
@@ -150,10 +150,14 @@ func (s *mqlMacosSoftwareupdate) scheduleEnabled() (bool, error) {
 		return false, err
 	}
 	cmd := res.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
+	run, err := commandResult(cmd)
+	if err != nil {
+		return false, err
+	}
+	if run.exitcode != 0 {
 		return false, errUpdateScheduleUnavailable
 	}
-	v, ok := parseSoftwareUpdateSchedule(cmd.GetStdout().Data)
+	v, ok := parseSoftwareUpdateSchedule(run.stdout)
 	if !ok {
 		return false, errUpdateScheduleUnavailable
 	}
@@ -228,10 +232,13 @@ func (s *mqlMacosSoftwareupdate) updates() ([]any, error) {
 		return nil, err
 	}
 	cmd := res.(*mqlCommand)
-	exit := cmd.GetExitcode()
-	stdout := cmd.GetStdout().Data
-	stderr := cmd.GetStderr().Data
-	if exit.Data != 0 {
+	run, err := commandResult(cmd)
+	if err != nil {
+		return nil, err
+	}
+	stdout := run.stdout
+	stderr := run.stderr
+	if run.exitcode != 0 {
 		// softwareupdate exits non-zero on Darwin in two well-known
 		// "no updates" situations that should still return an empty
 		// list rather than fail the query:
@@ -245,13 +252,13 @@ func (s *mqlMacosSoftwareupdate) updates() ([]any, error) {
 		// a clean device.
 		if isSoftwareUpdateNoUpdatesSignal(stdout, stderr) {
 			log.Debug().
-				Int64("exitcode", exit.Data).
+				Int64("exitcode", run.exitcode).
 				Str("stderr", stderr).
 				Msg("macos.softwareupdate: no updates available")
 			return []any{}, nil
 		}
 		log.Warn().
-			Int64("exitcode", exit.Data).
+			Int64("exitcode", run.exitcode).
 			Str("stderr", stderr).
 			Msg("macos.softwareupdate: `softwareupdate -l --no-scan` failed")
 		return nil, errors.New("softwareupdate failed: " + strings.TrimSpace(stderr))

--- a/providers/os/resources/mdadm.go
+++ b/providers/os/resources/mdadm.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 )
 
 // validMdDevicePath matches standard md device paths like /dev/md0, /dev/md127, /dev/md/name
@@ -42,16 +43,23 @@ func (m *mqlMdadm) arrays() ([]any, error) {
 		return nil, err
 	}
 	if run.exitcode != 0 {
-		// mdadm not installed or no arrays
-		return []any{}, nil
+		// mdadm is absent or refused to answer. That is not the same as a host
+		// with no RAID arrays: an empty list is vacuously true for
+		// `mdadm.arrays.none(...)` and `mdadm.arrays.all(...)`, so a scan that
+		// could not run would silently pass every array assertion. Report the
+		// arrays as unknown instead.
+		m.Arrays.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
 	}
 
 	arrayNames := parseMdadmScan(run.stdout)
 	if len(arrayNames) == 0 {
+		// The scan ran and listed nothing. This one is a measured fact, so it
+		// stays an empty list.
 		return []any{}, nil
 	}
 
-	var results []any
+	results := make([]any, 0, len(arrayNames))
 	for _, name := range arrayNames {
 		if !validMdDevicePath.MatchString(name) {
 			continue
@@ -93,6 +101,13 @@ func (m *mqlMdadm) arrays() ([]any, error) {
 		mqlArr.cachedDevices = arr.devices
 
 		results = append(results, mqlArray)
+	}
+	if len(results) == 0 {
+		// The scan named arrays but `mdadm --detail` answered for none of them.
+		// Reporting that as "no arrays" would hide the very arrays the scan
+		// just found.
+		m.Arrays.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
 	}
 	return results, nil
 }

--- a/providers/os/resources/mdadm.go
+++ b/providers/os/resources/mdadm.go
@@ -37,12 +37,16 @@ func (m *mqlMdadm) arrays() ([]any, error) {
 		return nil, err
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
+	run, err := commandResult(cmd)
+	if err != nil {
+		return nil, err
+	}
+	if run.exitcode != 0 {
 		// mdadm not installed or no arrays
 		return []any{}, nil
 	}
 
-	arrayNames := parseMdadmScan(cmd.Stdout.Data)
+	arrayNames := parseMdadmScan(run.stdout)
 	if len(arrayNames) == 0 {
 		return []any{}, nil
 	}
@@ -59,11 +63,15 @@ func (m *mqlMdadm) arrays() ([]any, error) {
 			return nil, err
 		}
 		detail := o.(*mqlCommand)
-		if detail.GetExitcode().Data != 0 {
+		detailRun, err := commandResult(detail)
+		if err != nil {
+			return nil, err
+		}
+		if detailRun.exitcode != 0 {
 			continue
 		}
 
-		arr := parseMdadmDetail(detail.Stdout.Data)
+		arr := parseMdadmDetail(detailRun.stdout)
 
 		mqlArray, err := CreateResource(m.MqlRuntime, "mdadm.array", map[string]*llx.RawData{
 			"name":           llx.StringData(name),

--- a/providers/os/resources/mount.go
+++ b/providers/os/resources/mount.go
@@ -135,15 +135,19 @@ func (m *mqlMount) fetchDfEntries() (map[string]*mount.DfEntry, error) {
 		return m.dfEntries, nil
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
+	run, err := commandResult(cmd)
+	if err != nil {
+		return nil, err
+	}
+	if run.exitcode != 0 {
 		// df failed (not installed, no permission, etc.) — return empty, not error
-		log.Debug().Str("stderr", cmd.Stderr.Data).Msg("mql[mount]> df command failed")
+		log.Debug().Str("stderr", run.stderr).Msg("mql[mount]> df command failed")
 		m.dfEntries = map[string]*mount.DfEntry{}
 		m.dfFetched = true
 		return m.dfEntries, nil
 	}
 
-	m.dfEntries = mount.ParseDf(strings.NewReader(cmd.Stdout.Data))
+	m.dfEntries = mount.ParseDf(strings.NewReader(run.stdout))
 	m.dfFetched = true
 	return m.dfEntries, nil
 }

--- a/providers/os/resources/nftables.go
+++ b/providers/os/resources/nftables.go
@@ -318,11 +318,15 @@ func (n *mqlNftables) fetchRuleset() (*nftRuleset, error) {
 		return nil, err
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return nil, fmt.Errorf("nft command failed (exit %d): %s", exit.Data, cmd.Stderr.Data)
+	run, err := commandResult(cmd)
+	if err != nil {
+		return nil, err
+	}
+	if run.exitcode != 0 {
+		return nil, fmt.Errorf("nft command failed (exit %d): %s", run.exitcode, run.stderr)
 	}
 
-	ruleset, err := parseNftRuleset([]byte(cmd.Stdout.Data))
+	ruleset, err := parseNftRuleset([]byte(run.stdout))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/resources/selinux.go
+++ b/providers/os/resources/selinux.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/afero"
 	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers/os/connection/shared"
 )
 
@@ -241,9 +242,17 @@ func ParseGetsebool(output string) []SELinuxBool {
 func (s *mqlSelinux) booleans() ([]any, error) {
 	conn, ok := s.MqlRuntime.Connection.(shared.Connection)
 	if !ok {
+		// Nothing was read. An empty list would be worse than no list at all:
+		// `booleans.none(...)` and `booleans.all(...)` are vacuously true over
+		// an empty list, so an unreadable host would pass every assertion. A
+		// null list fails them instead.
+		s.Booleans.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 
+	// read records whether a source answered at all, which is not the same as
+	// whether it answered with entries.
+	read := false
 	var parsed []SELinuxBool
 	if conn.Capabilities().Has(shared.Capability_RunCommand) {
 		o, err := CreateResource(s.MqlRuntime, "command", map[string]*llx.RawData{
@@ -256,17 +265,24 @@ func (s *mqlSelinux) booleans() ([]any, error) {
 			// also skip the /sys/fs/selinux fallback below.
 			if run, cmdErr := commandResult(cmd); cmdErr == nil && run.exitcode == 0 {
 				parsed = ParseGetsebool(run.stdout)
+				read = true
 			}
 		}
 	}
 
 	// Fall back to /sys/fs/selinux/booleans/ directory (each file contains
 	// "1" or "0" for the boolean's current value)
-	if parsed == nil {
-		parsed = readSelinuxBooleansFromFS(conn.FileSystem())
+	if len(parsed) == 0 {
+		if fsBools, fsRead := readSelinuxBooleansFromFS(conn.FileSystem()); fsRead {
+			parsed = fsBools
+			read = true
+		}
 	}
 
-	if parsed == nil {
+	if !read {
+		// Neither getsebool nor selinuxfs answered, so the boolean set is
+		// unknown rather than empty.
+		s.Booleans.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 
@@ -286,11 +302,15 @@ func (s *mqlSelinux) booleans() ([]any, error) {
 
 // readSelinuxBooleansFromFS reads boolean values from /sys/fs/selinux/booleans/.
 // Each file in that directory contains "1" (on) or "0" (off).
-func readSelinuxBooleansFromFS(fs afero.Fs) []SELinuxBool {
+//
+// The second return value reports whether the directory could be read at all.
+// It separates "selinuxfs is not mounted, so we know nothing" from "selinuxfs
+// is mounted and exposes no booleans", which the slice alone cannot express.
+func readSelinuxBooleansFromFS(fs afero.Fs) ([]SELinuxBool, bool) {
 	const dir = "/sys/fs/selinux/booleans"
 	entries, err := afero.ReadDir(fs, dir)
 	if err != nil {
-		return nil
+		return nil, false
 	}
 	var bools []SELinuxBool
 	for _, entry := range entries {
@@ -307,7 +327,7 @@ func readSelinuxBooleansFromFS(fs afero.Fs) []SELinuxBool {
 			Value: val == "1",
 		})
 	}
-	return bools
+	return bools, true
 }
 
 // SELinuxModule represents a parsed semodule entry.
@@ -367,6 +387,10 @@ func ParseSemodule(output string) []SELinuxModule {
 func (s *mqlSelinux) modules() ([]any, error) {
 	conn, ok := s.MqlRuntime.Connection.(shared.Connection)
 	if !ok || !conn.Capabilities().Has(shared.Capability_RunCommand) {
+		// Without command execution the module list was never read. An empty
+		// list is vacuously true for `modules.none(...)` and `modules.all(...)`,
+		// so report nothing rather than a measurement we never made.
+		s.Modules.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 
@@ -382,6 +406,9 @@ func (s *mqlSelinux) modules() ([]any, error) {
 		return nil, err
 	}
 	if run.exitcode != 0 {
+		// semodule is absent or refused to answer, so the loaded modules are
+		// unknown. Only an exit code of 0 licenses an empty list.
+		s.Modules.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 

--- a/providers/os/resources/selinux.go
+++ b/providers/os/resources/selinux.go
@@ -65,14 +65,18 @@ func (s *mqlSelinux) fetchGetenforce() (available bool, mode string, err error) 
 		return false, "", err
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
+	run, cmdErr := commandResult(cmd)
+	if cmdErr != nil || run.exitcode != 0 {
+		// Either getenforce is absent or the command never ran. Both mean we
+		// have no runtime mode to report, so fall through to the
+		// /etc/selinux/config read rather than claiming one we never measured.
 		s.getenforced = true
 		s.getenforceAvail = false
 		return false, "", nil
 	}
 
 	s.getenforceAvail = true
-	s.getenforceMode = strings.ToLower(strings.TrimSpace(cmd.Stdout.Data))
+	s.getenforceMode = strings.ToLower(strings.TrimSpace(run.stdout))
 	s.getenforced = true
 	return s.getenforceAvail, s.getenforceMode, nil
 }
@@ -247,8 +251,11 @@ func (s *mqlSelinux) booleans() ([]any, error) {
 		})
 		if err == nil {
 			cmd := o.(*mqlCommand)
-			if exit := cmd.GetExitcode(); exit.Data == 0 {
-				parsed = ParseGetsebool(cmd.Stdout.Data)
+			// exitcode reads as 0 on a command that never ran, so an errored
+			// result must not be parsed as an empty boolean list -- that would
+			// also skip the /sys/fs/selinux fallback below.
+			if run, cmdErr := commandResult(cmd); cmdErr == nil && run.exitcode == 0 {
+				parsed = ParseGetsebool(run.stdout)
 			}
 		}
 	}
@@ -370,11 +377,15 @@ func (s *mqlSelinux) modules() ([]any, error) {
 		return nil, err
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
+	run, err := commandResult(cmd)
+	if err != nil {
+		return nil, err
+	}
+	if run.exitcode != 0 {
 		return nil, nil
 	}
 
-	parsed := ParseSemodule(cmd.Stdout.Data)
+	parsed := ParseSemodule(run.stdout)
 	res := make([]any, 0, len(parsed))
 	for _, m := range parsed {
 		r, err := CreateResource(s.MqlRuntime, "selinux.module", map[string]*llx.RawData{

--- a/providers/os/resources/selinux_test.go
+++ b/providers/os/resources/selinux_test.go
@@ -133,7 +133,8 @@ func TestReadSelinuxBooleansFromFS(t *testing.T) {
 		_ = afero.WriteFile(fs, "/sys/fs/selinux/booleans/httpd_enable_cgi", []byte("0"), 0o444)
 		_ = afero.WriteFile(fs, "/sys/fs/selinux/booleans/virt_sandbox_use_all_caps", []byte("0\n"), 0o444)
 
-		bools := readSelinuxBooleansFromFS(fs)
+		bools, read := readSelinuxBooleansFromFS(fs)
+		require.True(t, read)
 		require.Len(t, bools, 3)
 
 		// afero.ReadDir returns sorted entries
@@ -145,16 +146,22 @@ func TestReadSelinuxBooleansFromFS(t *testing.T) {
 		require.False(t, bools[2].Value)
 	})
 
-	t.Run("missing directory returns nil", func(t *testing.T) {
+	// A missing directory and an empty one are different answers: the first
+	// means selinuxfs was never readable, the second that it is mounted and
+	// reports no booleans. selinux.booleans turns the first into a null list
+	// and the second into an empty one, so the bool has to distinguish them.
+	t.Run("missing directory reports not read", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		bools := readSelinuxBooleansFromFS(fs)
+		bools, read := readSelinuxBooleansFromFS(fs)
+		require.False(t, read)
 		require.Nil(t, bools)
 	})
 
-	t.Run("empty directory returns nil", func(t *testing.T) {
+	t.Run("empty directory reports read with no booleans", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		_ = fs.MkdirAll("/sys/fs/selinux/booleans", 0o755)
-		bools := readSelinuxBooleansFromFS(fs)
-		require.Nil(t, bools)
+		bools, read := readSelinuxBooleansFromFS(fs)
+		require.True(t, read)
+		require.Empty(t, bools)
 	})
 }

--- a/providers/os/resources/systemd_resolved.go
+++ b/providers/os/resources/systemd_resolved.go
@@ -329,5 +329,9 @@ func isSystemdUnitActive(runtime *plugin.Runtime, unit string) (bool, error) {
 		return false, err
 	}
 	cmd := o.(*mqlCommand)
-	return cmd.GetExitcode().Data == 0, nil
+	run, err := commandResult(cmd)
+	if err != nil {
+		return false, err
+	}
+	return run.exitcode == 0, nil
 }

--- a/providers/os/resources/systemd_target.go
+++ b/providers/os/resources/systemd_target.go
@@ -251,10 +251,14 @@ func runSystemctl(runtime *plugin.Runtime, cmdline string) (string, bool, error)
 		return "", false, err
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
+	run, err := commandResult(cmd)
+	if err != nil {
+		return "", false, err
+	}
+	if run.exitcode != 0 {
 		return "", false, nil
 	}
-	return cmd.Stdout.Data, true, nil
+	return run.stdout, true, nil
 }
 
 // shellQuoteUnit single-quotes a unit name for safe inclusion in a shell

--- a/providers/os/resources/tool_package.go
+++ b/providers/os/resources/tool_package.go
@@ -350,10 +350,11 @@ func inferCodexVersion(runtime *plugin.Runtime, configPath string) (string, erro
 		return "", nil
 	}
 	cmd := o.(*mqlCommand)
-	if cmd.GetExitcode().Data != 0 {
+	run, err := commandResult(cmd)
+	if err != nil || run.exitcode != 0 {
 		return "", nil
 	}
-	for _, field := range strings.Fields(cmd.GetStdout().Data) {
+	for _, field := range strings.Fields(run.stdout) {
 		// Validate with MQL's semver parser instead of a bespoke regex. The
 		// parser exposes only Compare, so we parse by self-compare: a valid
 		// version compares against itself without error.
@@ -377,10 +378,11 @@ func inferClaudeVersion(runtime *plugin.Runtime, configPath string) (string, err
 		return "", nil
 	}
 	cmd := o.(*mqlCommand)
-	if cmd.GetExitcode().Data != 0 {
+	run, err := commandResult(cmd)
+	if err != nil || run.exitcode != 0 {
 		return "", nil
 	}
-	fields := strings.Fields(cmd.GetStdout().Data)
+	fields := strings.Fields(run.stdout)
 	if len(fields) == 0 {
 		return "", nil
 	}

--- a/providers/os/resources/user.go
+++ b/providers/os/resources/user.go
@@ -227,12 +227,16 @@ func loggedInUsers(runtime *plugin.Runtime, conn shared.Connection) (map[string]
 		return nil, err
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
+	run, err := commandResult(cmd)
+	if err != nil {
+		return nil, err
+	}
+	if run.exitcode != 0 {
 		return map[string]bool{}, nil
 	}
 
 	users := map[string]bool{}
-	for i, line := range strings.Split(cmd.Stdout.Data, "\n") {
+	for i, line := range strings.Split(run.stdout, "\n") {
 		// Skip header row from "query user" on Windows
 		if isWindows && i == 0 {
 			continue

--- a/providers/os/resources/windows_auditpolicy.go
+++ b/providers/os/resources/windows_auditpolicy.go
@@ -29,7 +29,11 @@ func fetchAuditpolEntries(runtime *plugin.Runtime) ([]windows.AuditpolEntry, err
 	if out.Error != nil {
 		return nil, fmt.Errorf("could not run auditpol: %w", out.Error)
 	}
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
+	exit := cmd.GetExitcode()
+	if exit.Error != nil {
+		return nil, fmt.Errorf("could not run auditpol: %w", exit.Error)
+	}
+	if exit.Data != 0 {
 		return nil, fmt.Errorf("could not run auditpol: %s", strings.TrimSpace(cmd.Stderr.Data))
 	}
 

--- a/providers/os/resources/yum.go
+++ b/providers/os/resources/yum.go
@@ -38,11 +38,12 @@ func (y *mqlYum) repos() ([]any, error) {
 		return nil, err
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return nil, errors.New("could not retrieve yum repo list")
+	stdout, err := commandOutput(cmd, "yum -v repolist all")
+	if err != nil {
+		return nil, err
 	}
 
-	repos, err := yum.ParseRepos(strings.NewReader(cmd.Stdout.Data))
+	repos, err := yum.ParseRepos(strings.NewReader(stdout))
 	if err != nil {
 		return nil, err
 	}
@@ -106,11 +107,12 @@ func (y *mqlYum) vars() (map[string]any, error) {
 		return nil, err
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return nil, errors.New("could not retrieve yum repo list")
+	stdout, err := commandOutput(cmd, "yum repo variables")
+	if err != nil {
+		return nil, err
 	}
 
-	vars, err := yum.ParseVariables(strings.NewReader(cmd.Stdout.Data))
+	vars, err := yum.ParseVariables(strings.NewReader(stdout))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/resources/zfs.go
+++ b/providers/os/resources/zfs.go
@@ -32,10 +32,11 @@ func (z *mqlZfs) version() (string, error) {
 		return "", err
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return "", errors.New("could not retrieve zfs version: " + cmd.Stderr.Data)
+	stdout, err := commandOutput(cmd, "zfs version")
+	if err != nil {
+		return "", err
 	}
-	version := strings.TrimSpace(cmd.Stdout.Data)
+	version := strings.TrimSpace(stdout)
 	if i := strings.IndexByte(version, '\n'); i != -1 {
 		version = version[:i]
 	}
@@ -50,11 +51,12 @@ func (z *mqlZfs) pools() ([]any, error) {
 		return nil, err
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return nil, errors.New("could not retrieve zfs pools: " + cmd.Stderr.Data)
+	stdout, err := commandOutput(cmd, "zpool get")
+	if err != nil {
+		return nil, err
 	}
 
-	pools, err := zfs.ParsePools(cmd.Stdout.Data)
+	pools, err := zfs.ParsePools(stdout)
 	if err != nil {
 		return nil, err
 	}
@@ -92,11 +94,12 @@ func (z *mqlZfs) datasets() ([]any, error) {
 		return nil, err
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return nil, errors.New("could not retrieve zfs datasets: " + cmd.Stderr.Data)
+	stdout, err := commandOutput(cmd, "zfs get")
+	if err != nil {
+		return nil, err
 	}
 
-	datasets, err := zfs.ParseDatasets(cmd.Stdout.Data)
+	datasets, err := zfs.ParseDatasets(stdout)
 	if err != nil {
 		return nil, err
 	}
@@ -180,11 +183,12 @@ func (p *mqlZfsPool) vdevs() ([]any, error) {
 		return nil, err
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return nil, errors.New("could not retrieve zfs pool vdevs: " + cmd.Stderr.Data)
+	stdout, err := commandOutput(cmd, "zpool status")
+	if err != nil {
+		return nil, err
 	}
 
-	vdevs, err := zfs.ParseVdevs(cmd.Stdout.Data)
+	vdevs, err := zfs.ParseVdevs(stdout)
 	if err != nil {
 		return nil, err
 	}
@@ -243,11 +247,12 @@ func (p *mqlZfsPool) properties() (map[string]any, error) {
 		return nil, err
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return nil, errors.New("could not retrieve zfs pool properties: " + cmd.Stderr.Data)
+	stdout, err := commandOutput(cmd, "zpool get")
+	if err != nil {
+		return nil, err
 	}
 
-	props, err := zfs.ParseProperties(cmd.Stdout.Data)
+	props, err := zfs.ParseProperties(stdout)
 	if err != nil {
 		return nil, err
 	}
@@ -311,11 +316,12 @@ func (d *mqlZfsDataset) properties() (map[string]any, error) {
 		return nil, err
 	}
 	cmd := o.(*mqlCommand)
-	if exit := cmd.GetExitcode(); exit.Data != 0 {
-		return nil, errors.New("could not retrieve zfs dataset properties: " + cmd.Stderr.Data)
+	stdout, err := commandOutput(cmd, "zfs get")
+	if err != nil {
+		return nil, err
 	}
 
-	props, err := zfs.ParseProperties(cmd.Stdout.Data)
+	props, err := zfs.ParseProperties(stdout)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Security impact

On any target without command execution — a container image, a mounted volume, a tar or filesystem scan, all first-class mql use cases — three of macOS's most load-bearing controls reported themselves **disabled**:

| query | `mql run filesystem <debian:13 rootfs>` before | after |
|---|---|---|
| `macos.filevault.enabled` | **`false`** | error: `provider does not implement RunCommand` |
| `macos.gatekeeper.enabled` | **`false`** | error |
| `macos.sip.enabled` | **`false`** | error |
| `macos.filevault.status` | **`""`** | error |
| `zfs.pools.length` | **`0`** | error |

This is worse than a null. v14 already makes a null operand of `&&`/`||` falsy, so an unread field fails its check and the report says so. A concrete `false` reads as a measured fact: FileVault is off, Gatekeeper is off, SIP is off — on a Linux image where none of those were ever asked.

`mdadm.arrays` returned `[]` ("no RAID arrays"), `mount.point.size/used/available` came back null from a `df` that was never run, and `containerd`'s task list reported every container as taskless. Same shape, same cause.

## Cause

`command.exitcode` is a `plugin.TValue[int64]`. Its `Data` is meaningless unless `Error` is nil, and `command.execute` sets exactly that when the connection has no `RunCommand`:

```go
c.Exitcode = plugin.TValue[int64]{Error: err, State: plugin.StateIsSet}   // Data stays 0
```

37 call sites read `.Data` and never `.Error`. Exit code 0 with empty stdout is indistinguishable from a command that succeeded and printed nothing, so the guard passed, the empty output got parsed, and the caller returned a confident zero value.

The `command` resource is not at fault — it reports the condition on all three of its fields. Every consumer that ignored `.Error` discarded it.

Both comparison directions were affected: `exit.Data != 0` failed to fire on an errored command, and `exit.Data == 0` (`selinux.booleans`, containerd's task list) fired when it should not have.

## Fix

Two helpers in `providers/os/resources/command.go`:

- `commandResult(cmd) (commandRun, error)` — errors when the command could not run; otherwise returns exit code, stdout and stderr. **A non-zero exit is deliberately not an error here**, so callers that branch on a specific code keep the exit code in hand.
- `commandOutput(cmd, what) (string, error)` — the common case: stdout, or an error if the command could not run *or* exited non-zero.

39 sites converted (the 37 plus two inline `GetExitcode().Data` reads in the same files). Deliberate branches were read individually and preserved rather than flattened:

| site | branch kept |
|---|---|
| `lvm.runLvmReport` | exit 127 / "command not found" means lvm is not installed → empty list, not an error |
| `macos.softwareupdate.updates` | exit 1 with "No new software available." → empty list |
| `mdadm.arrays` | non-zero means mdadm is absent → `[]` |
| `macos.sharing` | non-zero means the release dropped `SPSharingDataType` → empty panel (still reported as unmeasured by `sharingFlag`) |
| `selinux.fetchGetenforce` | still falls through to `/etc/selinux/config` — a command that never ran now takes that path too, instead of recording a mode nobody measured |
| `selinux.booleans`, containerd task list | the `== 0` reads now require `Error == nil` first, so an errored command no longer skips the `/sys/fs/selinux` fallback or blanks the task map |
| `runSystemctl`, `isSystemdUnitActive` | non-zero still means "inactive", errors now propagate (which is what `isSystemdUnitActive`'s own doc comment already promised) |
| `firewalld.fetchStatus` | the polkit-authz discrimination is untouched; a command that never ran is now its own error |
| `nftables`, `macos.mdm.list` | keep their bespoke messages, which name the exit code / fall back to stdout |

**Not touched, in flight elsewhere:** `cgroups.go:424` (#10610). That is the one remaining site the scanner finds.

## Tests

`providers/os/resources/command_result_test.go`, built on a real `fs.FileSystemConnection` (no `RunCommand`) and a `mock.Connection` with a command table.

- `TestCommandCannotRun_Errors` — 9 resources must error rather than answer `false` / `[]` / `0`. **7 of the 9 fail without the fix** (proved by stashing the call-site changes and keeping the helper); `lsblk` and `lvm` already failed, but only by feeding empty stdout to a JSON parser, so they now assert `ErrorIs(plugin.ErrRunCommandNotImplemented)` and can no longer degrade into a silent empty list.
- `TestCommandExitsNonZero_Unchanged` / `TestCommandSucceeds_Unchanged` — regression control, green before and after.
- `TestDeliberateNonZeroExitBranchesSurvive` — guards the flattening risk directly: lvm's 127, lvm's exit 5 still erroring, mdadm, macos.sharing, systemctl.

## Verification

Filesystem backend against an extracted `debian:13` rootfs: the four queries above go from zero values to errors. `users.length` (18), `packages.length` (78), `os.rebootpending` and `selinux.installed` are unchanged.

Live linux (`podman run debian:13`, `mql run local`): `zfs.pools`, `mount.list.length` (35), `lvm.volumeGroups`, `mdadm.arrays`, `firewalld.status`, `nftables.tables`, `mount.point` df fields, `users` and `containerd.containers` all behave exactly as before — only two error message prefixes changed (`could not retrieve zfs pools:` → `zpool get failed:`, `failed to list namespaces:` → `ctr namespaces list failed:`).

No schema change; no provider version bump.
