### PR TITLE
✨ status: check that the ingest endpoint is reachable

### DIFF
--- a/apps/mql/cmd/status.go
+++ b/apps/mql/cmd/status.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"syscall"
@@ -185,6 +186,13 @@ func checkStatus(ctx context.Context) (Status, error) {
 		return s, cli_errors.NewCommandError(errors.Wrap(err, "failed to set up Mondoo API client"), 1)
 	}
 
+	// Probe the ingest endpoint alongside the checks below rather than in
+	// series. Uploads go to a different host than the API on a different static
+	// IP, so a firewall can allow the API and blackhole ingest — and a
+	// blackholed host answers nothing until the probe's own deadline, which
+	// would otherwise eat a third of this command's shared budget.
+	ingest := probeIngestEndpoint(ctx, httpClient, opts.UpstreamIngestEndpoint())
+
 	sysInfo, err := sysinfo.Get()
 	if err == nil {
 		s.Client.Platform = sysInfo.Platform
@@ -264,12 +272,42 @@ func checkStatus(ctx context.Context) (Status, error) {
 	}
 	s.Client.Providers = providersList
 
+	if ingest != nil {
+		ingestStatus := <-ingest
+		s.Ingest = &ingestStatus
+	}
+
 	return s, nil
+}
+
+// probeIngestEndpoint starts the ingest reachability probe in the background and
+// returns the channel its single result arrives on, or nil when there is no
+// endpoint to probe (see config.IngestEndpointFor: a self-hosted or otherwise
+// non-hosted API endpoint derives none, and the check is skipped rather than
+// reported as failing).
+//
+// The channel is buffered so the probe never blocks on a receiver: if
+// checkStatus returns early, the goroutine parks its result and exits, and ctx
+// — the command's overall deadline — bounds the request either way.
+func probeIngestEndpoint(ctx context.Context, httpClient *http.Client, endpoint string) <-chan health.IngestStatus {
+	if endpoint == "" {
+		return nil
+	}
+
+	results := make(chan health.IngestStatus, 1)
+	go func() {
+		results <- health.CheckIngestReachable(ctx, httpClient, endpoint)
+	}()
+	return results
 }
 
 type Status struct {
 	Client   ClientStatus  `json:"client"`
 	Upstream health.Status `json:"upstream"`
+	// Ingest is the reachability probe of the endpoint scan uploads are routed
+	// through. nil when the check did not run: no ingest endpoint could be
+	// derived from the configured API endpoint.
+	Ingest *health.IngestStatus `json:"ingest,omitempty"`
 }
 
 type ClientStatus struct {

--- a/apps/mql/cmd/status_render.go
+++ b/apps/mql/cmd/status_render.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -12,6 +13,7 @@ import (
 	"github.com/muesli/termenv"
 	"go.mondoo.com/mql/cli/theme"
 	"go.mondoo.com/mql/cli/theme/colors"
+	"go.mondoo.com/mql/providers-sdk/v1/upstream/health"
 	"go.mondoo.com/mql/providers/core/resources/versions/semver"
 )
 
@@ -192,6 +194,13 @@ func (s Status) renderPlatform(b *strings.Builder, st styler) {
 	st.row(b, "Status", statusStr+"   "+st.dim("API v"+s.Upstream.API.Version)+" "+sync)
 	st.row(b, "Time", s.Upstream.API.Timestamp)
 
+	// The upload endpoint is a separate host from the API above; the row is
+	// omitted entirely when no ingest endpoint could be derived, so a
+	// self-hosted deployment doesn't get a check it can't pass.
+	if s.Ingest != nil {
+		st.row(b, "Ingest", ingestRowValue(st, *s.Ingest))
+	}
+
 	if s.Client.Registered {
 		st.row(b, "Client", st.value(s.Client.Mrn))
 		st.row(b, "Account", st.value(s.Client.ServiceAccount))
@@ -226,7 +235,13 @@ func (s Status) renderHealth(b *strings.Builder, st styler) {
 
 	if s.platformHealthy() {
 		body := "reachable " + st.dim("·") + " " + st.value("SERVING")
-		st.summaryRow(b, st.ok("●"), "Platform", body, st.ok("✓ healthy"))
+		// A SERVING API with a blocked upload host is not a healthy platform
+		// from a scan's point of view: every scan runs and then fails to report.
+		if s.ingestBlocked() {
+			st.summaryRow(b, st.warn("●"), "Platform", body, st.warn("⚠ ingest unreachable"))
+		} else {
+			st.summaryRow(b, st.ok("●"), "Platform", body, st.ok("✓ healthy"))
+		}
 	} else {
 		status := s.Upstream.API.Status
 		if status == "" {
@@ -258,6 +273,46 @@ func (st styler) summaryRow(b *strings.Builder, dot, label, body, trailing strin
 }
 
 func (s Status) platformHealthy() bool { return s.Upstream.API.Status == "SERVING" }
+
+// ingestBlocked reports whether the ingest probe ran and the endpoint did not
+// answer. A nil Ingest means the check was skipped, which is not a failure.
+func (s Status) ingestBlocked() bool {
+	return s.Ingest != nil && !s.Ingest.Reachable
+}
+
+// ingestRowValue formats the ingest endpoint row. The HTTP status is
+// deliberately not shown on the success path: the endpoint answers an
+// unauthenticated probe with 404 by design, and printing "404" next to a green
+// check reads as a defect rather than as the proof of reachability it is.
+func ingestRowValue(st styler, ingest health.IngestStatus) string {
+	if ingest.Reachable {
+		return ingest.Endpoint + "   " + st.ok("✓ reachable") + " " +
+			st.dim("· "+strconv.FormatInt(ingest.LatencyMs, 10)+"ms")
+	}
+
+	row := ingest.Endpoint + "   " + st.bad("✗ unreachable")
+	if ingest.Reason != "" {
+		row += " " + st.dim("· "+ingest.Reason)
+	}
+	return row
+}
+
+// ingestHostPort renders the ingest endpoint as the host:port pair an egress
+// rule is written against, falling back to the raw endpoint if it cannot be
+// parsed.
+func ingestHostPort(endpoint string) string {
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Hostname() == "" {
+		return endpoint
+	}
+	if port := u.Port(); port != "" {
+		return u.Hostname() + ":" + port
+	}
+	if u.Scheme == "http" {
+		return u.Hostname() + ":80"
+	}
+	return u.Hostname() + ":443"
+}
 
 // clientAPINewer reports whether the client's API version is strictly newer
 // than the server's. Both are major-version strings (e.g. "13"); if either
@@ -424,7 +479,7 @@ func (s Status) renderFooter(b *strings.Builder, st styler) {
 	// registered at all, and remediated by re-registering with a fresh token.
 	authFailed := s.Client.Registered && s.Client.PingPongError != nil
 	hasError := !s.Client.Registered || s.Client.PingPongError != nil
-	actionable := hasError || s.updateAvailable() || s.outdatedCount() > 0
+	actionable := hasError || s.ingestBlocked() || s.updateAvailable() || s.outdatedCount() > 0
 
 	b.WriteString("\n")
 	switch {
@@ -444,6 +499,13 @@ func (s Status) renderFooter(b *strings.Builder, st styler) {
 	}
 	if authFailed {
 		st.footerStep(b, st.binary+" login --token <token>", "re-register with a fresh token from Mondoo Platform")
+	}
+	// No command fixes a blocked upload host, so the step names the egress rule
+	// to open instead. Kept above the update hints: a client that cannot upload
+	// is reporting nothing at all, which outranks being a version behind.
+	if s.ingestBlocked() {
+		st.footerStep(b, "allow egress to "+ingestHostPort(s.Ingest.Endpoint),
+			"scan results are uploaded to this endpoint")
 	}
 	if s.updateAvailable() {
 		st.footerStep(b, "visit "+s.Client.UpdatesURL, "upgrade "+s.Client.Version+" → "+s.Client.LatestVersion)

--- a/apps/mql/cmd/status_render_test.go
+++ b/apps/mql/cmd/status_render_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/upstream/health"
 )
 
 // update regenerates the golden files: go test ./apps/mql/cmd -run Golden -update
@@ -51,6 +52,12 @@ func healthyRegisteredStatus() Status {
 	s.Upstream.API.Status = "SERVING"
 	s.Upstream.API.Timestamp = "2026-06-29T21:37:00Z"
 	s.Upstream.API.Version = "13"
+	s.Ingest = &health.IngestStatus{
+		Endpoint:   "https://ingest.us.mondoo.com",
+		Reachable:  true,
+		StatusCode: 404,
+		LatencyMs:  41,
+	}
 	return s
 }
 
@@ -434,6 +441,108 @@ func staleNotRegisteredStatus() Status {
 	return s
 }
 
+// ingestUnreachableStatus mirrors the case this check exists for: the API is
+// reachable and SERVING, the credentials are good, and the upload endpoint is
+// blackholed — so every scan will run to completion and then fail to report.
+func ingestUnreachableStatus() Status {
+	s := healthyRegisteredStatus()
+	// isolate the ingest failure: everything else current
+	for i := range s.Client.Providers {
+		s.Client.Providers[i].Outdated = false
+		s.Client.Providers[i].Latest = s.Client.Providers[i].Installed
+	}
+	s.Ingest = &health.IngestStatus{
+		Endpoint:  "https://ingest.us.mondoo.com",
+		Reachable: false,
+		LatencyMs: 10000,
+		Reason:    health.IngestFailureTimeout,
+		Error:     "Get \"https://ingest.us.mondoo.com\": context deadline exceeded",
+	}
+	return s
+}
+
+func TestRenderCli_PlatformSection_IngestReachable(t *testing.T) {
+	s := healthyRegisteredStatus()
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "Ingest")
+	assert.Contains(t, out, "https://ingest.us.mondoo.com")
+	assert.Contains(t, out, "✓ reachable")
+	assert.Contains(t, out, "41ms")
+	// The endpoint answers an unauthenticated probe with 404 by design, so the
+	// status code must not be rendered next to the green check.
+	assert.NotContains(t, out, "404")
+}
+
+func TestRenderCli_PlatformSection_IngestOmittedWhenNotChecked(t *testing.T) {
+	// A self-hosted API endpoint derives no ingest host, so the check does not
+	// run and the row must not appear at all rather than render as a failure.
+	s := healthyRegisteredStatus()
+	s.Ingest = nil
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.NotContains(t, out, "Ingest")
+	assert.NotContains(t, out, "unreachable")
+}
+
+func TestRenderCli_IngestUnreachable_RowNamesTheReason(t *testing.T) {
+	s := ingestUnreachableStatus()
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "https://ingest.us.mondoo.com")
+	assert.Contains(t, out, "✗ unreachable")
+	assert.Contains(t, out, "timeout")
+}
+
+func TestRenderCli_IngestUnreachable_SummaryFlagsPlatform(t *testing.T) {
+	s := ingestUnreachableStatus()
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	// The API is SERVING, so the summary still reports it reachable — but it
+	// must not claim the platform is healthy when uploads cannot land.
+	assert.Contains(t, out, "SERVING")
+	assert.Contains(t, out, "⚠ ingest unreachable")
+	assert.NotContains(t, out, "✓ healthy")
+}
+
+func TestRenderCli_IngestUnreachable_FooterNamesTheEgressRule(t *testing.T) {
+	s := ingestUnreachableStatus()
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	// Nothing about the client is broken, so the next step is the firewall rule
+	// to open — as a host:port pair, which is how the rule is written.
+	assert.Contains(t, out, "next steps")
+	assert.Contains(t, out, "allow egress to ingest.us.mondoo.com:443")
+	assert.NotContains(t, out, "all systems healthy")
+	// ...but it is not an error state for the exit code, so no exit banner.
+	assert.NotContains(t, out, "exit 1")
+}
+
+func TestIngestHostPort(t *testing.T) {
+	tests := []struct {
+		endpoint string
+		expected string
+	}{
+		{"https://ingest.us.mondoo.com", "ingest.us.mondoo.com:443"},
+		{"https://ingest.eu.mondoo.com/", "ingest.eu.mondoo.com:443"},
+		{"https://ingest.us.mondoo.com:8443", "ingest.us.mondoo.com:8443"},
+		{"http://localhost", "localhost:80"},
+		// Unparseable input falls back to the raw endpoint rather than to an
+		// empty hint.
+		{"://nope", "://nope"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		assert.Equalf(t, tt.expected, ingestHostPort(tt.endpoint), "ingestHostPort(%q)", tt.endpoint)
+	}
+}
+
 func TestRenderCli_Golden(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -442,6 +551,7 @@ func TestRenderCli_Golden(t *testing.T) {
 		{"healthy_registered", healthyRegisteredStatus()},
 		{"stale_not_registered", staleNotRegisteredStatus()},
 		{"registered_auth_failed", registeredAuthFailedStatus()},
+		{"ingest_unreachable", ingestUnreachableStatus()},
 	}
 
 	for _, tc := range cases {

--- a/apps/mql/cmd/testdata/status_healthy_registered.golden
+++ b/apps/mql/cmd/testdata/status_healthy_registered.golden
@@ -17,6 +17,7 @@
   │  Endpoint   https://us.api.mondoo.com
   │  Status     SERVING   API v13 ✓ in sync
   │  Time       2026-06-29T21:37:00Z
+  │  Ingest     https://ingest.us.mondoo.com   ✓ reachable · 41ms
   │  Client     //agents.api.mondoo.app/spaces/test/agents/123
   │  Account    //agents.api.mondoo.app/spaces/test/serviceaccounts/abc
 

--- a/apps/mql/cmd/testdata/status_ingest_unreachable.golden
+++ b/apps/mql/cmd/testdata/status_ingest_unreachable.golden
@@ -1,6 +1,6 @@
 
-  ● Client     registered   ✗ authentication failed
-  ● Platform   reachable · SERVING   ✓ healthy
+  ● Client     registered   ✓ authenticated
+  ● Platform   reachable · SERVING   ⚠ ingest unreachable
   ● Updates    up to date
 
   ── System ──────────────────────────────────────────────
@@ -17,7 +17,7 @@
   │  Endpoint   https://us.api.mondoo.com
   │  Status     SERVING   API v13 ✓ in sync
   │  Time       2026-06-29T21:37:00Z
-  │  Ingest     https://ingest.us.mondoo.com   ✓ reachable · 41ms
+  │  Ingest     https://ingest.us.mondoo.com   ✗ unreachable · timeout
   │  Client     //agents.api.mondoo.app/spaces/test/agents/123
   │  Account    //agents.api.mondoo.app/spaces/test/serviceaccounts/abc
 
@@ -26,6 +26,6 @@
   │
   │  ✓ current  aws, core, os
 
-  ✗ authentication failed · exit 1 · next steps:
-    → mql login --token <token>       re-register with a fresh token from Mondoo Platform
+  next steps:
+    → allow egress to ingest.us.mondoo.com:443    scan results are uploaded to this endpoint
 

--- a/apps/mql/cmd/testdata/status_stale_not_registered.golden
+++ b/apps/mql/cmd/testdata/status_stale_not_registered.golden
@@ -17,6 +17,7 @@
   │  Endpoint   https://us.api.mondoo.com
   │  Status     SERVING   API v13 ✓ in sync
   │  Time       2026-06-29T21:37:00Z
+  │  Ingest     https://ingest.us.mondoo.com   ✓ reachable · 41ms
   │  Client     ✗ not registered — run mql login
 
   ── Providers ──────────────────────────────────────────────

--- a/cli/config/ingest.go
+++ b/cli/config/ingest.go
@@ -1,0 +1,104 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package config
+
+import (
+	"net/url"
+	"strings"
+)
+
+const (
+	// hostedDomain is the DNS domain of Mondoo's hosted regions. Ingest
+	// endpoints exist only there: a self-hosted or edge deployment publishes
+	// its ingest domain in its own server config, and the client never learns
+	// it (it only ever sees the host inside a signed upload URL, at upload
+	// time). So anything outside this domain derives no ingest endpoint at all
+	// rather than a guessed one.
+	hostedDomain = "mondoo.com"
+
+	// hostedAPILabel is the label every hosted API host carries in front of the
+	// domain: "us.api.mondoo.com", or a bare "api.mondoo.com" for the legacy
+	// unregioned endpoint.
+	hostedAPILabel = "api"
+
+	// ingestLabel prefixes the ingest host of a region:
+	// "us.api.mondoo.com" -> "ingest.us.mondoo.com".
+	ingestLabel = "ingest"
+
+	// legacyRegion is the region behind the unregioned https://api.mondoo.com,
+	// which is an alias for the US region.
+	legacyRegion = "us"
+)
+
+// UpstreamIngestEndpoint returns the ingest endpoint that scan uploads are
+// routed through for the configured region, or "" when none can be derived.
+//
+// It is the upload counterpart of UpstreamApiEndpoint and takes its region from
+// it, so the region follows the same resolution order the API endpoint does
+// (flag, env, config file, default). The two are separate hosts on separate
+// static IPs, which is the whole reason this exists: an egress firewall can
+// allow the API and still blackhole uploads.
+func (c *CommonOpts) UpstreamIngestEndpoint() string {
+	return IngestEndpointFor(c.UpstreamApiEndpoint())
+}
+
+// IngestEndpointFor derives the ingest endpoint that belongs to a Mondoo API
+// endpoint: https://us.api.mondoo.com -> https://ingest.us.mondoo.com.
+//
+// It returns "" when apiEndpoint is not a hosted Mondoo API host — a
+// self-hosted deployment, a staging endpoint on another domain, or localhost.
+// Callers treat that as "no ingest check to run": inventing a host would turn
+// an unknown into a resolution failure that reads like a blocked firewall.
+func IngestEndpointFor(apiEndpoint string) string {
+	region := hostedRegion(apiEndpoint)
+	if region == "" {
+		return ""
+	}
+	// Hosted regions are HTTPS-only, so the scheme is not carried over from
+	// apiEndpoint.
+	return "https://" + ingestLabel + "." + region + "." + hostedDomain
+}
+
+// hostedRegion extracts the region label from a hosted Mondoo API endpoint:
+// "https://eu.api.mondoo.com" -> "eu", and the unregioned legacy
+// "https://api.mondoo.com" -> "us". It returns "" for any host that is not
+// <region>.api or api under hostedDomain.
+//
+// The region label itself is not checked against a list of known regions, so a
+// region added to the platform later works without a client release. The cost
+// is that an api_endpoint pointed at some other host under the domain (a
+// token-exchange or scanner host, say) derives an ingest host that does not
+// exist; that is not a value a client's api_endpoint takes, and silently
+// skipping the check for a real new region is the worse failure.
+func hostedRegion(apiEndpoint string) string {
+	raw := strings.TrimSpace(apiEndpoint)
+	if raw == "" {
+		return ""
+	}
+	// api_endpoint is conventionally a full URL, but a bare host is accepted
+	// too — url.Parse would otherwise file the whole thing under Path and
+	// leave Host empty.
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+
+	// Hostname() drops the port and the brackets around an IPv6 literal.
+	host := strings.ToLower(strings.TrimSuffix(u.Hostname(), "."))
+	prefix, ok := strings.CutSuffix(host, "."+hostedDomain)
+	if !ok {
+		return ""
+	}
+	if prefix == hostedAPILabel {
+		return legacyRegion
+	}
+	region, ok := strings.CutSuffix(prefix, "."+hostedAPILabel)
+	if !ok || region == "" || strings.Contains(region, ".") {
+		return ""
+	}
+	return region
+}

--- a/cli/config/ingest_test.go
+++ b/cli/config/ingest_test.go
@@ -1,0 +1,155 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIngestEndpointFor(t *testing.T) {
+	tests := []struct {
+		name        string
+		apiEndpoint string
+		expected    string
+	}{
+		{
+			name:        "us region",
+			apiEndpoint: "https://us.api.mondoo.com",
+			expected:    "https://ingest.us.mondoo.com",
+		},
+		{
+			name:        "eu region",
+			apiEndpoint: "https://eu.api.mondoo.com",
+			expected:    "https://ingest.eu.mondoo.com",
+		},
+		{
+			// api.mondoo.com predates the regional hosts and is an alias for
+			// the US region, so it maps to the US ingest host rather than to
+			// nothing.
+			name:        "legacy unregioned endpoint",
+			apiEndpoint: "https://api.mondoo.com",
+			expected:    "https://ingest.us.mondoo.com",
+		},
+		{
+			// A region the platform adds later needs no client release: the
+			// label is carried across rather than matched against a list.
+			name:        "unknown region is carried across",
+			apiEndpoint: "https://ap.api.mondoo.com",
+			expected:    "https://ingest.ap.mondoo.com",
+		},
+		{
+			name:        "trailing path and slash are ignored",
+			apiEndpoint: "https://eu.api.mondoo.com/",
+			expected:    "https://ingest.eu.mondoo.com",
+		},
+		{
+			name:        "port is dropped",
+			apiEndpoint: "https://us.api.mondoo.com:443",
+			expected:    "https://ingest.us.mondoo.com",
+		},
+		{
+			name:        "host is matched case-insensitively",
+			apiEndpoint: "https://US.API.Mondoo.COM",
+			expected:    "https://ingest.us.mondoo.com",
+		},
+		{
+			name:        "bare host without a scheme",
+			apiEndpoint: "eu.api.mondoo.com",
+			expected:    "https://ingest.eu.mondoo.com",
+		},
+		{
+			name:        "surrounding whitespace is trimmed",
+			apiEndpoint: "  https://us.api.mondoo.com  ",
+			expected:    "https://ingest.us.mondoo.com",
+		},
+		{
+			// Hosted regions are HTTPS-only; an http:// API endpoint does not
+			// produce an http:// ingest endpoint.
+			name:        "scheme is not carried over",
+			apiEndpoint: "http://us.api.mondoo.com",
+			expected:    "https://ingest.us.mondoo.com",
+		},
+		{
+			// Ingest hosts exist only in the hosted mondoo.com regions. Every
+			// case below derives nothing, so `status` skips the check instead
+			// of probing a host that was never provisioned and reporting the
+			// resulting DNS failure as a blocked firewall.
+			name:        "self-hosted deployment",
+			apiEndpoint: "https://mondoo.example.com",
+			expected:    "",
+		},
+		{
+			name:        "staging on another domain",
+			apiEndpoint: "https://api.edge.mondoo.app",
+			expected:    "",
+		},
+		{
+			name:        "localhost development server",
+			apiEndpoint: "http://localhost:8989",
+			expected:    "",
+		},
+		{
+			name:        "hosted domain without the api label",
+			apiEndpoint: "https://releases.mondoo.com",
+			expected:    "",
+		},
+		{
+			name:        "deeper label than a single region",
+			apiEndpoint: "https://a.b.api.mondoo.com",
+			expected:    "",
+		},
+		{
+			// The domain itself is not an API host, so it derives nothing
+			// rather than the legacy US alias.
+			name:        "bare hosted domain",
+			apiEndpoint: "https://mondoo.com",
+			expected:    "",
+		},
+		{
+			// A suffix match on the domain alone would accept this.
+			name:        "lookalike domain",
+			apiEndpoint: "https://us.api.notmondoo.com",
+			expected:    "",
+		},
+		{
+			name:        "empty endpoint",
+			apiEndpoint: "",
+			expected:    "",
+		},
+		{
+			name:        "unparseable endpoint",
+			apiEndpoint: "https://us.api.mondoo.com/%zz",
+			expected:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IngestEndpointFor(tt.apiEndpoint))
+		})
+	}
+}
+
+func TestUpstreamIngestEndpoint_FollowsConfiguredApiEndpoint(t *testing.T) {
+	opts := &CommonOpts{APIEndpoint: "https://eu.api.mondoo.com"}
+
+	assert.Equal(t, "https://ingest.eu.mondoo.com", opts.UpstreamIngestEndpoint())
+}
+
+func TestUpstreamIngestEndpoint_DefaultsToTheDefaultRegion(t *testing.T) {
+	// With no api_endpoint configured, UpstreamApiEndpoint falls back to the
+	// default US endpoint, and the ingest endpoint has to follow it there.
+	opts := &CommonOpts{}
+
+	assert.Equal(t, "https://ingest.us.mondoo.com", opts.UpstreamIngestEndpoint())
+	assert.Equal(t, IngestEndpointFor(opts.UpstreamApiEndpoint()), opts.UpstreamIngestEndpoint())
+}
+
+func TestUpstreamIngestEndpoint_SelfHostedDerivesNothing(t *testing.T) {
+	opts := &CommonOpts{APIEndpoint: "https://mondoo.internal.example.com"}
+
+	assert.Empty(t, opts.UpstreamIngestEndpoint())
+}

--- a/providers-sdk/v1/upstream/health/ingest.go
+++ b/providers-sdk/v1/upstream/health/ingest.go
@@ -1,0 +1,177 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package health
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"syscall"
+	"time"
+
+	"go.mondoo.com/ranger-rpc"
+)
+
+// IngestStatus is the outcome of an unauthenticated reachability probe of the
+// scan-upload ingest endpoint. The endpoint is a different host from the API on
+// a different static IP, so it is possible — and in locked-down networks
+// common — for the API to be reachable while uploads are blackholed. This is
+// what makes that visible before a scan discovers it.
+type IngestStatus struct {
+	// Endpoint is the ingest endpoint that was probed.
+	Endpoint string `json:"endpoint,omitempty"`
+	// Reachable reports whether the endpoint answered at all. ANY HTTP status
+	// counts: the probe is not authenticated and carries no presigned
+	// signature, so the ingest proxy answers it with 404 — reaching that 404
+	// already proves DNS, TCP, TLS and the proxy are all working, which is
+	// exactly what a preflight needs to know.
+	Reachable bool `json:"reachable"`
+	// StatusCode is the HTTP status the endpoint answered with, 0 when it did
+	// not answer. Recorded for diagnostics only; see Reachable for why it is
+	// not compared against 200.
+	StatusCode int `json:"statusCode,omitempty"`
+	// LatencyMs is how long the probe took, on both the success and the failure
+	// path (a firewall that blackholes the connection shows up as a latency
+	// equal to the probe timeout, a rejecting one as a few milliseconds).
+	LatencyMs int64 `json:"latencyMs,omitempty"`
+	// Reason is a short stable label for why the probe failed, empty on
+	// success. See the IngestFailure* constants.
+	Reason string `json:"reason,omitempty"`
+	// Error is the underlying transport error, empty on success.
+	Error string `json:"error,omitempty"`
+}
+
+// Reasons an ingest probe failed. They are a closed set of short labels meant
+// to be rendered as-is and to stay stable in the JSON output of `status`.
+const (
+	// IngestFailureDNS means the host did not resolve.
+	IngestFailureDNS = "dns"
+	// IngestFailureTimeout means nothing came back before the deadline — the
+	// signature of a firewall that drops packets instead of rejecting them.
+	IngestFailureTimeout = "timeout"
+	// IngestFailureTLS means the TLS handshake failed, which is what an
+	// intercepting proxy without a trusted certificate looks like.
+	IngestFailureTLS = "tls"
+	// IngestFailureConnectionRefused means the connection was actively
+	// rejected, so something answered — a firewall that rejects rather than
+	// drops, or a proxy with no route.
+	IngestFailureConnectionRefused = "connection refused"
+	// IngestFailureConnectionReset means an established connection was dropped.
+	IngestFailureConnectionReset = "connection reset"
+	// IngestFailureRequest means the endpoint could not be turned into a
+	// request at all (a malformed URL), so nothing was ever sent.
+	IngestFailureRequest = "invalid endpoint"
+	// IngestFailureOther is the catch-all; Error carries the detail.
+	IngestFailureOther = "unreachable"
+)
+
+// ingestProbeTimeout bounds a single ingest probe. A blackholed host answers
+// nothing at all, so this is the wall-clock cost of the check in the worst
+// case, and the reason callers run it concurrently with their other checks
+// rather than in series.
+const ingestProbeTimeout = 10 * time.Second
+
+// ingestDrainLimit caps how much of the probe response body is read before the
+// connection is returned to the pool. The endpoint answers a short 404 body;
+// the limit is only there so a misconfigured host cannot stream at us.
+const ingestDrainLimit = 4 << 10
+
+// CheckIngestReachable probes the scan-upload ingest endpoint with a plain,
+// unauthenticated GET and reports whether it answered.
+//
+// It sends no credentials: the ingest proxy strips platform auth headers and
+// only honors the storage signature on a real upload, so there is nothing for a
+// probe to authenticate with — and nothing to leak by probing. httpClient
+// should be the caller's configured client so the probe traverses the same
+// proxy (api_proxy / HTTPS_PROXY) real uploads do; nil falls back to the
+// default client.
+//
+// An empty endpoint returns a zero IngestStatus without touching the network:
+// callers that could not derive an endpoint skip the check rather than report a
+// failure.
+func CheckIngestReachable(ctx context.Context, httpClient *http.Client, endpoint string) IngestStatus {
+	status := IngestStatus{Endpoint: endpoint}
+	if endpoint == "" {
+		return status
+	}
+	if httpClient == nil {
+		httpClient = ranger.DefaultHttpClient()
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, ingestProbeTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		status.Reason = IngestFailureRequest
+		status.Error = err.Error()
+		return status
+	}
+
+	start := time.Now()
+	resp, err := httpClient.Do(req)
+	status.LatencyMs = time.Since(start).Milliseconds()
+	if err != nil {
+		status.Reason = classifyIngestFailure(err)
+		status.Error = err.Error()
+		return status
+	}
+	defer resp.Body.Close()
+	// Drain a bounded amount so the connection can be reused.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, ingestDrainLimit))
+
+	status.Reachable = true
+	status.StatusCode = resp.StatusCode
+	return status
+}
+
+// classifyIngestFailure maps a transport error to one of the IngestFailure*
+// labels. It inspects the error tree with errors.Is/As rather than matching
+// message strings, so it survives standard-library wording changes, and it
+// checks the specific cases before the generic net.Error timeout: a DNS or TLS
+// failure is also a net.Error, and "timeout" is the least useful of the answers
+// that fit.
+func classifyIngestFailure(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return IngestFailureDNS
+	}
+
+	var certErr *tls.CertificateVerificationError
+	if errors.As(err, &certErr) {
+		return IngestFailureTLS
+	}
+	var recordErr tls.RecordHeaderError
+	if errors.As(err, &recordErr) {
+		return IngestFailureTLS
+	}
+
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return IngestFailureConnectionRefused
+	}
+	if errors.Is(err, syscall.ECONNRESET) {
+		return IngestFailureConnectionReset
+	}
+
+	// Checked after the cases above, and before context.Canceled: the probe's
+	// own deadline surfaces as DeadlineExceeded, while a parent context that
+	// was canceled (the whole command timed out) is still, from the user's
+	// point of view, "nothing came back in time".
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return IngestFailureTimeout
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return IngestFailureTimeout
+	}
+
+	return IngestFailureOther
+}

--- a/providers-sdk/v1/upstream/health/ingest_test.go
+++ b/providers-sdk/v1/upstream/health/ingest_test.go
@@ -1,0 +1,168 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package health
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckIngestReachable_AnyHttpStatusIsReachable(t *testing.T) {
+	// The real endpoint answers 404 to anything that is not a presigned upload,
+	// so a 404 is the healthy answer and 503 still proves the network path.
+	for _, code := range []int{http.StatusOK, http.StatusNotFound, http.StatusForbidden, http.StatusServiceUnavailable} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			w.WriteHeader(code)
+		}))
+
+		status := CheckIngestReachable(context.Background(), srv.Client(), srv.URL)
+		srv.Close()
+
+		assert.True(t, status.Reachable, "HTTP %d must count as reachable", code)
+		assert.Equal(t, code, status.StatusCode)
+		assert.Equal(t, srv.URL, status.Endpoint)
+		assert.Empty(t, status.Reason)
+		assert.Empty(t, status.Error)
+	}
+}
+
+func TestCheckIngestReachable_SendsNoCredentials(t *testing.T) {
+	var authorization, cookie string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization = r.Header.Get("Authorization")
+		cookie = r.Header.Get("Cookie")
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	status := CheckIngestReachable(context.Background(), srv.Client(), srv.URL)
+
+	require.True(t, status.Reachable)
+	assert.Empty(t, authorization, "the probe must not authenticate")
+	assert.Empty(t, cookie)
+}
+
+func TestCheckIngestReachable_EmptyEndpointSkipsTheNetwork(t *testing.T) {
+	// A caller that could not derive an endpoint gets a zero value, not a
+	// failure: nothing was checked, so nothing is wrong.
+	status := CheckIngestReachable(context.Background(), http.DefaultClient, "")
+
+	assert.False(t, status.Reachable)
+	assert.Empty(t, status.Endpoint)
+	assert.Empty(t, status.Reason)
+	assert.Zero(t, status.LatencyMs)
+}
+
+func TestCheckIngestReachable_ConnectionRefused(t *testing.T) {
+	// A listener that is closed before the probe runs gives a port nothing is
+	// listening on, which is the reject-rather-than-drop firewall shape.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	endpoint := "http://" + listener.Addr().String()
+	require.NoError(t, listener.Close())
+
+	status := CheckIngestReachable(context.Background(), http.DefaultClient, endpoint)
+
+	assert.False(t, status.Reachable)
+	assert.Equal(t, IngestFailureConnectionRefused, status.Reason)
+	assert.NotEmpty(t, status.Error)
+	assert.Zero(t, status.StatusCode)
+}
+
+func TestCheckIngestReachable_TimeoutReportsLatency(t *testing.T) {
+	// A handler that never answers stands in for a blackholing firewall. The
+	// deadline comes from the caller's context, which is tighter than the
+	// probe's own timeout, so the test does not wait it out.
+	blocked := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-blocked
+	}))
+	defer func() {
+		close(blocked)
+		srv.Close()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	status := CheckIngestReachable(ctx, srv.Client(), srv.URL)
+
+	assert.False(t, status.Reachable)
+	assert.Equal(t, IngestFailureTimeout, status.Reason)
+	assert.NotEmpty(t, status.Error)
+	// Latency is recorded on the failure path too — it is what tells a dropped
+	// connection (waited out the deadline) from a rejected one (immediate).
+	assert.GreaterOrEqual(t, status.LatencyMs, int64(40))
+}
+
+func TestCheckIngestReachable_MalformedEndpoint(t *testing.T) {
+	status := CheckIngestReachable(context.Background(), http.DefaultClient, "https://ingest.us.mondoo.com/\x7f")
+
+	assert.False(t, status.Reachable)
+	assert.Equal(t, IngestFailureRequest, status.Reason)
+	assert.NotEmpty(t, status.Error)
+}
+
+func TestCheckIngestReachable_NilClientIsUsable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	status := CheckIngestReachable(context.Background(), nil, srv.URL)
+
+	assert.True(t, status.Reachable)
+	assert.Equal(t, http.StatusNotFound, status.StatusCode)
+}
+
+func TestClassifyIngestFailure(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{"nil", nil, ""},
+		{
+			// Wrapped the way http.Client returns it, to prove the classifier
+			// walks the error tree instead of matching on the top-level type.
+			name:     "dns",
+			err:      &url.Error{Op: "Get", URL: "https://ingest.us.mondoo.com", Err: &net.DNSError{Err: "no such host", Name: "ingest.us.mondoo.com"}},
+			expected: IngestFailureDNS,
+		},
+		{"tls verification", &tls.CertificateVerificationError{}, IngestFailureTLS},
+		{"tls record header", tls.RecordHeaderError{Msg: "first record does not look like a TLS handshake"}, IngestFailureTLS},
+		{"connection refused", &url.Error{Op: "Get", Err: syscall.ECONNREFUSED}, IngestFailureConnectionRefused},
+		{"connection reset", &url.Error{Op: "Get", Err: syscall.ECONNRESET}, IngestFailureConnectionReset},
+		{"deadline exceeded", &url.Error{Op: "Get", Err: context.DeadlineExceeded}, IngestFailureTimeout},
+		{"canceled", &url.Error{Op: "Get", Err: context.Canceled}, IngestFailureTimeout},
+		{"net timeout", &url.Error{Op: "Get", Err: timeoutError{}}, IngestFailureTimeout},
+		{"unrecognised", errors.New("boom"), IngestFailureOther},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, classifyIngestFailure(tt.err))
+		})
+	}
+}
+
+// timeoutError is a net.Error that reports a timeout without being one of the
+// standard-library error values the classifier checks by identity.
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "i/o timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }


### PR DESCRIPTION
## Problem

Scan results do not go to the API host. When the ingest proxy is on, the platform rewrites the signed upload URL to a dedicated ingest domain on its own static IP — `ingest.us.mondoo.com`, `ingest.eu.mondoo.com` — precisely so customers behind an egress firewall have one stable IP to allow-list (`server/ingestproxy`). That makes it a second, independently blockable host on the critical path, and `status` said nothing about it: it verified the API, reported `✓ all systems healthy`, and the first sign of a blocked upload host was a scan that ran to completion and then failed to report.

## What changed

`status` now probes the upload endpoint as part of its preflight.

```
  ● Platform   reachable · SERVING   ✓ healthy
  │  Ingest     https://ingest.eu.mondoo.com   ✓ reachable · 126ms
```

```
  ● Platform   reachable · SERVING   ⚠ ingest unreachable
  │  Ingest     https://ingest.us.mondoo.com   ✗ unreachable · timeout

  next steps:
    → allow egress to ingest.us.mondoo.com:443    scan results are uploaded to this endpoint
```

- **`cli/config/ingest.go`** — `UpstreamIngestEndpoint()` is the upload counterpart of `UpstreamApiEndpoint()` and takes its region from it, so the region follows the same resolution order `api_endpoint` does (flag, env, config file, default). `us.api.mondoo.com` → `https://ingest.us.mondoo.com`; the unregioned `api.mondoo.com` maps to the US region it aliases (both resolve to the same address).
- **`providers-sdk/v1/upstream/health/ingest.go`** — one unauthenticated `GET`, sent through the caller's client so the probe traverses the same `api_proxy` / `HTTPS_PROXY` real uploads do. Failures are classified (`dns`, `timeout`, `tls`, `connection refused`, `connection reset`), because which one it is *is* the diagnosis: a timeout is a firewall dropping packets, a TLS failure is an intercepting proxy, DNS is split-horizon resolution.
- **`apps/mql/cmd/status.go`, `status_render.go`** — a row under Mondoo Platform, plus the failure treatment: the summary's Platform dot downgrades, `✓ all systems healthy` is suppressed, and the footer names the egress rule to open rather than a command (no command fixes a firewall).

## Decisions worth a reviewer's eye

- **Any HTTP answer counts as reachable.** The ingest proxy 404s everything that is not a presigned upload, so reaching that 404 already proves DNS, TCP, TLS and the proxy — which is all a preflight needs. The status code is kept in `-o json` for diagnostics but not rendered next to the green check, where "404" reads as a defect.
- **A non-hosted API endpoint derives no ingest endpoint, and the row is omitted.** Ingest hosts exist only in the hosted `mondoo.com` regions; a self-hosted deployment publishes its ingest domain in its own server config and the client never learns it (it only ever sees the host inside a signed URL, at upload time). Inventing a host would turn that unknown into a resolution failure that reads exactly like the firewall block we are hunting for.
- **The region label is not matched against a `{us, eu}` list,** so a region added to the platform later works without a client release. The cost is that an `api_endpoint` pointed at some other host under the domain derives an ingest host that does not exist — not a value a client's `api_endpoint` takes, and silently skipping the check for a real new region is the worse failure.
- **The probe runs concurrently with the remaining checks.** A blackholed host answers nothing until the probe's 10s deadline, which in series would eat a third of the command's 30s budget and push the provider-registry checks into reporting a false "registry unreachable".
- **The exit code is unchanged** — still registration and auth only. A blocked upload host is a warning, not an `exit 1`.

## Verification

- Ran the built binary against a real config (`eu.api.mondoo.com`): `Ingest https://ingest.eu.mondoo.com ✓ reachable · 126ms`, and `-o json` carries `{"endpoint": "https://ingest.eu.mondoo.com", "reachable": true, "statusCode": 404, "latencyMs": 152}`.
- Forced the failure path with a nonexistent region: row, summary downgrade, footer hint and the `dns` reason all render, and the JSON carries the underlying transport error.
- New unit tests for the derivation (regions, legacy alias, case/port/scheme handling, and every skip case), for the probe (any-status reachability, no credentials sent, refused, timeout with latency recorded, malformed endpoint, nil client) and for the rendering, plus a new `status_ingest_unreachable` golden. `go vet` and `golangci-lint` clean on the three touched packages.

## Follow-up

`cnspec status` is this same command, so it inherits the check with a mql bump — no cnspec-side change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)