### PR TITLE
🐛 providers: fix ABBA deadlock between the coordinator mutex and the schema lock

### DIFF
--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -64,6 +64,10 @@ type coordinator struct {
 	// holding mutex (unsafeStartProvider) and while holding schema.sync
 	// (extensibleSchema.unsafeLoadAll -> LoadSchema), so it must never be
 	// held while acquiring either of those.
+	//
+	// providers is only ever replaced wholesale (SetProviders), never
+	// mutated in place: Providers hands the map out after releasing
+	// providersMu, and callers hold that reference unguarded.
 	providersMu sync.RWMutex
 	providers   Providers
 	runningByID map[string]*RunningProvider
@@ -412,6 +416,9 @@ func (c *coordinator) SetProviders(providers Providers) {
 	c.providersMu.Unlock()
 }
 
+// Providers returns the current provider map. It is safe to read without
+// providersMu only because the map is replaced, never mutated (see the
+// field); don't write to the returned map.
 func (c *coordinator) Providers() Providers {
 	c.providersMu.RLock()
 	defer c.providersMu.RUnlock()

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -60,14 +60,25 @@ type coordinator struct {
 	lastConnectionID uint32
 	connectionsLock  sync.Mutex
 
+	// providersMu guards providers. It is a leaf lock: it is taken while
+	// holding mutex (unsafeStartProvider) and while holding schema.sync
+	// (extensibleSchema.unsafeLoadAll -> LoadSchema), so it must never be
+	// held while acquiring either of those.
+	providersMu sync.RWMutex
 	providers   Providers
 	runningByID map[string]*RunningProvider
 
 	unprocessedRuntimes []*Runtime
 	runtimes            map[string]*Runtime
 	runtimeCnt          int
-	mutex               sync.Mutex
-	schema              extensibleSchema
+	// mutex guards runningByID and the runtime bookkeeping. Lock order is
+	// mutex -> schema.sync -> providersMu: unsafeStartProvider holds mutex
+	// while it calls schema.Add (so a provider is never visible before its
+	// schema is registered), and schema lookups hold schema.sync while they
+	// call LoadSchema, which therefore must not take mutex. Doing so wedged
+	// scans in an ABBA deadlock; see TestCoordinatorSchemaLockOrder.
+	mutex  sync.Mutex
+	schema extensibleSchema
 }
 
 type builtinProvider struct {
@@ -277,25 +288,24 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 			mp.Init(x.Runtime)
 		}
 
-		// Builtins never go through Provider.LoadResources, so they need the
-		// same provenance stamp applied here (ADR 040 part 1).
-		if concrete, ok := x.Runtime.Schema.(*resources.Schema); ok && x.Config != nil {
-			stampProviderVersion(concrete, x.Config.ID, x.Config.Version)
-		}
-
+		// The provenance stamp (ADR 040 part 1) is applied once at init, see
+		// stampBuiltinSchemas: the schema object is shared with the
+		// aggregate, which reads it under schema.sync while we hold mutex.
 		c.schema.Add(id, x.Runtime.Schema)
 		return x.Runtime, nil
 	}
 
-	if c.providers == nil {
+	providers := c.Providers()
+	if providers == nil {
 		var err error
-		c.providers, err = ListActive()
+		providers, err = ListActive()
 		if err != nil {
 			return nil, err
 		}
+		c.SetProviders(providers)
 	}
 
-	provider, ok := c.providers[id]
+	provider, ok := providers[id]
 	if !ok {
 		return nil, errors.New("cannot find provider " + id)
 	}
@@ -397,10 +407,14 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 }
 
 func (c *coordinator) SetProviders(providers Providers) {
+	c.providersMu.Lock()
 	c.providers = providers
+	c.providersMu.Unlock()
 }
 
 func (c *coordinator) Providers() Providers {
+	c.providersMu.RLock()
+	defer c.providersMu.RUnlock()
 	return c.providers
 }
 
@@ -446,14 +460,20 @@ func (c *coordinator) Schema() resources.ResourcesSchema {
 // LoadSchema for a given provider. Providers also cache their Schemas, so
 // calling this with the same provider multiple times will use the loaded
 // cached schema after the first call.
+//
+// It is called by extensibleSchema with schema.sync held, so it must not
+// take c.mutex (unsafeStartProvider holds c.mutex while it waits for
+// schema.sync in schema.Add — the two would deadlock). Nothing here needs
+// it: builtinProviders is immutable, providers has its own lock, and
+// LoadResources synchronizes itself.
 func (c *coordinator) LoadSchema(name string) (resources.ResourcesSchema, error) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
 	if x, ok := builtinProviders[name]; ok {
 		return x.Runtime.Schema, nil
 	}
 
+	c.providersMu.RLock()
 	provider, ok := c.providers[name]
+	c.providersMu.RUnlock()
 	if !ok {
 		return nil, errors.New("cannot find provider '" + name + "'")
 	}

--- a/providers/coordinator_deadlock_test.go
+++ b/providers/coordinator_deadlock_test.go
@@ -1,0 +1,76 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCoordinatorSchemaLockOrder guards against an ABBA deadlock between
+// coordinator.mutex and extensibleSchema.sync. Before LoadSchema stopped
+// taking coordinator.mutex this test hung deterministically:
+//
+//	goroutine B: schema.Lookup(miss) ── holds schema.sync ──▶ unsafeLoadAll
+//	             ──▶ coordinator.LoadSchema(name) ── wants coordinator.mutex
+//	goroutine A: coordinator.GetRunningProvider(new) ── holds coordinator.mutex
+//	             ──▶ unsafeStartProvider ──▶ schema.Add ── wants schema.sync
+//
+// In a scan this is a dispatcher worker compiling the first policy filter
+// that references a not-yet-loaded resource (B) while the main goroutine
+// connects a discovered child asset whose provider isn't running yet (A) —
+// e.g. a github org scan starting the k8s provider for a manifest found in
+// a repo. Once wedged, nothing times out; the job runs to its deadline.
+func TestCoordinatorSchemaLockOrder(t *testing.T) {
+	active, err := ListActive()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(active) < 2 {
+		t.Skip("needs at least two installed providers for unsafeLoadAll to iterate")
+	}
+
+	c := newCoordinator()
+	// LoadSchema resolves names through c.providers; in production this is
+	// populated by the first unsafeStartProvider. Populating it here makes
+	// LoadSchema do the real (slow) LoadResources call under c.mutex.
+	c.providers = active
+
+	bDone := make(chan struct{})
+	go func() {
+		defer close(bDone)
+		// Any miss with lastRefreshed < LastProviderInstall triggers unsafeLoadAll.
+		c.schema.Lookup("resource.that.does.not.exist")
+	}()
+
+	// Let B enter unsafeLoadAll (it holds schema.sync from here until it has
+	// called LoadSchema for every installed provider).
+	time.Sleep(20 * time.Millisecond)
+
+	aDone := make(chan struct{})
+	go func() {
+		defer close(aDone)
+		// Builtin provider: no plugin subprocess, but the same lock order —
+		// c.mutex held, then schema.Add wants schema.sync.
+		_, _ = c.GetRunningProvider(BuiltinCoreID, UpdateProvidersConfig{})
+	}()
+
+	timeout := time.After(15 * time.Second)
+	for _, done := range []chan struct{}{aDone, bDone} {
+		select {
+		case <-done:
+		case <-timeout:
+			buf := make([]byte, 1<<20)
+			n := runtime.Stack(buf, true)
+			for _, g := range strings.Split(string(buf[:n]), "\n\n") {
+				if strings.Contains(g, "extensibleSchema") || strings.Contains(g, "coordinator)") {
+					t.Log(g)
+				}
+			}
+			t.Fatal("deadlock: GetRunningProvider and schema.Lookup never returned")
+		}
+	}
+}

--- a/providers/coordinator_deadlock_test.go
+++ b/providers/coordinator_deadlock_test.go
@@ -24,53 +24,76 @@ import (
 // connects a discovered child asset whose provider isn't running yet (A) —
 // e.g. a github org scan starting the k8s provider for a manifest found in
 // a repo. Once wedged, nothing times out; the job runs to its deadline.
+//
+// A is played out as its two lock steps rather than by calling
+// GetRunningProvider, so the interleaving is controlled instead of raced:
+// the test takes coordinator.mutex (what GetRunningProvider does first),
+// waits until B provably holds schema.sync, then calls schema.Add under
+// that mutex (what unsafeStartProvider does last). unsafeLoadAll calls
+// LoadSchema for every provider ListActive returns, and the builtins alone
+// are enough for that, so nothing needs to be installed on disk.
 func TestCoordinatorSchemaLockOrder(t *testing.T) {
-	active, err := ListActive()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(active) < 2 {
-		t.Skip("needs at least two installed providers for unsafeLoadAll to iterate")
-	}
-
 	c := newCoordinator()
-	// LoadSchema resolves names through c.providers; in production this is
-	// populated by the first unsafeStartProvider. Populating it here makes
-	// LoadSchema do the real (slow) LoadResources call under c.mutex.
-	c.providers = active
 
+	// A, step 1: GetRunningProvider takes coordinator.mutex before it starts
+	// the provider and registers its schema.
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	// B: a lookup that misses with lastRefreshed < LastProviderInstall runs
+	// unsafeLoadAll with schema.sync held.
 	bDone := make(chan struct{})
 	go func() {
 		defer close(bDone)
-		// Any miss with lastRefreshed < LastProviderInstall triggers unsafeLoadAll.
 		c.schema.Lookup("resource.that.does.not.exist")
 	}()
 
-	// Let B enter unsafeLoadAll (it holds schema.sync from here until it has
-	// called LoadSchema for every installed provider).
-	time.Sleep(20 * time.Millisecond)
+	// Wait until B holds schema.sync — TryLock succeeding means it isn't
+	// there yet, so give the lock straight back and poll again — or until B
+	// has finished, which it can only do if LoadSchema no longer needs
+	// coordinator.mutex (the fixed behavior).
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		select {
+		case <-bDone:
+		default:
+			if !c.schema.sync.TryLock() {
+				break
+			}
+			c.schema.sync.Unlock()
+			if time.Now().After(deadline) {
+				t.Fatal("schema.Lookup never took schema.sync")
+			}
+			time.Sleep(time.Millisecond)
+			continue
+		}
+		break
+	}
 
+	// A, step 2, still under coordinator.mutex: register the new provider's
+	// schema, which needs schema.sync.
 	aDone := make(chan struct{})
 	go func() {
 		defer close(aDone)
-		// Builtin provider: no plugin subprocess, but the same lock order —
-		// c.mutex held, then schema.Add wants schema.sync.
-		_, _ = c.GetRunningProvider(BuiltinCoreID, UpdateProvidersConfig{})
+		c.schema.Add(BuiltinCoreID, builtinProviders[BuiltinCoreID].Runtime.Schema)
 	}()
 
-	timeout := time.After(15 * time.Second)
-	for _, done := range []chan struct{}{aDone, bDone} {
-		select {
-		case <-done:
-		case <-timeout:
-			buf := make([]byte, 1<<20)
-			n := runtime.Stack(buf, true)
-			for _, g := range strings.Split(string(buf[:n]), "\n\n") {
-				if strings.Contains(g, "extensibleSchema") || strings.Contains(g, "coordinator)") {
-					t.Log(g)
-				}
+	select {
+	case <-aDone:
+	case <-time.After(15 * time.Second):
+		buf := make([]byte, 1<<20)
+		n := runtime.Stack(buf, true)
+		for _, g := range strings.Split(string(buf[:n]), "\n\n") {
+			if strings.Contains(g, "extensibleSchema") || strings.Contains(g, "coordinator)") {
+				t.Log(g)
 			}
-			t.Fatal("deadlock: GetRunningProvider and schema.Lookup never returned")
 		}
+		t.Fatal("deadlock: schema.Add (holding coordinator.mutex) and schema.Lookup (holding schema.sync) never returned")
+	}
+
+	select {
+	case <-bDone:
+	case <-time.After(15 * time.Second):
+		t.Fatal("schema.Lookup did not return after schema.Add completed")
 	}
 }

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -63,9 +63,25 @@ func init() {
 
 	LastProviderInstall = time.Now().Unix()
 
+	stampBuiltinSchemas()
+
 	// Initialize the global coordinator instance
 	coordinator := newCoordinator()
 	Coordinator = coordinator
+}
+
+// stampBuiltinSchemas applies the provenance stamp (ADR 040 part 1) to the
+// builtin providers' schemas. Builtins never go through Provider.LoadResources,
+// which stamps on-disk providers. It runs once at init rather than on every
+// builtin start: the schema object is shared with extensibleSchema's
+// aggregate, which ranges over ProviderVersions under schema.sync, and a
+// concurrent stamp is a map write during that iteration.
+func stampBuiltinSchemas() {
+	for _, x := range builtinProviders {
+		if concrete, ok := x.Runtime.Schema.(*resources.Schema); ok && x.Config != nil {
+			stampProviderVersion(concrete, x.Config.ID, x.Config.Version)
+		}
+	}
 }
 
 // deleteProvider removes a single resolved provider from disk. The path it


### PR DESCRIPTION
## Problem

A scan can wedge forever — no error, no timeout, the process just stops making progress until an external deadline kills it. In production this showed up as hosted GitHub and GitLab integration scans that intermittently ran silent for hours after `synchronizing assets with upstream` and were killed by the job's `activeDeadlineSeconds` (~30% of runs for one GitHub Enterprise integration; a live goroutine dump from a wedged pod is what pinned this down).

## Root cause

An ABBA deadlock between `coordinator.mutex` and `extensibleSchema.sync`:

```
goroutine A (main, connecting a discovered child asset):
  coordinator.GetRunningProvider          holds coordinator.mutex
  └─ unsafeStartProvider
     └─ extensibleSchema.Add              wants schema.sync

goroutine B (scan worker, compiling the first policy filter):
  extensibleSchema.Lookup                 holds schema.sync
  └─ unsafeLoadAll
     └─ coordinator.LoadSchema            wants coordinator.mutex
```

`unsafeLoadAll` runs exactly once per process — the first time a compile references a resource that isn't in the aggregate yet — and calls `LoadSchema` once per installed provider while holding `schema.sync`. Each `LoadSchema` took `coordinator.mutex`. If the main goroutine cold-starts a provider during that window (holds `mutex`, then blocks in `schema.Add` on `schema.sync`), B's next `LoadSchema` blocks on `mutex` and neither ever returns.

Why it needs two conditions and why GitHub/GitLab were the ones hitting it:

* The window is the first compile in the process. The core provider's schema is only registered when a query first executes, so the very first filter compile misses on `asset` itself and triggers `unsafeLoadAll` — any enabled policy is enough.
* Something has to cold-start a *different* provider concurrently. `scanSubtree` connects children on the main goroutine while dispatcher workers compile the previous batch's filters. GitHub/GitLab `auto` discovery yields IaC children of other provider types (`terraform-hcl-git`, k8s manifests), so the main goroutine starts `terraform`/`k8s` mid-scan — the dump's goroutine A was starting `…/providers/k8s`. Single-provider integrations only ever find the provider already running, so they never reach `schema.Add`.

The window is ~100 ms on a laptop with ~100 providers installed, and seconds on a CPU-starved sandboxed pod — which is why it was intermittent and correlated with node co-tenancy.

Production stacks (trimmed to the relevant frames):

```
goroutine 1 [sync.Mutex.Lock, 151 minutes]:
  providers.(*extensibleSchema).Add
  providers.(*coordinator).unsafeStartProvider
  providers.(*coordinator).GetRunningProvider
  providers.(*Runtime).addProvider → UseProvider → DetectProvider
  providers.(*coordinator).RuntimeFor
  discovery.createRuntimeForAsset → (*AssetExplorer).Connect
  cnspec/policy/scan.(*scanContext).scanSubtree
  cnspec/policy/scan.(*LocalScanner).distributeJob → Run

goroutine 129 [sync.Mutex.Lock, 151 minutes]:
  providers.(*coordinator).LoadSchema
  providers.(*extensibleSchema).unsafeLoadAll
  providers.(*extensibleSchema).Lookup
  mqlc.(*compiler).compileResource → … → mqlc.Compile
  cnspec/policy/executor.ExecuteFilterQueries
  cnspec/policy/scan.(*localAssetScanner).UpdateFilters → runPolicy → run
  cnspec/policy/scan.(*scanDispatcher).scanSingleAsset  (created by scanDispatcher.Submit)
```

## Fix

`LoadSchema` never needed `coordinator.mutex`: `builtinProviders` is immutable, `Provider.LoadResources` synchronizes itself, and the only shared state it reads is the `c.providers` map. That map now has its own leaf lock (`providersMu`), also used by `SetProviders`/`Providers` (which were previously unsynchronized), and `LoadSchema` no longer takes `mutex`. `schema.Add` stays under `mutex`, so a provider is still never visible in `runningByID` before its schema is registered. Lock order is documented on the struct: `mutex → schema.sync → providersMu`.

Removing the deadlock exposed a race it had been hiding on `main`: the builtin provenance stamp (ADR 040) mutated the shared builtin schema's `ProviderVersions` map on every builtin start, while the aggregate ranges over that same map under `schema.sync` — a concurrent map iteration/write. The stamp is idempotent and its inputs are static, so it now runs once at package init (`stampBuiltinSchemas`).

## Testing

* `TestCoordinatorSchemaLockOrder` reproduces the interleaving deterministically (a `Lookup` miss holding `schema.sync` through `unsafeLoadAll`, then a builtin `GetRunningProvider`). It hangs on `main` without the fix and passes in ~60 ms with it; also clean under `-race` (which is what caught the stamp race). It needs ≥2 installed providers and skips otherwise.
* `go test ./providers/` and `go test -race ./providers/ -run 'Coordinator|Schema|Runtime|Provider'` pass.
* Reproduced end to end locally with a `cnspec scan github user … --discover repos,terraform,k8s-manifests,…` under CPU load: the wedge shows the two stacks above; with this fix the same run completes.

Backport to `v13` follows; that is what the hosted scan runner ships.
