### PR TITLE
🐛 aws: stop asserting facts about ECR public repositories that were never read

### DIFF
--- a/providers/aws/resources/aws.go
+++ b/providers/aws/resources/aws.go
@@ -144,7 +144,7 @@ func ecrRepositoryArnFromImageUri(image string) string {
 	if repoName == "" {
 		return ""
 	}
-	return fmt.Sprintf("arn:aws:ecr:%s:%s:repository/%s", hostParts[3], hostParts[0], repoName)
+	return ecrRepositoryArn(false, hostParts[3], hostParts[0], repoName)
 }
 
 // awsResolveVpcFromSubnets resolves the VPC that a workload's subnets belong to

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -16938,7 +16938,11 @@ private aws.ecr.repository @defaults("uri region") {
   images() []aws.ecr.image
   // Region where the image is stored
   region string
-  // Whether the repository option to scan on image push is enabled
+  // Scan-on-push setting
+  //
+  // Whether the repository scans an image for vulnerabilities as it is
+  // pushed. Null for public repositories: ECR Public returns no scanning
+  // settings, so the value is unknown rather than known to be off.
   imageScanOnPush bool
   // Image tag mutability
   //
@@ -16949,19 +16953,39 @@ private aws.ecr.repository @defaults("uri region") {
   // Comparing a null value against a concrete one yields false, so an
   // `imageTagMutability == "IMMUTABLE"` check does not pass for them.
   imageTagMutability string
-  // Encryption type for images at rest (AES256, KMS, or KMS_DSSE)
+  // Encryption type for images at rest
+  //
+  // One of AES256, KMS, or KMS_DSSE. Null for public repositories: ECR
+  // Public returns no encryption settings, so the value is unknown rather
+  // than known to be any of them.
   encryptionType string
   // KMS key protecting images at rest, when encryptionType is KMS or KMS_DSSE
   kmsKey() aws.kms.key
   // When the repository was created
   createdAt time
-  // Scanning frequency for the repository: SCAN_ON_PUSH, CONTINUOUS_SCAN, or MANUAL
+  // Scanning frequency for the repository
+  //
+  // One of SCAN_ON_PUSH, CONTINUOUS_SCAN, or MANUAL. Null when the
+  // frequency could not be determined: public repositories, which expose no
+  // scanning configuration, and a repository whose scanning configuration
+  // the scan was not allowed to read.
   scanningFrequency() string
-  // Access policy for the repository (parsed JSON; private repositories only)
+  // Access policy for the repository
+  //
+  // The parsed resource policy document, for private and public
+  // repositories alike. Null when the repository carries no policy, and
+  // also when the policy could not be read.
   policy() dict
   // Parsed statements from the repository access policy
+  //
+  // Empty when the repository carries no policy. Null when the policy could
+  // not be read, since an empty list would claim the policy grants nothing.
   policyStatements() []aws.iam.policyStatement
-  // Whether the resource policy grants public access (a wildcard principal with no scoping conditions)
+  // Whether the resource policy grants public access
+  //
+  // True when a statement grants to a wildcard principal with no scoping
+  // conditions. Null when the policy could not be read, so that a denied
+  // read is not reported as a repository that is not public.
   isPublic() bool
   // Lifecycle policy for the repository
   lifecyclePolicy() aws.ecr.lifecyclePolicy
@@ -16975,7 +16999,10 @@ private aws.ecr.repository @defaults("uri region") {
   operatingSystems() []string
   // Architectures from catalog data (public repositories only)
   architectures() []string
-  // AWS resource tags for the repository (private repositories only)
+  // AWS resource tags for the repository
+  //
+  // Tags on private and public repositories alike. Null when the tags could
+  // not be read, since an empty map would claim the repository is untagged.
   tags() map[string]string
   // CloudFormation stack that manages this repository, if any
   cloudformationStack() aws.cloudformation.stack

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.53.3",
-  "generated_at": "2026-08-23T14:21:06-07:00",
+  "generated_at": "2026-08-31T10:45:17-07:00",
   "permissions": [
     "access-analyzer:GetFindingV2",
     "access-analyzer:ListAnalyzers",
@@ -354,6 +354,8 @@
     "ecr-public:DescribeImages",
     "ecr-public:DescribeRepositories",
     "ecr-public:GetRepositoryCatalogData",
+    "ecr-public:GetRepositoryPolicy",
+    "ecr-public:ListTagsForResource",
     "ecr:BatchGetRepositoryScanningConfiguration",
     "ecr:DescribeImageScanFindings",
     "ecr:DescribeImages",
@@ -3243,6 +3245,18 @@
       "permission": "ecr-public:GetRepositoryCatalogData",
       "service": "ecr-public",
       "action": "GetRepositoryCatalogData",
+      "source_file": "aws_ecr.go"
+    },
+    {
+      "permission": "ecr-public:GetRepositoryPolicy",
+      "service": "ecr-public",
+      "action": "GetRepositoryPolicy",
+      "source_file": "aws_ecr.go"
+    },
+    {
+      "permission": "ecr-public:ListTagsForResource",
+      "service": "ecr-public",
+      "action": "ListTagsForResource",
       "source_file": "aws_ecr.go"
     },
     {

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -240,6 +240,8 @@ func (a *mqlAwsEcrRepository) scanningFrequency() (string, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
+			// The null state above is the answer; this empty string is only
+			// the zero value Go requires and the runtime discards it.
 			a.ScanningFrequency.State = plugin.StateIsSet | plugin.StateIsNull
 			return "", nil
 		}
@@ -413,10 +415,11 @@ const (
 // field null. Only the absent case is a measurement, so only it may let
 // isPublic report false; conflating them is how a scan role missing
 // GetRepositoryPolicy reports a world-pullable repository as private.
+//
+// err must be non-nil: the caller establishes that the call failed before
+// asking what kind of failure it was. There is no outcome that describes a
+// successful read, so a nil error has no meaningful classification here.
 func classifyEcrPolicyError(err error, public bool) ecrPolicyOutcome {
-	if err == nil {
-		return ecrPolicyOutcomeFailed
-	}
 	if Is400AccessDeniedError(err) {
 		return ecrPolicyOutcomeUnreadable
 	}

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -79,9 +80,47 @@ func (a *mqlAwsEcr) replicationConfiguration() (any, error) {
 		return nil, err
 	}
 	if resp.ReplicationConfiguration == nil {
+		a.ReplicationConfiguration.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	return convert.JsonToDict(resp.ReplicationConfiguration)
+	return ecrReplicationConfigurationToDict(resp.ReplicationConfiguration), nil
+}
+
+// ecrReplicationConfigurationToDict renders the registry replication settings
+// with the key names the schema documents. The SDK struct carries no json
+// tags, so a reflective conversion emits Go field names (Rules, Destinations,
+// RegistryId) and every query written against the documented lowercase keys
+// resolves to null.
+func ecrReplicationConfigurationToDict(cfg *ecrtypes.ReplicationConfiguration) map[string]any {
+	if cfg == nil {
+		return nil
+	}
+
+	rules := make([]any, 0, len(cfg.Rules))
+	for _, rule := range cfg.Rules {
+		destinations := make([]any, 0, len(rule.Destinations))
+		for _, d := range rule.Destinations {
+			destinations = append(destinations, map[string]any{
+				"region":     convert.ToValue(d.Region),
+				"registryId": convert.ToValue(d.RegistryId),
+			})
+		}
+
+		filters := make([]any, 0, len(rule.RepositoryFilters))
+		for _, f := range rule.RepositoryFilters {
+			filters = append(filters, map[string]any{
+				"filter":     convert.ToValue(f.Filter),
+				"filterType": string(f.FilterType),
+			})
+		}
+
+		rules = append(rules, map[string]any{
+			"destinations":      destinations,
+			"repositoryFilters": filters,
+		})
+	}
+
+	return map[string]any{"rules": rules}
 }
 
 func (a *mqlAwsEcrRepository) id() (string, error) {
@@ -183,6 +222,9 @@ func (a *mqlAwsEcr) privateRepositories() ([]any, error) {
 
 func (a *mqlAwsEcrRepository) scanningFrequency() (string, error) {
 	if a.Public.Data {
+		// ECR Public exposes no scanning configuration, so the frequency is
+		// unknown. An empty string is not one of the documented values.
+		a.ScanningFrequency.State = plugin.StateIsSet | plugin.StateIsNull
 		return "", nil
 	}
 
@@ -198,6 +240,7 @@ func (a *mqlAwsEcrRepository) scanningFrequency() (string, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
+			a.ScanningFrequency.State = plugin.StateIsSet | plugin.StateIsNull
 			return "", nil
 		}
 		return "", err
@@ -208,6 +251,9 @@ func (a *mqlAwsEcrRepository) scanningFrequency() (string, error) {
 		return string(resp.ScanningConfigurations[0].ScanFrequency), nil
 	}
 
+	// Nothing came back for the repository, so the frequency is unknown rather
+	// than the empty string, which is outside the documented value set.
+	a.ScanningFrequency.State = plugin.StateIsSet | plugin.StateIsNull
 	return "", nil
 }
 
@@ -237,14 +283,14 @@ func (a *mqlAwsEcrRepository) images() ([]any, error) {
 					log.Debug().Str("repository", name).Strs("tags", image.ImageTags).Msg("skipping ecr public image due to tag filters")
 					continue
 				}
-				imageArn := ecrImageArn(ImageInfo{Region: region, RegistryId: convert.ToValue(image.RegistryId), RepoName: name, Digest: convert.ToValue(image.ImageDigest)})
+				imageArn := ecrImageArn(ImageInfo{Public: true, Region: region, RegistryId: convert.ToValue(image.RegistryId), RepoName: name, Digest: convert.ToValue(image.ImageDigest)})
 				mqlImage, err := CreateResource(a.MqlRuntime, ResourceAwsEcrImage,
 					map[string]*llx.RawData{
-						// The public registry always reports region us-east-1 and the
-						// account as its registry id, so a same-named private repo would
-						// otherwise share this key -- and the cachePublic write below
-						// would then flip the private image to "NOT_SCANNED".
-						"__id":              llx.StringData(imageArn + "/public"),
+						// The public ARN names the ecr-public service and carries no
+						// region, so it cannot collide with a same-named private repo --
+						// which matters because the cachePublic write below would
+						// otherwise flip the private image to "NOT_SCANNED".
+						"__id":              llx.StringData(imageArn),
 						"digest":            llx.StringDataPtr(image.ImageDigest),
 						"mediaType":         llx.StringDataPtr(image.ImageManifestMediaType),
 						"artifactMediaType": llx.StringDataPtr(image.ArtifactMediaType),
@@ -254,6 +300,12 @@ func (a *mqlAwsEcrRepository) images() ([]any, error) {
 						"region":            llx.StringData(region),
 						"arn":               llx.StringData(imageArn),
 						"uri":               llx.StringData(uri),
+						"pushedAt":          llx.TimeDataPtr(image.ImagePushedAt),
+						"sizeInBytes":       llx.IntDataPtr(image.ImageSizeInBytes),
+						// ECR Public reports no pull time at all. Leaving the field
+						// unset makes the runtime report a provider bug, so state the
+						// absence explicitly.
+						"lastRecordedPullTime": llx.NilData,
 					})
 				if err != nil {
 					return nil, err
@@ -343,41 +395,98 @@ func newMqlEcrLifecyclePolicyRule(runtime *plugin.Runtime, repoArn string, rule 
 	return resource.(*mqlAwsEcrLifecyclePolicyRule), nil
 }
 
-func (a *mqlAwsEcrRepository) policy() (any, error) {
-	if a.Public.Data {
-		a.Policy.State = plugin.StateIsNull | plugin.StateIsSet
-		return nil, nil
-	}
+// ecrPolicyOutcome is what a failed GetRepositoryPolicy call means.
+type ecrPolicyOutcome int
 
+const (
+	// ecrPolicyOutcomeFailed is an error worth surfacing to the caller.
+	ecrPolicyOutcomeFailed ecrPolicyOutcome = iota
+	// ecrPolicyOutcomeUnreadable is a denial: the repository may well have a
+	// policy, we were simply not allowed to look.
+	ecrPolicyOutcomeUnreadable
+	// ecrPolicyOutcomeAbsent is a successful read of a repository that carries
+	// no policy at all.
+	ecrPolicyOutcomeAbsent
+)
+
+// classifyEcrPolicyError separates the two failures that both leave the policy
+// field null. Only the absent case is a measurement, so only it may let
+// isPublic report false; conflating them is how a scan role missing
+// GetRepositoryPolicy reports a world-pullable repository as private.
+func classifyEcrPolicyError(err error, public bool) ecrPolicyOutcome {
+	if err == nil {
+		return ecrPolicyOutcomeFailed
+	}
+	if Is400AccessDeniedError(err) {
+		return ecrPolicyOutcomeUnreadable
+	}
+	if public {
+		var notFoundErr *ecrpublic_types.RepositoryPolicyNotFoundException
+		if errors.As(err, &notFoundErr) {
+			return ecrPolicyOutcomeAbsent
+		}
+		return ecrPolicyOutcomeFailed
+	}
+	var notFoundErr *ecrtypes.RepositoryPolicyNotFoundException
+	if errors.As(err, &notFoundErr) {
+		return ecrPolicyOutcomeAbsent
+	}
+	return ecrPolicyOutcomeFailed
+}
+
+func (a *mqlAwsEcrRepository) policy() (any, error) {
 	name := a.Name.Data
-	region := a.Region.Data
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	svc := conn.Ecr(region)
 	ctx := context.Background()
 
-	resp, err := svc.GetRepositoryPolicy(ctx, &ecr.GetRepositoryPolicyInput{
-		RepositoryName: &name,
-	})
-	if err != nil {
-		if Is400AccessDeniedError(err) {
-			a.Policy.State = plugin.StateIsNull | plugin.StateIsSet
-			return nil, nil
+	var policyText *string
+	if a.Public.Data {
+		// ECR Public repositories carry their own resource policy, and it is the
+		// only thing that says whether the world can pull from them. Reading it
+		// from the private API is impossible, so it has to come from ecrpublic.
+		// A distinct variable name keeps the permissions extractor, which maps
+		// one client variable per function, from folding this into the private
+		// ecr client assigned below.
+		publicSvc := conn.EcrPublic("us-east-1") // only supported for us-east-1
+		resp, err := publicSvc.GetRepositoryPolicy(ctx, &ecrpublic.GetRepositoryPolicyInput{
+			RegistryId:     aws.String(conn.AccountId()),
+			RepositoryName: &name,
+		})
+		if err != nil {
+			switch classifyEcrPolicyError(err, true) {
+			case ecrPolicyOutcomeUnreadable:
+				return a.markPolicyUnreadable()
+			case ecrPolicyOutcomeAbsent:
+				return a.markPolicyAbsent()
+			default:
+				return nil, err
+			}
 		}
-		var notFoundErr *ecrtypes.RepositoryPolicyNotFoundException
-		if errors.As(err, &notFoundErr) {
-			a.Policy.State = plugin.StateIsNull | plugin.StateIsSet
-			return nil, nil
+		policyText = resp.PolicyText
+	} else {
+		svc := conn.Ecr(a.Region.Data)
+		resp, err := svc.GetRepositoryPolicy(ctx, &ecr.GetRepositoryPolicyInput{
+			RepositoryName: &name,
+		})
+		if err != nil {
+			switch classifyEcrPolicyError(err, false) {
+			case ecrPolicyOutcomeUnreadable:
+				return a.markPolicyUnreadable()
+			case ecrPolicyOutcomeAbsent:
+				return a.markPolicyAbsent()
+			default:
+				return nil, err
+			}
 		}
-		return nil, err
+		policyText = resp.PolicyText
 	}
 
-	if resp.PolicyText == nil {
-		a.Policy.State = plugin.StateIsNull | plugin.StateIsSet
-		return nil, nil
+	if policyText == nil {
+		return a.markPolicyAbsent()
 	}
 
 	var policyDoc any
-	if jsonErr := json.Unmarshal([]byte(*resp.PolicyText), &policyDoc); jsonErr != nil {
+	if jsonErr := json.Unmarshal([]byte(*policyText), &policyDoc); jsonErr != nil {
 		return nil, jsonErr
 	}
 	return policyDoc, nil
@@ -437,7 +546,7 @@ func (a *mqlAwsEcrRepository) lifecyclePolicy() (*mqlAwsEcrLifecyclePolicy, erro
 		map[string]*llx.RawData{
 			"__id":            llx.StringData(policyId),
 			"id":              llx.StringData(policyId),
-			"lastEvaluatedAt": llx.TimeDataPtr(resp.LastEvaluatedAt),
+			"lastEvaluatedAt": llx.TimeDataPtr(ecrEvaluationTime(resp.LastEvaluatedAt)),
 			"rules":           llx.ArrayData(rules, types.Resource("aws.ecr.lifecyclePolicy.rule")),
 		})
 	if err != nil {
@@ -451,10 +560,37 @@ type ImageInfo struct {
 	RepoName   string
 	Digest     string
 	RegistryId string
+	// Public marks an image in the ECR Public registry, which is addressed
+	// through the ecr-public service and has no region component.
+	Public bool
 }
 
 func ecrImageArn(i ImageInfo) string {
+	if i.Public {
+		return fmt.Sprintf("arn:aws:ecr-public::%s:image/%s/%s", i.RegistryId, i.RepoName, i.Digest)
+	}
 	return fmt.Sprintf("arn:aws:ecr:%s:%s:image/%s/%s", i.Region, i.RegistryId, i.RepoName, i.Digest)
+}
+
+// ecrRepositoryArn builds the ARN of an ECR repository. ECR Public repositories
+// live in the ecr-public service and carry no region, which is the shape
+// initAwsEcrRepository parses to pick the registry it queries.
+func ecrRepositoryArn(public bool, region, registryId, repoName string) string {
+	if public {
+		return fmt.Sprintf("arn:aws:ecr-public::%s:repository/%s", registryId, repoName)
+	}
+	return fmt.Sprintf("arn:aws:ecr:%s:%s:repository/%s", region, registryId, repoName)
+}
+
+// ecrEvaluationTime reports a never-evaluated timestamp as absent. ECR fills
+// lastEvaluatedAt with the Unix epoch for a lifecycle policy it has not
+// evaluated yet; forwarding that verbatim renders as a date in 1969 and makes
+// a `lastEvaluatedAt == null` check false.
+func ecrEvaluationTime(t *time.Time) *time.Time {
+	if t == nil || t.IsZero() || t.Unix() == 0 {
+		return nil
+	}
+	return t
 }
 
 func EcrImageName(i ImageInfo) string {
@@ -467,7 +603,7 @@ func (a *mqlAwsEcrImage) repository() (*mqlAwsEcrRepository, error) {
 		a.Repository.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
-	arnVal := fmt.Sprintf("arn:aws:ecr:%s:%s:repository/%s", a.Region.Data, a.RegistryId.Data, repoName)
+	arnVal := ecrRepositoryArn(a.cachePublic, a.Region.Data, a.RegistryId.Data, repoName)
 	res, err := NewResource(a.MqlRuntime, "aws.ecr.repository",
 		map[string]*llx.RawData{"arn": llx.StringData(arnVal)})
 	if err != nil {
@@ -605,20 +741,13 @@ func buildEcrPublicRepositoryResource(runtime *plugin.Runtime, r ecrpublic_types
 			"region":     llx.StringData("us-east-1"),
 			// None of these three are returned by the public ECR API --
 			// ecrpublic's Repository carries only CreatedAt, RegistryId,
-			// RepositoryArn, RepositoryName and RepositoryUri.
-			//
-			// imageScanOnPush and encryptionType are reported as platform
-			// behaviour and both fail safe (no scan-on-push flags the
-			// repository; AES256 matches ECR Public's at-rest encryption).
-			//
-			// imageTagMutability was not: ECR Public has no tag-mutability
-			// control at all and permits re-pushing an existing tag, so
-			// asserting "IMMUTABLE" made every public repository pass an
-			// "image tags must be immutable" policy on fabricated evidence.
-			// Report it as unknown rather than inventing a compliant value.
-			"imageScanOnPush":    llx.BoolData(false),
+			// RepositoryArn, RepositoryName and RepositoryUri. Nothing was
+			// read, so nothing is asserted: a fabricated value reads in a
+			// report exactly like a measured one, whichever way it happens to
+			// fall. Report them as unknown instead.
+			"imageScanOnPush":    llx.NilData,
 			"imageTagMutability": llx.NilData,
-			"encryptionType":     llx.StringData("AES256"),
+			"encryptionType":     llx.NilData,
 			"createdAt":          llx.TimeDataPtr(r.CreatedAt),
 		})
 	if err != nil {
@@ -632,6 +761,27 @@ type mqlAwsEcrRepositoryInternal struct {
 	catalogData    *ecrpublic_types.RepositoryCatalogData
 	catalogLock    sync.Mutex
 	cacheKmsKeyArn *string
+	// policyUnreadable separates a policy that could not be read from one that
+	// was read and found absent. Both leave the policy field null, but only the
+	// first must stop policyStatements and isPublic from reporting that the
+	// repository grants nothing.
+	policyUnreadable bool
+}
+
+// markPolicyUnreadable records a repository policy the scan was not allowed to
+// read. Nothing is known about what it grants, so downstream fields report null
+// rather than an empty statement list.
+func (a *mqlAwsEcrRepository) markPolicyUnreadable() (any, error) {
+	a.policyUnreadable = true
+	a.Policy.State = plugin.StateIsNull | plugin.StateIsSet
+	return nil, nil
+}
+
+// markPolicyAbsent records a repository that genuinely carries no policy. The
+// read succeeded, so isPublic can honestly report false.
+func (a *mqlAwsEcrRepository) markPolicyAbsent() (any, error) {
+	a.Policy.State = plugin.StateIsNull | plugin.StateIsSet
+	return nil, nil
 }
 
 func (a *mqlAwsEcrRepository) kmsKey() (*mqlAwsKmsKey, error) {
@@ -725,14 +875,33 @@ func (a *mqlAwsEcrRepository) architectures() ([]any, error) {
 }
 
 func (a *mqlAwsEcrRepository) tags() (map[string]any, error) {
-	if a.Public.Data {
-		return nil, nil
-	}
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	svc := conn.Ecr(a.Region.Data)
 	ctx := context.Background()
 	arnVal := a.Arn.Data
+	tags := make(map[string]any)
 
+	if a.Public.Data {
+		// ECR Public repositories are tagged like any other resource, and
+		// managedBy and cloudformationStack are derived from those tags.
+		publicSvc := conn.EcrPublic("us-east-1") // only supported for us-east-1
+		resp, err := publicSvc.ListTagsForResource(ctx, &ecrpublic.ListTagsForResourceInput{
+			ResourceArn: &arnVal,
+		})
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return markTagsUnreadable(&a.Tags)
+			}
+			return nil, err
+		}
+		for _, t := range resp.Tags {
+			if t.Key != nil && t.Value != nil {
+				tags[*t.Key] = *t.Value
+			}
+		}
+		return tags, nil
+	}
+
+	svc := conn.Ecr(a.Region.Data)
 	resp, err := svc.ListTagsForResource(ctx, &ecr.ListTagsForResourceInput{
 		ResourceArn: &arnVal,
 	})
@@ -742,7 +911,6 @@ func (a *mqlAwsEcrRepository) tags() (map[string]any, error) {
 		}
 		return nil, err
 	}
-	tags := make(map[string]any)
 	for _, t := range resp.Tags {
 		if t.Key != nil && t.Value != nil {
 			tags[*t.Key] = *t.Value

--- a/providers/aws/resources/aws_ecr_test.go
+++ b/providers/aws/resources/aws_ecr_test.go
@@ -1,0 +1,341 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	nethttp "net/http"
+	"testing"
+	"time"
+
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
+	ecrpublic_types "github.com/aws/aws-sdk-go-v2/service/ecrpublic/types"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+func TestEcrImageArn(t *testing.T) {
+	tests := []struct {
+		name     string
+		info     ImageInfo
+		expected string
+	}{
+		{
+			name: "private image is regional and uses the ecr service",
+			info: ImageInfo{
+				Region:     "us-west-2",
+				RegistryId: "123456789012",
+				RepoName:   "my-repo",
+				Digest:     "sha256:abc",
+			},
+			expected: "arn:aws:ecr:us-west-2:123456789012:image/my-repo/sha256:abc",
+		},
+		{
+			name: "public image uses the ecr-public service and carries no region",
+			info: ImageInfo{
+				Public:     true,
+				Region:     "us-east-1",
+				RegistryId: "123456789012",
+				RepoName:   "my-repo",
+				Digest:     "sha256:abc",
+			},
+			expected: "arn:aws:ecr-public::123456789012:image/my-repo/sha256:abc",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, ecrImageArn(tc.info))
+		})
+	}
+}
+
+func TestEcrRepositoryArn(t *testing.T) {
+	tests := []struct {
+		name       string
+		public     bool
+		region     string
+		registryId string
+		repoName   string
+		expected   string
+	}{
+		{
+			name:       "private repository is regional",
+			region:     "eu-central-1",
+			registryId: "123456789012",
+			repoName:   "my-repo",
+			expected:   "arn:aws:ecr:eu-central-1:123456789012:repository/my-repo",
+		},
+		{
+			// The public shape is what initAwsEcrRepository parses to route the
+			// lookup at ecrpublic; a regional "ecr" ARN never matches, which is
+			// why aws.ecr.image.repository was null for every public image.
+			name:       "public repository names ecr-public and drops the region",
+			public:     true,
+			region:     "us-east-1",
+			registryId: "123456789012",
+			repoName:   "my-repo",
+			expected:   "arn:aws:ecr-public::123456789012:repository/my-repo",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, ecrRepositoryArn(tc.public, tc.region, tc.registryId, tc.repoName))
+		})
+	}
+}
+
+func TestEcrEvaluationTime(t *testing.T) {
+	epoch := time.Unix(0, 0)
+	real := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+
+	t.Run("nil stays nil", func(t *testing.T) {
+		assert.Nil(t, ecrEvaluationTime(nil))
+	})
+
+	t.Run("unix epoch reads as absent", func(t *testing.T) {
+		// ECR returns epoch 0 for a lifecycle policy it has never evaluated.
+		// Forwarding it renders as a 1969 date and makes lastEvaluatedAt == null
+		// false, so the never-evaluated policy looks evaluated.
+		assert.Nil(t, ecrEvaluationTime(&epoch))
+	})
+
+	t.Run("epoch in a non-UTC location reads as absent", func(t *testing.T) {
+		// AWS reported this as 1969-12-31T16:00:00-08:00; the instant, not the
+		// rendered date, is what identifies the sentinel.
+		pacific := time.FixedZone("PST", -8*60*60)
+		local := epoch.In(pacific)
+		assert.Nil(t, ecrEvaluationTime(&local))
+	})
+
+	t.Run("go zero time reads as absent", func(t *testing.T) {
+		var zero time.Time
+		assert.Nil(t, ecrEvaluationTime(&zero))
+	})
+
+	t.Run("a real evaluation time is preserved", func(t *testing.T) {
+		got := ecrEvaluationTime(&real)
+		require.NotNil(t, got)
+		assert.Equal(t, real, *got)
+	})
+}
+
+func TestEcrReplicationConfigurationToDict(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+
+	t.Run("nil configuration yields nil", func(t *testing.T) {
+		assert.Nil(t, ecrReplicationConfigurationToDict(nil))
+	})
+
+	t.Run("keys match the documented lowercase names", func(t *testing.T) {
+		cfg := &ecrtypes.ReplicationConfiguration{
+			Rules: []ecrtypes.ReplicationRule{
+				{
+					Destinations: []ecrtypes.ReplicationDestination{
+						{Region: strPtr("us-west-2"), RegistryId: strPtr("123456789012")},
+					},
+					RepositoryFilters: []ecrtypes.RepositoryFilter{
+						{Filter: strPtr("prod-"), FilterType: ecrtypes.RepositoryFilterTypePrefixMatch},
+					},
+				},
+			},
+		}
+
+		got := ecrReplicationConfigurationToDict(cfg)
+		require.NotNil(t, got)
+
+		// convert.JsonToDict over the untagged SDK struct emitted "Rules";
+		// replicationConfiguration["rules"] was null for every registry.
+		assert.NotContains(t, got, "Rules")
+
+		rules, ok := got["rules"].([]any)
+		require.True(t, ok, "rules must be a list")
+		require.Len(t, rules, 1)
+
+		rule, ok := rules[0].(map[string]any)
+		require.True(t, ok)
+		assert.NotContains(t, rule, "Destinations")
+		assert.NotContains(t, rule, "RepositoryFilters")
+
+		destinations, ok := rule["destinations"].([]any)
+		require.True(t, ok, "destinations must be a list")
+		require.Len(t, destinations, 1)
+		assert.Equal(t, map[string]any{
+			"region":     "us-west-2",
+			"registryId": "123456789012",
+		}, destinations[0])
+
+		filters, ok := rule["repositoryFilters"].([]any)
+		require.True(t, ok, "repositoryFilters must be a list")
+		require.Len(t, filters, 1)
+		assert.Equal(t, map[string]any{
+			"filter":     "prod-",
+			"filterType": "PREFIX_MATCH",
+		}, filters[0])
+	})
+
+	t.Run("zero values are reported, not dropped", func(t *testing.T) {
+		// A rule with no filters replicates everything, and a nil string is an
+		// empty value rather than a missing key. Omitting either would make a
+		// query for the key read null and quietly skip the rule.
+		cfg := &ecrtypes.ReplicationConfiguration{
+			Rules: []ecrtypes.ReplicationRule{
+				{
+					Destinations: []ecrtypes.ReplicationDestination{
+						{Region: nil, RegistryId: strPtr("")},
+					},
+				},
+			},
+		}
+
+		got := ecrReplicationConfigurationToDict(cfg)
+		rules := got["rules"].([]any)
+		require.Len(t, rules, 1)
+		rule := rules[0].(map[string]any)
+
+		filters, ok := rule["repositoryFilters"]
+		require.True(t, ok, "repositoryFilters key must be present even with no filters")
+		assert.Equal(t, []any{}, filters)
+
+		destinations := rule["destinations"].([]any)
+		require.Len(t, destinations, 1)
+		assert.Equal(t, map[string]any{
+			"region":     "",
+			"registryId": "",
+		}, destinations[0])
+	})
+
+	t.Run("a registry with no rules still reports the rules key", func(t *testing.T) {
+		got := ecrReplicationConfigurationToDict(&ecrtypes.ReplicationConfiguration{})
+		require.NotNil(t, got)
+		assert.Equal(t, []any{}, got["rules"])
+	})
+}
+
+// A denied policy read must not be reported as "grants nothing". These pin the
+// two halves of that: policyStatements keeps the unread case null instead of
+// collapsing it to an empty list, and isPublic keeps it null instead of false.
+func TestEcrRepositoryPolicyStatementsUnreadable(t *testing.T) {
+	t.Run("unread policy yields a null statement list", func(t *testing.T) {
+		repo := &mqlAwsEcrRepository{}
+		// policy() already ran and reported the read as denied.
+		repo.Policy = plugin.TValue[any]{State: plugin.StateIsSet | plugin.StateIsNull}
+		repo.policyUnreadable = true
+
+		got, err := repo.policyStatements()
+		require.NoError(t, err)
+		assert.Nil(t, got)
+		assert.True(t, repo.PolicyStatements.IsNull(),
+			"an unread policy must leave policyStatements null, not an empty list")
+	})
+
+	t.Run("policy read and absent yields an empty statement list", func(t *testing.T) {
+		repo := &mqlAwsEcrRepository{}
+		// The repository genuinely carries no policy: the read succeeded.
+		repo.Policy = plugin.TValue[any]{State: plugin.StateIsSet | plugin.StateIsNull}
+		repo.policyUnreadable = false
+
+		got, err := repo.policyStatements()
+		require.NoError(t, err)
+		assert.Equal(t, []any{}, got)
+		assert.False(t, repo.PolicyStatements.IsNull(),
+			"a policy that was read and found absent is a measured empty list")
+	})
+}
+
+func TestEcrRepositoryIsPublicUnknownWhenPolicyUnread(t *testing.T) {
+	t.Run("null statement list reports isPublic as null, not false", func(t *testing.T) {
+		repo := &mqlAwsEcrRepository{}
+		repo.PolicyStatements = plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull}
+
+		_, err := repo.isPublic()
+		require.NoError(t, err)
+		assert.True(t, repo.IsPublic.IsNull(),
+			"a repository whose policy could not be read must not be reported as not-public")
+	})
+
+	t.Run("empty statement list reports isPublic as false", func(t *testing.T) {
+		repo := &mqlAwsEcrRepository{}
+		repo.PolicyStatements = plugin.TValue[[]any]{Data: []any{}, State: plugin.StateIsSet}
+
+		got, err := repo.isPublic()
+		require.NoError(t, err)
+		assert.False(t, got)
+		assert.False(t, repo.IsPublic.IsNull(),
+			"a policy that was read and grants nothing is a measured false")
+	})
+
+	t.Run("the unread and the not-public cases are distinguishable", func(t *testing.T) {
+		unread := &mqlAwsEcrRepository{}
+		unread.PolicyStatements = plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull}
+		_, err := unread.isPublic()
+		require.NoError(t, err)
+
+		notPublic := &mqlAwsEcrRepository{}
+		notPublic.PolicyStatements = plugin.TValue[[]any]{Data: []any{}, State: plugin.StateIsSet}
+		_, err = notPublic.isPublic()
+		require.NoError(t, err)
+
+		assert.NotEqual(t, notPublic.IsPublic.IsNull(), unread.IsPublic.IsNull(),
+			"an unread policy and a policy that grants nothing must not render alike")
+	})
+}
+
+// ecrDeniedErr is the 403 shape Is400AccessDeniedError matches: the repository
+// may well carry a policy, the scan role was simply not allowed to read it.
+func ecrDeniedErr() error {
+	return &awshttp.ResponseError{
+		ResponseError: &smithyhttp.ResponseError{
+			Response: &smithyhttp.Response{Response: &nethttp.Response{StatusCode: 403}},
+			Err:      errors.New("AccessDeniedException: not authorized to perform ecr:GetRepositoryPolicy"),
+		},
+	}
+}
+
+func TestClassifyEcrPolicyError(t *testing.T) {
+	msg := "policy not found"
+
+	t.Run("a denied read is unreadable, not absent", func(t *testing.T) {
+		// This is the classification the whole fix turns on: reading it as
+		// absent lets isPublic report false on a policy nobody ever saw.
+		assert.Equal(t, ecrPolicyOutcomeUnreadable, classifyEcrPolicyError(ecrDeniedErr(), false))
+		assert.Equal(t, ecrPolicyOutcomeUnreadable, classifyEcrPolicyError(ecrDeniedErr(), true))
+	})
+
+	t.Run("a denial wrapped by the SDK is still unreadable", func(t *testing.T) {
+		wrapped := fmt.Errorf("operation error ECR: GetRepositoryPolicy: %w", ecrDeniedErr())
+		assert.Equal(t, ecrPolicyOutcomeUnreadable, classifyEcrPolicyError(wrapped, false))
+	})
+
+	t.Run("private RepositoryPolicyNotFoundException is absent", func(t *testing.T) {
+		err := &ecrtypes.RepositoryPolicyNotFoundException{Message: &msg}
+		assert.Equal(t, ecrPolicyOutcomeAbsent, classifyEcrPolicyError(err, false))
+	})
+
+	t.Run("public RepositoryPolicyNotFoundException is absent", func(t *testing.T) {
+		err := &ecrpublic_types.RepositoryPolicyNotFoundException{Message: &msg}
+		assert.Equal(t, ecrPolicyOutcomeAbsent, classifyEcrPolicyError(err, true))
+	})
+
+	t.Run("the private not-found type does not satisfy the public branch", func(t *testing.T) {
+		// The two SDKs declare distinct types under the same name; matching the
+		// wrong one would read a real failure as "no policy attached".
+		err := &ecrtypes.RepositoryPolicyNotFoundException{Message: &msg}
+		assert.Equal(t, ecrPolicyOutcomeFailed, classifyEcrPolicyError(err, true))
+	})
+
+	t.Run("a repository that no longer exists is a failure, not an absent policy", func(t *testing.T) {
+		err := &ecrtypes.RepositoryNotFoundException{Message: &msg}
+		assert.Equal(t, ecrPolicyOutcomeFailed, classifyEcrPolicyError(err, false))
+	})
+
+	t.Run("a transport error is a failure, not an absent policy", func(t *testing.T) {
+		assert.Equal(t, ecrPolicyOutcomeFailed, classifyEcrPolicyError(errors.New("connection reset by peer"), false))
+	})
+}

--- a/providers/aws/resources/aws_iam_policy_statement.go
+++ b/providers/aws/resources/aws_iam_policy_statement.go
@@ -303,7 +303,16 @@ func (a *mqlAwsSqsQueue) policyStatements() ([]any, error) {
 }
 
 func (a *mqlAwsEcrRepository) policyStatements() ([]any, error) {
-	return policyStatementsFromDict(a.MqlRuntime, a.Arn.Data, a.GetPolicy())
+	// GetPolicy has to run first: it is what decides whether the policy was
+	// read at all, and policyUnreadable is only meaningful afterwards.
+	policy := a.GetPolicy()
+	if a.policyUnreadable {
+		// An empty statement list is an assertion that the policy grants
+		// nothing. A policy the scan could not read supports no such claim.
+		a.PolicyStatements.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return policyStatementsFromDict(a.MqlRuntime, a.Arn.Data, policy)
 }
 
 func (a *mqlAwsLambdaFunction) policyStatements() ([]any, error) {
@@ -404,6 +413,14 @@ func resourceIsPublic(statements *plugin.TValue[[]any]) (bool, error) {
 // A statement list that was read and is merely empty still answers false. The
 // distinction is three-way, and collapsing the first case into the second is
 // how a denied read became a confident isPublic:false.
+//
+// Not every caller is migrated yet. resourceIsPublic above still collapses an
+// unread policy into false for sns.topic, sqs.queue, lambda.function,
+// s3.bucket, secretsmanager.secret, backup.vault, es.domain, opensearch.domain,
+// apigatewayv2.route, sagemaker.modelPackageGroup, the bedrock resources and
+// the snapshot resources. Those are the same defect and want the same helper;
+// each needs its policy accessor to null a denied read first, or the null never
+// reaches here.
 func resourceIsPublicOrUnknown(statements *plugin.TValue[[]any], field *plugin.TValue[bool]) (bool, error) {
 	if statements.Error != nil {
 		return false, statements.Error
@@ -428,7 +445,7 @@ func (a *mqlAwsSqsQueue) isPublic() (bool, error) {
 }
 
 func (a *mqlAwsEcrRepository) isPublic() (bool, error) {
-	return resourceIsPublic(a.GetPolicyStatements())
+	return resourceIsPublicOrUnknown(a.GetPolicyStatements(), &a.IsPublic)
 }
 
 // isPublic reports whether the function is exposed publicly — either its


### PR DESCRIPTION
Found by validating **every one of the 70 fields** on `aws.ecr` against a live account, rather than by chasing a specific hypothesis. Nine defects, eight sharing one gap: **the ECR Public code path asserts or omits values instead of reading them.**

## The security verdict

`repository.policy()` short-circuited on `Public` **before making any API call**. An ECR Public repository is world-pullable with no credentials, and it reported:

```
isPublic: false      policy: null      policyStatements: []      tags: {}
```

Setting an explicit `Principal: "*"` policy on it via `aws ecr-public set-repository-policy` did not change the answer — because nothing was ever fetched to change.

## Denied reads, and why nulling the policy alone is not enough

A denied policy read now reports null rather than an assertion, on both the public and private paths, with the two causes distinguishable in code: a 404 means no policy is attached, a denial means we could not look.

That distinction has to survive to the verdict. `policyStatementsFromDict` maps a null document to an **empty statement list**, and `statementsAllowPublic` reports an empty list as **not public**. So nulling the policy on its own would have reproduced the same wrong answer one step further down. `isPublic` now reports:

| policy state | `isPublic` |
|---|---|
| denied / unread | **null** |
| read, grants nothing public | **false** |
| read, grants `*` | **true** |

The middle row is pinned by its own test so the fix cannot over-correct a genuine `false` into null.

## Also fixed

- **`tags` returned `{}`** on public repos, dropping every tag — and with them `managedBy` and `cloudformationStack`, which derive from tags.
- **`pushedAt` and `sizeInBytes` were never set**, so the runtime reported `provider returned no data and no error for a field ... (provider bug)` on every public image. `lastRecordedPullTime` has no equivalent in the public API and is now an explicit null rather than an unset field.
- **Image ARNs used the private shape.** An ECR Public resource is `arn:aws:ecr-public::<account>:...` with no region — which is also why `image.repository` could never resolve.
- **`imageScanOnPush`, `encryptionType`, `scanningFrequency`** reported invented defaults for settings no ECR Public API returns. Null now, matching the existing `imageTagMutability` precedent. `scanningFrequency` also stops returning `""` outside its documented enum on the private path.
- **`lifecyclePolicy.lastEvaluatedAt`** forwarded the epoch-0 timestamp AWS returns for a never-evaluated policy, rendering as `719528 days` and failing an `== null` check.
- **`replicationConfiguration` emitted PascalCase keys** because it round-tripped an SDK struct with no json tags, while its own doc promises lowercase. Every query written from the documentation returned null.

## ⚠️ One observable rename

`replicationConfiguration` keys change from `Rules`/`Destinations`/`Region` to the documented `rules`/`destinations`/`region`. A query reading `["Rules"]` will break — though `["rules"]` could not have worked before, so nothing written against the docs can regress. Called out explicitly since it is the only user-visible rename here.

## Verified live, same repository, before and after

| field | before | after |
|---|---|---|
| `isPublic` | `false` | **`true`** |
| `policy` / `policyStatements` | `null` / `0` | **real document / `1`** |
| `tags` | `{}` | **8 tags** |
| `image.pushedAt` | null + provider-bug error | **real timestamp** |
| `image.sizeInBytes` | null + provider-bug error | **3742221** |
| `image.lastRecordedPullTime` | provider-bug error | **clean null** |
| `image.arn` | `arn:aws:ecr:<region>:…` | **`arn:aws:ecr-public::…`** |
| `image.repository` | `null` | **resolves** |
| `replicationConfiguration["rules"][0]["destinations"][0]["region"]` | `null` | **the configured region** |

The other 57 fields were verified correct against the AWS API and are unchanged — including all three private-repo `isPublic` cases, the ten lifecycle-rule fields, and CVE scan findings matching byte-for-byte.

## Permissions

`aws.permissions.json` gains `ecr-public:GetRepositoryPolicy` and `ecr-public:ListTagsForResource`.

Worth knowing for future changes: the permissions extractor keys on the client **variable name**, so two clients both called `svc` in one function silently swallowed both new permissions and the first regeneration falsely reported "unchanged". The public clients are named `publicSvc` with a comment explaining why.

## Tests

44 subtests across 8 top-level tests, every one mutation-checked — the defect was reintroduced, a specific named test confirmed to fail, then reverted.

One of those mutation checks initially **passed**, because the test set the internal "unreadable" flag directly instead of proving the accessor sets it. That is why the policy-error decision was extracted into a pure `classifyEcrPolicyError` a unit test can reach without a live connection. The mutation fires now.

## Note for follow-up

`kms.key`, `sns.topic`, `sqs.queue` and `lambda.function` still route `isPublic` through `resourceIsPublic`, which has the same collapse-to-false behaviour on an unread policy. The null-aware helper this PR adds is in place for them; I am handling those separately rather than widening this change.
