### PR TITLE
🐛 aws: stop discovering terminated EC2 instances as scan targets

### DIFF
--- a/providers/aws/resources/discovery.go
+++ b/providers/aws/resources/discovery.go
@@ -280,6 +280,9 @@ func discover(runtime *plugin.Runtime, awsAccount *mqlAwsAccount, target string,
 
 		for i := range ins.Data {
 			instance := ins.Data[i].(*mqlAwsEc2Instance)
+			if !ec2InstanceIsDiscoverable(instance.State.Data) {
+				continue
+			}
 			assetList = append(assetList, addConnectionInfoToEc2Asset(instance, accountId, conn))
 		}
 	case DiscoverySSMInstances:

--- a/providers/aws/resources/discovery_conversion.go
+++ b/providers/aws/resources/discovery_conversion.go
@@ -570,6 +570,27 @@ func addConnectionInfoToEc2Asset(instance *mqlAwsEc2Instance, accountId string, 
 	return asset
 }
 
+// ec2InstanceIsDiscoverable reports whether an EC2 instance in this state can
+// still be reached by any connection this provider knows how to build.
+//
+// EC2 keeps a terminated instance visible to DescribeInstances for roughly an
+// hour after it goes away. Such an instance has no network interfaces, no
+// volumes and no SSM agent, so addConnectionInfoToEc2Asset attaches no
+// connections to it and every scan reports it as an asset that could not be
+// connected to. It can never transition back, so there is nothing to wait for.
+// An instance shutting down is on its way to the same place.
+//
+// Stopped instances deliberately stay discoverable: they keep their volumes,
+// can be started again, and are still reachable through EBS scanning.
+func ec2InstanceIsDiscoverable(state string) bool {
+	switch state {
+	case string(types.InstanceStateNameTerminated), string(types.InstanceStateNameShuttingDown):
+		return false
+	default:
+		return true
+	}
+}
+
 func mapEc2InstanceStateCode(state string) inventory.State {
 	switch state {
 	case string(types.InstanceStateNameRunning):

--- a/providers/aws/resources/discovery_conversion_test.go
+++ b/providers/aws/resources/discovery_conversion_test.go
@@ -1,0 +1,63 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/assert"
+
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+)
+
+// TestEc2InstanceIsDiscoverable pins which instance states become scan targets.
+//
+// A terminated instance stays visible to DescribeInstances for about an hour
+// after it goes away, and it has no interfaces, volumes or SSM agent, so
+// addConnectionInfoToEc2Asset gives it no connections and the scan reports it
+// as an asset it could not connect to. Stopped instances must keep being
+// discovered: they still hold their volumes and are reachable through EBS.
+func TestEc2InstanceIsDiscoverable(t *testing.T) {
+	cases := []struct {
+		state string
+		want  bool
+	}{
+		{string(types.InstanceStateNameRunning), true},
+		{string(types.InstanceStateNamePending), true},
+		{string(types.InstanceStateNameStopping), true},
+		{string(types.InstanceStateNameStopped), true},
+		{string(types.InstanceStateNameShuttingDown), false},
+		{string(types.InstanceStateNameTerminated), false},
+		// An unrecognized state errs toward discovering it: a state this code
+		// has not seen is not evidence the instance is gone.
+		{"some-future-state", true},
+		{"", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.state, func(t *testing.T) {
+			assert.Equal(t, tc.want, ec2InstanceIsDiscoverable(tc.state))
+		})
+	}
+}
+
+// TestEc2InstanceIsDiscoverableAgreesWithStateMapping ties the two functions
+// together: every state this drops must be one the state mapping already calls
+// terminated, so the filter cannot drift from what the asset would report.
+func TestEc2InstanceIsDiscoverableAgreesWithStateMapping(t *testing.T) {
+	for _, state := range []string{
+		string(types.InstanceStateNameRunning),
+		string(types.InstanceStateNamePending),
+		string(types.InstanceStateNameStopping),
+		string(types.InstanceStateNameStopped),
+		string(types.InstanceStateNameShuttingDown),
+		string(types.InstanceStateNameTerminated),
+	} {
+		if !ec2InstanceIsDiscoverable(state) {
+			assert.Equal(t, inventory.State_STATE_TERMINATED, mapEc2InstanceStateCode(state),
+				"state %q is dropped from discovery but does not map to terminated", state)
+		}
+	}
+}


### PR DESCRIPTION
Found while running live asset-scan discovery against a real AWS account.

`--discover instances` enumerated five instances that had been **terminated** roughly forty minutes earlier and emitted every one as a scan target:

```
x failed to connect to asset error="asset has no connections, can't detect provider" asset=<instance>
```

one line per terminated instance.

## Why it happens

EC2 keeps a terminated instance visible to `DescribeInstances` for about an hour. The `DiscoveryInstances` branch iterates `ec2.GetInstances()` with **no state filter**, while `addConnectionInfoToEc2Asset` only attaches a connection when the instance is *running* with a public IP, or when the SSM agent is online. A terminated instance satisfies neither, so the asset is emitted with an empty `Connections` slice and the scan fails on it.

The state was already being recorded correctly — `mapEc2InstanceStateCode` maps both `terminated` and `shutting-down` to `State_STATE_TERMINATED`. Nothing ever filtered on it.

## Why it matters beyond teardown noise

`Auto` does not include this target, but `--discover all` and `--discover instances` do. Autoscaling groups terminate instances continuously, so in a real estate this is a steady stream of guaranteed-failing assets, not a one-off after someone tears down a stack.

## Scope of the fix

Drops **terminated** and **shutting-down** only.

- **Stopped stays discoverable** — a stopped instance keeps its volumes, can be started again, and is reachable through EBS scanning. It genuinely exists.
- **An unrecognized state stays discoverable** — a state this code has not seen is not evidence the instance is gone.

The distinction the fix rests on is narrow: a terminated instance can never be connected to by any means, and can never transition back. There is nothing to wait for.

## What this does *not* fix

A **stopped** instance also gets no connections under this discovery target, and still produces the same `asset has no connections` error. That is visible in the verification below and is left alone deliberately — whether `--discover instances` should attach an EBS connection for stopped instances, or skip them, is a design question rather than a bug, and folding it in silently would be the wrong call.

## Verified live

Against an account holding five terminated instances plus one running instance that deliberately shares a name with one of them:

| run | terminated (5) | the live instance |
|---|---|---|
| before | emitted, 5 connection failures | — |
| after | **dropped** | emitted, `STATE_RUNNING`, 1 connection |
| after, instance stopped | dropped | **still emitted**, `STATE_STOPPED`, 0 connections |

The third row is the control that matters: filtering everything would have produced the same clean output as filtering correctly, so a live instance had to be shown surviving the filter — and the stopped case pins the exact boundary the fix draws.

## Tests

`TestEc2InstanceIsDiscoverable` covers every state including the empty and unrecognized cases. `TestEc2InstanceIsDiscoverableAgreesWithStateMapping` ties the filter to `mapEc2InstanceStateCode`, so the two cannot drift: any state the filter drops must be one the asset would report as terminated.
