### PR TITLE
🐛 os: kernel hardening controls must report null when unmeasured

### DIFF
--- a/providers/os/resources/kernel_hardening.go
+++ b/providers/os/resources/kernel_hardening.go
@@ -70,24 +70,37 @@ func (k *mqlKernel) taint() (*mqlKernelTaint, error) {
 		return nil, err
 	}
 
-	var bitmask int64
-	if ok {
-		if v, perr := strconv.ParseInt(strings.TrimSpace(raw), 10, 64); perr == nil {
-			bitmask = v
-		}
-	}
-
-	reasons := taintReasons(bitmask)
-
-	resource, err := CreateResource(k.MqlRuntime, "kernel.taint", map[string]*llx.RawData{
-		"bitmask": llx.IntData(bitmask),
-		"tainted": llx.BoolData(bitmask != 0),
-		"reasons": llx.ArrayData(stringsAsAnySlice(reasons), types.String),
-	})
+	resource, err := CreateResource(k.MqlRuntime, "kernel.taint", kernelTaintArgs(raw, ok))
 	if err != nil {
 		return nil, err
 	}
 	return resource.(*mqlKernelTaint), nil
+}
+
+// kernelTaintArgs turns the contents of /proc/sys/kernel/tainted into the
+// resource fields. ok reports whether the file was read at all.
+//
+// Every field is null when the taint word could not be read. A bitmask of 0
+// with no reasons is exactly what a genuinely clean kernel reports, so filling
+// those values in for an unread kernel would make the two indistinguishable,
+// and `tainted: false` is the answer a compliance check passes on. Zero is a
+// real measurement here and must not be forged.
+func kernelTaintArgs(raw string, ok bool) map[string]*llx.RawData {
+	if ok {
+		if bitmask, perr := strconv.ParseInt(strings.TrimSpace(raw), 10, 64); perr == nil {
+			return map[string]*llx.RawData{
+				"bitmask": llx.IntData(bitmask),
+				"tainted": llx.BoolData(bitmask != 0),
+				"reasons": llx.ArrayData(stringsAsAnySlice(taintReasons(bitmask)), types.String),
+			}
+		}
+	}
+
+	return map[string]*llx.RawData{
+		"bitmask": llx.NilData,
+		"tainted": llx.NilData,
+		"reasons": llx.NilData,
+	}
 }
 
 func (t *mqlKernelTaint) id() (string, error) {
@@ -142,19 +155,33 @@ func (k *mqlKernel) lockdown() (*mqlKernelLockdown, error) {
 		return nil, err
 	}
 
+	resource, err := CreateResource(k.MqlRuntime, "kernel.lockdown", kernelLockdownArgs(raw, ok))
+	if err != nil {
+		return nil, err
+	}
+	return resource.(*mqlKernelLockdown), nil
+}
+
+// kernelLockdownArgs turns the contents of /sys/kernel/security/lockdown into
+// the resource fields. ok reports whether the file was read at all.
+//
+// `mode` keeps its sentinel so the reason is visible, but `enabled` is null
+// whenever no mode was actually observed: the lockdown LSM being unreadable is
+// not evidence that lockdown is off.
+func kernelLockdownArgs(raw string, ok bool) map[string]*llx.RawData {
 	mode := "unavailable"
 	if ok {
 		mode = parseLockdownMode(raw)
 	}
 
-	resource, err := CreateResource(k.MqlRuntime, "kernel.lockdown", map[string]*llx.RawData{
+	args := map[string]*llx.RawData{
 		"mode":    llx.StringData(mode),
-		"enabled": llx.BoolData(mode == "integrity" || mode == "confidentiality"),
-	})
-	if err != nil {
-		return nil, err
+		"enabled": llx.NilData,
 	}
-	return resource.(*mqlKernelLockdown), nil
+	if mode != "unavailable" && mode != "unknown" {
+		args["enabled"] = llx.BoolData(mode == "integrity" || mode == "confidentiality")
+	}
+	return args
 }
 
 func (l *mqlKernelLockdown) id() (string, error) {
@@ -189,24 +216,36 @@ func (k *mqlKernel) aslr() (*mqlKernelAslr, error) {
 		return nil, err
 	}
 
-	mode := int64(-1)
-	level := "unknown"
-	if ok {
-		if v, perr := strconv.ParseInt(strings.TrimSpace(raw), 10, 64); perr == nil {
-			mode = v
-			level = aslrLevel(v)
-		}
-	}
-
-	resource, err := CreateResource(k.MqlRuntime, "kernel.aslr", map[string]*llx.RawData{
-		"mode":    llx.IntData(mode),
-		"level":   llx.StringData(level),
-		"enabled": llx.BoolData(mode > 0),
-	})
+	resource, err := CreateResource(k.MqlRuntime, "kernel.aslr", kernelAslrArgs(raw, ok))
 	if err != nil {
 		return nil, err
 	}
 	return resource.(*mqlKernelAslr), nil
+}
+
+// kernelAslrArgs turns the contents of /proc/sys/kernel/randomize_va_space into
+// the resource fields. ok reports whether the file was read at all.
+//
+// `mode` and `level` keep their sentinels so the reason is visible, but
+// `enabled` is null whenever no value was actually observed. A container image
+// or an extracted filesystem carries no /proc, and reporting ASLR as disabled
+// there asserts a measurement that was never taken.
+func kernelAslrArgs(raw string, ok bool) map[string]*llx.RawData {
+	if ok {
+		if mode, perr := strconv.ParseInt(strings.TrimSpace(raw), 10, 64); perr == nil {
+			return map[string]*llx.RawData{
+				"mode":    llx.IntData(mode),
+				"level":   llx.StringData(aslrLevel(mode)),
+				"enabled": llx.BoolData(mode > 0),
+			}
+		}
+	}
+
+	return map[string]*llx.RawData{
+		"mode":    llx.IntData(-1),
+		"level":   llx.StringData("unknown"),
+		"enabled": llx.NilData,
+	}
 }
 
 func (a *mqlKernelAslr) id() (string, error) {
@@ -231,9 +270,17 @@ func aslrLevel(mode int64) string {
 // =============================================================================
 
 // readKernelHardeningFile reads a file in /proc or /sys via the file
-// resource, returning (content, true, nil) on success and ("", false,
-// nil) when the file is unavailable (missing kernel feature, non-Linux
-// host, or unreadable). Honest errors from the runtime still surface.
+// resource, returning (content, true, nil) on success and ("", false, nil)
+// when the file is simply not there: a missing kernel feature, a non-Linux
+// host, or a container image / extracted filesystem that carries no /proc at
+// all. That absence is a legitimate answer, not a failure, and callers must
+// report the values it would have produced as null.
+//
+// A file that IS present but cannot be read is a different condition. The
+// measurement failed for a reason the user should see, so that error is
+// returned rather than folded into the absent case, where it would surface as
+// an unexplained null. The file resource reports absence by leaving its
+// content null with no error, so the two are distinguishable here.
 func readKernelHardeningFile(runtime *plugin.Runtime, path string) (string, bool, error) {
 	o, err := CreateResource(runtime, "file", map[string]*llx.RawData{
 		"path": llx.StringData(path),
@@ -244,6 +291,9 @@ func readKernelHardeningFile(runtime *plugin.Runtime, path string) (string, bool
 	f := o.(*mqlFile)
 	content := f.GetContent()
 	if content.Error != nil {
+		return "", false, content.Error
+	}
+	if content.IsNull() {
 		return "", false, nil
 	}
 	return content.Data, true, nil

--- a/providers/os/resources/kernel_hardening_test.go
+++ b/providers/os/resources/kernel_hardening_test.go
@@ -4,10 +4,17 @@
 package resources
 
 import (
+	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+	"go.mondoo.com/mql/utils/syncx"
 )
 
 // =============================================================================
@@ -155,4 +162,219 @@ func TestStringsAsAnySlice(t *testing.T) {
 	assert.Equal(t, "a", out[0])
 	assert.Equal(t, "b", out[1])
 	assert.Empty(t, stringsAsAnySlice(nil))
+}
+
+// =============================================================================
+// unmeasured controls must read null, never a measured negative
+//
+// The three hardening controls read a file in /proc or /sys. A container
+// image, an extracted root filesystem, or any scan of a disk rather than a
+// running kernel has none of those files. Before the guard below, that absence
+// was reported as ASLR disabled, lockdown disabled, and the kernel clean --
+// and "not tainted" is the answer a compliance check passes on.
+// =============================================================================
+
+// kernelFromFixture builds the kernel resource against a mock root filesystem.
+func kernelFromFixture(t *testing.T, fixture string) *mqlKernel {
+	t.Helper()
+
+	fixturePath, err := filepath.Abs(fixture)
+	require.NoError(t, err)
+
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:   "debian",
+			Family: []string{"debian", "linux", "unix"},
+		},
+	}, mock.WithPath(fixturePath))
+	require.NoError(t, err)
+
+	raw, err := CreateResource(&plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}, "kernel", map[string]*llx.RawData{})
+	require.NoError(t, err)
+	return raw.(*mqlKernel)
+}
+
+func TestKernelAslr_AbsentFileReadsNull(t *testing.T) {
+	aslr := kernelFromFixture(t, "testdata/kernel_hardening_absent.toml").GetAslr()
+	require.NoError(t, aslr.Error)
+	require.NoError(t, aslr.Data.Enabled.Error)
+
+	// The sentinels stay, so the report says why nothing is known.
+	assert.Equal(t, int64(-1), aslr.Data.Mode.Data)
+	assert.Equal(t, "unknown", aslr.Data.Level.Data)
+
+	// enabled must not answer. `false` here reads as "ASLR is off on this
+	// host", which is a claim about a kernel that was never consulted.
+	assert.True(t, aslr.Data.Enabled.IsNull(),
+		"an absent randomize_va_space must leave enabled null, not false")
+}
+
+func TestKernelLockdown_AbsentFileReadsNull(t *testing.T) {
+	lockdown := kernelFromFixture(t, "testdata/kernel_hardening_absent.toml").GetLockdown()
+	require.NoError(t, lockdown.Error)
+	require.NoError(t, lockdown.Data.Enabled.Error)
+
+	assert.Equal(t, "unavailable", lockdown.Data.Mode.Data)
+	assert.True(t, lockdown.Data.Enabled.IsNull(),
+		"an absent lockdown file must leave enabled null, not false")
+}
+
+func TestKernelTaint_AbsentFileReadsNull(t *testing.T) {
+	taint := kernelFromFixture(t, "testdata/kernel_hardening_absent.toml").GetTaint()
+	require.NoError(t, taint.Error)
+	require.NoError(t, taint.Data.Tainted.Error)
+
+	// taint carries no sentinel field: bitmask 0 / reasons [] / tainted false
+	// is byte-identical to a verified-clean kernel, so all three must be null.
+	assert.True(t, taint.Data.Tainted.IsNull(),
+		"an absent tainted file must leave tainted null -- false is the PASSING answer")
+	assert.True(t, taint.Data.Bitmask.IsNull(),
+		"bitmask 0 is a real measurement and must not be forged")
+	assert.True(t, taint.Data.Reasons.IsNull(),
+		"an empty reasons list would read as a verified-clean kernel")
+}
+
+func TestKernelHardening_MeasuredValuesUnchanged(t *testing.T) {
+	k := kernelFromFixture(t, "testdata/kernel_hardening_measured.toml")
+
+	aslr := k.GetAslr()
+	require.NoError(t, aslr.Error)
+	assert.Equal(t, int64(2), aslr.Data.Mode.Data)
+	assert.Equal(t, "full", aslr.Data.Level.Data)
+	assert.False(t, aslr.Data.Enabled.IsNull())
+	assert.True(t, aslr.Data.Enabled.Data)
+
+	lockdown := k.GetLockdown()
+	require.NoError(t, lockdown.Error)
+	assert.Equal(t, "integrity", lockdown.Data.Mode.Data)
+	assert.False(t, lockdown.Data.Enabled.IsNull())
+	assert.True(t, lockdown.Data.Enabled.Data)
+
+	taint := k.GetTaint()
+	require.NoError(t, taint.Error)
+	assert.False(t, taint.Data.Bitmask.IsNull())
+	assert.Equal(t, int64(4096), taint.Data.Bitmask.Data)
+	assert.True(t, taint.Data.Tainted.Data)
+	assert.Equal(t, []any{"out-of-tree module loaded"}, taint.Data.Reasons.Data)
+}
+
+// TestKernelHardening_MeasuredNegativesAreNotNull is the test the whole change
+// turns on: a kernel that was read and reported "off" must keep saying so. If
+// the guard were widened from "the file was not read" to "the value is zero",
+// every clean kernel would silently become unmeasured and stop failing.
+func TestKernelHardening_MeasuredNegativesAreNotNull(t *testing.T) {
+	k := kernelFromFixture(t, "testdata/kernel_hardening_clean.toml")
+
+	taint := k.GetTaint()
+	require.NoError(t, taint.Error)
+	assert.False(t, taint.Data.Tainted.IsNull(),
+		"a tainted file holding 0 is a measured clean kernel, not an unmeasured one")
+	assert.False(t, taint.Data.Tainted.Data)
+	assert.False(t, taint.Data.Bitmask.IsNull())
+	assert.Equal(t, int64(0), taint.Data.Bitmask.Data)
+	assert.Empty(t, taint.Data.Reasons.Data)
+	assert.False(t, taint.Data.Reasons.IsNull())
+
+	aslr := k.GetAslr()
+	require.NoError(t, aslr.Error)
+	assert.Equal(t, int64(0), aslr.Data.Mode.Data)
+	assert.Equal(t, "disabled", aslr.Data.Level.Data)
+	assert.False(t, aslr.Data.Enabled.IsNull(),
+		"randomize_va_space of 0 is a measured negative, not an unmeasured one")
+	assert.False(t, aslr.Data.Enabled.Data)
+
+	lockdown := k.GetLockdown()
+	require.NoError(t, lockdown.Error)
+	assert.Equal(t, "none", lockdown.Data.Mode.Data)
+	assert.False(t, lockdown.Data.Enabled.IsNull(),
+		"a lockdown file reporting [none] is a measured negative")
+	assert.False(t, lockdown.Data.Enabled.Data)
+}
+
+// A file that IS there but cannot be read is not the absent case. The
+// measurement failed for a reason the user should see, so the error is
+// reported rather than folded into an unexplained null.
+func TestReadKernelHardeningFile_UnreadableFileSurfacesTheError(t *testing.T) {
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+
+	unreadable := &mqlFile{MqlRuntime: runtime, __id: "/proc/sys/kernel/tainted"}
+	unreadable.Path = plugin.TValue[string]{Data: "/proc/sys/kernel/tainted", State: plugin.StateIsSet}
+	unreadable.Content = plugin.TValue[string]{
+		Error: errors.New("permission denied"),
+		State: plugin.StateIsSet | plugin.StateIsNull,
+	}
+	runtime.Resources.Set("file\x00/proc/sys/kernel/tainted", unreadable)
+
+	_, ok, err := readKernelHardeningFile(runtime, "/proc/sys/kernel/tainted")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "permission denied")
+	assert.False(t, ok)
+}
+
+// =============================================================================
+// argument builders
+// =============================================================================
+
+func TestKernelAslrArgs(t *testing.T) {
+	unmeasured := kernelAslrArgs("", false)
+	assert.Same(t, llx.NilData, unmeasured["enabled"])
+	assert.Equal(t, int64(-1), unmeasured["mode"].Value)
+	assert.Equal(t, "unknown", unmeasured["level"].Value)
+
+	// The file was read but holds something that is not a number: still
+	// nothing measured, so still null.
+	garbage := kernelAslrArgs("yes please\n", true)
+	assert.Same(t, llx.NilData, garbage["enabled"])
+
+	off := kernelAslrArgs("0\n", true)
+	assert.Equal(t, false, off["enabled"].Value)
+	assert.Equal(t, "disabled", off["level"].Value)
+
+	full := kernelAslrArgs("2\n", true)
+	assert.Equal(t, true, full["enabled"].Value)
+	assert.Equal(t, int64(2), full["mode"].Value)
+}
+
+func TestKernelLockdownArgs(t *testing.T) {
+	unmeasured := kernelLockdownArgs("", false)
+	assert.Same(t, llx.NilData, unmeasured["enabled"])
+	assert.Equal(t, "unavailable", unmeasured["mode"].Value)
+
+	// Read, but no bracketed token: the mode is unknown, so enabled cannot
+	// be derived from it.
+	malformed := kernelLockdownArgs("none integrity confidentiality", true)
+	assert.Same(t, llx.NilData, malformed["enabled"])
+	assert.Equal(t, "unknown", malformed["mode"].Value)
+
+	none := kernelLockdownArgs("[none] integrity confidentiality\n", true)
+	assert.Equal(t, false, none["enabled"].Value)
+
+	for _, mode := range []string{"integrity", "confidentiality"} {
+		on := kernelLockdownArgs("none ["+mode+"]\n", true)
+		assert.Equal(t, true, on["enabled"].Value, mode+" is an engaged lockdown")
+	}
+}
+
+func TestKernelTaintArgs(t *testing.T) {
+	unmeasured := kernelTaintArgs("", false)
+	assert.Same(t, llx.NilData, unmeasured["tainted"])
+	assert.Same(t, llx.NilData, unmeasured["bitmask"])
+	assert.Same(t, llx.NilData, unmeasured["reasons"])
+
+	garbage := kernelTaintArgs("not a number", true)
+	assert.Same(t, llx.NilData, garbage["tainted"])
+	assert.Same(t, llx.NilData, garbage["bitmask"])
+
+	clean := kernelTaintArgs("0\n", true)
+	assert.Equal(t, false, clean["tainted"].Value, "a measured 0 is a clean kernel, not an unread one")
+	assert.Equal(t, int64(0), clean["bitmask"].Value)
+	assert.Equal(t, []any{}, clean["reasons"].Value)
+
+	tainted := kernelTaintArgs("4096\n", true)
+	assert.Equal(t, true, tainted["tainted"].Value)
+	assert.Equal(t, int64(4096), tainted["bitmask"].Value)
+	assert.Equal(t, []any{"out-of-tree module loaded"}, tainted["reasons"].Value)
 }

--- a/providers/os/resources/testdata/kernel_hardening_absent.toml
+++ b/providers/os/resources/testdata/kernel_hardening_absent.toml
@@ -1,0 +1,13 @@
+# A target that carries no /proc and no /sys: a container image, an extracted
+# root filesystem, or any scan of a disk rather than a running kernel. None of
+# the three kernel-hardening files exist here, so nothing about ASLR, lockdown
+# or taint was measured.
+#
+# /etc/os-release is present only so the fixture describes a real root
+# filesystem rather than an empty one.
+
+[files."/etc/os-release"]
+path = "/etc/os-release"
+content = """PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
+ID=debian
+"""

--- a/providers/os/resources/testdata/kernel_hardening_clean.toml
+++ b/providers/os/resources/testdata/kernel_hardening_clean.toml
@@ -1,0 +1,21 @@
+# A running Linux kernel that answered all three reads with the "nothing is
+# on" values: ASLR off, lockdown not engaged, and an untainted kernel.
+#
+# The taint word of 0 here is a real measurement of a clean kernel and must
+# stay distinguishable from the unmeasured case in kernel_hardening_absent.toml,
+# which produces the same numbers if the reads are not guarded.
+
+[files."/proc/sys/kernel/randomize_va_space"]
+path = "/proc/sys/kernel/randomize_va_space"
+content = """0
+"""
+
+[files."/sys/kernel/security/lockdown"]
+path = "/sys/kernel/security/lockdown"
+content = """[none] integrity confidentiality
+"""
+
+[files."/proc/sys/kernel/tainted"]
+path = "/proc/sys/kernel/tainted"
+content = """0
+"""

--- a/providers/os/resources/testdata/kernel_hardening_measured.toml
+++ b/providers/os/resources/testdata/kernel_hardening_measured.toml
@@ -1,0 +1,18 @@
+# A running Linux kernel that answered all three reads: ASLR at full
+# randomization, lockdown engaged in integrity mode, and a taint word with bit
+# 12 (out-of-tree module) set.
+
+[files."/proc/sys/kernel/randomize_va_space"]
+path = "/proc/sys/kernel/randomize_va_space"
+content = """2
+"""
+
+[files."/sys/kernel/security/lockdown"]
+path = "/sys/kernel/security/lockdown"
+content = """none [integrity] confidentiality
+"""
+
+[files."/proc/sys/kernel/tainted"]
+path = "/proc/sys/kernel/tainted"
+content = """4096
+"""


### PR DESCRIPTION
On a container-image or filesystem scan, `kernel.aslr.enabled` and
`kernel.lockdown.enabled` report **disabled**, and `kernel.taint.tainted`
reports the kernel **not tainted** — on targets where none of those files were
ever read. There is no /proc and no /sys in an image, so nothing was measured;
the resources answered anyway.

**`taint` is the dangerous one.** Its unmeasured state was `bitmask: 0`,
`reasons: []`, `tainted: false` — byte-identical to a genuinely clean kernel,
with no sentinel to give it away. And `tainted: false` is the *passing* answer
for a compliance check, so an unread kernel silently passed.

`aslr` and `lockdown` at least kept an honest sentinel in a sibling field, so
they contradicted themselves in the same breath: `level: "unknown"` alongside
`enabled: false`.

## Measured, `mql run filesystem` on an extracted rootfs

Identical on debian:13, almalinux:9 and alpine:3.22.

| field | before | after | live (`run local`) |
|---|---|---|---|
| `kernel.aslr.mode` | `-1` | `-1` | `2` |
| `kernel.aslr.level` | `"unknown"` | `"unknown"` | `"full"` |
| `kernel.aslr.enabled` | `false` | **`null`** | `true` |
| `kernel.lockdown.mode` | `"unknown"` | `"unavailable"` | — |
| `kernel.lockdown.enabled` | `false` | **`null`** | — |
| `kernel.taint.bitmask` | `0` | **`null`** | `0` |
| `kernel.taint.tainted` | `false` | **`null`** | `false` |
| `kernel.taint.reasons` | `[]` | **`null`** | `[]` |

A live Debian 13 container is unchanged where it was measured: ASLR still
`mode: 2, level: full, enabled: true`, and a real taint word of 0 still reads
`bitmask: 0, tainted: false` — **not** null. Distinguishing a measured-clean
kernel from an unread one is the whole point of the change. Live `lockdown`
does move to `mode: "unavailable", enabled: null`, and that is the fix rather
than a regression: `/sys/kernel/security/lockdown` does not exist in that
container, so the old `enabled: false` was a claim about a file nobody read.

## The change

The unmeasured branches now pass `llx.NilData` for the derived fields, which
`RawToTValue` turns into `StateIsSet | StateIsNull`, so the value arrives null
rather than as a zero. `mode` and `level` keep their sentinels so the report
still says why nothing is known. A file that was read but holds something
unparseable is treated the same way — reading garbage is not a measurement.

Under v14 semantics a null operand of `&&`/`||` is falsy, so a check requiring
`kernel.aslr.enabled` still fails on an image scan, which is correct for "not
verified". What changes is that the resource stops asserting a measured `false`
in the report, and `tainted` stops silently passing.

### `readKernelHardeningFile` had absence detection backwards

The `file` resource signals a missing file by leaving its content **null with
no error** (`mqlFile.content` sets that state proactively). The old
`content.Error != nil` check therefore returned `ok == true` for a file that was
not there — which is why `lockdown.mode` read `"unknown"` (parsed from an empty
string) instead of its `"unavailable"` sentinel on every image scan above.

Absence is now detected with `IsNull()`, and the error is no longer swallowed.
That split is deliberate: absent and unreadable are different conditions. An
image legitimately has no `/proc`, so absence stays a non-error that yields
null. A file that *is* present and still cannot be read is a failed measurement
with a reason the user should see, and folding it into the absent case turned
"permission denied" into an unexplained null. It now surfaces as the error it is.

## Tests

`providers/os/resources/kernel_hardening_test.go`, driven by three mock-root
fixtures (absent / measured / measured-clean) through the same `mock.New` +
`CreateResource` harness `rsyslog_test.go` uses, plus direct tests of the three
new argument builders.

Every test was confirmed red before the fix:

- the three absent-file tests fail against the shipped `kernel_hardening.go`
  (`enabled: false`, `tainted: false`, `bitmask: 0`, and `lockdown.mode:
  "unknown"` rather than `"unavailable"`)
- the unreadable-file test fails against the shipped helper, which returned
  `ok == false, err == nil`
- the two guard tests pass before and after by design, so each was proved
  capable of failing by mutation: widening the taint guard from "not read" to
  "value is zero" makes a measured-clean kernel go null and trips
  `MeasuredNegativesAreNotNull`; forcing `enabled` to null trips
  `MeasuredValuesUnchanged`
- the argument-builder tests were re-run with the shipped zero-value returns
  restored, and each null assertion failed

No schema change — all four fields already exist.
