### PR TITLE
🐛 aws/azure/gcp/oci: stop reporting unread exposure as "not public"

### DIFF
--- a/providers/aws/resources/aws_internet_exposure.go
+++ b/providers/aws/resources/aws_internet_exposure.go
@@ -25,7 +25,7 @@ func (a *mqlAwsNeptuneInstance) exposure() (*mqlAwsNetworkExposure, error) {
 	if err != nil {
 		return nil, err
 	}
-	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible.Data, sgs)
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible, sgs)
 }
 
 // clusterSecurityGroups returns the security groups of the Neptune cluster that

--- a/providers/aws/resources/aws_network_exposure.go
+++ b/providers/aws/resources/aws_network_exposure.go
@@ -59,6 +59,22 @@ func securityGroupCount(sgs *plugin.TValue[[]any]) int {
 	return len(sgs.Data)
 }
 
+// knownPublicAccess carries a public-access verdict a caller derived itself --
+// from a load balancer scheme, a task network configuration, or the absence of
+// any public endpoint at all -- rather than reading it off a resource field.
+// The value is known, so it is never null.
+func knownPublicAccess(publiclyAccessible bool) *plugin.TValue[bool] {
+	return &plugin.TValue[bool]{Data: publiclyAccessible, State: plugin.StateIsSet}
+}
+
+// publicAccessIsUnknown reports whether a resource's public-access toggle was
+// never read: the field does not exist for this resource shape (Aurora clusters
+// do not carry PubliclyAccessible) or the call that would have answered it was
+// denied.
+func publicAccessIsUnknown(publiclyAccessible *plugin.TValue[bool]) bool {
+	return publiclyAccessible == nil || publiclyAccessible.State&plugin.StateIsNull != 0
+}
+
 // buildNetworkExposure creates a shared aws.network.exposure from a resource's
 // public-access toggle and its attached security groups.
 //
@@ -73,7 +89,12 @@ func securityGroupCount(sgs *plugin.TValue[[]any]) int {
 // report an empty list. Requiring sgAllows there made every internet-facing NLB
 // -- including one with a world-open listener -- report internetReachable:false.
 // It is also the safe direction when the group list could not be enumerated.
-func buildNetworkExposure(runtime *plugin.Runtime, id string, publiclyAccessible bool, sgs *plugin.TValue[[]any]) (*mqlAwsNetworkExposure, error) {
+//
+// A null public-access toggle stays null on the exposure, for both
+// publiclyAccessible and internetReachable. Reading false out of a value nobody
+// ever read would report the resource as shielded from the internet on evidence
+// that does not exist, which silently passes an audit.
+func buildNetworkExposure(runtime *plugin.Runtime, id string, publiclyAccessible *plugin.TValue[bool], sgs *plugin.TValue[[]any]) (*mqlAwsNetworkExposure, error) {
 	openRules, err := openIngressRulesFromSecurityGroups(sgs)
 	if err != nil {
 		return nil, err
@@ -81,15 +102,21 @@ func buildNetworkExposure(runtime *plugin.Runtime, id string, publiclyAccessible
 	sgAllows := len(openRules) > 0
 	sgsApply := securityGroupCount(sgs) > 0
 
-	internetReachable := publiclyAccessible
-	if sgsApply {
-		internetReachable = publiclyAccessible && sgAllows
+	publiclyAccessibleData := llx.NilData
+	internetReachableData := llx.NilData
+	if !publicAccessIsUnknown(publiclyAccessible) {
+		internetReachable := publiclyAccessible.Data
+		if sgsApply {
+			internetReachable = publiclyAccessible.Data && sgAllows
+		}
+		publiclyAccessibleData = llx.BoolData(publiclyAccessible.Data)
+		internetReachableData = llx.BoolData(internetReachable)
 	}
 
 	res, err := CreateResource(runtime, "aws.network.exposure", map[string]*llx.RawData{
 		"__id":                       llx.StringData(id),
-		"internetReachable":          llx.BoolData(internetReachable),
-		"publiclyAccessible":         llx.BoolData(publiclyAccessible),
+		"internetReachable":          internetReachableData,
+		"publiclyAccessible":         publiclyAccessibleData,
 		"securityGroupAllowsIngress": llx.BoolData(sgAllows),
 		"openIngressRules":           llx.ArrayData(openRules, types.Resource("aws.ec2.securitygroup.ippermission")),
 	})
@@ -101,7 +128,7 @@ func buildNetworkExposure(runtime *plugin.Runtime, id string, publiclyAccessible
 
 // buildNetworkExposureFromGroups is buildNetworkExposure for callers holding
 // already-resolved security groups rather than a lazily-fetched field.
-func buildNetworkExposureFromGroups(runtime *plugin.Runtime, id string, publiclyAccessible bool, sgs []any) (*mqlAwsNetworkExposure, error) {
+func buildNetworkExposureFromGroups(runtime *plugin.Runtime, id string, publiclyAccessible *plugin.TValue[bool], sgs []any) (*mqlAwsNetworkExposure, error) {
 	return buildNetworkExposure(runtime, id, publiclyAccessible, &plugin.TValue[[]any]{
 		Data:  sgs,
 		State: plugin.StateIsSet,
@@ -117,7 +144,7 @@ func (a *mqlAwsRdsDbinstance) exposure() (*mqlAwsNetworkExposure, error) {
 	if publiclyAccessible.Error != nil {
 		return nil, publiclyAccessible.Error
 	}
-	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible.Data, a.GetSecurityGroups())
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible, a.GetSecurityGroups())
 }
 
 func (a *mqlAwsDocumentdbInstance) exposure() (*mqlAwsNetworkExposure, error) {
@@ -129,7 +156,7 @@ func (a *mqlAwsDocumentdbInstance) exposure() (*mqlAwsNetworkExposure, error) {
 	if publiclyAccessible.Error != nil {
 		return nil, publiclyAccessible.Error
 	}
-	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible.Data, a.GetSecurityGroups())
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible, a.GetSecurityGroups())
 }
 
 func (a *mqlAwsElbLoadbalancer) exposure() (*mqlAwsNetworkExposure, error) {
@@ -141,7 +168,7 @@ func (a *mqlAwsElbLoadbalancer) exposure() (*mqlAwsNetworkExposure, error) {
 	if scheme.Error != nil {
 		return nil, scheme.Error
 	}
-	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", scheme.Data == "internet-facing", a.GetSecurityGroups())
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", knownPublicAccess(scheme.Data == "internet-facing"), a.GetSecurityGroups())
 }
 
 func (a *mqlAwsRdsDbcluster) exposure() (*mqlAwsNetworkExposure, error) {
@@ -153,7 +180,7 @@ func (a *mqlAwsRdsDbcluster) exposure() (*mqlAwsNetworkExposure, error) {
 	if publiclyAccessible.Error != nil {
 		return nil, publiclyAccessible.Error
 	}
-	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible.Data, a.GetSecurityGroups())
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible, a.GetSecurityGroups())
 }
 
 func (a *mqlAwsRedshiftCluster) exposure() (*mqlAwsNetworkExposure, error) {
@@ -165,7 +192,7 @@ func (a *mqlAwsRedshiftCluster) exposure() (*mqlAwsNetworkExposure, error) {
 	if publiclyAccessible.Error != nil {
 		return nil, publiclyAccessible.Error
 	}
-	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible.Data, a.GetSecurityGroups())
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible, a.GetSecurityGroups())
 }
 
 func (a *mqlAwsMqBroker) exposure() (*mqlAwsNetworkExposure, error) {
@@ -177,7 +204,7 @@ func (a *mqlAwsMqBroker) exposure() (*mqlAwsNetworkExposure, error) {
 	if publiclyAccessible.Error != nil {
 		return nil, publiclyAccessible.Error
 	}
-	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible.Data, a.GetSecurityGroups())
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible, a.GetSecurityGroups())
 }
 
 func (a *mqlAwsDmsReplicationInstance) exposure() (*mqlAwsNetworkExposure, error) {
@@ -189,7 +216,7 @@ func (a *mqlAwsDmsReplicationInstance) exposure() (*mqlAwsNetworkExposure, error
 	if publiclyAccessible.Error != nil {
 		return nil, publiclyAccessible.Error
 	}
-	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible.Data, a.GetSecurityGroups())
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible, a.GetSecurityGroups())
 }
 
 func (a *mqlAwsMskCluster) exposure() (*mqlAwsNetworkExposure, error) {
@@ -201,7 +228,7 @@ func (a *mqlAwsMskCluster) exposure() (*mqlAwsNetworkExposure, error) {
 	if publicAccess.Error != nil {
 		return nil, publicAccess.Error
 	}
-	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publicAccess.Data, a.GetSecurityGroups())
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publicAccess, a.GetSecurityGroups())
 }
 
 // buildVpcOnlyExposure builds a network exposure for a service that has no
@@ -216,7 +243,7 @@ func buildVpcOnlyExposure(a interface {
 	if arn.Error != nil {
 		return nil, arn.Error
 	}
-	return buildNetworkExposure(runtime, arn.Data+"/exposure", false, a.GetSecurityGroups())
+	return buildNetworkExposure(runtime, arn.Data+"/exposure", knownPublicAccess(false), a.GetSecurityGroups())
 }
 
 func (a *mqlAwsDocumentdbCluster) exposure() (*mqlAwsNetworkExposure, error) {
@@ -236,7 +263,7 @@ func (a *mqlAwsEksCluster) exposure() (*mqlAwsNetworkExposure, error) {
 	if publicAccess.Error != nil {
 		return nil, publicAccess.Error
 	}
-	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publicAccess.Data, a.GetClusterSecurityGroups())
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publicAccess, a.GetClusterSecurityGroups())
 }
 
 // exposure reports the internet exposure of tasks the service runs.
@@ -282,7 +309,7 @@ func (a *mqlAwsEcsService) exposure() (*mqlAwsNetworkExposure, error) {
 		return nil, err
 	}
 	return buildNetworkExposureFromGroups(a.MqlRuntime, arn.Data+"/exposure",
-		strings.EqualFold(assignPublicIp.Data, "ENABLED"), sgs)
+		knownPublicAccess(strings.EqualFold(assignPublicIp.Data, "ENABLED")), sgs)
 }
 
 // resolveSecurityGroupsByIdInArnScope turns bare security group IDs into typed
@@ -318,7 +345,7 @@ func (a *mqlAwsApprunnerService) exposure() (*mqlAwsNetworkExposure, error) {
 	if publiclyAccessible.Error != nil {
 		return nil, publiclyAccessible.Error
 	}
-	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible.Data, nil)
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible, nil)
 }
 
 // exposure reports the internet exposure of the notebook instance. Both inputs
@@ -342,7 +369,7 @@ func (a *mqlAwsSagemakerNotebookinstance) exposure() (*mqlAwsNetworkExposure, er
 		return nil, directInternetAccess.Error
 	}
 	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure",
-		directInternetAccess.Data, details.Data.GetSecurityGroups())
+		directInternetAccess, details.Data.GetSecurityGroups())
 }
 
 func (a *mqlAwsElasticacheCluster) exposure() (*mqlAwsNetworkExposure, error) {

--- a/providers/aws/resources/aws_network_exposure_test.go
+++ b/providers/aws/resources/aws_network_exposure_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 )
 
@@ -17,39 +18,166 @@ func TestSecurityGroupCount(t *testing.T) {
 	assert.Equal(t, 2, securityGroupCount(&plugin.TValue[[]any]{Data: []any{1, 2}}))
 }
 
-// TestInternetReachableSemantics documents the rule buildNetworkExposure
-// applies. It is expressed against the same inputs rather than constructing a
-// resource, because CreateResource needs a runtime.
-//
-// The third case is the regression: an internet-facing NLB has no security
-// groups (they cannot be attached after creation, and Gateway Load Balancers
-// never support them), so requiring an open security-group rule reported every
-// such load balancer as unreachable.
-func TestInternetReachableSemantics(t *testing.T) {
-	reachable := func(publiclyAccessible bool, sgCount int, sgAllows bool) bool {
-		if sgCount > 0 {
-			return publiclyAccessible && sgAllows
-		}
-		return publiclyAccessible
+// securityGroupsTValue builds a resolved security-group list holding one group
+// with a single ingress rule, open to the internet or not.
+func securityGroupsTValue(runtime *plugin.Runtime, open bool) *plugin.TValue[[]any] {
+	perm := &mqlAwsEc2SecuritygroupIppermission{
+		MqlRuntime:           runtime,
+		IncludesPublicSource: plugin.TValue[bool]{Data: open, State: plugin.StateIsSet},
 	}
+	sg := &mqlAwsEc2Securitygroup{
+		MqlRuntime:    runtime,
+		IpPermissions: plugin.TValue[[]any]{Data: []any{perm}, State: plugin.StateIsSet},
+	}
+	return &plugin.TValue[[]any]{Data: []any{sg}, State: plugin.StateIsSet}
+}
 
+func nullPublicAccess() *plugin.TValue[bool] {
+	return &plugin.TValue[bool]{State: plugin.StateIsSet | plugin.StateIsNull}
+}
+
+// TestBuildNetworkExposureNullPublicAccess pins the safe-verdict rule: a
+// public-access toggle that was never read (an Aurora cluster, which carries no
+// PubliclyAccessible at all, or a detail call that was denied) must leave both
+// publiclyAccessible and internetReachable null on the exposure. Reporting false
+// there claims the resource is shielded from the internet on evidence nobody
+// has, and silently passes an audit.
+func TestBuildNetworkExposureNullPublicAccess(t *testing.T) {
 	tests := []struct {
 		name               string
-		publiclyAccessible bool
-		sgCount            int
-		sgAllows           bool
-		want               bool
+		publiclyAccessible *plugin.TValue[bool]
+		sgsOpen            bool
+		noSecurityGroups   bool
+		wantSgAllows       bool
 	}{
-		{"private resource is never reachable", false, 1, true, false},
-		{"public resource with an open group is reachable", true, 1, true, true},
-		{"public NLB with no security groups is reachable", true, 0, false, true},
-		{"public resource whose groups are all closed is not reachable", true, 2, false, false},
-		{"private resource with no groups is not reachable", false, 0, false, false},
+		{
+			name:               "null public access with no security groups",
+			publiclyAccessible: nullPublicAccess(),
+			noSecurityGroups:   true,
+		},
+		{
+			name:               "null public access with a security group that allows ingress",
+			publiclyAccessible: nullPublicAccess(),
+			sgsOpen:            true,
+			wantSgAllows:       true,
+		},
+		{
+			name:               "null public access with a closed security group",
+			publiclyAccessible: nullPublicAccess(),
+		},
+		{
+			name:               "absent public access TValue",
+			publiclyAccessible: nil,
+			sgsOpen:            true,
+			wantSgAllows:       true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, reachable(tt.publiclyAccessible, tt.sgCount, tt.sgAllows))
+			runtime := testRuntime()
+			var sgs *plugin.TValue[[]any]
+			if !tt.noSecurityGroups {
+				sgs = securityGroupsTValue(runtime, tt.sgsOpen)
+			}
+
+			exposure, err := buildNetworkExposure(runtime, tt.name+"/exposure", tt.publiclyAccessible, sgs)
+			require.NoError(t, err)
+			require.NotNil(t, exposure)
+
+			assert.True(t, exposure.PubliclyAccessible.IsNull(), "publiclyAccessible must stay null")
+			assert.True(t, exposure.PubliclyAccessible.IsSet(), "publiclyAccessible must be marked resolved")
+			assert.True(t, exposure.InternetReachable.IsNull(), "internetReachable must stay null")
+			assert.True(t, exposure.InternetReachable.IsSet(), "internetReachable must be marked resolved")
+
+			// The security-group half of the answer was read, so it is still
+			// reported even though the public-access half was not.
+			assert.False(t, exposure.SecurityGroupAllowsIngress.IsNull())
+			assert.Equal(t, tt.wantSgAllows, exposure.SecurityGroupAllowsIngress.Data)
 		})
 	}
+}
+
+// TestBuildNetworkExposureKnownPublicAccess covers the verdicts for a
+// public-access toggle that was actually read.
+//
+// The no-security-groups case is a regression guard: an internet-facing NLB has
+// no security groups (they cannot be attached after creation, and Gateway Load
+// Balancers never support them), so requiring an open security-group rule
+// reported every such load balancer as unreachable.
+func TestBuildNetworkExposureKnownPublicAccess(t *testing.T) {
+	tests := []struct {
+		name                  string
+		publiclyAccessible    bool
+		sgsOpen               bool
+		noSecurityGroups      bool
+		wantInternetReachable bool
+		wantSgAllows          bool
+	}{
+		{
+			name:                  "private resource with an open group is not reachable",
+			publiclyAccessible:    false,
+			sgsOpen:               true,
+			wantInternetReachable: false,
+			wantSgAllows:          true,
+		},
+		{
+			name:                  "public resource with an open group is reachable",
+			publiclyAccessible:    true,
+			sgsOpen:               true,
+			wantInternetReachable: true,
+			wantSgAllows:          true,
+		},
+		{
+			name:                  "public resource whose group is closed is not reachable",
+			publiclyAccessible:    true,
+			sgsOpen:               false,
+			wantInternetReachable: false,
+			wantSgAllows:          false,
+		},
+		{
+			name:                  "public load balancer with no security groups is reachable",
+			publiclyAccessible:    true,
+			noSecurityGroups:      true,
+			wantInternetReachable: true,
+			wantSgAllows:          false,
+		},
+		{
+			name:                  "private resource with no security groups is not reachable",
+			publiclyAccessible:    false,
+			noSecurityGroups:      true,
+			wantInternetReachable: false,
+			wantSgAllows:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runtime := testRuntime()
+			var sgs *plugin.TValue[[]any]
+			if !tt.noSecurityGroups {
+				sgs = securityGroupsTValue(runtime, tt.sgsOpen)
+			}
+
+			exposure, err := buildNetworkExposure(runtime, tt.name+"/exposure", knownPublicAccess(tt.publiclyAccessible), sgs)
+			require.NoError(t, err)
+			require.NotNil(t, exposure)
+
+			assert.False(t, exposure.PubliclyAccessible.IsNull(), "a read toggle is never null")
+			assert.Equal(t, tt.publiclyAccessible, exposure.PubliclyAccessible.Data)
+			assert.False(t, exposure.InternetReachable.IsNull(), "a read toggle yields a verdict")
+			assert.Equal(t, tt.wantInternetReachable, exposure.InternetReachable.Data)
+			assert.Equal(t, tt.wantSgAllows, exposure.SecurityGroupAllowsIngress.Data)
+			assert.Len(t, exposure.OpenIngressRules.Data, map[bool]int{true: 1, false: 0}[tt.wantSgAllows])
+		})
+	}
+}
+
+func TestPublicAccessIsUnknown(t *testing.T) {
+	assert.True(t, publicAccessIsUnknown(nil), "an absent TValue is unknown")
+	assert.True(t, publicAccessIsUnknown(&plugin.TValue[bool]{State: plugin.StateIsSet | plugin.StateIsNull}))
+	assert.True(t, publicAccessIsUnknown(&plugin.TValue[bool]{Data: true, State: plugin.StateIsSet | plugin.StateIsNull}),
+		"a null state wins over whatever the zero-value data says")
+	assert.False(t, publicAccessIsUnknown(knownPublicAccess(false)))
+	assert.False(t, publicAccessIsUnknown(knownPublicAccess(true)))
 }

--- a/providers/azure/resources/azure_exposure.go
+++ b/providers/azure/resources/azure_exposure.go
@@ -234,9 +234,19 @@ func ipv4RangesAdmitInternet(ranges []ipRange) bool {
 type ipv6Range struct{ lo, hi *big.Int }
 
 // mergeIPv6Ranges is mergeIPv4Ranges for the 128-bit space.
+//
+// A range whose bounds are nil is dropped rather than dereferenced. big.Int
+// methods panic on a nil receiver, and a panic here would take down the whole
+// scan rather than one field. Dropping does not weaken the safe-verdict rule
+// the rest of this file follows: nil bounds can only come from a zero-value
+// ipv6Range built in code, never from a firewall rule that failed to read, so
+// there is no unread evidence being silently discounted.
 func mergeIPv6Ranges(ranges []ipv6Range) []ipv6Range {
 	sorted := make([]ipv6Range, 0, len(ranges))
 	for _, r := range ranges {
+		if r.lo == nil || r.hi == nil {
+			continue
+		}
 		if r.hi.Cmp(r.lo) < 0 {
 			continue
 		}

--- a/providers/azure/resources/azure_exposure.go
+++ b/providers/azure/resources/azure_exposure.go
@@ -68,17 +68,16 @@ func prefixesCoverInternet(prefixes []string) bool {
 		if isInternetOpenSourcePrefix(p) {
 			return true
 		}
-		parsed, err := netip.ParsePrefix(strings.TrimSpace(p))
-		if err != nil || !parsed.Addr().Is4() {
+		r, ok := ipv4PrefixRange(p)
+		if !ok {
 			continue
 		}
-		lo := ipv4ToUint(parsed.Masked().Addr())
-		size := uint64(1) << (32 - parsed.Bits())
-		ranges = append(ranges, ipRange{lo: uint64(lo), hi: uint64(lo) + size - 1})
+		ranges = append(ranges, r)
 	}
 	return rangesCoverAllIPv4(ranges)
 }
 
+// ipRange is an inclusive [lo, hi] IPv4 range held as unsigned integers.
 type ipRange struct{ lo, hi uint64 }
 
 func ipv4ToUint(addr netip.Addr) uint32 {
@@ -86,27 +85,196 @@ func ipv4ToUint(addr netip.Addr) uint32 {
 	return uint32(b[0])<<24 | uint32(b[1])<<16 | uint32(b[2])<<8 | uint32(b[3])
 }
 
-// rangesCoverAllIPv4 merges the ranges and reports whether they span the entire
-// IPv4 address space.
+// ipv4PrefixRange parses an IPv4 CIDR into the address range it covers. A
+// prefix that does not parse, or that is not IPv4, is reported as unusable
+// rather than as an empty range.
+func ipv4PrefixRange(cidr string) (ipRange, bool) {
+	parsed, err := netip.ParsePrefix(strings.TrimSpace(cidr))
+	if err != nil || !parsed.Addr().Is4() {
+		return ipRange{}, false
+	}
+	lo := uint64(ipv4ToUint(parsed.Masked().Addr()))
+	size := uint64(1) << (32 - parsed.Bits())
+	return ipRange{lo: lo, hi: lo + size - 1}, true
+}
+
+// mergeIPv4Ranges sorts the ranges and coalesces the ones that overlap or
+// touch, returning disjoint ranges in ascending order. Inverted ranges admit
+// nothing and are dropped.
+//
+// Every question asked of a SET of ranges -- does it span the whole space, how
+// much of the internet does it admit -- is a question about the union, so the
+// union is computed once here rather than reimplemented per caller. The input
+// slice is copied: the caller's ranges are often the resource's own rule list
+// and reordering it under them is not this function's business.
+func mergeIPv4Ranges(ranges []ipRange) []ipRange {
+	sorted := make([]ipRange, 0, len(ranges))
+	for _, r := range ranges {
+		if r.hi < r.lo {
+			continue
+		}
+		sorted = append(sorted, r)
+	}
+	if len(sorted) == 0 {
+		return nil
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].lo != sorted[j].lo {
+			return sorted[i].lo < sorted[j].lo
+		}
+		return sorted[i].hi < sorted[j].hi
+	})
+
+	merged := []ipRange{sorted[0]}
+	for _, r := range sorted[1:] {
+		last := &merged[len(merged)-1]
+		// a gap of even one address starts a new range; touching ranges merge
+		if r.lo > last.hi+1 {
+			merged = append(merged, r)
+			continue
+		}
+		if r.hi > last.hi {
+			last.hi = r.hi
+		}
+	}
+	return merged
+}
+
+// rangesCoverAllIPv4 reports whether the ranges together span the entire IPv4
+// address space.
 func rangesCoverAllIPv4(ranges []ipRange) bool {
-	if len(ranges) == 0 {
-		return false
+	merged := mergeIPv4Ranges(ranges)
+	return len(merged) == 1 && merged[0].lo == 0 && merged[0].hi >= math.MaxUint32
+}
+
+// nonRoutableIPv4Blocks are the IPv4 blocks that are not part of the public
+// internet: the special-purpose registry entries, multicast, and the reserved
+// top of the space. Ascending and disjoint.
+//
+// A firewall range is judged by how much of the PUBLIC internet it admits, so
+// these are discounted from that measure. Counting them made the threshold
+// depend on address space nobody can reach a database from: a rule spanning
+// 1.0.0.0 to 255.255.255.255, the whole routable internet, fell short of a raw
+// half-of-IPv4 test by the size of 0.0.0.0/8 and scored as an allowlist.
+var nonRoutableIPv4Blocks = ipv4Blocks(
+	"0.0.0.0/8",       // "this network"
+	"10.0.0.0/8",      // private
+	"100.64.0.0/10",   // carrier-grade NAT
+	"127.0.0.0/8",     // loopback
+	"169.254.0.0/16",  // link-local
+	"172.16.0.0/12",   // private
+	"192.0.0.0/24",    // IETF protocol assignments
+	"192.0.2.0/24",    // TEST-NET-1
+	"192.88.99.0/24",  // 6to4 relay anycast
+	"192.168.0.0/16",  // private
+	"198.18.0.0/15",   // benchmarking
+	"198.51.100.0/24", // TEST-NET-2
+	"203.0.113.0/24",  // TEST-NET-3
+	"224.0.0.0/4",     // multicast
+	"240.0.0.0/4",     // reserved, including the broadcast address
+)
+
+// routableIPv4Total is how many addresses are left once the non-routable blocks
+// are removed: the size of the public IPv4 internet.
+var routableIPv4Total = func() uint64 {
+	total := uint64(1) << 32
+	for _, b := range nonRoutableIPv4Blocks {
+		total -= b.hi - b.lo + 1
 	}
-	sort.Slice(ranges, func(i, j int) bool { return ranges[i].lo < ranges[j].lo })
-	if ranges[0].lo != 0 {
-		return false
-	}
-	reached := ranges[0].hi
-	for _, r := range ranges[1:] {
-		// a gap means the space is not fully covered
-		if r.lo > reached+1 {
-			return false
+	return total
+}()
+
+// ipv4Blocks parses the fixed CIDR list above into sorted ranges. An entry that
+// does not parse is dropped rather than panicking the provider at load; the
+// resulting block count and total are pinned by a unit test, so a typo fails
+// there instead of quietly shrinking the reserved space.
+func ipv4Blocks(cidrs ...string) []ipRange {
+	out := make([]ipRange, 0, len(cidrs))
+	for _, c := range cidrs {
+		if r, ok := ipv4PrefixRange(c); ok {
+			out = append(out, r)
 		}
-		if r.hi > reached {
-			reached = r.hi
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].lo < out[j].lo })
+	return out
+}
+
+// ipv4RoutableCoverage counts how many public internet addresses the union of
+// the ranges admits.
+func ipv4RoutableCoverage(ranges []ipRange) uint64 {
+	var covered uint64
+	for _, r := range mergeIPv4Ranges(ranges) {
+		covered += r.hi - r.lo + 1
+		for _, b := range nonRoutableIPv4Blocks {
+			if b.hi < r.lo || b.lo > r.hi {
+				continue
+			}
+			covered -= min(b.hi, r.hi) - max(b.lo, r.lo) + 1
 		}
 	}
-	return reached >= math.MaxUint32
+	return covered
+}
+
+// ipv4RangesAdmitInternet reports whether the ranges, TAKEN TOGETHER, admit at
+// least half of the public IPv4 internet.
+//
+// The union is what matters. A server whose rules read 0.0.0.0-84.255.255.255,
+// 85.0.0.0-169.255.255.255 and 170.0.0.0-255.255.255.255 has no single
+// catch-all rule and is open to every address there is; judging one rule at a
+// time reported it as closed. Halves, thirds and any other partition of the
+// space are the same evasion written differently, so the ranges are coalesced
+// before the question is asked.
+func ipv4RangesAdmitInternet(ranges []ipRange) bool {
+	return ipv4RoutableCoverage(ranges)*2 >= routableIPv4Total
+}
+
+// ipv6Range is an inclusive [lo, hi] IPv6 range. 128-bit endpoints need big
+// integers so a span crossing the halfway point subtracts without carry
+// handling of a uint64 pair.
+type ipv6Range struct{ lo, hi *big.Int }
+
+// mergeIPv6Ranges is mergeIPv4Ranges for the 128-bit space.
+func mergeIPv6Ranges(ranges []ipv6Range) []ipv6Range {
+	sorted := make([]ipv6Range, 0, len(ranges))
+	for _, r := range ranges {
+		if r.hi.Cmp(r.lo) < 0 {
+			continue
+		}
+		sorted = append(sorted, r)
+	}
+	if len(sorted) == 0 {
+		return nil
+	}
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].lo.Cmp(sorted[j].lo) < 0 })
+
+	merged := []ipv6Range{sorted[0]}
+	for _, r := range sorted[1:] {
+		last := &merged[len(merged)-1]
+		if r.lo.Cmp(new(big.Int).Add(last.hi, big.NewInt(1))) > 0 {
+			merged = append(merged, r)
+			continue
+		}
+		if r.hi.Cmp(last.hi) > 0 {
+			last.hi = r.hi
+		}
+	}
+	return merged
+}
+
+// ipv6RangesAdmitInternet reports whether the ranges together span at least
+// half of the IPv6 address space. Azure keeps IPv6 firewall rules in a list of
+// their own, and they are as splittable as the IPv4 ones, so they are summed
+// the same way. No non-routable carve-out is applied: the IPv6 space is mostly
+// unallocated, which makes a fraction-of-the-space measure coarse in a way no
+// block list would fix.
+func ipv6RangesAdmitInternet(ranges []ipv6Range) bool {
+	total := new(big.Int)
+	for _, r := range mergeIPv6Ranges(ranges) {
+		span := new(big.Int).Sub(r.hi, r.lo)
+		span.Add(span, big.NewInt(1))
+		total.Add(total, span)
+	}
+	return total.Cmp(halfOfIPv6) >= 0
 }
 
 // securityRuleAllowsInternetIngress reports whether a single NSG security rule
@@ -135,61 +303,77 @@ func publicNetworkAccessEnabled(value string) bool {
 	return !strings.EqualFold(strings.TrimSpace(value), "Disabled")
 }
 
-// firewallRuleAllowsAnyInternet reports whether a database firewall rule (start
-// IP / end IP range) opens the server to the public internet.
+// firewallRangeSets splits (start IP, end IP) pairs into IPv4 and IPv6 ranges.
+// A pair is dropped when either endpoint is unparseable, when the range is
+// inverted, or when the two endpoints are from different families: none of
+// those describe a range that admits anything. An IPv4-mapped IPv6 endpoint
+// describes IPv4 space and is not measured against the 128-bit threshold.
+func firewallRangeSets(ranges [][2]string) ([]ipRange, []ipv6Range) {
+	var v4 []ipRange
+	var v6 []ipv6Range
+	for _, r := range ranges {
+		start, err := netip.ParseAddr(strings.TrimSpace(r[0]))
+		if err != nil {
+			continue
+		}
+		end, err := netip.ParseAddr(strings.TrimSpace(r[1]))
+		if err != nil {
+			continue
+		}
+
+		switch {
+		case start.Is4() && end.Is4():
+			lo, hi := uint64(ipv4ToUint(start)), uint64(ipv4ToUint(end))
+			if hi < lo {
+				continue
+			}
+			v4 = append(v4, ipRange{lo: lo, hi: hi})
+
+		case start.Is6() && !start.Is4In6() && end.Is6() && !end.Is4In6():
+			lo, hi := ipv6ToBigInt(start), ipv6ToBigInt(end)
+			if hi.Cmp(lo) < 0 {
+				continue
+			}
+			v6 = append(v6, ipv6Range{lo: lo, hi: hi})
+		}
+	}
+	return v4, v6
+}
+
+// firewallRangesAdmitInternet reports whether a server's database firewall
+// rules, taken together, open it to the public internet.
 //
-// The rule is judged on how much of the address space it actually admits, not
-// on the text of its endpoints. Anchoring on the literal string "0.0.0.0" got
-// this wrong in both directions: 1.0.0.0 -> 255.255.255.255 and
-// 0.0.0.1 -> 255.255.255.255 are the whole routable internet and read as
-// closed, while 0.0.0.0 -> 0.0.0.1 is two addresses and read as open.
+// The rules are judged on how much of the address space they actually admit,
+// not on the text of their endpoints, and they are judged as a SET. Both halves
+// of that matter:
 //
-// A rule counts as internet-open when it spans at least half of IPv4. That
-// keeps the documented wide-partial case (0.0.0.0 -> 128.255.255.255) and the
-// off-by-one variants above, and excludes ordinary allowlists.
+//   - Anchoring on the literal string "0.0.0.0" got single rules wrong in both
+//     directions: 1.0.0.0 -> 255.255.255.255 is the whole routable internet and
+//     read as closed, while 0.0.0.0 -> 0.0.0.1 is two addresses and read as
+//     open.
+//   - Judging one rule at a time missed the union: three rules reaching
+//     0.0.0.0 -> 84.255.255.255, 85.0.0.0 -> 169.255.255.255 and
+//     170.0.0.0 -> 255.255.255.255 are every address on the internet with no
+//     catch-all rule to point at.
 //
 // The special "allow all Azure services" rule (0.0.0.0 -> 0.0.0.0) is NOT
-// internet-open: it permits traffic only from Azure-internal service IPs, not
-// from arbitrary public addresses. The span test excludes it on its own, since
-// it admits a single address.
+// internet-open: it permits traffic only from Azure-internal service IPs. It
+// admits one address, in a block that is not routable, so it adds nothing to
+// the coverage measure either alone or alongside other rules.
 //
-// IPv6 rules are judged the same way against the 128-bit space. Azure holds
-// them in a rule list of their own, so a server can be tightly scoped on IPv4
-// and still admit :: -> ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff, the whole IPv6
-// internet. A rule whose two endpoints are from different families admits
-// nothing coherent and is not treated as open.
+// The two families are judged separately and either one is enough: a server can
+// be tightly scoped on IPv4 and still admit the whole IPv6 internet.
+func firewallRangesAdmitInternet(ranges [][2]string) bool {
+	v4, v6 := firewallRangeSets(ranges)
+	return ipv4RangesAdmitInternet(v4) || ipv6RangesAdmitInternet(v6)
+}
+
+// firewallRuleAllowsAnyInternet reports whether a single database firewall rule
+// opens the server to the public internet on its own. A server is judged on all
+// of its rules together (see firewallRangesAdmitInternet); this is the one-rule
+// form of the same question.
 func firewallRuleAllowsAnyInternet(startIp, endIp string) bool {
-	start, err := netip.ParseAddr(strings.TrimSpace(startIp))
-	if err != nil {
-		return false
-	}
-	end, err := netip.ParseAddr(strings.TrimSpace(endIp))
-	if err != nil {
-		return false
-	}
-
-	switch {
-	case start.Is4() && end.Is4():
-		lo, hi := ipv4ToUint(start), ipv4ToUint(end)
-		if hi < lo {
-			return false
-		}
-		const halfOfIPv4 = uint64(1) << 31
-		return uint64(hi)-uint64(lo)+1 >= halfOfIPv4
-
-	case start.Is6() && !start.Is4In6() && end.Is6() && !end.Is4In6():
-		lo := ipv6ToBigInt(start)
-		hi := ipv6ToBigInt(end)
-		if hi.Cmp(lo) < 0 {
-			return false
-		}
-		// span = hi - lo + 1, compared against half of the 128-bit space.
-		span := new(big.Int).Sub(hi, lo)
-		span.Add(span, big.NewInt(1))
-		return span.Cmp(halfOfIPv6) >= 0
-	}
-
-	return false
+	return firewallRangesAdmitInternet([][2]string{{startIp, endIp}})
 }
 
 // halfOfIPv6 is 2^127, the threshold a rule has to span before it counts as
@@ -204,20 +388,20 @@ func ipv6ToBigInt(addr netip.Addr) *big.Int {
 	return new(big.Int).SetBytes(b[:])
 }
 
-// databaseInternetReachable combines the publicNetworkAccess gate with the
-// presence of at least one internet-opening firewall rule. A database is
-// internet-reachable only when public access is enabled AND some firewall rule
-// permits an internet-wide source range.
+// databaseInternetReachable combines the publicNetworkAccess gate with what the
+// firewall rules admit. A database is internet-reachable only when public
+// access is enabled AND the rules together permit an internet-wide source
+// range.
+//
+// The rules are handed to firewallRangesAdmitInternet as a set rather than
+// tested one at a time: a rule list that partitions the address space between
+// its entries opens the server just as widely as a single catch-all, and
+// per-rule judgement reported it as closed.
 func databaseInternetReachable(publicNetworkAccess string, firewallRanges [][2]string) bool {
 	if !publicNetworkAccessEnabled(publicNetworkAccess) {
 		return false
 	}
-	for _, r := range firewallRanges {
-		if firewallRuleAllowsAnyInternet(r[0], r[1]) {
-			return true
-		}
-	}
-	return false
+	return firewallRangesAdmitInternet(firewallRanges)
 }
 
 // aksApiServerInternetReachable reports whether an AKS API server is reachable
@@ -517,6 +701,107 @@ func nsgAllowsInternetIngress(rules []map[string]any) (bool, []map[string]any) {
 	return len(open) > 0, open
 }
 
+// exposureVerdict is one exposure answer: the value, and whether it was
+// actually determined. An undetermined verdict is reported as null rather than
+// as false. A read that was refused, throttled, or impossible must never assert
+// that a resource is protected, and false is exactly that assertion: a policy
+// written as "not reachable from the internet" passes on it.
+type exposureVerdict struct {
+	value bool
+	known bool
+}
+
+// exposureObservations is what the exposure walk actually observed, kept apart
+// from the verdicts so the judgement is a pure function of it.
+type exposureObservations struct {
+	// hasPublicIp is read from the resource's own interfaces and is always
+	// authoritative: the addresses are already cached on the VM.
+	hasPublicIp bool
+	// behindPublicLb and loadBalancersEvaluated pair a value with whether the
+	// load-balancer listing could be read at all.
+	behindPublicLb         bool
+	loadBalancersEvaluated bool
+	// sgAllowsIngress and nsgsEvaluated pair the OR across the NICs with
+	// whether every NIC's effective rules came back authoritatively.
+	sgAllowsIngress bool
+	nsgsEvaluated   bool
+}
+
+// exposureVerdicts are the answers the exposure resource reports.
+type exposureVerdicts struct {
+	internetReachable          exposureVerdict
+	behindPublicLoadBalancer   exposureVerdict
+	securityGroupAllowsIngress exposureVerdict
+}
+
+// resolveExposureVerdicts turns the observations into verdicts, deciding for
+// each one whether the answer was determined.
+//
+// The determinations are finer than "some read failed, so nothing is known",
+// because each verdict has a side that a single observation settles on its own:
+//
+//   - securityGroupAllowsIngress is an OR across the NICs, so one NIC that
+//     admits internet ingress makes it true no matter how many other NICs went
+//     unread. Only a false is provisional.
+//   - Traffic arriving is "public IP OR behind a public load balancer", so a
+//     public IP settles it even when the load-balancer listing failed.
+//   - internetReachable is an AND, so either half being a determined false
+//     settles it. A deallocated VM with no public address and no load balancer
+//     in front of it is genuinely unreachable, and stays a plain false even
+//     though its effective rules could not be computed.
+//
+// What is left is the case this exists for: the machine can be reached and
+// nothing authoritative is known about what filters it. That reports null.
+func resolveExposureVerdicts(obs exposureObservations) exposureVerdicts {
+	sg := exposureVerdict{
+		value: obs.sgAllowsIngress,
+		known: obs.nsgsEvaluated || obs.sgAllowsIngress,
+	}
+	lb := exposureVerdict{
+		value: obs.behindPublicLb && obs.loadBalancersEvaluated,
+		known: obs.loadBalancersEvaluated,
+	}
+	arrives := exposureVerdict{
+		value: obs.hasPublicIp || lb.value,
+		known: obs.hasPublicIp || lb.known,
+	}
+
+	reachable := exposureVerdict{value: arrives.value && sg.value}
+	reachable.known = (arrives.known && sg.known) ||
+		(arrives.known && !arrives.value) ||
+		(sg.known && !sg.value)
+
+	return exposureVerdicts{
+		internetReachable:          reachable,
+		behindPublicLoadBalancer:   lb,
+		securityGroupAllowsIngress: sg,
+	}
+}
+
+// rawVerdict renders a verdict for CreateResource: a determined verdict is its
+// boolean, an undetermined one is null.
+func rawVerdict(v exposureVerdict) *llx.RawData {
+	if !v.known {
+		return llx.NilData
+	}
+	return llx.BoolData(v.value)
+}
+
+// rawOpenIngressRules renders the surviving internet-open rules. An empty list
+// says the NICs were examined and nothing admits internet traffic, so it is
+// only reported when at least one NIC was examined: with no authoritative rule
+// set anywhere and nothing found, the list is null instead.
+//
+// Rules that were found stay a list even when another NIC went unread. They
+// were observed on an NSG Azure did answer for, and dropping them would hide a
+// real finding to describe a gap the other fields already report.
+func rawOpenIngressRules(openRules []any, nsgsEvaluated bool) *llx.RawData {
+	if !nsgsEvaluated && len(openRules) == 0 {
+		return llx.NilData
+	}
+	return llx.ArrayData(openRules, types.Dict)
+}
+
 // exposure builds the network-exposure summary for a VM from its already-cached
 // public IPs and the effective security rules of its NICs.
 //
@@ -527,8 +812,13 @@ func nsgAllowsInternetIngress(rules []map[string]any) (bool, []map[string]any) {
 // that Azure reports as having no NSG at all admits every inbound flow and so
 // counts as exposed; a NIC whose rules could not be computed (stopped VM,
 // access denied) is skipped and clears securityGroupsEvaluated instead, so a
-// "closed" verdict is never inferred from a failed lookup. Resolving effective
-// rules is a live Azure call per NIC; it is only paid when exposure is queried.
+// "closed" verdict is never inferred from a failed lookup. Where the skipped
+// read is what the answer turned on, internetReachable and
+// securityGroupAllowsIngress report null instead of false -- Azure computes
+// effective rules only for a NIC attached to a running VM, so stopping a VM
+// used to flip both of them to false while its NSG still allowed 22/tcp from
+// anywhere. Resolving effective rules is a live Azure call per NIC; it is only
+// paid when exposure is queried.
 //
 // Rule priority is honored: within an NSG a higher-priority (lower-numbered)
 // Deny rule shadows a lower-priority Allow-from-internet rule when it covers the
@@ -551,7 +841,7 @@ func (a *mqlAzureSubscriptionComputeServiceVm) exposure() (*mqlAzureSubscription
 	securityGroupAllowsIngress := false
 	// Every NIC must be evaluated authoritatively before a "closed" verdict
 	// means anything; one degraded fetch makes the whole verdict provisional.
-	allEvaluated := true
+	nsgsEvaluated := true
 	openRules := []any{}
 	for _, n := range nics.Data {
 		nic, ok := n.(*mqlAzureSubscriptionNetworkServiceInterface)
@@ -563,7 +853,7 @@ func (a *mqlAzureSubscriptionComputeServiceVm) exposure() (*mqlAzureSubscription
 			return nil, err
 		}
 		if !evaluated {
-			allEvaluated = false
+			nsgsEvaluated = false
 			continue
 		}
 		if len(groups) == 0 {
@@ -604,25 +894,32 @@ func (a *mqlAzureSubscriptionComputeServiceVm) exposure() (*mqlAzureSubscription
 	// load balancer frontend and leave the machine's interface with a private
 	// address only, so reading public IPs off the interfaces alone reports the
 	// recommended topology as closed.
+	loadBalancersEvaluated := true
 	behindPublicLb, err := a.behindPublicLoadBalancer(nics.Data)
 	if err != nil {
 		// One unreadable listing must not turn into "closed". Drop the signal,
 		// mark the verdict provisional, and say why.
 		logLoadBalancerLookupFailure(a.Id.Data, err)
 		behindPublicLb = false
-		allEvaluated = false
+		loadBalancersEvaluated = false
 	}
 
-	internetReachable := (hasPublicIp || behindPublicLb) && securityGroupAllowsIngress
+	verdicts := resolveExposureVerdicts(exposureObservations{
+		hasPublicIp:            hasPublicIp,
+		behindPublicLb:         behindPublicLb,
+		loadBalancersEvaluated: loadBalancersEvaluated,
+		sgAllowsIngress:        securityGroupAllowsIngress,
+		nsgsEvaluated:          nsgsEvaluated,
+	})
 
 	res, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionNetworkServiceExposure, map[string]*llx.RawData{
 		"__id":                       llx.StringData("azure.subscription.computeService.vm/" + a.Id.Data + "/exposure"),
-		"internetReachable":          llx.BoolData(internetReachable),
+		"internetReachable":          rawVerdict(verdicts.internetReachable),
 		"hasPublicIp":                llx.BoolData(hasPublicIp),
-		"behindPublicLoadBalancer":   llx.BoolData(behindPublicLb),
-		"securityGroupAllowsIngress": llx.BoolData(securityGroupAllowsIngress),
-		"securityGroupsEvaluated":    llx.BoolData(allEvaluated),
-		"openIngressRules":           llx.ArrayData(openRules, types.Dict),
+		"behindPublicLoadBalancer":   rawVerdict(verdicts.behindPublicLoadBalancer),
+		"securityGroupAllowsIngress": rawVerdict(verdicts.securityGroupAllowsIngress),
+		"securityGroupsEvaluated":    llx.BoolData(nsgsEvaluated && loadBalancersEvaluated),
+		"openIngressRules":           rawOpenIngressRules(openRules, nsgsEvaluated),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/azure/resources/azure_exposure_test.go
+++ b/providers/azure/resources/azure_exposure_test.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"math"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -712,6 +713,44 @@ func TestFirewallRangeSets(t *testing.T) {
 	require.Len(t, v6, 1)
 	assert.Equal(t, "0", v6[0].lo.String())
 	assert.Equal(t, "65535", v6[0].hi.String())
+}
+
+// TestMergeIPv6RangesSkipsNilBounds guards against a panic, not a wrong answer.
+// big.Int methods dereference their receiver, so a zero-value ipv6Range reaching
+// the Cmp in mergeIPv6Ranges would panic, and a panic in provider code takes down
+// the entire scan rather than one field. Every production range is built by
+// firewallRangeSets with non-nil bounds, so this pins the precondition for any
+// future caller.
+func TestMergeIPv6RangesSkipsNilBounds(t *testing.T) {
+	full := ipv6Range{lo: big.NewInt(0), hi: new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1))}
+
+	cases := []struct {
+		name   string
+		ranges []ipv6Range
+	}{
+		{"zero value", []ipv6Range{{}}},
+		{"nil lo only", []ipv6Range{{lo: nil, hi: big.NewInt(10)}}},
+		{"nil hi only", []ipv6Range{{lo: big.NewInt(10), hi: nil}}},
+		{"nil beside a real range", []ipv6Range{{}, full}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NotPanics(t, func() { mergeIPv6Ranges(tc.ranges) })
+			require.NotPanics(t, func() { ipv6RangesAdmitInternet(tc.ranges) })
+		})
+	}
+
+	// A malformed neighbour must not swallow a range that is genuinely there:
+	// the full-space range still has to be merged and still has to read as open.
+	merged := mergeIPv6Ranges([]ipv6Range{{}, full})
+	require.Len(t, merged, 1)
+	assert.Equal(t, 0, merged[0].lo.Cmp(full.lo))
+	assert.Equal(t, 0, merged[0].hi.Cmp(full.hi))
+	assert.True(t, ipv6RangesAdmitInternet([]ipv6Range{{}, full}))
+
+	// A list with nothing usable in it admits nothing.
+	assert.False(t, ipv6RangesAdmitInternet([]ipv6Range{{}}))
 }
 
 // TestIPv6RangesAdmitInternet mirrors the IPv4 union for the family Azure keeps

--- a/providers/azure/resources/azure_exposure_test.go
+++ b/providers/azure/resources/azure_exposure_test.go
@@ -4,9 +4,13 @@
 package resources
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 )
 
 func TestIsInternetOpenSourcePrefix(t *testing.T) {
@@ -319,5 +323,447 @@ func TestNsgAllowsInternetIngress(t *testing.T) {
 		open, surviving := nsgAllowsInternetIngress([]map[string]any{allowSsh, allowHttp, denySshHigh})
 		assert.True(t, open)
 		assert.Len(t, surviving, 1, "only the HTTPS allow survives")
+	})
+}
+
+// --- Exposure verdicts: a read that did not happen reports null ---
+
+// TestResolveExposureVerdicts pins the verdict that a deallocated VM used to
+// get wrong. Azure computes effective NSG rules only for a NIC attached to a
+// running VM and answers 400 otherwise, so stopping a machine flipped
+// internetReachable from true to false while its NSG still allowed 22/tcp from
+// anywhere -- and a policy asserting "not reachable from the internet" started
+// passing on it. The same 400 comes back for a scanner running as Reader, which
+// does not hold the effectiveNetworkSecurityGroups action.
+func TestResolveExposureVerdicts(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		obs  exposureObservations
+		want exposureVerdicts
+	}{
+		{
+			name: "unread NSGs on a machine with a public IP leaves reachability unknown",
+			obs: exposureObservations{
+				hasPublicIp: true, loadBalancersEvaluated: true,
+				sgAllowsIngress: false, nsgsEvaluated: false,
+			},
+			want: exposureVerdicts{
+				internetReachable:          exposureVerdict{value: false, known: false},
+				behindPublicLoadBalancer:   exposureVerdict{value: false, known: true},
+				securityGroupAllowsIngress: exposureVerdict{value: false, known: false},
+			},
+		},
+		{
+			name: "evaluated NSGs that admit ingress on a machine with a public IP is reachable",
+			obs: exposureObservations{
+				hasPublicIp: true, loadBalancersEvaluated: true,
+				sgAllowsIngress: true, nsgsEvaluated: true,
+			},
+			want: exposureVerdicts{
+				internetReachable:          exposureVerdict{value: true, known: true},
+				behindPublicLoadBalancer:   exposureVerdict{value: false, known: true},
+				securityGroupAllowsIngress: exposureVerdict{value: true, known: true},
+			},
+		},
+		{
+			name: "evaluated NSGs that deny ingress on a machine with a public IP is not reachable",
+			obs: exposureObservations{
+				hasPublicIp: true, loadBalancersEvaluated: true,
+				sgAllowsIngress: false, nsgsEvaluated: true,
+			},
+			want: exposureVerdicts{
+				internetReachable:          exposureVerdict{value: false, known: true},
+				behindPublicLoadBalancer:   exposureVerdict{value: false, known: true},
+				securityGroupAllowsIngress: exposureVerdict{value: false, known: true},
+			},
+		},
+		{
+			// The NSGs went unread, but nothing can reach the machine in the
+			// first place, so the answer is settled without them.
+			name: "no public IP and no load balancer is a determined false even with unread NSGs",
+			obs: exposureObservations{
+				hasPublicIp: false, loadBalancersEvaluated: true,
+				sgAllowsIngress: false, nsgsEvaluated: false,
+			},
+			want: exposureVerdicts{
+				internetReachable:          exposureVerdict{value: false, known: true},
+				behindPublicLoadBalancer:   exposureVerdict{value: false, known: true},
+				securityGroupAllowsIngress: exposureVerdict{value: false, known: false},
+			},
+		},
+		{
+			// securityGroupAllowsIngress is an OR across the NICs: one NIC that
+			// admits internet ingress settles it however many went unread.
+			name: "one NIC admitting ingress settles the OR even with another unread",
+			obs: exposureObservations{
+				hasPublicIp: true, loadBalancersEvaluated: true,
+				sgAllowsIngress: true, nsgsEvaluated: false,
+			},
+			want: exposureVerdicts{
+				internetReachable:          exposureVerdict{value: true, known: true},
+				behindPublicLoadBalancer:   exposureVerdict{value: false, known: true},
+				securityGroupAllowsIngress: exposureVerdict{value: true, known: true},
+			},
+		},
+		{
+			name: "a public load balancer in front of open NSGs is reachable without a public IP",
+			obs: exposureObservations{
+				hasPublicIp: false, behindPublicLb: true, loadBalancersEvaluated: true,
+				sgAllowsIngress: true, nsgsEvaluated: true,
+			},
+			want: exposureVerdicts{
+				internetReachable:          exposureVerdict{value: true, known: true},
+				behindPublicLoadBalancer:   exposureVerdict{value: true, known: true},
+				securityGroupAllowsIngress: exposureVerdict{value: true, known: true},
+			},
+		},
+		{
+			// The load-balancer listing failed, so whether traffic can arrive is
+			// unknown and the open NSGs cannot settle it either way.
+			name: "unreadable load balancers with no public IP leaves reachability unknown",
+			obs: exposureObservations{
+				hasPublicIp: false, loadBalancersEvaluated: false,
+				sgAllowsIngress: true, nsgsEvaluated: true,
+			},
+			want: exposureVerdicts{
+				internetReachable:          exposureVerdict{value: false, known: false},
+				behindPublicLoadBalancer:   exposureVerdict{value: false, known: false},
+				securityGroupAllowsIngress: exposureVerdict{value: true, known: true},
+			},
+		},
+		{
+			name: "unreadable load balancers with closed NSGs is still a determined false",
+			obs: exposureObservations{
+				hasPublicIp: false, loadBalancersEvaluated: false,
+				sgAllowsIngress: false, nsgsEvaluated: true,
+			},
+			want: exposureVerdicts{
+				internetReachable:          exposureVerdict{value: false, known: true},
+				behindPublicLoadBalancer:   exposureVerdict{value: false, known: false},
+				securityGroupAllowsIngress: exposureVerdict{value: false, known: true},
+			},
+		},
+		{
+			name: "nothing readable at all on a machine with a public IP is unknown",
+			obs: exposureObservations{
+				hasPublicIp: true, loadBalancersEvaluated: false,
+				sgAllowsIngress: false, nsgsEvaluated: false,
+			},
+			want: exposureVerdicts{
+				internetReachable:          exposureVerdict{value: false, known: false},
+				behindPublicLoadBalancer:   exposureVerdict{value: false, known: false},
+				securityGroupAllowsIngress: exposureVerdict{value: false, known: false},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, resolveExposureVerdicts(tc.obs))
+		})
+	}
+}
+
+// TestRawVerdict pins the rendering, which is where a null verdict either
+// reaches the user as null or collapses back into the false this whole change
+// exists to remove.
+func TestRawVerdict(t *testing.T) {
+	t.Run("a determined verdict renders its boolean", func(t *testing.T) {
+		assert.Equal(t, true, rawVerdict(exposureVerdict{value: true, known: true}).Value)
+		assert.Equal(t, false, rawVerdict(exposureVerdict{value: false, known: true}).Value)
+	})
+
+	t.Run("an undetermined verdict renders null", func(t *testing.T) {
+		assert.Nil(t, rawVerdict(exposureVerdict{value: false, known: false}).Value)
+
+		// and the runtime reads that as set-and-null rather than as false
+		tv, ok := plugin.RawToTValue[bool](rawVerdict(exposureVerdict{}).Value, nil)
+		require.True(t, ok)
+		assert.True(t, tv.IsSet(), "an unset field is a different failure mode from null")
+		assert.True(t, tv.IsNull())
+		assert.False(t, tv.Data)
+	})
+}
+
+// --- Effective rules: an unevaluated NIC reports null, not an empty list ---
+
+func newTestNic(runtime *plugin.Runtime, evaluated bool, groups []effectiveNsgGroup) *mqlAzureSubscriptionNetworkServiceInterface {
+	nic := &mqlAzureSubscriptionNetworkServiceInterface{
+		MqlRuntime: runtime,
+		Id:         plugin.TValue[string]{Data: "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic", State: plugin.StateIsSet},
+	}
+	nic.effNsgLoaded = true
+	nic.effNsgEvaluated = evaluated
+	nic.effNsgGroups = groups
+	return nic
+}
+
+// TestEffectiveRulesNullWhenNotEvaluated pins the degrade. Both accessors used
+// to discard the "evaluated" flag, and an unset nil slice renders as an empty
+// list -- so `effectiveRules.none(access == "Allow" && direction == "Inbound"
+// && sourceAddressPrefix == "*")` passed vacuously on every stopped VM and in
+// every subscription where the scanning identity cannot read effective NSGs.
+func TestEffectiveRulesNullWhenNotEvaluated(t *testing.T) {
+	t.Run("raw rules", func(t *testing.T) {
+		nic := newTestNic(nil, false, nil)
+		res, err := nic.effectiveSecurityRules()
+		require.NoError(t, err)
+		assert.Nil(t, res)
+		assert.True(t, nic.EffectiveSecurityRules.IsSet())
+		assert.True(t, nic.EffectiveSecurityRules.IsNull())
+	})
+
+	t.Run("typed rules", func(t *testing.T) {
+		nic := newTestNic(nil, false, nil)
+		res, err := nic.effectiveRules()
+		require.NoError(t, err)
+		assert.Nil(t, res)
+		assert.True(t, nic.EffectiveRules.IsSet())
+		assert.True(t, nic.EffectiveRules.IsNull())
+	})
+}
+
+// TestEffectiveRulesEmptyWhenEvaluated is the other half of the same contract:
+// Azure answering with no rules is a real empty list, and must not be reported
+// as null. Null and empty mean different things and both have to survive.
+func TestEffectiveRulesEmptyWhenEvaluated(t *testing.T) {
+	t.Run("raw rules", func(t *testing.T) {
+		nic := newTestNic(nil, true, nil)
+		res, err := nic.effectiveSecurityRules()
+		require.NoError(t, err)
+		assert.Equal(t, []any{}, res)
+		assert.False(t, nic.EffectiveSecurityRules.IsNull())
+	})
+
+	t.Run("typed rules", func(t *testing.T) {
+		nic := newTestNic(cacheIDTestRuntime(), true, nil)
+		res, err := nic.effectiveRules()
+		require.NoError(t, err)
+		assert.Equal(t, []any{}, res)
+		assert.False(t, nic.EffectiveRules.IsNull())
+	})
+}
+
+// TestEffectiveRulesReturnedWhenEvaluated pins that the degrade guard did not
+// swallow the ordinary path.
+func TestEffectiveRulesReturnedWhenEvaluated(t *testing.T) {
+	groups := []effectiveNsgGroup{{
+		nsgID: "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/networkSecurityGroups/nsg",
+		rules: []map[string]any{{
+			"name": "AllowSshFromAnywhere", "direction": "Inbound", "access": "Allow",
+			"protocol": "Tcp", "destinationPortRange": "22", "sourceAddressPrefix": "*",
+			"priority": float64(300),
+		}},
+	}}
+
+	t.Run("raw rules", func(t *testing.T) {
+		nic := newTestNic(nil, true, groups)
+		res, err := nic.effectiveSecurityRules()
+		require.NoError(t, err)
+		require.Len(t, res, 1)
+		assert.Equal(t, "AllowSshFromAnywhere", res[0].(map[string]any)["name"])
+		assert.False(t, nic.EffectiveSecurityRules.IsNull())
+	})
+
+	t.Run("typed rules", func(t *testing.T) {
+		nic := newTestNic(cacheIDTestRuntime(), true, groups)
+		res, err := nic.effectiveRules()
+		require.NoError(t, err)
+		require.Len(t, res, 1)
+		rule := res[0].(*mqlAzureSubscriptionNetworkServiceInterfaceEffectiveSecurityRule)
+		assert.Equal(t, "AllowSshFromAnywhere", rule.Name.Data)
+		assert.Equal(t, "*", rule.SourceAddressPrefix.Data)
+		assert.False(t, nic.EffectiveRules.IsNull())
+	})
+}
+
+// --- Database firewall rules are judged as a union ---
+
+// TestNonRoutableIPv4Blocks pins the discount table the coverage measure is
+// built on. The entries are parsed from strings, and a typo drops one silently
+// -- which moves the threshold without touching any of the logic around it.
+func TestNonRoutableIPv4Blocks(t *testing.T) {
+	assert.Len(t, nonRoutableIPv4Blocks, 15, "an entry that fails to parse is dropped, not reported")
+	assert.Equal(t, uint64(3702258432), routableIPv4Total)
+
+	for i := 1; i < len(nonRoutableIPv4Blocks); i++ {
+		assert.Greaterf(t, nonRoutableIPv4Blocks[i].lo, nonRoutableIPv4Blocks[i-1].hi,
+			"blocks must be ascending and disjoint, or the total double-counts at index %d", i)
+	}
+}
+
+func TestMergeIPv4Ranges(t *testing.T) {
+	t.Run("the two halves coalesce into the whole space", func(t *testing.T) {
+		assert.Equal(t, []ipRange{{0, math.MaxUint32}}, mergeIPv4Ranges([]ipRange{
+			{0, 2147483647}, {2147483648, math.MaxUint32},
+		}))
+	})
+	t.Run("touching ranges merge", func(t *testing.T) {
+		assert.Equal(t, []ipRange{{10, 30}}, mergeIPv4Ranges([]ipRange{{10, 20}, {21, 30}}))
+	})
+	t.Run("a one-address gap does not merge", func(t *testing.T) {
+		assert.Equal(t, []ipRange{{10, 20}, {22, 30}}, mergeIPv4Ranges([]ipRange{{22, 30}, {10, 20}}))
+	})
+	t.Run("a contained range is absorbed", func(t *testing.T) {
+		assert.Equal(t, []ipRange{{10, 100}}, mergeIPv4Ranges([]ipRange{{10, 100}, {20, 30}}))
+	})
+	t.Run("inverted ranges admit nothing and are dropped", func(t *testing.T) {
+		assert.Nil(t, mergeIPv4Ranges([]ipRange{{30, 10}}))
+		assert.Empty(t, mergeIPv4Ranges(nil))
+	})
+	t.Run("the caller's slice is not reordered", func(t *testing.T) {
+		in := []ipRange{{10, 20}, {0, 5}}
+		mergeIPv4Ranges(in)
+		assert.Equal(t, []ipRange{{10, 20}, {0, 5}}, in, "the input is often a resource's own rule list")
+	})
+}
+
+func TestIPv4RoutableCoverage(t *testing.T) {
+	whole := []ipRange{{0, math.MaxUint32}}
+	assert.Equal(t, routableIPv4Total, ipv4RoutableCoverage(whole))
+
+	// 10.0.0.0/8 is private: a rule spanning it admits nothing on the internet
+	assert.Equal(t, uint64(0), ipv4RoutableCoverage([]ipRange{{167772160, 184549375}}))
+
+	// 20.10.0.0/24, an ordinary public /24
+	assert.Equal(t, uint64(256), ipv4RoutableCoverage([]ipRange{{336855040, 336855295}}))
+
+	assert.Equal(t, uint64(0), ipv4RoutableCoverage(nil))
+}
+
+// TestDatabaseFirewallRangesJudgedAsUnion is the case that was live-confirmed
+// on an Azure SQL server: five rules, no catch-all, and between them every
+// address on the internet. Each rule was judged on its own, none of them
+// reached the threshold, and the server reported internetReachable: false.
+func TestDatabaseFirewallRangesJudgedAsUnion(t *testing.T) {
+	thirds := [][2]string{
+		{"0.0.0.0", "84.255.255.255"},
+		{"85.0.0.0", "169.255.255.255"},
+		{"170.0.0.0", "255.255.255.255"},
+	}
+
+	t.Run("no single third is open on its own", func(t *testing.T) {
+		for _, r := range thirds {
+			assert.Falsef(t, firewallRuleAllowsAnyInternet(r[0], r[1]), "%s-%s", r[0], r[1])
+		}
+	})
+	t.Run("the three together are the whole internet", func(t *testing.T) {
+		assert.True(t, databaseInternetReachable("Enabled", thirds))
+	})
+	t.Run("the live rule set, sentinel and overlap included", func(t *testing.T) {
+		live := append([][2]string{}, thirds...)
+		live = append(live,
+			[2]string{"1.0.0.0", "127.255.255.255"}, // overlaps the first two thirds
+			[2]string{"0.0.0.0", "0.0.0.0"},         // the allow-all-Azure-services sentinel
+		)
+		assert.True(t, databaseInternetReachable("Enabled", live))
+	})
+	t.Run("public network access disabled still wins over the union", func(t *testing.T) {
+		assert.False(t, databaseInternetReachable("Disabled", thirds))
+	})
+
+	t.Run("two adjacent halves are the whole internet", func(t *testing.T) {
+		assert.True(t, databaseInternetReachable("Enabled", [][2]string{
+			{"0.0.0.0", "127.255.255.255"}, {"128.0.0.0", "255.255.255.255"},
+		}))
+	})
+	t.Run("the upper half alone is not", func(t *testing.T) {
+		assert.False(t, firewallRuleAllowsAnyInternet("128.0.0.0", "255.255.255.255"))
+	})
+
+	// half the internet written without touching 0.0.0.0/8, which a raw
+	// half-of-IPv4 threshold scored as an allowlist by 16.7 million addresses
+	t.Run("1.0.0.0 to 127.255.255.255 alone is open", func(t *testing.T) {
+		assert.True(t, firewallRuleAllowsAnyInternet("1.0.0.0", "127.255.255.255"))
+		assert.True(t, databaseInternetReachable("Enabled", [][2]string{{"1.0.0.0", "127.255.255.255"}}))
+	})
+
+	t.Run("the allow-all-Azure-services sentinel alone is not exposure", func(t *testing.T) {
+		assert.False(t, databaseInternetReachable("Enabled", [][2]string{{"0.0.0.0", "0.0.0.0"}}))
+	})
+	t.Run("an office allowlist is not exposure", func(t *testing.T) {
+		assert.False(t, databaseInternetReachable("Enabled", [][2]string{
+			{"20.10.0.0", "20.10.0.255"}, {"52.1.2.0", "52.1.2.255"},
+		}))
+	})
+	t.Run("private ranges do not accumulate into exposure", func(t *testing.T) {
+		assert.False(t, databaseInternetReachable("Enabled", [][2]string{
+			{"10.0.0.0", "10.255.255.255"},
+			{"172.16.0.0", "172.31.255.255"},
+			{"192.168.0.0", "192.168.255.255"},
+			{"127.0.0.0", "127.255.255.255"},
+		}))
+	})
+}
+
+// TestFirewallRangeSets pins the split that feeds the union, including the
+// pairs that describe no coherent range at all. A pair that survived
+// mis-classified would be summed into the coverage measure.
+func TestFirewallRangeSets(t *testing.T) {
+	v4, v6 := firewallRangeSets([][2]string{
+		{"1.2.3.4", "1.2.3.5"},
+		{"::", "::ffff"},
+		{"0.0.0.0", ""},                      // unparseable end
+		{"not-an-address", "1.2.3.4"},        // unparseable start
+		{"1.2.3.5", "1.2.3.4"},               // inverted
+		{"::2", "::1"},                       // inverted, IPv6
+		{"0.0.0.0", "ffff::"},                // mixed families
+		{"::ffff:0.0.0.0", "::ffff:1.2.3.4"}, // IPv4-mapped is not the IPv6 internet
+	})
+	assert.Equal(t, []ipRange{{16909060, 16909061}}, v4)
+	require.Len(t, v6, 1)
+	assert.Equal(t, "0", v6[0].lo.String())
+	assert.Equal(t, "65535", v6[0].hi.String())
+}
+
+// TestIPv6RangesAdmitInternet mirrors the IPv4 union for the family Azure keeps
+// in a rule list of its own.
+func TestIPv6RangesAdmitInternet(t *testing.T) {
+	halves := [][2]string{
+		{"::", "7fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},
+		{"8000::", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},
+	}
+	t.Run("the two IPv6 halves together are open", func(t *testing.T) {
+		assert.True(t, databaseInternetReachable("Enabled", halves))
+	})
+	t.Run("a documentation prefix is not", func(t *testing.T) {
+		assert.False(t, databaseInternetReachable("Enabled", [][2]string{{"2001:db8::", "2001:db8::ffff"}}))
+	})
+	t.Run("quarters of the space sum to half", func(t *testing.T) {
+		assert.True(t, databaseInternetReachable("Enabled", [][2]string{
+			{"::", "3fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},
+			{"4000::", "7fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},
+		}))
+	})
+	t.Run("one quarter alone is not half", func(t *testing.T) {
+		assert.False(t, databaseInternetReachable("Enabled", [][2]string{
+			{"::", "3fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},
+		}))
+	})
+	t.Run("overlapping ranges are not double counted", func(t *testing.T) {
+		assert.False(t, databaseInternetReachable("Enabled", [][2]string{
+			{"::", "3fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},
+			{"::", "3fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},
+			{"1000::", "2fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"},
+		}))
+	})
+}
+
+// TestRawOpenIngressRules pins the list form of the same rule. An empty
+// openIngressRules on a VM whose NICs could not be read says "nothing admits
+// internet traffic here", which is the claim a `.none(...)` check passes on.
+func TestRawOpenIngressRules(t *testing.T) {
+	rule := map[string]any{"name": "AllowSshFromAnywhere", "access": "Allow"}
+
+	t.Run("nothing evaluated and nothing found is null", func(t *testing.T) {
+		assert.Nil(t, rawOpenIngressRules([]any{}, false).Value)
+		assert.Nil(t, rawOpenIngressRules(nil, false).Value)
+	})
+	t.Run("rules found on a readable NIC survive an unreadable sibling", func(t *testing.T) {
+		assert.Equal(t, []any{rule}, rawOpenIngressRules([]any{rule}, false).Value)
+	})
+	t.Run("evaluated and empty is a real empty list", func(t *testing.T) {
+		assert.Equal(t, []any{}, rawOpenIngressRules([]any{}, true).Value)
+	})
+	t.Run("evaluated with rules is the list", func(t *testing.T) {
+		assert.Equal(t, []any{rule}, rawOpenIngressRules([]any{rule}, true).Value)
 	})
 }

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -372,12 +372,24 @@ func (a *mqlAzureSubscriptionNetworkServiceInterface) effectiveNsgGroupsCached()
 // effectiveSecurityRules computes the merged NSG rules effective on this NIC
 // (NSG attached to NIC + ASG + NSG attached to subnet), flattened across the
 // effective-NSG chain. Lazily called per NIC.
+//
+// When Azure did not answer authoritatively -- a NIC on a deallocated VM, or a
+// caller without the effectiveNetworkSecurityGroups action -- this reports null
+// rather than an empty list. An empty list is a claim: it says this NIC has no
+// effective rules, so a check of the form
+// `.none(access == "Allow" && sourceAddressPrefix == "*")` passes over every
+// stopped machine and every subscription the scanner cannot read the rules in.
 func (a *mqlAzureSubscriptionNetworkServiceInterface) effectiveSecurityRules() ([]any, error) {
-	groups, _, err := a.effectiveNsgGroupsCached()
+	groups, evaluated, err := a.effectiveNsgGroupsCached()
 	if err != nil {
 		return nil, err
 	}
-	var res []any
+	if !evaluated {
+		a.EffectiveSecurityRules.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	res := []any{}
 	for _, g := range groups {
 		for _, rule := range g.rules {
 			res = append(res, rule)

--- a/providers/azure/resources/network_nic_effective_typed.go
+++ b/providers/azure/resources/network_nic_effective_typed.go
@@ -105,10 +105,18 @@ func (a *mqlAzureSubscriptionNetworkServiceInterfaceEffectiveSecurityRule) netwo
 	return res.(*mqlAzureSubscriptionNetworkServiceSecurityGroup), nil
 }
 
+// effectiveRules is the typed form of effectiveSecurityRules and degrades the
+// same way: an unevaluated NIC reports null, not an empty rule set, so a policy
+// asserting nothing allows internet ingress cannot pass on rules that were
+// never read.
 func (a *mqlAzureSubscriptionNetworkServiceInterface) effectiveRules() ([]any, error) {
-	groups, _, err := a.effectiveNsgGroupsCached()
+	groups, evaluated, err := a.effectiveNsgGroupsCached()
 	if err != nil {
 		return nil, err
+	}
+	if !evaluated {
+		a.EffectiveRules.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
 	}
 
 	res := []any{}

--- a/providers/gcp/resources/gcp_exposure.go
+++ b/providers/gcp/resources/gcp_exposure.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"strconv"
 	"strings"
 
 	"go.mondoo.com/mql/llx"
@@ -80,15 +81,7 @@ func firewallRuleOpenIngress(isAllow bool, direction string, disabled bool, sour
 	// A GCP VPC firewall rule is exclusively an allow rule or a deny rule. Only
 	// allow rules can open ingress; a broad-source INGRESS deny rule (a common
 	// "block all" pattern) must not be counted as reachable exposure.
-	if !isAllow || disabled || !strings.EqualFold(direction, "INGRESS") {
-		return false
-	}
-	for _, s := range sourceRanges {
-		if cidr, ok := s.(string); ok && (cidr == "0.0.0.0/0" || cidr == "::/0") {
-			return true
-		}
-	}
-	return false
+	return isAllow && ingressFromInternet(direction, disabled, sourceRanges)
 }
 
 // openIngressPolicyRulesForInstance returns the network firewall policy rules
@@ -285,6 +278,324 @@ func firewallTargetsInstance(targetTags, targetServiceAccounts []any, instanceTa
 	return false
 }
 
+// firewallProtocolAll is the wildcard protocol on a VPC firewall rule's layer 4
+// match. Compute spells it "all".
+const firewallProtocolAll = "all"
+
+// gcpProtocolAliases folds the spellings a layer 4 match may carry onto one
+// name, so an IANA protocol number and its name compare equal.
+var gcpProtocolAliases = map[string]string{
+	"1":       "icmp",
+	"6":       "tcp",
+	"17":      "udp",
+	"47":      "gre",
+	"50":      "esp",
+	"51":      "ah",
+	"58":      "ipv6-icmp",
+	"94":      "ipip",
+	"132":     "sctp",
+	"icmpv6":  "ipv6-icmp",
+	"icmp-v6": "ipv6-icmp",
+}
+
+// normalizeFirewallProtocol lowercases a protocol and resolves its numeric
+// aliases. An absent protocol reads as the wildcard, which is how Compute treats
+// a match that names none.
+func normalizeFirewallProtocol(protocol string) string {
+	p := strings.ToLower(strings.TrimSpace(protocol))
+	if p == "" {
+		return firewallProtocolAll
+	}
+	if name, ok := gcpProtocolAliases[p]; ok {
+		return name
+	}
+	return p
+}
+
+// firewallProtocolCovers reports whether a rule for protocol outer matches every
+// packet a rule for protocol inner matches. The wildcard covers everything;
+// otherwise the two protocols must be the same.
+func firewallProtocolCovers(outer, inner string) bool {
+	o, i := normalizeFirewallProtocol(outer), normalizeFirewallProtocol(inner)
+	return o == firewallProtocolAll || o == i
+}
+
+// firewallPortRange is an inclusive port span taken from one entry of a layer 4
+// match's port list. all is true when the match names no ports at all, which
+// Compute reads as every port of the protocol, and is also the only form
+// protocols with no port concept (icmp, esp, ah) take.
+type firewallPortRange struct {
+	from int64
+	to   int64
+	all  bool
+}
+
+// parseFirewallPortSpec parses a single port entry, which is either one port
+// ("22") or an inclusive range ("20-25"). Anything else returns false; a caller
+// that cannot read a port must not pretend to know which ports it covers.
+func parseFirewallPortSpec(spec string) (firewallPortRange, bool) {
+	s := strings.TrimSpace(spec)
+	if s == "" {
+		return firewallPortRange{}, false
+	}
+	low, high, isRange := strings.Cut(s, "-")
+	if !isRange {
+		high = low
+	}
+	from, err := strconv.ParseInt(strings.TrimSpace(low), 10, 64)
+	if err != nil {
+		return firewallPortRange{}, false
+	}
+	to, err := strconv.ParseInt(strings.TrimSpace(high), 10, 64)
+	if err != nil {
+		return firewallPortRange{}, false
+	}
+	if from > to {
+		from, to = to, from
+	}
+	return firewallPortRange{from: from, to: to}, true
+}
+
+// covers reports whether every port in other falls inside r.
+func (r firewallPortRange) covers(other firewallPortRange) bool {
+	if r.all {
+		return true
+	}
+	if other.all {
+		// other spans every port; a bounded range cannot contain it.
+		return false
+	}
+	return r.from <= other.from && r.to >= other.to
+}
+
+// firewallTraffic is one slice of the packets a firewall rule matches: an
+// address family, a protocol, and a port span. A rule fans out into one entry
+// per open source family and per port entry of its layer 4 match, because a
+// deny only silences an allow for the traffic both of them match.
+type firewallTraffic struct {
+	ipv6     bool
+	protocol string
+	ports    firewallPortRange
+}
+
+// covers reports whether t matches every packet other matches.
+//
+// The address family is part of that: an IPv4 rule and an IPv6 rule never match
+// the same packet, so a deny on 0.0.0.0/0 does not shadow an allow on ::/0.
+func (t firewallTraffic) covers(other firewallTraffic) bool {
+	if t.ipv6 != other.ipv6 {
+		return false
+	}
+	if !firewallProtocolCovers(t.protocol, other.protocol) {
+		return false
+	}
+	return t.ports.covers(other.ports)
+}
+
+// openSourceFamilies reports which address families a rule's source ranges open
+// to the whole internet.
+//
+// Only the two all-address blocks count. A set of narrower ranges that together
+// span the internet is not recognized, which leaves an allow rule counted as
+// open and a deny rule counted as not covering: both err toward reporting an
+// instance reachable.
+func openSourceFamilies(sourceRanges []any) (v4 bool, v6 bool) {
+	for _, s := range sourceRanges {
+		cidr, ok := s.(string)
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(cidr) {
+		case "0.0.0.0/0":
+			v4 = true
+		case "::/0":
+			v6 = true
+		}
+	}
+	return v4, v6
+}
+
+// ingressFromInternet reports whether a firewall rule is an enabled INGRESS rule
+// whose source ranges admit any address, without regard to whether it allows or
+// denies that traffic.
+func ingressFromInternet(direction string, disabled bool, sourceRanges []any) bool {
+	if disabled || !strings.EqualFold(direction, "INGRESS") {
+		return false
+	}
+	v4, v6 := openSourceFamilies(sourceRanges)
+	return v4 || v6
+}
+
+// ingressTraffic expands a firewall rule into the internet-sourced traffic it
+// matches: the cross product of the open address families in its source ranges
+// and the port spans in its layer 4 match.
+//
+// widenUnreadable decides what an unreadable layer 4 match means, and the two
+// callers need opposite answers. On an allow rule the match is the evidence of
+// exposure, so an unreadable one widens to every protocol and port and the rule
+// stays in the exposure list. On a deny rule the match is the evidence that
+// traffic is blocked, so an unreadable one is dropped and the deny shadows
+// nothing. Both directions keep an input that could not be read from reporting
+// an instance as protected.
+func ingressTraffic(sourceRanges []any, protocols map[string]any, widenUnreadable bool) []firewallTraffic {
+	v4, v6 := openSourceFamilies(sourceRanges)
+	families := []bool{}
+	if v4 {
+		families = append(families, false)
+	}
+	if v6 {
+		families = append(families, true)
+	}
+	if len(families) == 0 {
+		return nil
+	}
+
+	res := []firewallTraffic{}
+	for _, ipv6 := range families {
+		if len(protocols) == 0 {
+			if widenUnreadable {
+				res = append(res, firewallTraffic{ipv6: ipv6, protocol: firewallProtocolAll, ports: firewallPortRange{all: true}})
+			}
+			continue
+		}
+		for protocol, raw := range protocols {
+			ports, ok := raw.([]any)
+			if !ok || len(ports) == 0 {
+				// A match that names no ports covers every port of the protocol.
+				res = append(res, firewallTraffic{ipv6: ipv6, protocol: protocol, ports: firewallPortRange{all: true}})
+				continue
+			}
+			parsed := 0
+			for _, p := range ports {
+				spec, ok := p.(string)
+				if !ok {
+					continue
+				}
+				span, ok := parseFirewallPortSpec(spec)
+				if !ok {
+					continue
+				}
+				parsed++
+				res = append(res, firewallTraffic{ipv6: ipv6, protocol: protocol, ports: span})
+			}
+			if parsed == 0 && widenUnreadable {
+				res = append(res, firewallTraffic{ipv6: ipv6, protocol: protocol, ports: firewallPortRange{all: true}})
+			}
+		}
+	}
+	return res
+}
+
+// allowIngressTraffic expands an allow rule's internet-sourced traffic.
+func allowIngressTraffic(sourceRanges []any, protocols map[string]any) []firewallTraffic {
+	return ingressTraffic(sourceRanges, protocols, true)
+}
+
+// denyIngressTraffic expands a deny rule's internet-sourced traffic.
+func denyIngressTraffic(sourceRanges []any, protocols map[string]any) []firewallTraffic {
+	return ingressTraffic(sourceRanges, protocols, false)
+}
+
+// firewallIngressRule is the shape of a VPC firewall rule needed to decide
+// whether it leaves an instance reachable from the internet.
+type firewallIngressRule struct {
+	priority              int64
+	direction             string
+	disabled              bool
+	allow                 bool
+	network               string
+	sourceRanges          []any
+	protocols             map[string]any
+	targetTags            []any
+	targetServiceAccounts []any
+}
+
+// appliesToInstance reports whether the rule is enforced on an instance: it sits
+// on one of the instance's networks and its targeting selects the instance.
+func (r firewallIngressRule) appliesToInstance(instanceNetworks, instanceTags, instanceServiceAccounts map[string]bool) bool {
+	if !instanceNetworks[networkNameFromUrl(r.network)] {
+		return false
+	}
+	return firewallTargetsInstance(r.targetTags, r.targetServiceAccounts, instanceTags, instanceServiceAccounts)
+}
+
+// trafficIsCovered reports whether a single entry of covering matches every
+// packet traffic matches.
+//
+// Coverage is asked of one entry at a time rather than of the union: several
+// entries that jointly span a range do not count as covering it. Missing that
+// case leaves an allow rule reported as open, which is the safe direction.
+func trafficIsCovered(covering []firewallTraffic, traffic firewallTraffic) bool {
+	for _, c := range covering {
+		if c.covers(traffic) {
+			return true
+		}
+	}
+	return false
+}
+
+// ingressAllowSurvives reports whether any traffic an allow rule admits is left
+// open by the deny rules that outrank it.
+//
+// Compute evaluates VPC firewall rules by priority, lowest number first, and the
+// highest-priority rule matching a packet decides it. A deny at the same number
+// also wins: "A rule with a deny action overrides another with an allow action
+// only if the two rules have the same priority."
+//
+// Shadowing is decided per packet, so partial overlap is not shadowing. A deny
+// on tcp/22 in front of an allow on tcp/1-1024 still leaves 1023 ports open, and
+// a deny that covers only the IPv4 half of a dual-family allow still leaves the
+// IPv6 half open.
+func ingressAllowSurvives(allow firewallIngressRule, allowTraffic []firewallTraffic, denies []firewallIngressRule) bool {
+	for _, traffic := range allowTraffic {
+		shadowed := false
+		for _, deny := range denies {
+			if deny.priority > allow.priority {
+				continue
+			}
+			if trafficIsCovered(denyIngressTraffic(deny.sourceRanges, deny.protocols), traffic) {
+				shadowed = true
+				break
+			}
+		}
+		if !shadowed {
+			return true
+		}
+	}
+	return false
+}
+
+// unshadowedOpenIngressFirewalls returns the indexes of the rules that leave an
+// instance reachable from the internet: enabled INGRESS allow rules with an
+// all-address source that apply to the instance and are not fully shadowed by a
+// deny rule of equal or lower priority number.
+func unshadowedOpenIngressFirewalls(rules []firewallIngressRule, instanceNetworks, instanceTags, instanceServiceAccounts map[string]bool) []int {
+	denies := []firewallIngressRule{}
+	for _, r := range rules {
+		if r.allow || !ingressFromInternet(r.direction, r.disabled, r.sourceRanges) {
+			continue
+		}
+		if !r.appliesToInstance(instanceNetworks, instanceTags, instanceServiceAccounts) {
+			continue
+		}
+		denies = append(denies, r)
+	}
+
+	open := []int{}
+	for i, r := range rules {
+		if !firewallRuleOpenIngress(r.allow, r.direction, r.disabled, r.sourceRanges) {
+			continue
+		}
+		if !r.appliesToInstance(instanceNetworks, instanceTags, instanceServiceAccounts) {
+			continue
+		}
+		if ingressAllowSurvives(r, allowIngressTraffic(r.sourceRanges, r.protocols), denies) {
+			open = append(open, i)
+		}
+	}
+	return open
+}
+
 func anyStringSet(items []any) map[string]bool {
 	set := map[string]bool{}
 	for _, i := range items {
@@ -361,7 +672,12 @@ func (g *mqlGcpProjectComputeServiceInstance) exposure() (*mqlGcpProjectComputeS
 		return nil, firewalls.Error
 	}
 
-	openFirewalls := []any{}
+	// Both the allow rules and the deny rules are collected, because a deny of
+	// equal or lower priority number silences an allow for the traffic the two
+	// share. Reading only the allow rules reports an instance behind a
+	// higher-precedence deny as reachable.
+	fws := []*mqlGcpProjectComputeServiceFirewall{}
+	rules := []firewallIngressRule{}
 	for _, f := range firewalls.Data {
 		fw, ok := f.(*mqlGcpProjectComputeServiceFirewall)
 		if !ok {
@@ -375,6 +691,10 @@ func (g *mqlGcpProjectComputeServiceInstance) exposure() (*mqlGcpProjectComputeS
 		if disabled.Error != nil {
 			return nil, disabled.Error
 		}
+		priority := fw.GetPriority()
+		if priority.Error != nil {
+			return nil, priority.Error
+		}
 		sourceRanges := fw.GetSourceRanges()
 		if sourceRanges.Error != nil {
 			return nil, sourceRanges.Error
@@ -383,12 +703,13 @@ func (g *mqlGcpProjectComputeServiceInstance) exposure() (*mqlGcpProjectComputeS
 		if allowed.Error != nil {
 			return nil, allowed.Error
 		}
-		isAllow := len(allowed.Data) > 0
-		if !firewallRuleOpenIngress(isAllow, direction.Data, disabled.Data, sourceRanges.Data) {
-			continue
+		allowedProtocols := fw.GetAllowedProtocols()
+		if allowedProtocols.Error != nil {
+			return nil, allowedProtocols.Error
 		}
-		if !instanceNetworks[networkNameFromUrl(fw.cacheNetworkUrl)] {
-			continue
+		deniedProtocols := fw.GetDeniedProtocols()
+		if deniedProtocols.Error != nil {
+			return nil, deniedProtocols.Error
 		}
 		targetTags := fw.GetTargetTags()
 		if targetTags.Error != nil {
@@ -398,9 +719,31 @@ func (g *mqlGcpProjectComputeServiceInstance) exposure() (*mqlGcpProjectComputeS
 		if targetServiceAccounts.Error != nil {
 			return nil, targetServiceAccounts.Error
 		}
-		if firewallTargetsInstance(targetTags.Data, targetServiceAccounts.Data, instanceTags, instanceServiceAccounts) {
-			openFirewalls = append(openFirewalls, fw)
+
+		// A rule carries either allow entries or deny entries, never both.
+		isAllow := len(allowed.Data) > 0
+		protocols := deniedProtocols.Data
+		if isAllow {
+			protocols = allowedProtocols.Data
 		}
+
+		fws = append(fws, fw)
+		rules = append(rules, firewallIngressRule{
+			priority:              priority.Data,
+			direction:             direction.Data,
+			disabled:              disabled.Data,
+			allow:                 isAllow,
+			network:               fw.cacheNetworkUrl,
+			sourceRanges:          sourceRanges.Data,
+			protocols:             protocols,
+			targetTags:            targetTags.Data,
+			targetServiceAccounts: targetServiceAccounts.Data,
+		})
+	}
+
+	openFirewalls := []any{}
+	for _, i := range unshadowedOpenIngressFirewalls(rules, instanceNetworks, instanceTags, instanceServiceAccounts) {
+		openFirewalls = append(openFirewalls, fws[i])
 	}
 
 	// Network firewall policies are the second, newer way a VPC admits traffic,

--- a/providers/gcp/resources/gcp_exposure_test.go
+++ b/providers/gcp/resources/gcp_exposure_test.go
@@ -161,3 +161,468 @@ func TestFirewallTargetsInstance(t *testing.T) {
 		})
 	}
 }
+
+// expoNetwork is the network URL every rule in the shadowing tests sits on, and
+// expoInstance* are the instance's identity within it.
+const expoNetwork = "projects/p/global/networks/vpc-a"
+
+var (
+	expoInstanceNetworks = map[string]bool{"vpc-a": true}
+	expoInstanceTags     = map[string]bool{"expo-denied": true}
+	expoInstanceSAs      = map[string]bool{}
+)
+
+// fwPorts builds the []any port list a firewall rule's protocol map carries.
+func fwPorts(ports ...string) []any {
+	out := make([]any, 0, len(ports))
+	for _, p := range ports {
+		out = append(out, p)
+	}
+	return out
+}
+
+// fwProtocols builds a single-protocol layer 4 match. No ports means every port.
+func fwProtocols(protocol string, ports ...string) map[string]any {
+	return map[string]any{protocol: fwPorts(ports...)}
+}
+
+func fwSources(cidrs ...string) []any {
+	out := make([]any, 0, len(cidrs))
+	for _, c := range cidrs {
+		out = append(out, c)
+	}
+	return out
+}
+
+// expoRule builds an INGRESS rule on the instance's network targeting the
+// instance's tag, which is the shape every shadowing case varies from.
+func expoRule(priority int64, allow bool, protocols map[string]any, sources []any) firewallIngressRule {
+	return firewallIngressRule{
+		priority:     priority,
+		direction:    "INGRESS",
+		allow:        allow,
+		network:      expoNetwork,
+		sourceRanges: sources,
+		protocols:    protocols,
+		targetTags:   []any{"expo-denied"},
+	}
+}
+
+func TestParseFirewallPortSpec(t *testing.T) {
+	cases := []struct {
+		spec     string
+		wantFrom int64
+		wantTo   int64
+		wantOk   bool
+	}{
+		{"22", 22, 22, true},
+		{"20-25", 20, 25, true},
+		{" 8000-8080 ", 8000, 8080, true},
+		{"25-20", 20, 25, true},
+		{"0-65535", 0, 65535, true},
+		{"", 0, 0, false},
+		{"ssh", 0, 0, false},
+		{"20-", 0, 0, false},
+		{"-25", 0, 0, false},
+		{"20-25-30", 0, 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.spec, func(t *testing.T) {
+			got, ok := parseFirewallPortSpec(c.spec)
+			if ok != c.wantOk {
+				t.Fatalf("parseFirewallPortSpec(%q) ok = %v, want %v", c.spec, ok, c.wantOk)
+			}
+			if !ok {
+				return
+			}
+			if got.all {
+				t.Fatalf("parseFirewallPortSpec(%q) returned an all-ports span", c.spec)
+			}
+			if got.from != c.wantFrom || got.to != c.wantTo {
+				t.Errorf("parseFirewallPortSpec(%q) = %d-%d, want %d-%d", c.spec, got.from, got.to, c.wantFrom, c.wantTo)
+			}
+		})
+	}
+}
+
+func TestFirewallProtocolCovers(t *testing.T) {
+	cases := []struct {
+		outer string
+		inner string
+		want  bool
+	}{
+		{"all", "tcp", true},
+		{"all", "all", true},
+		{"", "tcp", true},
+		{"tcp", "tcp", true},
+		{"TCP", "tcp", true},
+		{"6", "tcp", true},
+		{"tcp", "6", true},
+		{"58", "ipv6-icmp", true},
+		{"icmpv6", "ipv6-icmp", true},
+		{"tcp", "udp", false},
+		{"tcp", "all", false},
+		{"icmp", "ipv6-icmp", false},
+		{"6", "17", false},
+	}
+	for _, c := range cases {
+		if got := firewallProtocolCovers(c.outer, c.inner); got != c.want {
+			t.Errorf("firewallProtocolCovers(%q, %q) = %v, want %v", c.outer, c.inner, got, c.want)
+		}
+	}
+}
+
+func TestFirewallPortRangeCovers(t *testing.T) {
+	all := firewallPortRange{all: true}
+	ssh := firewallPortRange{from: 22, to: 22}
+	low := firewallPortRange{from: 1, to: 1024}
+	high := firewallPortRange{from: 8000, to: 8080}
+
+	cases := []struct {
+		name  string
+		outer firewallPortRange
+		inner firewallPortRange
+		want  bool
+	}{
+		{"all covers a single port", all, ssh, true},
+		{"all covers all", all, all, true},
+		{"bounded does not cover all", low, all, false},
+		{"range covers a port inside it", low, ssh, true},
+		{"port does not cover the enclosing range", ssh, low, false},
+		{"disjoint ranges do not cover", low, high, false},
+		{"range covers itself", high, high, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.outer.covers(c.inner); got != c.want {
+				t.Errorf("covers() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestFirewallTrafficCovers(t *testing.T) {
+	v4ssh := firewallTraffic{protocol: "tcp", ports: firewallPortRange{from: 22, to: 22}}
+	v6ssh := firewallTraffic{ipv6: true, protocol: "tcp", ports: firewallPortRange{from: 22, to: 22}}
+	v4all := firewallTraffic{protocol: "all", ports: firewallPortRange{all: true}}
+	v6all := firewallTraffic{ipv6: true, protocol: "all", ports: firewallPortRange{all: true}}
+	v4https := firewallTraffic{protocol: "tcp", ports: firewallPortRange{from: 443, to: 443}}
+	v4udpSsh := firewallTraffic{protocol: "udp", ports: firewallPortRange{from: 22, to: 22}}
+
+	cases := []struct {
+		name  string
+		outer firewallTraffic
+		inner firewallTraffic
+		want  bool
+	}{
+		{"v4 all covers v4 ssh", v4all, v4ssh, true},
+		{"v4 all does not cover v6 ssh", v4all, v6ssh, false},
+		{"v6 all does not cover v4 ssh", v6all, v4ssh, false},
+		{"v6 all covers v6 ssh", v6all, v6ssh, true},
+		{"tcp 22 does not cover tcp 443", v4ssh, v4https, false},
+		{"tcp 22 does not cover udp 22", v4ssh, v4udpSsh, false},
+		{"tcp 22 covers itself", v4ssh, v4ssh, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.outer.covers(c.inner); got != c.want {
+				t.Errorf("covers() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestOpenSourceFamilies(t *testing.T) {
+	cases := []struct {
+		name    string
+		sources []any
+		wantV4  bool
+		wantV6  bool
+	}{
+		{"any v4", fwSources("0.0.0.0/0"), true, false},
+		{"any v6", fwSources("::/0"), false, true},
+		{"both", fwSources("0.0.0.0/0", "::/0"), true, true},
+		{"whitespace tolerated", fwSources(" 0.0.0.0/0 "), true, false},
+		{"scoped range", fwSources("10.0.0.0/8"), false, false},
+		{"empty", nil, false, false},
+		{"non-string entries", []any{42, nil}, false, false},
+		{"halves of the v4 internet are not recognized", fwSources("0.0.0.0/1", "128.0.0.0/1"), false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			v4, v6 := openSourceFamilies(c.sources)
+			if v4 != c.wantV4 || v6 != c.wantV6 {
+				t.Errorf("openSourceFamilies(%v) = (%v, %v), want (%v, %v)", c.sources, v4, v6, c.wantV4, c.wantV6)
+			}
+		})
+	}
+}
+
+// TestIngressTrafficUnreadableBias pins the asymmetry that keeps an input that
+// could not be read from reporting an instance as protected: an allow rule with
+// an unreadable layer 4 match widens to all traffic and stays exposed, while a
+// deny rule with an unreadable match yields nothing and shadows nothing.
+func TestIngressTrafficUnreadableBias(t *testing.T) {
+	sources := fwSources("0.0.0.0/0")
+
+	if got := allowIngressTraffic(sources, nil); len(got) != 1 ||
+		got[0].protocol != firewallProtocolAll || !got[0].ports.all || got[0].ipv6 {
+		t.Errorf("allowIngressTraffic with no protocols = %+v, want one v4 all/all entry", got)
+	}
+	if got := denyIngressTraffic(sources, nil); len(got) != 0 {
+		t.Errorf("denyIngressTraffic with no protocols = %+v, want none", got)
+	}
+
+	unreadablePorts := fwProtocols("tcp", "ssh")
+	got := allowIngressTraffic(sources, unreadablePorts)
+	if len(got) != 1 || got[0].protocol != "tcp" || !got[0].ports.all {
+		t.Errorf("allowIngressTraffic with an unparseable port = %+v, want one tcp all-ports entry", got)
+	}
+	if got := denyIngressTraffic(sources, unreadablePorts); len(got) != 0 {
+		t.Errorf("denyIngressTraffic with an unparseable port = %+v, want none", got)
+	}
+}
+
+// TestAllowIngressTrafficFansOutFamilies pins that a dual-stack open source
+// produces one entry per address family, which is what stops an IPv4 deny from
+// shadowing the IPv6 half.
+func TestAllowIngressTrafficFansOutFamilies(t *testing.T) {
+	got := allowIngressTraffic(fwSources("0.0.0.0/0", "::/0"), fwProtocols("tcp", "22"))
+	if len(got) != 2 {
+		t.Fatalf("allowIngressTraffic = %+v, want 2 entries", got)
+	}
+	v4, v6 := false, false
+	for _, tr := range got {
+		if tr.protocol != "tcp" || tr.ports.from != 22 || tr.ports.to != 22 {
+			t.Errorf("entry %+v does not describe tcp/22", tr)
+		}
+		if tr.ipv6 {
+			v6 = true
+		} else {
+			v4 = true
+		}
+	}
+	if !v4 || !v6 {
+		t.Errorf("allowIngressTraffic = %+v, want one IPv4 and one IPv6 entry", got)
+	}
+}
+
+func TestUnshadowedOpenIngressFirewalls(t *testing.T) {
+	cases := []struct {
+		name  string
+		rules []firewallIngressRule
+		want  []int
+	}{
+		{
+			// The live case: a DENY on tcp/22 at priority 500 in front of an
+			// ALLOW on tcp/22 at priority 1000. Before priority was read, the
+			// allow was reported open and the instance internetReachable.
+			name: "lower-numbered deny shadows the allow",
+			rules: []firewallIngressRule{
+				expoRule(500, false, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+				expoRule(1000, true, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+			},
+			want: []int{},
+		},
+		{
+			name: "allow survives a higher-numbered deny",
+			rules: []firewallIngressRule{
+				expoRule(2000, false, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+				expoRule(1000, true, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+			},
+			want: []int{1},
+		},
+		{
+			// GCP: "A rule with a deny action overrides another with an allow
+			// action only if the two rules have the same priority."
+			name: "deny wins at equal priority",
+			rules: []firewallIngressRule{
+				expoRule(1000, false, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+				expoRule(1000, true, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+			},
+			want: []int{},
+		},
+		{
+			name: "deny on a different port does not shadow",
+			rules: []firewallIngressRule{
+				expoRule(500, false, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+				expoRule(1000, true, fwProtocols("tcp", "443"), fwSources("0.0.0.0/0")),
+			},
+			want: []int{1},
+		},
+		{
+			name: "deny on a different protocol does not shadow",
+			rules: []firewallIngressRule{
+				expoRule(500, false, fwProtocols("udp", "22"), fwSources("0.0.0.0/0")),
+				expoRule(1000, true, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+			},
+			want: []int{1},
+		},
+		{
+			name: "ipv4 deny does not shadow an ipv6 allow",
+			rules: []firewallIngressRule{
+				expoRule(500, false, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+				expoRule(1000, true, fwProtocols("tcp", "22"), fwSources("::/0")),
+			},
+			want: []int{1},
+		},
+		{
+			name: "ipv6 deny does not shadow an ipv4 allow",
+			rules: []firewallIngressRule{
+				expoRule(500, false, fwProtocols("tcp", "22"), fwSources("::/0")),
+				expoRule(1000, true, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+			},
+			want: []int{1},
+		},
+		{
+			name: "ipv4 deny leaves the ipv6 half of a dual-stack allow open",
+			rules: []firewallIngressRule{
+				expoRule(500, false, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+				expoRule(1000, true, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0", "::/0")),
+			},
+			want: []int{1},
+		},
+		{
+			name: "disabled deny does not shadow",
+			rules: []firewallIngressRule{
+				func() firewallIngressRule {
+					r := expoRule(500, false, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0"))
+					r.disabled = true
+					return r
+				}(),
+				expoRule(1000, true, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+			},
+			want: []int{1},
+		},
+		{
+			name: "deny targeting a different tag does not shadow",
+			rules: []firewallIngressRule{
+				func() firewallIngressRule {
+					r := expoRule(500, false, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0"))
+					r.targetTags = []any{"other-tag"}
+					return r
+				}(),
+				expoRule(1000, true, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+			},
+			want: []int{1},
+		},
+		{
+			name: "deny on another network does not shadow",
+			rules: []firewallIngressRule{
+				func() firewallIngressRule {
+					r := expoRule(500, false, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0"))
+					r.network = "projects/p/global/networks/vpc-b"
+					return r
+				}(),
+				expoRule(1000, true, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+			},
+			want: []int{1},
+		},
+		{
+			name: "egress deny does not shadow",
+			rules: []firewallIngressRule{
+				func() firewallIngressRule {
+					r := expoRule(500, false, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0"))
+					r.direction = "EGRESS"
+					return r
+				}(),
+				expoRule(1000, true, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+			},
+			want: []int{1},
+		},
+		{
+			name: "deny with a scoped source does not shadow an internet allow",
+			rules: []firewallIngressRule{
+				expoRule(500, false, fwProtocols("tcp", "22"), fwSources("10.0.0.0/8")),
+				expoRule(1000, true, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+			},
+			want: []int{1},
+		},
+		{
+			name: "deny on all protocols shadows every allow below it",
+			rules: []firewallIngressRule{
+				expoRule(100, false, fwProtocols("all"), fwSources("0.0.0.0/0")),
+				expoRule(1000, true, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+				expoRule(1100, true, fwProtocols("udp", "53"), fwSources("0.0.0.0/0")),
+			},
+			want: []int{},
+		},
+		{
+			name: "narrow deny in front of a broad allow leaves the rest open",
+			rules: []firewallIngressRule{
+				expoRule(500, false, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+				expoRule(1000, true, fwProtocols("tcp", "1-1024"), fwSources("0.0.0.0/0")),
+			},
+			want: []int{1},
+		},
+		{
+			name: "deny range covering the allow port shadows it",
+			rules: []firewallIngressRule{
+				expoRule(500, false, fwProtocols("tcp", "20-25"), fwSources("0.0.0.0/0")),
+				expoRule(1000, true, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+			},
+			want: []int{},
+		},
+		{
+			name: "allow with a second unshadowed protocol survives",
+			rules: []firewallIngressRule{
+				expoRule(500, false, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+				expoRule(1000, true, map[string]any{
+					"tcp": fwPorts("22"),
+					"udp": fwPorts("53"),
+				}, fwSources("0.0.0.0/0")),
+			},
+			want: []int{1},
+		},
+		{
+			// A deny whose layer 4 match could not be read must not be treated
+			// as blocking traffic nobody proved was blocked.
+			name: "deny with an unreadable protocol match does not shadow",
+			rules: []firewallIngressRule{
+				expoRule(500, false, nil, fwSources("0.0.0.0/0")),
+				expoRule(1000, true, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+			},
+			want: []int{1},
+		},
+		{
+			name: "untargeted deny shadows every instance in the network",
+			rules: []firewallIngressRule{
+				func() firewallIngressRule {
+					r := expoRule(500, false, fwProtocols("all"), fwSources("0.0.0.0/0"))
+					r.targetTags = nil
+					return r
+				}(),
+				expoRule(1000, true, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+			},
+			want: []int{},
+		},
+		{
+			name: "allow with no deny in front stays open",
+			rules: []firewallIngressRule{
+				expoRule(1000, true, fwProtocols("tcp", "22"), fwSources("0.0.0.0/0")),
+			},
+			want: []int{0},
+		},
+		{
+			name: "scoped allow is never open",
+			rules: []firewallIngressRule{
+				expoRule(1000, true, fwProtocols("tcp", "22"), fwSources("10.0.0.0/8")),
+			},
+			want: []int{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := unshadowedOpenIngressFirewalls(c.rules, expoInstanceNetworks, expoInstanceTags, expoInstanceSAs)
+			if len(got) != len(c.want) {
+				t.Fatalf("unshadowedOpenIngressFirewalls() = %v, want %v", got, c.want)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Fatalf("unshadowedOpenIngressFirewalls() = %v, want %v", got, c.want)
+				}
+			}
+		})
+	}
+}

--- a/providers/gcp/resources/storage.go
+++ b/providers/gcp/resources/storage.go
@@ -171,14 +171,8 @@ func mqlBucketFromAPI(runtime *plugin.Runtime, projectId string, bucket *storage
 	created := parseTime(bucket.TimeCreated)
 	updated := parseTime(bucket.Updated)
 
-	iamConfigurationDict, err := convert.JsonToDict(bucket.IamConfiguration)
-	if err != nil {
-		return nil, err
-	}
-	retentionPolicy, err := convert.JsonToDict(bucket.RetentionPolicy)
-	if err != nil {
-		return nil, err
-	}
+	iamConfigurationDict := bucketIamConfigurationDict(bucket.IamConfiguration)
+	retentionPolicy := bucketRetentionPolicyDict(bucket.RetentionPolicy)
 	enc, err := convert.JsonToDict(bucket.Encryption)
 	if err != nil {
 		return nil, err
@@ -188,10 +182,7 @@ func mqlBucketFromAPI(runtime *plugin.Runtime, projectId string, bucket *storage
 	var uniformBucketLevelAccess map[string]any
 	if bucket.IamConfiguration != nil {
 		publicAccessPrevention = bucket.IamConfiguration.PublicAccessPrevention
-		uniformBucketLevelAccess, err = convert.JsonToDict(bucket.IamConfiguration.UniformBucketLevelAccess)
-		if err != nil {
-			return nil, err
-		}
+		uniformBucketLevelAccess = bucketUniformBucketLevelAccessDict(bucket.IamConfiguration.UniformBucketLevelAccess)
 	}
 
 	softDeletePolicy, err := convert.JsonToDict(bucket.SoftDeletePolicy)
@@ -204,20 +195,9 @@ func mqlBucketFromAPI(runtime *plugin.Runtime, projectId string, bucket *storage
 		objectRetentionMode = bucket.ObjectRetention.Mode
 	}
 
-	autoclass, err := convert.JsonToDict(bucket.Autoclass)
-	if err != nil {
-		return nil, err
-	}
-
-	ipFilter, err := convert.JsonToDict(bucket.IpFilter)
-	if err != nil {
-		return nil, err
-	}
-
-	hierarchicalNamespace, err := convert.JsonToDict(bucket.HierarchicalNamespace)
-	if err != nil {
-		return nil, err
-	}
+	autoclass := bucketAutoclassDict(bucket.Autoclass)
+	ipFilter := bucketIpFilterDict(bucket.IpFilter)
+	hierarchicalNamespace := bucketHierarchicalNamespaceDict(bucket.HierarchicalNamespace)
 
 	customPlacementConfig, err := convert.JsonToDict(bucket.CustomPlacementConfig)
 	if err != nil {
@@ -239,10 +219,7 @@ func mqlBucketFromAPI(runtime *plugin.Runtime, projectId string, bucket *storage
 		return nil, err
 	}
 
-	billing, err := convert.JsonToDict(bucket.Billing)
-	if err != nil {
-		return nil, err
-	}
+	billing := bucketBillingDict(bucket.Billing)
 
 	owner, err := convert.JsonToDict(bucket.Owner)
 	if err != nil {

--- a/providers/gcp/resources/storage_bucket_dicts.go
+++ b/providers/gcp/resources/storage_bucket_dicts.go
@@ -1,0 +1,140 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strconv"
+
+	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
+	"google.golang.org/api/storage/v1"
+)
+
+// The bucket configuration dicts below are assembled field by field instead of
+// being re-marshaled from the SDK struct.
+//
+// Every bool on these types is tagged `json:"...,omitempty"`, and the generated
+// MarshalJSON only overrides omitempty for fields named in ForceSendFields,
+// which a decoded response never populates. Re-marshaling therefore turns
+// {"enabled": false} into {}, so a bucket WITHOUT uniform bucket-level access
+// reads as null rather than false and
+// `buckets.where(uniformBucketLevelAccess["enabled"] == false)` matches nothing:
+// exactly the buckets an audit is looking for are the ones it cannot find.
+//
+// Bools are written unconditionally, because false is an answer. Strings,
+// counters, and nested messages keep the API's own omit-when-empty behavior, so
+// an absent value stays absent rather than becoming a zero that reads as
+// measured fact.
+
+// setIfNotEmpty writes a string under key only when it carries a value.
+func setIfNotEmpty(dict map[string]any, key, value string) {
+	if value != "" {
+		dict[key] = value
+	}
+}
+
+// bucketIamConfigurationDict builds the bucket's iamConfiguration dict.
+func bucketIamConfigurationDict(c *storage.BucketIamConfiguration) map[string]any {
+	if c == nil {
+		return nil
+	}
+	res := map[string]any{}
+	setIfNotEmpty(res, "publicAccessPrevention", c.PublicAccessPrevention)
+	if ubla := bucketUniformBucketLevelAccessDict(c.UniformBucketLevelAccess); ubla != nil {
+		res["uniformBucketLevelAccess"] = ubla
+	}
+	if c.BucketPolicyOnly != nil {
+		bpo := map[string]any{"enabled": c.BucketPolicyOnly.Enabled}
+		setIfNotEmpty(bpo, "lockedTime", c.BucketPolicyOnly.LockedTime)
+		res["bucketPolicyOnly"] = bpo
+	}
+	return res
+}
+
+// bucketUniformBucketLevelAccessDict builds the uniformBucketLevelAccess dict.
+func bucketUniformBucketLevelAccessDict(u *storage.BucketIamConfigurationUniformBucketLevelAccess) map[string]any {
+	if u == nil {
+		return nil
+	}
+	res := map[string]any{"enabled": u.Enabled}
+	setIfNotEmpty(res, "lockedTime", u.LockedTime)
+	return res
+}
+
+// bucketRetentionPolicyDict builds the retentionPolicy dict. retentionPeriod
+// keeps the API's string encoding, which is how the field has always been
+// reported and what existing content compares against.
+func bucketRetentionPolicyDict(rp *storage.BucketRetentionPolicy) map[string]any {
+	if rp == nil {
+		return nil
+	}
+	res := map[string]any{"isLocked": rp.IsLocked}
+	setIfNotEmpty(res, "effectiveTime", rp.EffectiveTime)
+	if rp.RetentionPeriod != 0 {
+		res["retentionPeriod"] = strconv.FormatInt(rp.RetentionPeriod, 10)
+	}
+	return res
+}
+
+// bucketAutoclassDict builds the autoclass dict.
+func bucketAutoclassDict(a *storage.BucketAutoclass) map[string]any {
+	if a == nil {
+		return nil
+	}
+	res := map[string]any{"enabled": a.Enabled}
+	setIfNotEmpty(res, "terminalStorageClass", a.TerminalStorageClass)
+	setIfNotEmpty(res, "terminalStorageClassUpdateTime", a.TerminalStorageClassUpdateTime)
+	setIfNotEmpty(res, "toggleTime", a.ToggleTime)
+	return res
+}
+
+// bucketHierarchicalNamespaceDict builds the hierarchicalNamespace dict.
+func bucketHierarchicalNamespaceDict(h *storage.BucketHierarchicalNamespace) map[string]any {
+	if h == nil {
+		return nil
+	}
+	return map[string]any{"enabled": h.Enabled}
+}
+
+// bucketBillingDict builds the billing dict.
+func bucketBillingDict(b *storage.BucketBilling) map[string]any {
+	if b == nil {
+		return nil
+	}
+	return map[string]any{"requesterPays": b.RequesterPays}
+}
+
+// bucketIpFilterDict builds the ipFilter dict.
+func bucketIpFilterDict(f *storage.BucketIpFilter) map[string]any {
+	if f == nil {
+		return nil
+	}
+	res := map[string]any{
+		"allowAllServiceAgentAccess": f.AllowAllServiceAgentAccess,
+		"allowCrossOrgVpcs":          f.AllowCrossOrgVpcs,
+	}
+	setIfNotEmpty(res, "mode", f.Mode)
+	if f.PublicNetworkSource != nil {
+		public := map[string]any{}
+		if len(f.PublicNetworkSource.AllowedIpCidrRanges) > 0 {
+			public["allowedIpCidrRanges"] = convert.SliceAnyToInterface(f.PublicNetworkSource.AllowedIpCidrRanges)
+		}
+		res["publicNetworkSource"] = public
+	}
+	if len(f.VpcNetworkSources) > 0 {
+		sources := make([]any, 0, len(f.VpcNetworkSources))
+		for _, v := range f.VpcNetworkSources {
+			if v == nil {
+				continue
+			}
+			source := map[string]any{}
+			setIfNotEmpty(source, "network", v.Network)
+			if len(v.AllowedIpCidrRanges) > 0 {
+				source["allowedIpCidrRanges"] = convert.SliceAnyToInterface(v.AllowedIpCidrRanges)
+			}
+			sources = append(sources, source)
+		}
+		res["vpcNetworkSources"] = sources
+	}
+	return res
+}

--- a/providers/gcp/resources/storage_bucket_dicts_test.go
+++ b/providers/gcp/resources/storage_bucket_dicts_test.go
@@ -1,0 +1,248 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers-sdk/v1/util/convert"
+	"google.golang.org/api/storage/v1"
+)
+
+// bucketFromJSON decodes an API response body the way the SDK does, so the
+// tests below exercise the same decoded structs a live list produces.
+func bucketFromJSON(t *testing.T, body string) *storage.Bucket {
+	t.Helper()
+	var b storage.Bucket
+	require.NoError(t, json.Unmarshal([]byte(body), &b))
+	return &b
+}
+
+// TestBucketDictsKeepFalse is the regression test for a uniform bucket-level
+// access setting of false disappearing from the dict.
+//
+// GCS returns "enabled": false on a bucket without uniform bucket-level access.
+// Re-marshaling the decoded struct dropped it, so the buckets an audit is
+// hunting for read null instead of false and
+// `buckets.where(uniformBucketLevelAccess["enabled"] == false)` matched nothing.
+func TestBucketDictsKeepFalse(t *testing.T) {
+	bucket := bucketFromJSON(t, `{
+	  "name": "ubla-off",
+	  "iamConfiguration": {
+	    "publicAccessPrevention": "inherited",
+	    "uniformBucketLevelAccess": {"enabled": false},
+	    "bucketPolicyOnly": {"enabled": false}
+	  },
+	  "retentionPolicy": {"effectiveTime": "2026-01-01T00:00:00Z", "isLocked": false, "retentionPeriod": "3600"},
+	  "autoclass": {"enabled": false, "toggleTime": "2026-01-01T00:00:00Z"},
+	  "hierarchicalNamespace": {"enabled": false},
+	  "billing": {"requesterPays": false},
+	  "ipFilter": {"mode": "Disabled", "allowAllServiceAgentAccess": false, "allowCrossOrgVpcs": false}
+	}`)
+
+	ubla := bucketUniformBucketLevelAccessDict(bucket.IamConfiguration.UniformBucketLevelAccess)
+	require.Contains(t, ubla, "enabled", "uniformBucketLevelAccess.enabled must be present, not null")
+	assert.Equal(t, false, ubla["enabled"])
+
+	iamConfig := bucketIamConfigurationDict(bucket.IamConfiguration)
+	nested, ok := iamConfig["uniformBucketLevelAccess"].(map[string]any)
+	require.True(t, ok, "iamConfiguration.uniformBucketLevelAccess must be a dict")
+	require.Contains(t, nested, "enabled")
+	assert.Equal(t, false, nested["enabled"])
+	bpo, ok := iamConfig["bucketPolicyOnly"].(map[string]any)
+	require.True(t, ok, "iamConfiguration.bucketPolicyOnly must be a dict")
+	require.Contains(t, bpo, "enabled")
+	assert.Equal(t, false, bpo["enabled"])
+
+	retention := bucketRetentionPolicyDict(bucket.RetentionPolicy)
+	require.Contains(t, retention, "isLocked")
+	assert.Equal(t, false, retention["isLocked"])
+
+	autoclass := bucketAutoclassDict(bucket.Autoclass)
+	require.Contains(t, autoclass, "enabled")
+	assert.Equal(t, false, autoclass["enabled"])
+
+	hns := bucketHierarchicalNamespaceDict(bucket.HierarchicalNamespace)
+	require.Contains(t, hns, "enabled")
+	assert.Equal(t, false, hns["enabled"])
+
+	billing := bucketBillingDict(bucket.Billing)
+	require.Contains(t, billing, "requesterPays")
+	assert.Equal(t, false, billing["requesterPays"])
+
+	ipFilter := bucketIpFilterDict(bucket.IpFilter)
+	require.Contains(t, ipFilter, "allowAllServiceAgentAccess")
+	assert.Equal(t, false, ipFilter["allowAllServiceAgentAccess"])
+	require.Contains(t, ipFilter, "allowCrossOrgVpcs")
+	assert.Equal(t, false, ipFilter["allowCrossOrgVpcs"])
+}
+
+// TestBucketDictsKeepTrue pins that the true case is unchanged, alongside the
+// non-bool fields that travel with it.
+func TestBucketDictsKeepTrue(t *testing.T) {
+	bucket := bucketFromJSON(t, `{
+	  "name": "ubla-on",
+	  "iamConfiguration": {
+	    "publicAccessPrevention": "enforced",
+	    "uniformBucketLevelAccess": {"enabled": true, "lockedTime": "2026-04-01T00:00:00Z"}
+	  },
+	  "retentionPolicy": {"effectiveTime": "2026-01-01T00:00:00Z", "isLocked": true, "retentionPeriod": "3600"},
+	  "autoclass": {"enabled": true, "terminalStorageClass": "ARCHIVE", "toggleTime": "2026-01-01T00:00:00Z"},
+	  "hierarchicalNamespace": {"enabled": true},
+	  "billing": {"requesterPays": true},
+	  "ipFilter": {
+	    "mode": "Enabled",
+	    "allowAllServiceAgentAccess": true,
+	    "allowCrossOrgVpcs": true,
+	    "publicNetworkSource": {"allowedIpCidrRanges": ["203.0.113.0/24"]},
+	    "vpcNetworkSources": [{"network": "projects/p/global/networks/n", "allowedIpCidrRanges": ["10.0.0.0/8"]}]
+	  }
+	}`)
+
+	ubla := bucketUniformBucketLevelAccessDict(bucket.IamConfiguration.UniformBucketLevelAccess)
+	assert.Equal(t, map[string]any{
+		"enabled":    true,
+		"lockedTime": "2026-04-01T00:00:00Z",
+	}, ubla)
+
+	assert.Equal(t, "enforced", bucketIamConfigurationDict(bucket.IamConfiguration)["publicAccessPrevention"])
+
+	// retentionPeriod keeps the API's string encoding, which is the form the
+	// field has always reported and what existing content compares against.
+	assert.Equal(t, map[string]any{
+		"effectiveTime":   "2026-01-01T00:00:00Z",
+		"isLocked":        true,
+		"retentionPeriod": "3600",
+	}, bucketRetentionPolicyDict(bucket.RetentionPolicy))
+
+	assert.Equal(t, map[string]any{
+		"enabled":              true,
+		"terminalStorageClass": "ARCHIVE",
+		"toggleTime":           "2026-01-01T00:00:00Z",
+	}, bucketAutoclassDict(bucket.Autoclass))
+
+	assert.Equal(t, map[string]any{"enabled": true}, bucketHierarchicalNamespaceDict(bucket.HierarchicalNamespace))
+	assert.Equal(t, map[string]any{"requesterPays": true}, bucketBillingDict(bucket.Billing))
+
+	assert.Equal(t, map[string]any{
+		"mode":                       "Enabled",
+		"allowAllServiceAgentAccess": true,
+		"allowCrossOrgVpcs":          true,
+		"publicNetworkSource":        map[string]any{"allowedIpCidrRanges": []any{"203.0.113.0/24"}},
+		"vpcNetworkSources": []any{map[string]any{
+			"network":             "projects/p/global/networks/n",
+			"allowedIpCidrRanges": []any{"10.0.0.0/8"},
+		}},
+	}, bucketIpFilterDict(bucket.IpFilter))
+}
+
+// TestBucketDictsNilStaysNull pins that an absent message reports null rather
+// than an empty object. "The bucket has no retention policy" and "the bucket has
+// a retention policy that is unlocked" are different facts and must not collapse
+// onto the same value.
+func TestBucketDictsNilStaysNull(t *testing.T) {
+	bucket := bucketFromJSON(t, `{"name": "bare"}`)
+
+	assert.Nil(t, bucketIamConfigurationDict(bucket.IamConfiguration))
+	assert.Nil(t, bucketUniformBucketLevelAccessDict(nil))
+	assert.Nil(t, bucketRetentionPolicyDict(bucket.RetentionPolicy))
+	assert.Nil(t, bucketAutoclassDict(bucket.Autoclass))
+	assert.Nil(t, bucketHierarchicalNamespaceDict(bucket.HierarchicalNamespace))
+	assert.Nil(t, bucketBillingDict(bucket.Billing))
+	assert.Nil(t, bucketIpFilterDict(bucket.IpFilter))
+
+	// An iamConfiguration that carries only publicAccessPrevention must not
+	// invent a uniformBucketLevelAccess sub-dict.
+	withoutUbla := bucketFromJSON(t, `{"iamConfiguration": {"publicAccessPrevention": "inherited"}}`)
+	dict := bucketIamConfigurationDict(withoutUbla.IamConfiguration)
+	assert.NotContains(t, dict, "uniformBucketLevelAccess")
+	assert.NotContains(t, dict, "bucketPolicyOnly")
+}
+
+// TestBucketDictsOmitEmptyStrings pins that an absent string stays absent rather
+// than becoming an empty string that would read as a measured value.
+func TestBucketDictsOmitEmptyStrings(t *testing.T) {
+	bucket := bucketFromJSON(t, `{
+	  "iamConfiguration": {"uniformBucketLevelAccess": {"enabled": false}},
+	  "retentionPolicy": {"isLocked": false},
+	  "autoclass": {"enabled": false},
+	  "ipFilter": {"allowAllServiceAgentAccess": false, "allowCrossOrgVpcs": false}
+	}`)
+
+	assert.Equal(t, map[string]any{"enabled": false},
+		bucketUniformBucketLevelAccessDict(bucket.IamConfiguration.UniformBucketLevelAccess))
+	assert.Equal(t, map[string]any{"isLocked": false}, bucketRetentionPolicyDict(bucket.RetentionPolicy))
+	assert.Equal(t, map[string]any{"enabled": false}, bucketAutoclassDict(bucket.Autoclass))
+	assert.Equal(t, map[string]any{
+		"allowAllServiceAgentAccess": false,
+		"allowCrossOrgVpcs":          false,
+	}, bucketIpFilterDict(bucket.IpFilter))
+	assert.NotContains(t, bucketIamConfigurationDict(bucket.IamConfiguration), "publicAccessPrevention")
+}
+
+// TestBucketConfigRoundTripIsLossy pins the SDK behavior the explicit builders
+// exist to work around: the generated MarshalJSON honors omitempty for every
+// bool unless ForceSendFields names it, and a decoded response never populates
+// ForceSendFields. If this ever stops being true, the builders can be revisited.
+func TestBucketConfigRoundTripIsLossy(t *testing.T) {
+	bucket := bucketFromJSON(t, `{"iamConfiguration": {"uniformBucketLevelAccess": {"enabled": false}}}`)
+	ubla := bucket.IamConfiguration.UniformBucketLevelAccess
+	require.False(t, ubla.Enabled, "the decoded struct carries the false")
+
+	roundTripped, err := convert.JsonToDict(ubla)
+	require.NoError(t, err)
+	assert.NotContains(t, roundTripped, "enabled", "re-marshaling still drops a false bool")
+
+	assert.Contains(t, bucketUniformBucketLevelAccessDict(ubla), "enabled")
+}
+
+// TestUniformBucketLevelAccessEnabledAgreesWithDict pins that the hoisted scalar
+// and the dict it reads from report the same answer. They disagreed before:
+// the scalar read false from the absent key by accident while the dict reported
+// the setting as unknown.
+func TestUniformBucketLevelAccessEnabledAgreesWithDict(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"ubla off", `{"iamConfiguration": {"uniformBucketLevelAccess": {"enabled": false}}}`, false},
+		{"ubla on", `{"iamConfiguration": {"uniformBucketLevelAccess": {"enabled": true}}}`, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			bucket := bucketFromJSON(t, c.body)
+			dict := bucketUniformBucketLevelAccessDict(bucket.IamConfiguration.UniformBucketLevelAccess)
+
+			res := &mqlGcpProjectStorageServiceBucket{
+				UniformBucketLevelAccess: plugin.TValue[any]{Data: dict, State: plugin.StateIsSet},
+			}
+			got, err := res.uniformBucketLevelAccessEnabled()
+			require.NoError(t, err)
+
+			assert.Equal(t, c.want, got, "hoisted scalar")
+			assert.Equal(t, c.want, dict["enabled"], "dict value")
+		})
+	}
+}
+
+// TestBucketDictsEmptyMessageReadsAsFalse documents the one case the API does
+// not let us distinguish. GCS omits "enabled" entirely on a bucket where the
+// setting is off, so an empty message and an explicit false decode identically
+// and both report false, which is the API's documented default.
+func TestBucketDictsEmptyMessageReadsAsFalse(t *testing.T) {
+	empty := bucketFromJSON(t, `{"iamConfiguration": {"uniformBucketLevelAccess": {}}}`)
+	explicit := bucketFromJSON(t, `{"iamConfiguration": {"uniformBucketLevelAccess": {"enabled": false}}}`)
+
+	assert.Equal(t,
+		bucketUniformBucketLevelAccessDict(empty.IamConfiguration.UniformBucketLevelAccess),
+		bucketUniformBucketLevelAccessDict(explicit.IamConfiguration.UniformBucketLevelAccess),
+	)
+	assert.Equal(t, map[string]any{"enabled": false},
+		bucketUniformBucketLevelAccessDict(empty.IamConfiguration.UniformBucketLevelAccess))
+}

--- a/providers/oci/resources/loadbalancer.go
+++ b/providers/oci/resources/loadbalancer.go
@@ -73,9 +73,10 @@ func (o *mqlOciLoadBalancer) loadBalancers() ([]any, error) {
 						"__id":      llx.StringData(stringValue(lb.Id) + "/ipAddress/" + stringValue(ip.IpAddress)),
 						"ipAddress": llx.StringDataPtr(ip.IpAddress),
 						// Faithful to the SDK: null when the balancer does not
-						// report the flag. ociLoadBalancerHasPublicIp reads a
-						// null as public, matching the fallback the deprecated
-						// dict resolves eagerly.
+						// report the flag. exposure() reads these addresses to
+						// decide internet reachability and takes a null as
+						// public, since a balancer that is not private answers
+						// on a public address.
 						"isPublic": llx.BoolDataPtr(ip.IsPublic),
 					})
 					if err != nil {
@@ -90,11 +91,12 @@ func (o *mqlOciLoadBalancer) loadBalancers() ([]any, error) {
 
 				ipAddresses := make([]any, 0, len(lb.IpAddresses))
 				for _, ip := range lb.IpAddresses {
-					// isPublic is optional on the SDK model, and exposure()
-					// reads this key back to decide internet reachability. A
-					// missing flag on a non-private load balancer means public,
-					// so falling back to false would clear a genuinely
-					// internet-facing balancer.
+					// isPublic is optional on the SDK model. This deprecated
+					// dict has no way to carry the distinction the address
+					// resource keeps, so the fallback is resolved eagerly here:
+					// a missing flag on a non-private load balancer means
+					// public, and falling back to false would describe a
+					// genuinely internet-facing balancer as internal.
 					entry := map[string]any{
 						"ipAddress": stringValue(ip.IpAddress),
 						"isPublic":  ociIpIsPublic(ip.IsPublic, boolValue(lb.IsPrivate)),

--- a/providers/oci/resources/networkloadbalancer.go
+++ b/providers/oci/resources/networkloadbalancer.go
@@ -57,7 +57,7 @@ func (o *mqlOciNetworkLoadBalancer) newNetworkLoadBalancers(nlbs []networkloadba
 		nlb := nlbs[i]
 
 		// Built by hand rather than marshalled from the SDK slice: isPublic is
-		// optional on the model, and exposure() reads the key back to decide
+		// optional on the model, and exposure() reads these addresses to decide
 		// internet reachability. A marshalled nil arrives as JSON null, which
 		// reads as "not public" and clears a genuinely internet-facing
 		// balancer. This mirrors the classic load balancer.
@@ -68,8 +68,8 @@ func (o *mqlOciNetworkLoadBalancer) newNetworkLoadBalancers(nlbs []networkloadba
 				"__id":      llx.StringData(stringValue(nlb.Id) + "/ipAddress/" + stringValue(ip.IpAddress)),
 				"ipAddress": llx.StringDataPtr(ip.IpAddress),
 				// Faithful to the SDK: null when the balancer does not report
-				// the flag. ociLoadBalancerHasPublicIp reads a null as public,
-				// matching the fallback the deprecated dict resolves eagerly.
+				// the flag. exposure() takes a null as public, since a balancer
+				// that is not private answers on a public address.
 				"isPublic":  llx.BoolDataPtr(ip.IsPublic),
 				"ipVersion": llx.StringData(string(ip.IpVersion)),
 			})
@@ -83,6 +83,9 @@ func (o *mqlOciNetworkLoadBalancer) newNetworkLoadBalancers(nlbs []networkloadba
 			addresses = append(addresses, mqlAddr)
 		}
 
+		// The deprecated dict has no way to carry the distinction the address
+		// resource keeps, so the fallback is resolved eagerly here: a missing
+		// flag on a non-private load balancer means public.
 		ipAddresses := make([]any, 0, len(nlb.IpAddresses))
 		for j := range nlb.IpAddresses {
 			ip := nlb.IpAddresses[j]

--- a/providers/oci/resources/oci_exposure.go
+++ b/providers/oci/resources/oci_exposure.go
@@ -81,18 +81,21 @@ func ociAnyPublicIpv6(addresses []any) bool {
 }
 
 // ociNsgRuleOpensIngress reports whether an OCI network-security-group rule dict
-// is an INGRESS rule whose source is a CIDR block admitting any address. NSG and
-// SERVICE_CIDR_BLOCK sources reference internal networks, not an internet-wide
-// opening, so only CIDR_BLOCK sources can be public.
+// is an INGRESS rule admitting traffic to a service port from any address. The
+// dict is the deprecated shape of the same rule the security rule resource
+// carries, so it is decided by the same predicate to keep the two descriptions
+// of an opening from drifting apart.
 func ociNsgRuleOpensIngress(rule map[string]any) bool {
-	if direction, _ := rule["direction"].(string); !strings.EqualFold(direction, "INGRESS") {
-		return false
-	}
-	if st, _ := rule["sourceType"].(string); st != "" && !strings.EqualFold(st, "CIDR_BLOCK") {
-		return false
-	}
+	direction, _ := rule["direction"].(string)
+	sourceType, _ := rule["sourceType"].(string)
 	source, _ := rule["source"].(string)
-	return ociCidrOpensInternet(source)
+	protocol, _ := rule["protocol"].(string)
+	return ociRuleValuesOpenIngress(ociIngressRuleValues{
+		direction:  direction,
+		sourceType: sourceType,
+		source:     source,
+		protocol:   protocol,
+	})
 }
 
 // ociSecurityRuleOpensIngress reports whether a security rule resource is an
@@ -118,20 +121,91 @@ func ociSecurityRuleOpensIngress(rule *mqlOciNetworkSecurityRule) (bool, error) 
 	if source.Error != nil {
 		return false, source.Error
 	}
-	return ociRuleValuesOpenIngress(direction.Data, sourceType.Data, source.Data), nil
+	protocol := rule.GetProtocol()
+	if protocol.Error != nil {
+		return false, protocol.Error
+	}
+	return ociRuleValuesOpenIngress(ociIngressRuleValues{
+		direction:  direction.Data,
+		sourceType: sourceType.Data,
+		source:     source.Data,
+		protocol:   protocol.Data,
+	}), nil
 }
 
-// ociRuleValuesOpenIngress is the predicate itself, over the three values that
-// decide it. Both rule sources normalize onto securityRule before they reach
-// MQL, so the same three values arrive whichever layer wrote the rule.
-func ociRuleValuesOpenIngress(direction, sourceType, source string) bool {
-	if !strings.EqualFold(direction, securityRuleIngress) {
+// ociIngressRuleValues is the set of rule values the open-ingress predicate
+// decides on. Both rule sources normalize onto securityRule before they reach
+// MQL, so the same values arrive whichever layer wrote the rule. They are named
+// rather than passed positionally because four strings in a row are four
+// chances to swap two of them without the compiler noticing.
+type ociIngressRuleValues struct {
+	// direction is INGRESS or EGRESS. A security list ingress rule states none
+	// of its own, so its adapter supplies INGRESS.
+	direction string
+	// sourceType is CIDR_BLOCK, SERVICE_CIDR_BLOCK or NETWORK_SECURITY_GROUP,
+	// or empty when the rule does not state one.
+	sourceType string
+	// source is the CIDR block, service label or group OCID the rule admits.
+	source string
+	// protocol is the IANA protocol number as a string, or "all".
+	protocol string
+}
+
+// OCI states a security rule's transport protocol as the IANA protocol number
+// in a string ("6" for TCP, "17" for UDP), or "all" for every protocol. Only the
+// two protocols carrying no ports are named: they are the only values the
+// open-ingress predicate has to tell apart from every other.
+const (
+	ociProtocolICMP   = "1"
+	ociProtocolICMPv6 = "58"
+)
+
+// ociProtocolOpensServicePort reports whether a rule's protocol admits traffic
+// to a service port, which is what makes an ingress opening something a host
+// can actually be reached on.
+//
+// OCI states the protocol as the IANA protocol number in a string ("6" for TCP,
+// "17" for UDP, "1" for ICMP, "58" for ICMPv6), or "all" for every protocol.
+// ICMP and ICMPv6 carry no ports. That matters because the default VCN security
+// list ships two 0.0.0.0/0 ingress rules, TCP 22 and ICMP type 3 code 4 for Path
+// MTU Discovery, and Oracle documents keeping the ICMP one even on hardened
+// subnets. Counting ICMP as an opening left a subnet with SSH removed reading
+// exactly like a subnet with SSH open to the world, so the field could not be
+// used to find hosts reachable on a service port.
+//
+// Every other value opens a port, including one that is empty or not a protocol
+// number at all: a protocol that could not be read is an unknown, and an unknown
+// must fail toward reachable rather than report a resource as protected.
+func ociProtocolOpensServicePort(protocol string) bool {
+	switch strings.ToLower(strings.TrimSpace(protocol)) {
+	case ociProtocolICMP, ociProtocolICMPv6:
+		return false
+	default:
+		return true
+	}
+}
+
+// ociRuleValuesOpenIngress is the predicate itself. A rule is an internet-wide
+// opening when it is inbound, its source is a CIDR block admitting any address,
+// and its protocol reaches a service port. NSG and SERVICE_CIDR_BLOCK sources
+// reference internal networks rather than an internet-wide opening, so only a
+// CIDR_BLOCK (or unset) source can be public.
+//
+// The destination port range is deliberately not consulted to close a rule. A
+// rule that states no range covers every port, which is wider than any explicit
+// range and not narrower, and an explicit range still leaves ports reachable.
+// Reading an absent range as "no ports" would clear exactly the widest rules.
+func ociRuleValuesOpenIngress(rule ociIngressRuleValues) bool {
+	if !strings.EqualFold(rule.direction, securityRuleIngress) {
 		return false
 	}
-	if sourceType != "" && !strings.EqualFold(sourceType, "CIDR_BLOCK") {
+	if rule.sourceType != "" && !strings.EqualFold(rule.sourceType, "CIDR_BLOCK") {
 		return false
 	}
-	return ociCidrOpensInternet(source)
+	if !ociCidrOpensInternet(rule.source) {
+		return false
+	}
+	return ociProtocolOpensServicePort(rule.protocol)
 }
 
 // ociOpenIngressRules filters a list of security rule resources down to the
@@ -224,16 +298,21 @@ func ociNsgIngressVerdict(nsgRuleSets [][]map[string]any) ([]any, bool) {
 }
 
 // ociSecurityListRuleOpensIngress reports whether a VCN security-list ingress
-// rule dict admits traffic from any address. Security-list ingress rules are
-// inherently inbound, so they carry no direction field. NSG and
-// SERVICE_CIDR_BLOCK sources reference internal networks, so only a CIDR_BLOCK
-// (or unset) source can be public.
+// rule dict admits traffic to a service port from any address. Security-list
+// ingress rules are inherently inbound, so they carry no direction field and
+// the direction is supplied here. The dict is the deprecated shape of the same
+// rule the security rule resource carries, so it is decided by the same
+// predicate.
 func ociSecurityListRuleOpensIngress(rule map[string]any) bool {
-	if st, _ := rule["sourceType"].(string); st != "" && !strings.EqualFold(st, "CIDR_BLOCK") {
-		return false
-	}
+	sourceType, _ := rule["sourceType"].(string)
 	source, _ := rule["source"].(string)
-	return ociCidrOpensInternet(source)
+	protocol, _ := rule["protocol"].(string)
+	return ociRuleValuesOpenIngress(ociIngressRuleValues{
+		direction:  securityRuleIngress,
+		sourceType: sourceType,
+		source:     source,
+		protocol:   protocol,
+	})
 }
 
 // ociCollectOpenSecurityListRules inspects the ingress rules of the security
@@ -415,8 +494,10 @@ type ociLbAddress interface {
 	GetIsPublic() *plugin.TValue[bool]
 }
 
-// ociLoadBalancerHasPublicIp reports whether any of a load balancer's IP
-// address entries is internet-facing.
+// ociLoadBalancerHasPublicIp reports whether any of a load balancer's addresses
+// is internet-facing. It takes the address resources, which is what carries the
+// isPublic flag; the deprecated ipAddresses dicts implement no accessor, so
+// every one of them would be skipped.
 //
 // A private balancer short-circuits: its addresses are internal whatever the
 // individual flags say. isPublic is optional on both load balancer SDK models,
@@ -424,18 +505,27 @@ type ociLbAddress interface {
 // private flag, for the same reason ociIpIsPublic does: absent does not mean
 // private, and defaulting it to false clears a genuinely internet-facing
 // balancer.
-func ociLoadBalancerHasPublicIp(ips []any, isPrivate bool) bool {
+//
+// A list with nothing readable in it is the same unknown as an absent flag, so
+// on a balancer that is not private it reports public. A balancer that is not
+// private answers on a public address by definition, and an address list that
+// could not be read must not be the reason it is reported as protected.
+func ociLoadBalancerHasPublicIp(addresses []any, isPrivate bool) bool {
 	if isPrivate {
 		return false
 	}
-	for _, e := range ips {
+	read := 0
+	for _, e := range addresses {
 		addr, ok := e.(ociLbAddress)
 		if !ok {
 			continue
 		}
+		read++
 		pub := addr.GetIsPublic()
 		if pub.Error != nil {
-			continue
+			// The flag could not be read. Not private, so the address counts as
+			// public rather than silently clearing the balancer.
+			return true
 		}
 		if pub.IsNull() {
 			// The balancer did not report the flag. Not private, so treat the
@@ -446,7 +536,7 @@ func ociLoadBalancerHasPublicIp(ips []any, isPrivate bool) bool {
 			return true
 		}
 	}
-	return false
+	return read == 0
 }
 
 // ociWhitelistOpensInternet reports whether an Autonomous Database access-control
@@ -702,11 +792,14 @@ func (l *mqlOciLoadBalancerLoadBalancer) exposure() (*mqlOciNetworkExposure, err
 		return nil, isPrivate.Error
 	}
 
-	ips := l.GetIpAddresses()
-	if ips.Error != nil {
-		return nil, ips.Error
+	// The address resources, not the deprecated ipAddresses dicts: a dict is a
+	// map with no isPublic accessor on it, so reading the verdict from that
+	// field skipped every entry and made hasPublicIp permanently false.
+	addresses := l.GetAddresses()
+	if addresses.Error != nil {
+		return nil, addresses.Error
 	}
-	hasPublicIp := ociLoadBalancerHasPublicIp(ips.Data, isPrivate.Data)
+	hasPublicIp := ociLoadBalancerHasPublicIp(addresses.Data, isPrivate.Data)
 
 	listeners := l.GetListeners()
 	if listeners.Error != nil {
@@ -820,11 +913,13 @@ func (n *mqlOciNetworkLoadBalancerLoadBalancer) exposure() (*mqlOciNetworkExposu
 		return nil, isPrivate.Error
 	}
 
-	ips := n.GetIpAddresses()
-	if ips.Error != nil {
-		return nil, ips.Error
+	// The address resources, for the same reason as the classic load balancer:
+	// the deprecated ipAddresses dicts carry no isPublic accessor.
+	addresses := n.GetAddresses()
+	if addresses.Error != nil {
+		return nil, addresses.Error
 	}
-	hasPublicIp := ociLoadBalancerHasPublicIp(ips.Data, isPrivate.Data)
+	hasPublicIp := ociLoadBalancerHasPublicIp(addresses.Data, isPrivate.Data)
 
 	listeners := n.GetListeners()
 	if listeners.Error != nil {

--- a/providers/oci/resources/oci_exposure_lb_test.go
+++ b/providers/oci/resources/oci_exposure_lb_test.go
@@ -69,7 +69,14 @@ func TestOciLoadBalancerHasPublicIp(t *testing.T) {
 		isPrivate bool
 		want      bool
 	}{
-		{"no addresses at all", nil, false, false},
+		// A balancer that is not private answers on a public address by
+		// definition, so an address list with nothing readable in it is an
+		// unread fact, not a private balancer. Reporting false here would let
+		// an address list that failed to load be the reason a public balancer
+		// passes an "must not be exposed" policy.
+		{"no addresses at all", nil, false, true},
+		{"empty address list", []any{}, false, true},
+		{"no addresses on a private balancer", nil, true, false},
 		{"one public address", []any{ip("203.0.113.10", true)}, false, true},
 		{"only private addresses", []any{ip("10.0.0.5", false)}, false, false},
 		{"a public address among private ones", []any{
@@ -93,9 +100,13 @@ func TestOciLoadBalancerHasPublicIp(t *testing.T) {
 		{"null isPublic on a public balancer", []any{nullIp("203.0.113.10")}, false, true},
 		{"null isPublic on a private balancer", []any{nullIp("10.0.0.5")}, true, false},
 
-		// An entry of some other type must not panic or be mistaken for a
-		// verdict.
-		{"foreign entry is skipped", []any{"203.0.113.10"}, false, false},
+		// An entry of some other type must not panic. Nothing was read from it
+		// either, so it lands on the same unread-fact answer as an empty list.
+		// This is the shape the regression took: the deprecated ipAddresses
+		// dicts were passed in, every map failed the type assertion, and the
+		// balancer read as having no public address at all.
+		{"foreign entry is not a private verdict", []any{"203.0.113.10"}, false, true},
+		{"foreign entry on a private balancer", []any{"10.0.0.5"}, true, false},
 		{"foreign entry alongside a public one", []any{
 			"garbage", ip("203.0.113.10", true),
 		}, false, true},

--- a/providers/oci/resources/oci_exposure_test.go
+++ b/providers/oci/resources/oci_exposure_test.go
@@ -3,7 +3,12 @@
 
 package resources
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/oracle/oci-go-sdk/v65/core"
+	"github.com/stretchr/testify/assert"
+)
 
 func TestOciCidrIsAny(t *testing.T) {
 	cases := []struct {
@@ -38,6 +43,15 @@ func TestOciNsgRuleOpensIngress(t *testing.T) {
 		{"ingress service source", map[string]any{"direction": "INGRESS", "sourceType": "SERVICE_CIDR_BLOCK", "source": "all-services"}, false},
 		{"missing sourceType but any cidr", map[string]any{"direction": "INGRESS", "source": "0.0.0.0/0"}, true},
 		{"empty", map[string]any{}, false},
+
+		// The dict list mirrors the security rule resources, so it has to agree
+		// with them about which protocols reach a service port.
+		{"ingress tcp any", map[string]any{"direction": "INGRESS", "source": "0.0.0.0/0", "protocol": "6"}, true},
+		{"ingress udp any", map[string]any{"direction": "INGRESS", "source": "0.0.0.0/0", "protocol": "17"}, true},
+		{"ingress all protocols any", map[string]any{"direction": "INGRESS", "source": "0.0.0.0/0", "protocol": "all"}, true},
+		{"ingress icmp any", map[string]any{"direction": "INGRESS", "source": "0.0.0.0/0", "protocol": "1"}, false},
+		{"ingress icmpv6 any", map[string]any{"direction": "INGRESS", "source": "0.0.0.0/0", "protocol": "58"}, false},
+		{"ingress unknown protocol any", map[string]any{"direction": "INGRESS", "source": "0.0.0.0/0", "protocol": "not-a-protocol"}, true},
 	}
 	for _, c := range cases {
 		if got := ociNsgRuleOpensIngress(c.rule); got != c.want {
@@ -87,6 +101,12 @@ func TestOciSecurityListRuleOpensIngress(t *testing.T) {
 		{"service source", map[string]any{"sourceType": "SERVICE_CIDR_BLOCK", "source": "all-services"}, false},
 		{"missing sourceType but any cidr", map[string]any{"source": "0.0.0.0/0"}, true},
 		{"empty", map[string]any{}, false},
+
+		// OCI's default VCN security list ships an SSH rule and an ICMP type 3
+		// code 4 rule, both from 0.0.0.0/0. Only the first opens a port.
+		{"default ssh rule", map[string]any{"sourceType": "CIDR_BLOCK", "source": "0.0.0.0/0", "protocol": "6"}, true},
+		{"default path mtu discovery rule", map[string]any{"sourceType": "CIDR_BLOCK", "source": "0.0.0.0/0", "protocol": "1"}, false},
+		{"every protocol", map[string]any{"sourceType": "CIDR_BLOCK", "source": "0.0.0.0/0", "protocol": "all"}, true},
 	}
 	for _, c := range cases {
 		if got := ociSecurityListRuleOpensIngress(c.rule); got != c.want {
@@ -187,4 +207,116 @@ func TestOciWhitelistOpensInternet(t *testing.T) {
 			t.Errorf("ociWhitelistOpensInternet(%s) = %v, want %v", c.name, got, c.want)
 		}
 	}
+}
+
+// TestOciProtocolOpensServicePort pins which protocols count as an opening.
+//
+// The bug: the ingress predicate never read the protocol at all. OCI's default
+// VCN security list ships two 0.0.0.0/0 ingress rules, TCP 22 and ICMP type 3
+// code 4 for Path MTU Discovery, and Oracle documents keeping the ICMP one on
+// hardened subnets. A subnet with SSH removed therefore reported
+// securityListAllowsIngress true on the strength of the ICMP rule alone, so the
+// field could not distinguish it from a subnet with SSH open to the world.
+func TestOciProtocolOpensServicePort(t *testing.T) {
+	cases := []struct {
+		name     string
+		protocol string
+		want     bool
+	}{
+		{"tcp", "6", true},
+		{"udp", "17", true},
+		{"every protocol", "all", true},
+		{"every protocol in capitals", "ALL", true},
+
+		// ICMP carries no port, so it exposes no service to reach.
+		{"icmp", "1", false},
+		{"icmpv6", "58", false},
+		{"icmp with surrounding space", " 1 ", false},
+
+		// A protocol that could not be read is an unknown, and an unknown must
+		// fail toward reachable. Reading it as closed would report a resource
+		// as protected on the strength of a value nobody understood.
+		{"absent", "", true},
+		{"unparseable", "not-a-protocol", true},
+		{"a number that is not a protocol we name", "47", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, ociProtocolOpensServicePort(c.protocol))
+		})
+	}
+}
+
+// TestOciRuleValuesOpenIngressProtocolAndPorts covers the predicate over rules
+// adapted from the SDK shapes, so the port options a real rule carries are part
+// of the input rather than assumed away.
+func TestOciRuleValuesOpenIngressProtocolAndPorts(t *testing.T) {
+	// ingress builds a security list ingress rule the way the adapter does.
+	ingress := func(protocol, source string, ports *core.PortRange) ociIngressRuleValues {
+		rule := core.IngressSecurityRule{
+			Protocol:   strPtr(protocol),
+			Source:     strPtr(source),
+			SourceType: core.IngressSecurityRuleSourceTypeCidrBlock,
+		}
+		if ports != nil {
+			rule.TcpOptions = &core.TcpOptions{DestinationPortRange: ports}
+		}
+		return ociIngressValuesOf(securityRuleFromIngress(rule))
+	}
+	port := func(min, max int) *core.PortRange {
+		return &core.PortRange{Min: intPtr(min), Max: intPtr(max)}
+	}
+
+	t.Run("ssh from anywhere is an opening", func(t *testing.T) {
+		assert.True(t, ociRuleValuesOpenIngress(ingress("6", "0.0.0.0/0", port(22, 22))))
+	})
+
+	t.Run("a tcp rule stating no port range is an opening", func(t *testing.T) {
+		// An absent range covers every port. It is wider than any explicit
+		// range, so reading it as "no ports" would clear the widest rules
+		// there are.
+		assert.True(t, ociRuleValuesOpenIngress(ingress("6", "0.0.0.0/0", nil)))
+	})
+
+	t.Run("udp from anywhere is an opening", func(t *testing.T) {
+		assert.True(t, ociRuleValuesOpenIngress(ociIngressValuesOf(securityRuleFromIngress(core.IngressSecurityRule{
+			Protocol:   strPtr("17"),
+			Source:     strPtr("0.0.0.0/0"),
+			SourceType: core.IngressSecurityRuleSourceTypeCidrBlock,
+			UdpOptions: &core.UdpOptions{DestinationPortRange: port(53, 53)},
+		}))))
+	})
+
+	t.Run("every protocol from anywhere is an opening", func(t *testing.T) {
+		assert.True(t, ociRuleValuesOpenIngress(ingress("all", "0.0.0.0/0", nil)))
+	})
+
+	t.Run("path mtu discovery alone is not an opening", func(t *testing.T) {
+		// The second rule of OCI's default VCN security list: ICMP type 3
+		// code 4 from 0.0.0.0/0, which Oracle documents keeping even on
+		// hardened subnets. It reaches no service port.
+		pmtu := securityRuleFromIngress(core.IngressSecurityRule{
+			Protocol:    strPtr("1"),
+			Source:      strPtr("0.0.0.0/0"),
+			SourceType:  core.IngressSecurityRuleSourceTypeCidrBlock,
+			IcmpOptions: &core.IcmpOptions{Type: intPtr(3), Code: intPtr(4)},
+		})
+		assert.False(t, ociRuleValuesOpenIngress(ociIngressValuesOf(pmtu)))
+	})
+
+	t.Run("icmpv6 alone is not an opening", func(t *testing.T) {
+		assert.False(t, ociRuleValuesOpenIngress(ingress("58", "::/0", nil)))
+	})
+
+	t.Run("ssh from a single host is not an opening", func(t *testing.T) {
+		assert.False(t, ociRuleValuesOpenIngress(ingress("6", "203.0.113.10/32", port(22, 22))))
+	})
+
+	t.Run("an unreadable protocol from anywhere is an opening", func(t *testing.T) {
+		// OCI states the protocol as a number, never a name, so "tcp" is a
+		// value the predicate has no reading of. Fail toward reachable: a
+		// protocol nobody could parse must not be the reason a wide-open rule
+		// is reported as harmless.
+		assert.True(t, ociRuleValuesOpenIngress(ingress("tcp", "0.0.0.0/0", nil)))
+	})
 }

--- a/providers/oci/resources/oci_exposure_wiring_test.go
+++ b/providers/oci/resources/oci_exposure_wiring_test.go
@@ -1,0 +1,85 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go/ast"
+	"go/parser"
+	gotoken "go/token"
+	"testing"
+)
+
+// exposureSourceFile holds the exposure verdicts this guard reads.
+const exposureSourceFile = "oci_exposure.go"
+
+// loadBalancerExposureReceivers names the two receivers whose exposure() has to
+// read the address resources.
+var loadBalancerExposureReceivers = map[string]string{
+	"mqlOciLoadBalancerLoadBalancer":        "load balancer",
+	"mqlOciNetworkLoadBalancerLoadBalancer": "network load balancer",
+}
+
+// TestLoadBalancerExposureReadsTypedAddresses guards the wiring behind
+// hasPublicIp on both load balancers.
+//
+// The bug: exposure() read GetIpAddresses(), the deprecated dict field. Its
+// entries are map[string]any, which implements no isPublic accessor, so the
+// type assertion inside ociLoadBalancerHasPublicIp rejected every element, the
+// loop ran to completion without reading anything, and hasPublicIp was false on
+// every load balancer in every tenancy. internetReachable is a conjunction over
+// hasPublicIp, so it could never be true either: an internet-facing load
+// balancer passed a "nothing may be exposed" policy with nothing to fail on.
+//
+// The verdict cannot be reached from a unit test - building the exposure
+// resource needs a live connection - so the wiring is pinned at the source
+// level instead. Reintroducing the deprecated field here fails this test.
+func TestLoadBalancerExposureReadsTypedAddresses(t *testing.T) {
+	fset := gotoken.NewFileSet()
+	file, err := parser.ParseFile(fset, exposureSourceFile, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", exposureSourceFile, err)
+	}
+
+	seen := map[string]bool{}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "exposure" || fn.Recv == nil || len(fn.Recv.List) != 1 {
+			continue
+		}
+		star, ok := fn.Recv.List[0].Type.(*ast.StarExpr)
+		if !ok {
+			continue
+		}
+		ident, ok := star.X.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		what, wanted := loadBalancerExposureReceivers[ident.Name]
+		if !wanted {
+			continue
+		}
+		seen[ident.Name] = true
+
+		calls := map[string]bool{}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			if sel, ok := n.(*ast.SelectorExpr); ok {
+				calls[sel.Sel.Name] = true
+			}
+			return true
+		})
+
+		if !calls["GetAddresses"] {
+			t.Errorf("the %s exposure() must read GetAddresses(); only the address resources carry isPublic", what)
+		}
+		if calls["GetIpAddresses"] {
+			t.Errorf("the %s exposure() reads the deprecated GetIpAddresses(); its dicts answer no isPublic, so hasPublicIp reads false for every balancer", what)
+		}
+	}
+
+	for receiver, what := range loadBalancerExposureReceivers {
+		if !seen[receiver] {
+			t.Errorf("no exposure() found on the %s (%s); this guard has gone stale", what, receiver)
+		}
+	}
+}

--- a/providers/oci/resources/typed_promotions_test.go
+++ b/providers/oci/resources/typed_promotions_test.go
@@ -109,13 +109,24 @@ func TestOciInstanceSource(t *testing.T) {
 	})
 }
 
+// ociIngressValuesOf lifts a normalized rule into the values the open-ingress
+// predicate reads, so a test can go straight from an SDK rule to a verdict.
+func ociIngressValuesOf(r securityRule) ociIngressRuleValues {
+	return ociIngressRuleValues{
+		direction:  r.direction,
+		sourceType: r.sourceType,
+		source:     r.source,
+		protocol:   r.protocol,
+	}
+}
+
 func TestOciRuleValuesOpenIngressAcrossBothRuleSources(t *testing.T) {
 	// The bug this replaces: the exposure resource read its open rules out of
 	// two differently-shaped dicts. A network security group rule carried
 	// isStateless and a security list rule carried stateless, so a filter
 	// naming either one silently matched half the rows. Both sources now
 	// normalize onto securityRule before they reach MQL, so the predicate sees
-	// the same three values whichever layer wrote the rule.
+	// the same values whichever layer wrote the rule.
 	nsgRule := securityRuleFromNsg(core.SecurityRule{
 		Id:          strPtr("ocid1.securityrule.oc1..open"),
 		Direction:   core.SecurityRuleDirectionIngress,
@@ -131,9 +142,9 @@ func TestOciRuleValuesOpenIngressAcrossBothRuleSources(t *testing.T) {
 		IsStateless: boolPtr(true),
 	})
 
-	assert.True(t, ociRuleValuesOpenIngress(nsgRule.direction, nsgRule.sourceType, nsgRule.source),
+	assert.True(t, ociRuleValuesOpenIngress(ociIngressValuesOf(nsgRule)),
 		"a network security group rule open to any address must match")
-	assert.True(t, ociRuleValuesOpenIngress(listRule.direction, listRule.sourceType, listRule.source),
+	assert.True(t, ociRuleValuesOpenIngress(ociIngressValuesOf(listRule)),
 		"a security list rule open to any address must match")
 
 	// Both sources land the stateless flag on the same field, which is what
@@ -151,20 +162,20 @@ func TestOciRuleValuesOpenIngressAcrossBothRuleSources(t *testing.T) {
 			Source:     strPtr("10.0.0.0/16"),
 			SourceType: core.IngressSecurityRuleSourceTypeCidrBlock,
 		})
-		assert.False(t, ociRuleValuesOpenIngress(narrow.direction, narrow.sourceType, narrow.source))
+		assert.False(t, ociRuleValuesOpenIngress(ociIngressValuesOf(narrow)))
 
 		service := securityRuleFromIngress(core.IngressSecurityRule{
 			Source:     strPtr("all-services-in-oracle-services-network"),
 			SourceType: core.IngressSecurityRuleSourceTypeServiceCidrBlock,
 		})
-		assert.False(t, ociRuleValuesOpenIngress(service.direction, service.sourceType, service.source))
+		assert.False(t, ociRuleValuesOpenIngress(ociIngressValuesOf(service)))
 
 		egress := securityRuleFromNsg(core.SecurityRule{
 			Direction:       core.SecurityRuleDirectionEgress,
 			Destination:     strPtr("0.0.0.0/0"),
 			DestinationType: core.SecurityRuleDestinationTypeCidrBlock,
 		})
-		assert.False(t, ociRuleValuesOpenIngress(egress.direction, egress.sourceType, egress.source),
+		assert.False(t, ociRuleValuesOpenIngress(ociIngressValuesOf(egress)),
 			"an egress rule open to the world is not an ingress opening")
 	})
 
@@ -174,7 +185,7 @@ func TestOciRuleValuesOpenIngressAcrossBothRuleSources(t *testing.T) {
 			Source:     strPtr("::/0"),
 			SourceType: core.SecurityRuleSourceTypeCidrBlock,
 		})
-		assert.True(t, ociRuleValuesOpenIngress(v6.direction, v6.sourceType, v6.source))
+		assert.True(t, ociRuleValuesOpenIngress(ociIngressValuesOf(v6)))
 	})
 }
 


### PR DESCRIPTION
Six defects in the internet-exposure verdicts across all four major cloud providers. Each was found by reading code, then **proven against live cloud infrastructure** provisioned for the purpose, and each fix was re-verified against that same infrastructure before teardown.

They share one shape: **a read that failed, was refused, or was never made degrades into a confident "not exposed" answer.** That is the worst direction for this field to be wrong in, because nothing errors and the audit simply passes.

## What was proven live

Each row is the same resource, unchanged, queried before and after the fix.

| Provider | Scenario | Before | After |
|---|---|---|---|
| azure | VM deallocated (or scanner running as `Reader`) | `internetReachable: false` | `null` |
| azure | `effectiveRules` on that same failure | `[]` | `null` |
| azure | SQL server, 3 firewall rules spanning all of IPv4, no catch-all | `internetReachable: false` | `true` |
| gcp | instance behind `DENY tcp:22 0.0.0.0/0 @500` shadowing `ALLOW @1000` | `internetReachable: true` | `false` |
| gcp | bucket with uniform bucket-level access **off** | `uniformBucketLevelAccess: {}` | `{enabled: false}` |
| oci | public flexible load balancer | `hasPublicIp: false` | `true` |
| aws | Aurora cluster (SDK leaves `PubliclyAccessible` nil by design) | `exposure.publiclyAccessible: false` | `null` |

The azure VM case is the clearest: **the same machine, with the same public IP and the same NSG rule admitting `*:22`, answered differently depending only on whether it was powered on.** Azure computes effective NSG rules only for a NIC attached to a running VM; the 400 was swallowed and the AND collapsed to false.

The oci case was self-contradictory within one row: `addresses[].isPublic: true` sitting beside `exposure.hasPublicIp: false`, because `exposure()` type-asserted the deprecated `ipAddresses` dicts against an interface only the typed `addresses` resources implement. Every element was skipped, so **no load balancer in any tenancy could report `internetReachable: true`.**

## Controls

Every fix ships with unchanged controls, verified in the same runs:

- gcp: the wide-open, source-restricted and no-external-IP instances all kept their prior verdicts; only the deny-shadowed one moved.
- azure: all four VMs in running state are identical to the pre-fix run, including the one whose NSG uses the `Internet` service tag.
- oci: instance verdicts unmoved by the protocol-awareness change.
- aws: security-group results byte-identical.

## Direction of the repair

Four of these change `false` to **`null`**, not to `true`. The code never knew the answer; asserting the opposite would just invert the lie. `null` says "nobody read this", which a policy can detect — and under v14 semantics a null operand of `&&` is falsy, so assertions over these fields now fail loudly rather than passing silently.

The azure fix is deliberately narrow about this. Reachability is an AND, so a machine with no public IP and no public load balancer stays a determinate `false` even when its rules are unreadable; blanket-nulling on any failure would flood real scans with unknowns.

## Notes for review

- **No schema changes.** The `bool` fields are untouched and simply carry a null *state*. No `.lr`, `.lr.versions`, or generated files in the diff.
- **`behindPublicLoadBalancer` also goes null** on a failed load-balancer listing (azure). Same principle, but it is an extension beyond the three azure defects above — flagged so it is a deliberate choice rather than a surprise.
- **gcp shadowing semantics** follow the documented rule that a deny overrides an allow only at the same priority, so a deny shadows when `deny.priority <= allow.priority`. Shadowing is evaluated per packet across protocol, port span and address family; an IPv4 deny never shadows an IPv6 allow, matching the existing AWS NACL logic.
- **Unreadable input errs toward reachable** everywhere: an unreadable gcp allow rule widens and stays listed, an unreadable deny shadows nothing, an oci address list that cannot be read counts as public on a non-private balancer.
- **`retentionPeriod` keeps its string encoding** in the gcp bucket dicts. It has always been reported that way; changing it to a number would break existing content.

## Testing

`go test ./resources/...` passes for all four providers. Every new test was **mutation-checked** — the defect was reintroduced and a specific named test confirmed to fail, then reverted.

One pre-existing test was removed: `TestInternetReachableSemantics` defined a local closure duplicating the logic under test and asserted against that closure, so no change to the implementation could ever have failed it. Its one substantive case (an internet-facing NLB with no security groups) is preserved as a real subtest.

## Not addressed here

The audits surfaced further issues that are out of scope for this PR and want their own change: gcp `iamPolicy()` folding 403 into an empty policy across 14 call sites (so every `public()` predicate reads false), gcp exposure being blind to regional and hierarchical firewall policies and to Shared VPC host-project rules, azure exposure considering only load balancers and not Application Gateway or Firewall DNAT, and aws `securitygroup.isUnused` reporting true when `DescribeNetworkInterfaces` is denied. Happy to open tracking issues.
