### PR TITLE
🐛 aws: a refused EFS read must not report a file system as not public

### DIFF
--- a/providers/aws/connection/connection.go
+++ b/providers/aws/connection/connection.go
@@ -91,6 +91,15 @@ func NewMockConnection(id uint32, asset *inventory.Asset, conf *inventory.Config
 	}
 }
 
+// NewTestConnection builds a connection around a caller-supplied aws.Config.
+// It exists so that tests can hand the SDK clients a config carrying
+// APIOptions middleware and exercise a lister end to end without network or
+// credentials; cfg is unexported, so there is no other way to reach it from
+// outside this package.
+func NewTestConnection(cfg aws.Config) *AwsConnection {
+	return &AwsConnection{cfg: cfg}
+}
+
 func NewAwsConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*AwsConnection, error) {
 	log.Debug().Msg("new aws connection")
 	// check flags for connection options

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -1973,6 +1973,10 @@ private aws.efs.filesystem @defaults("name id region") {
   // Access points for the file system
   accessPoints() []aws.efs.accessPoint
   // Resource-based policy document (JSON)
+  //
+  // Empty only when the file system carries no policy at all. A policy that
+  // could not be read errors rather than reading as the empty document, so
+  // that an unread policy is never mistaken for an absent one.
   fileSystemPolicy() string
   // Parsed statements from the file system policy
   policyStatements() []aws.iam.policyStatement
@@ -2067,7 +2071,7 @@ private aws.efs.rootDirectory @defaults("path permissions") {
   ownerGid int
   // POSIX permission bits EFS applies when it creates the root directory
   //
-  // A three- or four-digit octal string, for example "0755". Empty when the
+  // A three- or four-digit octal string, for example "0755". Null when the
   // access point supplies no creation info.
   permissions string
 }

--- a/providers/aws/resources/aws_efs.go
+++ b/providers/aws/resources/aws_efs.go
@@ -224,12 +224,20 @@ func initAwsEfsFilesystem(runtime *plugin.Runtime, args map[string]*llx.RawData)
 	return nil, nil, errors.New("efs filesystem does not exist")
 }
 
+// backupPolicy is the deprecated dict view of automaticBackup. It emits only
+// the documented shape, a `BackupPolicy` object carrying `Status`; serializing
+// the whole SDK output would also publish its ResultMetadata, which describes
+// the API call rather than the file system.
 func (a *mqlAwsEfsFilesystem) backupPolicy() (any, error) {
 	resp, err := a.fetchBackupPolicy()
-	if err != nil || resp == nil {
+	if err != nil || resp == nil || resp.BackupPolicy == nil {
 		return nil, err
 	}
-	return convert.JsonToDict(resp)
+	return map[string]any{
+		"BackupPolicy": map[string]any{
+			"Status": string(resp.BackupPolicy.Status),
+		},
+	}, nil
 }
 
 func (a *mqlAwsEfsFilesystem) automaticBackup() (*mqlAwsEfsBackupPolicy, error) {
@@ -263,10 +271,10 @@ func (a *mqlAwsEfsFilesystem) lifecycleConfiguration() (*mqlAwsEfsFilesystemLife
 		FileSystemId: &id,
 	})
 	if err != nil {
-		if Is400AccessDeniedError(err) {
-			a.LifecycleConfiguration.State = plugin.StateIsNull | plugin.StateIsSet
-			return nil, nil
-		}
+		// A 404 establishes that the file system has no lifecycle
+		// configuration. A denial establishes nothing, and null would make a
+		// file system with no lifecycle policy and one nobody could check read
+		// identically, so it propagates.
 		var respErr *http.ResponseError
 		if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
 			a.LifecycleConfiguration.State = plugin.StateIsNull | plugin.StateIsSet
@@ -323,10 +331,9 @@ func (a *mqlAwsEfsFilesystem) replicationConfiguration() (*mqlAwsEfsFilesystemRe
 		FileSystemId: &id,
 	})
 	if err != nil {
-		if Is400AccessDeniedError(err) {
-			a.ReplicationConfiguration.State = plugin.StateIsNull | plugin.StateIsSet
-			return nil, nil
-		}
+		// ReplicationConfigurationNotFound (404) establishes that the file
+		// system is not replicated. A denial does not, so an unreplicated file
+		// system and one nobody could check must not read the same way.
 		var respErr *http.ResponseError
 		if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
 			a.ReplicationConfiguration.State = plugin.StateIsNull | plugin.StateIsSet
@@ -473,19 +480,22 @@ func (a *mqlAwsEfsFilesystem) mountTargets() ([]any, error) {
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			if Is400AccessDeniedError(err) {
-				log.Warn().Str("region", region).Str("fileSystemId", id).Msg("error accessing EFS mount targets")
-				return res, nil
-			}
+			// A denial truncates the list without saying so. Returning the
+			// partial slice would let mountTargets.all(...) pass vacuously on a
+			// file system whose mount targets nobody could enumerate, so the
+			// failure propagates instead.
 			return nil, err
 		}
 
 		for _, mt := range page.MountTargets {
-			// Fetch security groups for this mount target
-			sgRes, err := svc.DescribeMountTargetSecurityGroups(ctx, &efs.DescribeMountTargetSecurityGroupsInput{
+			// A failed group read is carried on the mount target rather than
+			// failing the whole list: one unreadable mount target must not
+			// erase the rest, but its securityGroups field must not read as an
+			// empty list either.
+			sgRes, sgErr := svc.DescribeMountTargetSecurityGroups(ctx, &efs.DescribeMountTargetSecurityGroupsInput{
 				MountTargetId: mt.MountTargetId,
 			})
-			if err != nil {
+			if sgErr != nil {
 				log.Warn().Str("mountTargetId", convert.ToValue(mt.MountTargetId)).Msg("error fetching security groups for mount target")
 			}
 
@@ -506,9 +516,11 @@ func (a *mqlAwsEfsFilesystem) mountTargets() ([]any, error) {
 			mqlMountTarget.(*mqlAwsEfsMountTarget).cacheSubnetId = convert.ToValue(mt.SubnetId)
 			mqlMountTarget.(*mqlAwsEfsMountTarget).cacheNetworkInterfaceId = convert.ToValue(mt.NetworkInterfaceId)
 
-			// Cache the security group IDs for lazy loading
-			if sgRes != nil && len(sgRes.SecurityGroups) > 0 {
-				mqlMountTarget.(*mqlAwsEfsMountTarget).cacheSecurityGroupIDs = sgRes.SecurityGroups
+			// Cache the security group IDs, or the reason there are none.
+			mqlMt := mqlMountTarget.(*mqlAwsEfsMountTarget)
+			mqlMt.cacheSecurityGroupsErr = sgErr
+			if sgErr == nil && sgRes != nil {
+				mqlMt.cacheSecurityGroupIDs = sgRes.SecurityGroups
 			}
 
 			res = append(res, mqlMountTarget)
@@ -534,10 +546,9 @@ func (a *mqlAwsEfsFilesystem) accessPoints() ([]any, error) {
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			if Is400AccessDeniedError(err) {
-				log.Warn().Str("region", region).Str("fileSystemId", id).Msg("error accessing EFS access points")
-				return res, nil
-			}
+			// As with mount targets, a truncated list presented as complete is
+			// what makes an accessPoints.all(...) check pass on evidence that
+			// was never read.
 			return nil, err
 		}
 
@@ -616,6 +627,31 @@ func (a *mqlAwsEfsFilesystem) accessPoints() ([]any, error) {
 	return res, nil
 }
 
+// efsPolicyNotFound reports the answer EFS gives for a file system that
+// carries no resource policy at all: PolicyNotFound, HTTP 404.
+//
+// It is a statement about the file system, not a failure to read one, which is
+// why it is deliberately narrow. A denial (403) and a transport error both
+// leave the policy unknown, and neither may be folded in here: the empty
+// document they would produce is byte-identical to the one a file system with
+// no policy produces, and isPublic, which is derived from it, would then report
+// a file system open to the world as private.
+func efsPolicyNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var respErr *http.ResponseError
+	if errors.As(err, &respErr) {
+		return respErr.HTTPStatusCode() == 404
+	}
+	return false
+}
+
+// fileSystemPolicy returns the file system's resource policy document. The
+// empty string means one thing only: the file system carries no policy. Any
+// error other than the 404 that establishes that propagates, so that
+// policyStatements and isPublic, both derived from this field, report an
+// unreadable policy as unreadable rather than as absent.
 func (a *mqlAwsEfsFilesystem) fileSystemPolicy() (string, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	id := a.Id.Data
@@ -628,13 +664,7 @@ func (a *mqlAwsEfsFilesystem) fileSystemPolicy() (string, error) {
 		FileSystemId: &id,
 	})
 	if err != nil {
-		if Is400AccessDeniedError(err) {
-			log.Warn().Str("region", region).Str("fileSystemId", id).Msg("error accessing EFS file system policy")
-			return "", nil
-		}
-		var respErr *http.ResponseError
-		if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
-			// No policy exists
+		if efsPolicyNotFound(err) {
 			return "", nil
 		}
 		return "", err
@@ -653,11 +683,25 @@ type mqlAwsEfsMountTargetInternal struct {
 	cacheSubnetId           string
 	cacheNetworkInterfaceId string
 	cacheSecurityGroupIDs   []string
+	// cacheSecurityGroupsErr records why the group list could not be read, so
+	// the accessor can report the refusal instead of an empty list.
+	cacheSecurityGroupsErr error
 }
 
+// securityGroups returns the security groups attached to the mount target.
+//
+// EFS attaches at least one security group to every mount target, so an empty
+// list is never a reading the API produced: it means the group list was not
+// read. Reporting it as a list would make a
+// mountTargets.all(securityGroups.none(...)) check pass on a mount target
+// nobody could inspect, so an unread list is an error.
 func (a *mqlAwsEfsMountTarget) securityGroups() ([]any, error) {
+	if a.cacheSecurityGroupsErr != nil {
+		return nil, fmt.Errorf("could not read security groups for EFS mount target %s: %w",
+			a.MountTargetId.Data, a.cacheSecurityGroupsErr)
+	}
 	if len(a.cacheSecurityGroupIDs) == 0 {
-		return []any{}, nil
+		return nil, fmt.Errorf("no security groups were read for EFS mount target %s", a.MountTargetId.Data)
 	}
 
 	region := a.Region.Data

--- a/providers/aws/resources/aws_efs_test.go
+++ b/providers/aws/resources/aws_efs_test.go
@@ -1,0 +1,449 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	nethttp "net/http"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/aws-sdk-go-v2/service/efs"
+	efstypes "github.com/aws/aws-sdk-go-v2/service/efs/types"
+	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/aws/connection"
+)
+
+// awsAPIErr builds the error shape an SDK call actually returns: a service API
+// error wrapped in the smithy response error that carries the HTTP status,
+// wrapped again in the AWS response error that carries the request id. The
+// classifiers under test walk that chain, so a bare smithy error would not
+// exercise them.
+func awsAPIErr(status int, code, message string) error {
+	return &awshttp.ResponseError{
+		ResponseError: &smithyhttp.ResponseError{
+			Response: &smithyhttp.Response{Response: &nethttp.Response{StatusCode: status}},
+			Err:      &smithy.GenericAPIError{Code: code, Message: message},
+		},
+		RequestID: "0123456789",
+	}
+}
+
+// efsAccessDenied is the response a role denied a single elasticfilesystem
+// permission gets back.
+func efsAccessDenied(action string) error {
+	return awsAPIErr(403, "AccessDeniedException",
+		"User is not authorized to perform: "+action)
+}
+
+type efsStub struct {
+	out any
+	err error
+}
+
+// stubEfsConn returns a connection whose EFS clients answer from stubs instead
+// of the network. The middleware short-circuits at the Initialize step, before
+// serialization, signing, and transport, so no credentials are needed and the
+// stubbed value is returned as the typed SDK output struct.
+func stubEfsConn(t *testing.T, stubs map[string]efsStub) *connection.AwsConnection {
+	t.Helper()
+	apiOption := func(s *middleware.Stack) error {
+		return s.Initialize.Add(middleware.InitializeMiddlewareFunc("mqlEfsTestStub",
+			func(ctx context.Context, in middleware.InitializeInput, next middleware.InitializeHandler) (
+				middleware.InitializeOutput, middleware.Metadata, error,
+			) {
+				key := fmt.Sprintf("%T", in.Parameters)
+				stub, ok := stubs[key]
+				if !ok {
+					return middleware.InitializeOutput{}, middleware.Metadata{},
+						fmt.Errorf("test called unstubbed EFS operation %s", key)
+				}
+				if stub.err != nil {
+					return middleware.InitializeOutput{}, middleware.Metadata{}, stub.err
+				}
+				return middleware.InitializeOutput{Result: stub.out}, middleware.Metadata{}, nil
+			}), middleware.Before)
+	}
+	return connection.NewTestConnection(aws.Config{
+		Region:     "us-east-1",
+		APIOptions: []func(*middleware.Stack) error{apiOption},
+	})
+}
+
+func stubbedEfsFilesystem(t *testing.T, stubs map[string]efsStub) *mqlAwsEfsFilesystem {
+	t.Helper()
+	rt := testRuntime()
+	rt.Connection = stubEfsConn(t, stubs)
+	return &mqlAwsEfsFilesystem{
+		MqlRuntime: rt,
+		Id:         setString("fs-0123456789abcdef0"),
+		Region:     setString("us-east-1"),
+		Arn:        setString("arn:aws:elasticfilesystem:us-east-1:123456789012:file-system/fs-0123456789abcdef0"),
+	}
+}
+
+// A file system policy that grants ClientMount to every principal. This is the
+// live shape that reported isPublic:false under a denied read.
+const efsPublicPolicy = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "public-mount",
+      "Effect": "Allow",
+      "Principal": {"AWS": "*"},
+      "Action": "elasticfilesystem:ClientMount",
+      "Resource": "arn:aws:elasticfilesystem:us-east-1:123456789012:file-system/fs-0123456789abcdef0"
+    }
+  ]
+}`
+
+// PolicyNotFound is what establishes that a file system has no policy. Nothing
+// else may: a denial and a transport failure both leave the policy unknown,
+// and folding either one in is what made a public file system read as private.
+func TestEfsPolicyNotFound(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "no policy on the file system",
+			err:  awsAPIErr(404, "PolicyNotFound", "Policy not found for file system fs-0123456789abcdef0"),
+			want: true,
+		},
+		{
+			name: "denied DescribeFileSystemPolicy is not an absent policy",
+			err:  efsAccessDenied("elasticfilesystem:DescribeFileSystemPolicy"),
+			want: false,
+		},
+		{
+			name: "a 400 access denial is not an absent policy",
+			err:  awsAPIErr(400, "AccessDenied", "not authorized"),
+			want: false,
+		},
+		{
+			name: "a server error is not an absent policy",
+			err:  awsAPIErr(500, "InternalServerError", "internal error"),
+			want: false,
+		},
+		{
+			name: "a transport error is not an absent policy",
+			err:  errors.New("dial tcp: lookup elasticfilesystem.us-east-1.amazonaws.com: no such host"),
+			want: false,
+		},
+		{
+			name: "nil is not a match",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "wrapped 404 still matches",
+			err: fmt.Errorf("describe policy: %w",
+				awsAPIErr(404, "PolicyNotFound", "Policy not found")),
+			want: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, efsPolicyNotFound(tc.err))
+		})
+	}
+}
+
+// The critical case. A role denied only DescribeFileSystemPolicy must not
+// produce the same reading as a file system that has no policy: the policy
+// errors, the statements error, and isPublic errors rather than reporting a
+// world-readable file system as private.
+func TestEfsDeniedPolicyDoesNotReportNotPublic(t *testing.T) {
+	fs := stubbedEfsFilesystem(t, map[string]efsStub{
+		"*efs.DescribeFileSystemPolicyInput": {
+			err: efsAccessDenied("elasticfilesystem:DescribeFileSystemPolicy"),
+		},
+	})
+
+	policy := fs.GetFileSystemPolicy()
+	require.Error(t, policy.Error, "a denied policy read must not be reported as a value")
+	assert.Equal(t, "", policy.Data)
+	assert.True(t, policy.State&plugin.StateIsNull != 0, "the denied field must read as null, not as the empty string")
+
+	statements := fs.GetPolicyStatements()
+	require.Error(t, statements.Error, "statements parsed from an unread policy must not be an empty list")
+
+	isPublic := fs.GetIsPublic()
+	require.Error(t, isPublic.Error, "isPublic must not report false when the policy was refused")
+	assert.True(t, isPublic.State&plugin.StateIsNull != 0, "isPublic must read as null, not as false")
+}
+
+// The other half: a file system that genuinely has no policy still reports a
+// real, confident false. The 404 fix must not regress this into null.
+func TestEfsAbsentPolicyReportsNotPublic(t *testing.T) {
+	fs := stubbedEfsFilesystem(t, map[string]efsStub{
+		"*efs.DescribeFileSystemPolicyInput": {
+			err: awsAPIErr(404, "PolicyNotFound", "Policy not found for file system fs-0123456789abcdef0"),
+		},
+	})
+
+	policy := fs.GetFileSystemPolicy()
+	require.NoError(t, policy.Error)
+	assert.Equal(t, "", policy.Data)
+
+	statements := fs.GetPolicyStatements()
+	require.NoError(t, statements.Error)
+	assert.Equal(t, []any{}, statements.Data)
+
+	isPublic := fs.GetIsPublic()
+	require.NoError(t, isPublic.Error)
+	assert.False(t, isPublic.Data, "a file system with no policy is measurably not public")
+}
+
+// A file system whose policy really does grant a wildcard principal reports
+// true, so the two failure-free readings stay distinguishable from each other
+// as well as from the denial.
+func TestEfsWildcardPolicyReportsPublic(t *testing.T) {
+	policyDoc := efsPublicPolicy
+	fs := stubbedEfsFilesystem(t, map[string]efsStub{
+		"*efs.DescribeFileSystemPolicyInput": {
+			out: &efs.DescribeFileSystemPolicyOutput{
+				FileSystemId: aws.String("fs-0123456789abcdef0"),
+				Policy:       &policyDoc,
+			},
+		},
+	})
+
+	statements := fs.GetPolicyStatements()
+	require.NoError(t, statements.Error)
+	require.Len(t, statements.Data, 1)
+
+	isPublic := fs.GetIsPublic()
+	require.NoError(t, isPublic.Error)
+	assert.True(t, isPublic.Data)
+}
+
+// A denied DescribeMountTargets must not return the partial (empty) slice: a
+// mountTargets.all(...) check would then pass on a file system whose mount
+// targets nobody enumerated.
+func TestEfsDeniedMountTargetsIsNotAnEmptyList(t *testing.T) {
+	fs := stubbedEfsFilesystem(t, map[string]efsStub{
+		"*efs.DescribeMountTargetsInput": {
+			err: efsAccessDenied("elasticfilesystem:DescribeMountTargets"),
+		},
+	})
+
+	res, err := fs.mountTargets()
+	require.Error(t, err, "a denied mount target listing must not be reported as a complete list")
+	assert.Nil(t, res)
+}
+
+// A denied DescribeAccessPoints must not return the partial (empty) slice.
+func TestEfsDeniedAccessPointsIsNotAnEmptyList(t *testing.T) {
+	fs := stubbedEfsFilesystem(t, map[string]efsStub{
+		"*efs.DescribeAccessPointsInput": {
+			err: efsAccessDenied("elasticfilesystem:DescribeAccessPoints"),
+		},
+	})
+
+	res, err := fs.accessPoints()
+	require.Error(t, err, "a denied access point listing must not be reported as a complete list")
+	assert.Nil(t, res)
+}
+
+// A mount target whose security groups could not be read must say so. The
+// listing itself still succeeds: one unreadable mount target must not erase
+// the others.
+func TestEfsMountTargetSecurityGroupsDeniedIsNotAnEmptyList(t *testing.T) {
+	fs := stubbedEfsFilesystem(t, map[string]efsStub{
+		"*efs.DescribeMountTargetsInput": {
+			out: &efs.DescribeMountTargetsOutput{
+				MountTargets: []efstypes.MountTargetDescription{{
+					MountTargetId:        aws.String("fsmt-0123456789abcdef0"),
+					FileSystemId:         aws.String("fs-0123456789abcdef0"),
+					SubnetId:             aws.String("subnet-0123456789abcdef0"),
+					NetworkInterfaceId:   aws.String("eni-0123456789abcdef0"),
+					AvailabilityZoneName: aws.String("us-east-1a"),
+					IpAddress:            aws.String("10.0.1.10"),
+					LifeCycleState:       efstypes.LifeCycleStateAvailable,
+				}},
+			},
+		},
+		"*efs.DescribeMountTargetSecurityGroupsInput": {
+			err: efsAccessDenied("elasticfilesystem:DescribeMountTargetSecurityGroups"),
+		},
+	})
+
+	res, err := fs.mountTargets()
+	require.NoError(t, err, "one unreadable security group list must not fail the whole listing")
+	require.Len(t, res, 1)
+
+	mt := res[0].(*mqlAwsEfsMountTarget)
+	sgs, sgErr := mt.securityGroups()
+	require.Error(t, sgErr, "a denied security group read must not read as no security groups")
+	assert.Nil(t, sgs)
+}
+
+// EFS attaches at least one security group to every mount target, so a mount
+// target that carries no cached ids was never read and must not report an
+// empty list.
+func TestEfsMountTargetSecurityGroupsUnreadIsAnError(t *testing.T) {
+	mt := &mqlAwsEfsMountTarget{
+		MqlRuntime:    testRuntime(),
+		MountTargetId: setString("fsmt-0123456789abcdef0"),
+		Region:        setString("us-east-1"),
+	}
+	sgs, err := mt.securityGroups()
+	require.Error(t, err)
+	assert.Nil(t, sgs)
+}
+
+// A successful listing caches every returned group id, including the second
+// and later ones.
+func TestEfsMountTargetSecurityGroupsAreCached(t *testing.T) {
+	fs := stubbedEfsFilesystem(t, map[string]efsStub{
+		"*efs.DescribeMountTargetsInput": {
+			out: &efs.DescribeMountTargetsOutput{
+				MountTargets: []efstypes.MountTargetDescription{{
+					MountTargetId:        aws.String("fsmt-0123456789abcdef0"),
+					FileSystemId:         aws.String("fs-0123456789abcdef0"),
+					AvailabilityZoneName: aws.String("us-east-1a"),
+					LifeCycleState:       efstypes.LifeCycleStateAvailable,
+				}},
+			},
+		},
+		"*efs.DescribeMountTargetSecurityGroupsInput": {
+			out: &efs.DescribeMountTargetSecurityGroupsOutput{
+				SecurityGroups: []string{"sg-0123456789abcdef0", "sg-0fedcba9876543210"},
+			},
+		},
+	})
+
+	res, err := fs.mountTargets()
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+
+	mt := res[0].(*mqlAwsEfsMountTarget)
+	require.NoError(t, mt.cacheSecurityGroupsErr)
+	assert.Equal(t, []string{"sg-0123456789abcdef0", "sg-0fedcba9876543210"}, mt.cacheSecurityGroupIDs)
+}
+
+// A denied lifecycle read must not read like a file system with no lifecycle
+// policy, and the 404 that establishes there is none must still read as null.
+func TestEfsLifecycleConfigurationDeniedIsNotNull(t *testing.T) {
+	denied := stubbedEfsFilesystem(t, map[string]efsStub{
+		"*efs.DescribeLifecycleConfigurationInput": {
+			err: efsAccessDenied("elasticfilesystem:DescribeLifecycleConfiguration"),
+		},
+	})
+	res, err := denied.lifecycleConfiguration()
+	require.Error(t, err, "a denied lifecycle read must not read as no lifecycle policy")
+	assert.Nil(t, res)
+
+	absent := stubbedEfsFilesystem(t, map[string]efsStub{
+		"*efs.DescribeLifecycleConfigurationInput": {
+			out: &efs.DescribeLifecycleConfigurationOutput{},
+		},
+	})
+	res, err = absent.lifecycleConfiguration()
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	assert.True(t, absent.LifecycleConfiguration.State&plugin.StateIsNull != 0)
+}
+
+// A denied replication read must not read like an unreplicated file system.
+func TestEfsReplicationConfigurationDeniedIsNotNull(t *testing.T) {
+	denied := stubbedEfsFilesystem(t, map[string]efsStub{
+		"*efs.DescribeReplicationConfigurationsInput": {
+			err: efsAccessDenied("elasticfilesystem:DescribeReplicationConfigurations"),
+		},
+	})
+	res, err := denied.replicationConfiguration()
+	require.Error(t, err, "a denied replication read must not read as unreplicated")
+	assert.Nil(t, res)
+
+	absent := stubbedEfsFilesystem(t, map[string]efsStub{
+		"*efs.DescribeReplicationConfigurationsInput": {
+			out: &efs.DescribeReplicationConfigurationsOutput{},
+		},
+	})
+	res, err = absent.replicationConfiguration()
+	require.NoError(t, err)
+	assert.Nil(t, res)
+	assert.True(t, absent.ReplicationConfiguration.State&plugin.StateIsNull != 0)
+}
+
+// The deprecated dict promises a BackupPolicy object and nothing else. The SDK
+// output also carries ResultMetadata, which describes the API call rather than
+// the file system.
+func TestEfsBackupPolicyDictShape(t *testing.T) {
+	fs := stubbedEfsFilesystem(t, map[string]efsStub{
+		"*efs.DescribeBackupPolicyInput": {
+			out: &efs.DescribeBackupPolicyOutput{
+				BackupPolicy: &efstypes.BackupPolicy{Status: efstypes.StatusEnabled},
+			},
+		},
+	})
+
+	dict, err := fs.backupPolicy()
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		"BackupPolicy": map[string]any{"Status": "ENABLED"},
+	}, dict)
+}
+
+// A denied backup policy read still errors, and the dict is not a value.
+func TestEfsBackupPolicyDeniedIsAnError(t *testing.T) {
+	fs := stubbedEfsFilesystem(t, map[string]efsStub{
+		"*efs.DescribeBackupPolicyInput": {
+			err: efsAccessDenied("elasticfilesystem:DescribeBackupPolicy"),
+		},
+	})
+
+	dict, err := fs.backupPolicy()
+	require.Error(t, err)
+	assert.Nil(t, dict)
+}
+
+// The three-way distinction the isPublic verdict rests on, exercised directly
+// on the helper so that the null-without-error case is covered too: an empty
+// statement list is a measurement (not public), a null one is the absence of a
+// measurement, and only the first may produce false.
+func TestEfsIsPublicSeparatesNullStatementsFromEmptyOnes(t *testing.T) {
+	t.Run("null statements report null, not false", func(t *testing.T) {
+		fs := &mqlAwsEfsFilesystem{MqlRuntime: testRuntime()}
+		fs.PolicyStatements = plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull}
+
+		got, err := fs.isPublic()
+		require.NoError(t, err)
+		assert.False(t, got)
+		assert.True(t, fs.IsPublic.State&plugin.StateIsNull != 0,
+			"an unread policy must leave isPublic null rather than false")
+	})
+
+	t.Run("an empty statement list reports a real false", func(t *testing.T) {
+		fs := &mqlAwsEfsFilesystem{MqlRuntime: testRuntime()}
+		fs.PolicyStatements = plugin.TValue[[]any]{Data: []any{}, State: plugin.StateIsSet}
+
+		got, err := fs.isPublic()
+		require.NoError(t, err)
+		assert.False(t, got)
+		assert.True(t, fs.IsPublic.State&plugin.StateIsNull == 0,
+			"a file system with no policy statements is measurably not public")
+	})
+
+	t.Run("a statement error propagates", func(t *testing.T) {
+		fs := &mqlAwsEfsFilesystem{MqlRuntime: testRuntime()}
+		fs.PolicyStatements = plugin.TValue[[]any]{
+			State: plugin.StateIsSet | plugin.StateIsNull,
+			Error: efsAccessDenied("elasticfilesystem:DescribeFileSystemPolicy"),
+		}
+
+		_, err := fs.isPublic()
+		require.Error(t, err)
+	})
+}

--- a/providers/aws/resources/aws_internet_exposure.go
+++ b/providers/aws/resources/aws_internet_exposure.go
@@ -69,8 +69,13 @@ func (a *mqlAwsSecretsmanagerSecret) isPublic() (bool, error) {
 	return resourceIsPublic(a.GetPolicyStatements())
 }
 
+// isPublic reports whether the file system policy grants a wildcard principal.
+// It routes through resourceIsPublicOrUnknown so that a policy that could not
+// be read reports null: a denied DescribeFileSystemPolicy used to collapse
+// into an empty statement list and a confident false on a file system that
+// grants ClientMount to everyone.
 func (a *mqlAwsEfsFilesystem) isPublic() (bool, error) {
-	return resourceIsPublic(a.GetPolicyStatements())
+	return resourceIsPublicOrUnknown(a.GetPolicyStatements(), &a.IsPublic)
 }
 
 func (a *mqlAwsBackupVault) isPublic() (bool, error) {


### PR DESCRIPTION
Found by validating **all 73 fields** of `aws.efs` against a live account, using IAM roles that deny exactly one permission each. Six fields report a confident, falsifiable answer when the underlying read was **refused**.

The pattern is identical in every case: an access-denied error is logged as a warning and the empty value returned as if measured. **The warning goes to stderr and never reaches the scan result.**

## The security verdict

A file system granting `elasticfilesystem:ClientMount` to `Principal: "*"`, scanned by a role denied only `elasticfilesystem:DescribeFileSystemPolicy`:

```
isPublic: false        fileSystemPolicy: ""        policyStatements: []
```

**Byte-for-byte identical** to a file system with genuinely no policy. A least-privilege scanner reported every internet-mountable file system in the account as not public, and the audit passed.

`""` was carrying three meanings at once — "no policy exists", "the read was refused", and "the policy is the empty string" — with nothing downstream able to tell them apart.

## Why nulling the policy alone would not have worked

`policyStatementsFromDict` maps a null document to an **empty statement list**, and an empty statement list reports as **not public**. So nulling the policy would have reproduced the same wrong answer one step further down. `isPublic` now routes through a new `resourceIsPublicOrUnknown` helper, preserving a three-way distinction:

| policy | `isPublic` |
|---|---|
| refused | **error / null** |
| read, none attached | **false** |
| read, grants `*` | **true** |

## The other five, all previously silent

- **`mountTargets` / `accessPoints`** returned the partial slice on a denial, so `mountTargets.all(...)` passed vacuously.
- **`mountTarget.securityGroups`** returned `[]`. EFS **always** assigns at least one security group to a mount target, so an empty list there was *always* the failure case and never a real reading.
- **`lifecycleConfiguration` / `replicationConfiguration`** nulled on a denial, making an unreplicated file system and one nobody could read indistinguishable.

Only a 404 establishes absence now; everything else propagates.

## Why error rather than null

This follows `fetchBackupPolicy` **in this same file**, which already handled the distinction correctly and was the one path that behaved properly under live denial. An error is attributed — it names the field, the permission and the principal — where null is silent.

Worth noting for reviewers weighing the convention: I verified empirically that for list assertions an **empty list passes `.none()` vacuously while a null list fails closed**, so null would also have been safe here. Error was chosen for attribution, and because it matches the local precedent. The sibling ECR PR (#10626) uses null for the same class; if the project wants one convention, that is a reasonable follow-up rather than a blocker.

## Also

- `backupPolicy` no longer dumps the whole SDK response into the dict, so the undocumented `ResultMetadata` key is gone. This changes an observable key set on a **deprecated** field.
- `rootDirectory.permissions` doc said "Empty" where the implementation correctly reports null.

## Verified live

**Under the denied role**, on the world-mountable file system:
- before: `isPublic: false`
- after: the `AccessDeniedException`, naming the permission and the principal

**With full credentials** (the regression control — a fix that only worked under denial would be useless):

| file system | `isPublic` | mount targets | access points |
|---|---|---|---|
| wildcard policy | `true` | 2 | 3 |
| genuinely no policy | **`false`** — not regressed to null | 0 | 0 |

## Tests

14 tests, all driving a stubbed EFS client that returns a real `awshttp.ResponseError`-wrapped 403 through the actual code path rather than hand-setting internal flags. **11 of 11 mutations produced a specific named failure**, including a regression guard that a genuine 404 still reports `isPublic: false`.

## One judgment call to review

`connection.NewTestConnection(aws.Config)` is new exported production API whose only consumer is tests — `cfg` is unexported, so there is no other way to hand the SDK clients middleware from `package resources`. Without it, three of these defects could only be tested by asserting on internal flags, which is exactly the weak-test trap. The alternative is moving the tests into `package connection`, which is worse. Happy to change it if you disagree.
