### PR TITLE
🌙 providers: publish and hand out provider-map snapshots, not aliases (v13)

### DIFF
--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -4,6 +4,7 @@
 package providers
 
 import (
+	"maps"
 	"math"
 	"os/exec"
 	"strconv"
@@ -65,9 +66,15 @@ type coordinator struct {
 	// (extensibleSchema.unsafeLoadAll -> LoadSchema), so it must never be
 	// held while acquiring either of those.
 	//
-	// providers is only ever replaced wholesale (SetProviders), never
-	// mutated in place: Providers hands the map out after releasing
-	// providersMu, and callers hold that reference unguarded.
+	// providers is only ever replaced wholesale, never mutated in place.
+	// That is enforced rather than assumed: SetProviders stores a clone and
+	// Providers returns one, so no caller holds an alias of the published
+	// map. It has to be, because callers do mutate what they are handed —
+	// EnsureProvider adds the builtin connection providers, and
+	// installDependencies adds freshly installed dependencies — while
+	// LoadSchema reads the published map under providersMu without
+	// coordinator.mutex to keep the lock order below acyclic. Concurrent
+	// map read and write is a fatal runtime error, not a recoverable one.
 	providersMu sync.RWMutex
 	providers   Providers
 	runningByID map[string]*RunningProvider
@@ -274,6 +281,45 @@ func (c *coordinator) GetRunningProvider(id string, update UpdateProvidersConfig
 	return running, nil
 }
 
+// lookupProvider reads a single entry from the published snapshot. Callers on
+// the provider-start path use this rather than Providers, which has to clone
+// the whole map to hand it out safely.
+func (c *coordinator) lookupProvider(id string) (*Provider, bool) {
+	c.providersMu.RLock()
+	defer c.providersMu.RUnlock()
+	provider, ok := c.providers[id]
+	return provider, ok
+}
+
+// unsafeResolveProvider finds an installed provider by id, re-listing once if
+// the published snapshot doesn't have it. A snapshot goes stale on the
+// install-on-demand path: EnsureProvider installs the provider an asset needs
+// and adds it to the map it was handed, which is the caller's own copy, so the
+// coordinator never sees that write. Install resets CachedProviders, so
+// re-listing re-scans disk and picks it up. When the id is simply unknown the
+// re-list is cheap — ListActive rebuilds its map from CachedProviders without
+// touching disk.
+//
+// It is called with coordinator.mutex held and takes only providersMu, which
+// is the documented order: mutex -> schema.sync -> providersMu.
+func (c *coordinator) unsafeResolveProvider(id string) (*Provider, error) {
+	if provider, ok := c.lookupProvider(id); ok {
+		return provider, nil
+	}
+
+	refreshed, err := ListActive()
+	if err != nil {
+		return nil, err
+	}
+	c.SetProviders(refreshed)
+
+	provider, ok := refreshed[id]
+	if !ok {
+		return nil, errors.New("cannot find provider " + id)
+	}
+	return provider, nil
+}
+
 // unsafeStartProvider will start a provider and add it to the list of running providers. Must be called
 // with a mutex lock around it.
 func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfig) (*RunningProvider, error) {
@@ -296,19 +342,9 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 		return x.Runtime, nil
 	}
 
-	providers := c.Providers()
-	if providers == nil {
-		var err error
-		providers, err = ListActive()
-		if err != nil {
-			return nil, err
-		}
-		c.SetProviders(providers)
-	}
-
-	provider, ok := providers[id]
-	if !ok {
-		return nil, errors.New("cannot find provider " + id)
+	provider, err := c.unsafeResolveProvider(id)
+	if err != nil {
+		return nil, err
 	}
 
 	if update.Enabled {
@@ -407,19 +443,25 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 	return res, nil
 }
 
+// SetProviders publishes a snapshot of providers. It clones because callers
+// keep and mutate the map they pass (ListActive hands its map to
+// installDependencies), and the published one is read by LoadSchema under
+// providersMu alone.
 func (c *coordinator) SetProviders(providers Providers) {
 	c.providersMu.Lock()
-	c.providers = providers
+	c.providers = maps.Clone(providers)
 	c.providersMu.Unlock()
 }
 
-// Providers returns the current provider map. It is safe to read without
-// providersMu only because the map is replaced, never mutated (see the
-// field); don't write to the returned map.
+// Providers returns a snapshot of the installed providers. It is a clone:
+// callers mutate what they get (see EnsureProvider), and the published map
+// is read concurrently by LoadSchema. Writes to the returned map are local
+// to the caller — a provider installed that way is picked up by the next
+// ListActive, which re-scans after Install resets the cache.
 func (c *coordinator) Providers() Providers {
 	c.providersMu.RLock()
 	defer c.providersMu.RUnlock()
-	return c.providers
+	return maps.Clone(c.providers)
 }
 
 // stop will stop a provider and remove it from the list of running providers. Must be called
@@ -475,9 +517,7 @@ func (c *coordinator) LoadSchema(name string) (resources.ResourcesSchema, error)
 		return x.Runtime.Schema, nil
 	}
 
-	c.providersMu.RLock()
-	provider, ok := c.providers[name]
-	c.providersMu.RUnlock()
+	provider, ok := c.lookupProvider(name)
 	if !ok {
 		return nil, errors.New("cannot find provider '" + name + "'")
 	}

--- a/providers/coordinator_providers_snapshot_test.go
+++ b/providers/coordinator_providers_snapshot_test.go
@@ -1,0 +1,133 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"sync"
+	"testing"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+var (
+	snapshotProviderA = plugin.Provider{Name: "snapshot-a", ID: "go.mondoo.com/mql/v13/providers/snapshot-a", Version: "1.0.0"}
+	snapshotProviderB = plugin.Provider{Name: "snapshot-b", ID: "go.mondoo.com/mql/v13/providers/snapshot-b", Version: "1.0.0"}
+)
+
+// TestCoordinatorProvidersSnapshot pins the contract that lets LoadSchema read
+// c.providers under providersMu alone, without coordinator.mutex: nobody else
+// holds an alias of the published map.
+//
+// Callers really do mutate the map they are handed — EnsureProvider adds the
+// builtin connection providers (mock/sbom/recording) to the map it is given,
+// and installDependencies adds freshly installed dependencies to the map
+// ListActive returned — so an alias would be an unsynchronized write racing
+// LoadSchema's read. That is a fatal runtime error ("concurrent map read and
+// map write"), which kills the scanner rather than returning an error.
+//
+// This check is deliberately deterministic instead of relying on -race: the
+// repo's race job only covers internal/workerpool, so a -race-only guard
+// would not run here.
+func TestCoordinatorProvidersSnapshot(t *testing.T) {
+	t.Run("SetProviders stores a snapshot", func(t *testing.T) {
+		c := newCoordinator()
+		published := Providers{snapshotProviderA.ID: {Provider: &snapshotProviderA}}
+		c.SetProviders(published)
+
+		published.Add(&Provider{Provider: &snapshotProviderB})
+
+		if _, ok := c.Providers()[snapshotProviderB.ID]; ok {
+			t.Fatal("a write to the map passed to SetProviders reached the published map")
+		}
+	})
+
+	t.Run("Providers returns a snapshot", func(t *testing.T) {
+		c := newCoordinator()
+		c.SetProviders(Providers{snapshotProviderA.ID: {Provider: &snapshotProviderA}})
+
+		c.Providers().Add(&Provider{Provider: &snapshotProviderB})
+
+		if _, ok := c.Providers()[snapshotProviderB.ID]; ok {
+			t.Fatal("a write to the map returned by Providers reached the published map")
+		}
+	})
+
+	// The snapshots above must not cost us the install-on-demand handoff:
+	// EnsureProvider installs a missing provider and adds it to the map it
+	// was handed (its own copy), then the runtime immediately asks the
+	// coordinator to start it by id. The coordinator has to find it.
+	t.Run("a provider installed on demand is startable", func(t *testing.T) {
+		cached := CachedProviders
+		t.Cleanup(func() { CachedProviders = cached })
+
+		installed := &Provider{Provider: &snapshotProviderA}
+		CachedProviders = []*Provider{installed}
+
+		c := newCoordinator()
+		listed, err := ListActive()
+		if err != nil {
+			t.Fatal(err)
+		}
+		c.SetProviders(listed)
+
+		// What EnsureProvider does: install, then add to the caller's map.
+		// Install resets the cache, so the next listing re-scans and sees it.
+		newlyInstalled := &Provider{Provider: &snapshotProviderB}
+		listed.Add(newlyInstalled)
+		CachedProviders = []*Provider{installed, newlyInstalled}
+
+		resolved, err := c.unsafeResolveProvider(snapshotProviderB.ID)
+		if err != nil {
+			t.Fatalf("provider installed on demand is not startable: %v", err)
+		}
+		if resolved.ID != snapshotProviderB.ID {
+			t.Fatalf("resolved the wrong provider: %s", resolved.ID)
+		}
+	})
+
+	t.Run("an unknown provider is still an error", func(t *testing.T) {
+		cached := CachedProviders
+		t.Cleanup(func() { CachedProviders = cached })
+		CachedProviders = []*Provider{{Provider: &snapshotProviderA}}
+
+		c := newCoordinator()
+		if _, err := c.unsafeResolveProvider("go.mondoo.com/mql/v13/providers/nope"); err == nil {
+			t.Fatal("expected an error for an unknown provider")
+		}
+	})
+
+	// Belt and braces: under -race this also catches an alias the two checks
+	// above would miss. It is a no-op otherwise.
+	t.Run("concurrent readers and writers", func(t *testing.T) {
+		c := newCoordinator()
+		c.SetProviders(Providers{snapshotProviderA.ID: {Provider: &snapshotProviderA}})
+
+		var wg sync.WaitGroup
+		wg.Add(3)
+		// The installDependencies shape: mutates under coordinator.mutex.
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				c.mutex.Lock()
+				c.Providers().Add(&Provider{Provider: &snapshotProviderB})
+				c.mutex.Unlock()
+			}
+		}()
+		// The EnsureProvider shape: mutates with no lock at all.
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				c.Providers().Add(&Provider{Provider: &snapshotProviderB})
+			}
+		}()
+		// LoadSchema's read, which holds only providersMu.
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				_, _ = c.LoadSchema(snapshotProviderA.ID)
+			}
+		}()
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
Backport of the #10621 follow-up to `v13` — the line the hosted scan runner ships. `v13` has the identical aliasing (`providers.go:436, 441, 446, 466, 661`, `runtime.go:313`) and the identical install-on-demand handoff.

## Problem

#10618 took `coordinator.mutex` out of `LoadSchema` so the lock order would be acyclic. That part is right, but it left `LoadSchema`'s read of `c.providers` — now guarded by `providersMu` alone — racing writes that take no lock at all.

`providersMu` guards the map *header*, not its contents, and the package writes into the published map **in place** from five sites, all via `Providers.Add` (`providers/providers.go:231-235`), none of which takes `providersMu`:

- `EnsureProvider` adds the builtin connection providers (`providers.go:452, 457, 462`) and is handed the published map directly — `runtime.go:317` passes `r.coordinator.Providers()`.
- `installDependencies` adds freshly installed dependencies (`providers.go:677`, and `:482`) and is handed the map `ListActive` returned, which `ListActive` also published via `SetProviders` — the same map object (`providers.go:298-304`).

The second path is reachable from exactly the provider start #10618 was about: `unsafeStartProvider` (holding `coordinator.mutex`) → `TryProviderUpdate` (`coordinator.go:321`) → `ListActive()` → `installDependencies` → in-place `Add`. Before #10618, `LoadSchema` also held `coordinator.mutex`, so the two were mutually excluded. They no longer are.

Concurrent map read and write is a fatal runtime error in Go (`fatal error: concurrent map read and map write`) — an unrecoverable abort of the scan process, not an error return. Nothing in the suite exercises it, so it would have shipped silently.

Reproduced with a writer in the `installDependencies` shape (`coordinator.mutex` held, in-place `Add`) and `LoadSchema` as the reader:

- against `40e788c5e` (before #10618): clean
- against `d3f643b0e` (after #10618): `WARNING: DATA RACE` — write at `providers.go:233`, read at `coordinator.go:482`

The `EnsureProvider` path (`runtime.go:317`, no lock at all) races both before and after #10618 — that one is pre-existing, and this change closes it too.

## Fix

Make the "replaced wholesale, never mutated" contract that `LoadSchema` relies on true by construction rather than by convention, at the two choke points:

- **`SetProviders` stores a clone** — no publisher keeps an alias of the published map. This is the part that matters for `unsafeStartProvider`: it publishes the very map `ListActive` returned, which `installDependencies` then writes to. Cloning only in `ListActive` would leave that hole open.
- **`Providers()` returns a clone** — no consumer can write through to the published map.

After this the published map is only ever touched under `providersMu`.

Cloning alone would have broken install-on-demand, so it comes with a third change. `EnsureProvider` installs the provider an asset needs and adds it to the map it was handed (`providers.go:482`) — now the caller's own copy — and `DetectProvider` then asks the coordinator to start it by id (`runtime.go:298`). That lookup used to succeed *only* because the write landed in the published map. `unsafeResolveProvider` makes the coordinator re-list once on a miss instead:

- correct regardless of who installed what: `Install` resets `CachedProviders` (`providers.go:905-907`), so the re-list re-scans disk and finds it;
- cheap for a genuinely unknown id: `ListActive` rebuilds its map from `CachedProviders` without touching disk;
- and it *collapses* the old `providers == nil` branch rather than adding one.

The other four in-place writes are harmless: `providers.go:452/457/462` add mock/sbom/recording, which `unsafeStartProvider` resolves through `builtinProviders` before any map lookup, and `providers.go:677`'s dependency add isn't looked up by id in that flow.

Cost is a ~100-entry map clone on cold paths only: the four `Providers()` callers are per-provider-start, per-connection, and two SBOM/mock lookups, and `SetProviders` is driven by `ListActive`, which already does a directory scan plus a JSON parse per provider.

## Testing

`TestCoordinatorProvidersSnapshot` pins both halves of the contract. It is **deterministic rather than `-race`-only on purpose**: `make race/go` (`Makefile:446-447`) only covers `internal/workerpool`, so a `-race`-only guard would never actually run in CI for this package. A third subtest drives both mutation shapes concurrently against `LoadSchema`, which adds `-race` value for anyone who does run it.

- the new test fails on `d3f643b0e` (both aliasing assertions) and passes with this change
- the install-on-demand subtest fails with the clones but without `unsafeResolveProvider` (`cannot find provider …/snapshot-b`), which is how that regression was caught before it shipped
- `go test ./providers/` and `go test -race ./providers/` both pass
- `TestCoordinatorSchemaLockOrder` from #10618 still passes, and still hangs against the pre-#10618 `LoadSchema`
