### PR TITLE
🐛 aws: a refused KMS read must not report rotation off or a key as not public

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2372,6 +2372,11 @@ private aws.kms.key @defaults("id region aliases metadata.Description") {
   // Region the key lives in
   region string
   // Whether key rotation is enabled
+  //
+  // Null when the key policy withholds kms:GetKeyRotationStatus, which
+  // AWS-managed keys such as alias/aws/acm do even for an account
+  // administrator. Null means the rotation state could not be read, not that
+  // rotation is off.
   keyRotationEnabled() bool
   // Raw key metadata as returned by the KMS DescribeKey API
   //
@@ -2402,14 +2407,25 @@ private aws.kms.key @defaults("id region aliases metadata.Description") {
   // Description of the key
   description() string
   // Grants for the key
+  //
+  // Null when the key policy withholds kms:ListGrants, since a partial list
+  // cannot be told apart from a complete one.
   grants() []aws.kms.grant
   // Whether the key is managed by AWS or the customer (AWS or CUSTOMER)
   keyManager() string
   // Key policy document in JSON format
+  //
+  // Null when kms:GetKeyPolicy is denied. Every KMS key has a key policy, so
+  // an empty document is never a valid reading of one.
   policy() string
   // Parsed statements from the key policy
+  //
+  // Null when the key policy could not be read.
   policyStatements() []aws.iam.policyStatement
   // Whether the resource policy grants public access (a wildcard principal with no scoping conditions)
+  //
+  // Null when the key policy could not be read, which leaves the answer
+  // unknown rather than false.
   isPublic() bool
   // IAM Access Analyzer findings reporting external or public access to this resource
   externalAccessFindings() []aws.iam.accessAnalyzer.finding
@@ -2435,11 +2451,21 @@ private aws.kms.key @defaults("id region aliases metadata.Description") {
   //
   // Shape (when present): `{id: "external-key-id"}` — the identifier the external key store proxy uses to address the external key. Null for keys not backed by an External Key Store.
   xksKeyConfiguration() dict
-  // Number of days between each automatic rotation (default 365)
+  // Number of days between each automatic rotation
+  //
+  // Null when the key does not rotate automatically, since AWS reports no
+  // period for a key with rotation off, and null when the rotation status
+  // could not be read. Automatic rotation defaults to 365 days.
   rotationPeriodInDays() int
   // Next date that KMS will automatically rotate the key material
+  //
+  // Null when the key does not rotate automatically, and null when the
+  // rotation status could not be read.
   nextRotationAt() time
   // Date and time an in-progress on-demand rotation was initiated
+  //
+  // Null when no on-demand rotation is in progress, and null when the
+  // rotation status could not be read.
   onDemandRotationStartedAt() time
   // Encryption algorithms the key supports (e.g., SYMMETRIC_DEFAULT, RSAES_OAEP_SHA_1, RSAES_OAEP_SHA_256)
   encryptionAlgorithms() []string
@@ -2455,9 +2481,12 @@ private aws.kms.key @defaults("id region aliases metadata.Description") {
   validTo() time
   // Last successful cryptographic operation
   //
-  // For example: Decrypt, Encrypt, Sign, Verify, GenerateDataKey, GenerateMac, ReEncrypt, DeriveSharedSecret. Empty if the key has not been used since KMS began tracking.
+  // For example: Decrypt, Encrypt, Sign, Verify, GenerateDataKey, GenerateMac, ReEncrypt, DeriveSharedSecret. Null if the key has not been used since KMS began tracking, and null when kms:GetKeyLastUsage is denied.
   lastUsageOperation() string
-  // Date the key was last used for a successful cryptographic operation. Null if the key has not been used since KMS began tracking.
+  // Date the key was last used for a successful cryptographic operation
+  //
+  // Null if the key has not been used since KMS began tracking, and null when
+  // kms:GetKeyLastUsage is denied.
   lastUsedAt() time
   // EBS volumes encrypted with this key
   //

--- a/providers/aws/resources/aws_iam_policy_statement.go
+++ b/providers/aws/resources/aws_iam_policy_statement.go
@@ -269,6 +269,13 @@ func (a *mqlAwsKmsKey) policyStatements() ([]any, error) {
 	if policy.Error != nil {
 		return nil, policy.Error
 	}
+	// A key policy AWS refused to disclose reads null, and its statements are
+	// unknown with it. Parsing the empty string would produce an empty
+	// statement list, which statementsAllowPublic answers "not public" for.
+	if policy.IsNull() {
+		a.PolicyStatements.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
 	return newPolicyStatementResources(a.MqlRuntime, a.Arn.Data, policy.Data)
 }
 
@@ -389,8 +396,27 @@ func resourceIsPublic(statements *plugin.TValue[[]any]) (bool, error) {
 	return statementsAllowPublic(statements.Data)
 }
 
+// resourceIsPublicOrUnknown is resourceIsPublic for a resource whose policy
+// read can be refused. A null statement list means the policy could not be
+// read, and "we were not allowed to look" must not be published as "not
+// public": the isPublic field is marked null instead.
+//
+// A statement list that was read and is merely empty still answers false. The
+// distinction is three-way, and collapsing the first case into the second is
+// how a denied read became a confident isPublic:false.
+func resourceIsPublicOrUnknown(statements *plugin.TValue[[]any], field *plugin.TValue[bool]) (bool, error) {
+	if statements.Error != nil {
+		return false, statements.Error
+	}
+	if statements.IsNull() {
+		field.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
+	return statementsAllowPublic(statements.Data)
+}
+
 func (a *mqlAwsKmsKey) isPublic() (bool, error) {
-	return resourceIsPublic(a.GetPolicyStatements())
+	return resourceIsPublicOrUnknown(a.GetPolicyStatements(), &a.IsPublic)
 }
 
 func (a *mqlAwsSnsTopic) isPublic() (bool, error) {

--- a/providers/aws/resources/aws_kms.go
+++ b/providers/aws/resources/aws_kms.go
@@ -279,7 +279,11 @@ func (a *mqlAwsKms) grants() ([]any, error) {
 	poolOfJobs := jobpool.CreatePool(tasks, 5)
 	poolOfJobs.Run()
 	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
+		// A key whose grants we may not list leaves the account-wide list
+		// incomplete, and this list has no way to say which part is missing.
+		// Reporting the rest as the whole is the truncation
+		// aws.kms.key.grants refuses one key at a time.
+		return kmsGrantsOrUnreadable(&a.Grants, nil, poolOfJobs.GetErrors())
 	}
 	for i := range poolOfJobs.Jobs {
 		result, ok := poolOfJobs.Jobs[i].Result.([]any)
@@ -373,7 +377,71 @@ func (a *mqlAwsKmsKey) metadata() (any, error) {
 	return convert.JsonToDict(md)
 }
 
-func (a *mqlAwsKmsKey) getRotationStatus() (*kms.GetKeyRotationStatusOutput, error) {
+// errKmsGrantsUnreadable marks a ListGrants call AWS refused. The grants a key
+// carries are then unknown, which is not the same as a key with no grants.
+var errKmsGrantsUnreadable = errors.New("kms: grants could not be listed")
+
+// markKmsUnreadable publishes a field whose backing read AWS refused as null,
+// the same way markTagsUnreadable does for tags.
+//
+// The zero value of a bool, an int or a string cannot say "we were not allowed
+// to look": keyRotationEnabled:false is a claim that rotation is off, and
+// policy:"" a claim a key has no key policy, neither of which a denial
+// establishes. Setting the state before returning is what makes GetOrCompute
+// keep the null instead of caching the zero value it is handed.
+func markKmsUnreadable[T any](field *plugin.TValue[T]) (T, error) {
+	field.State = plugin.StateIsSet | plugin.StateIsNull
+	var zero T
+	return zero, nil
+}
+
+// kmsRotationReading is what the four rotation fields publish for one key.
+type kmsRotationReading struct {
+	// known is false when AWS refused GetKeyRotationStatus. Every rotation
+	// field then publishes null.
+	known bool
+	// enabled is meaningful only when known.
+	enabled bool
+	// periodDays is nil when AWS omitted RotationPeriodInDays, which it does on
+	// every key with rotation off. Zero is not a rotation period.
+	periodDays                *int64
+	nextRotationAt            *time.Time
+	onDemandRotationStartedAt *time.Time
+}
+
+// kmsRotationReadingFrom turns a GetKeyRotationStatus answer into the reading
+// the rotation fields publish, and is where the refusal is classified.
+//
+// A key policy can withhold kms:GetKeyRotationStatus from a caller that holds
+// it in IAM, and AWS-managed keys do exactly that: alias/aws/acm refuses the
+// call even to an account administrator, and it rotates. Folding that refusal
+// into keyRotationEnabled:false states the opposite of the truth about such a
+// key, so it is reported as unknown instead.
+func kmsRotationReadingFrom(resp *kms.GetKeyRotationStatusOutput, err error) (kmsRotationReading, error) {
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return kmsRotationReading{}, nil
+		}
+		return kmsRotationReading{}, err
+	}
+	if resp == nil {
+		return kmsRotationReading{}, nil
+	}
+
+	reading := kmsRotationReading{
+		known:                     true,
+		enabled:                   resp.KeyRotationEnabled,
+		nextRotationAt:            resp.NextRotationDate,
+		onDemandRotationStartedAt: resp.OnDemandRotationStartDate,
+	}
+	if resp.RotationPeriodInDays != nil {
+		days := int64(*resp.RotationPeriodInDays)
+		reading.periodDays = &days
+	}
+	return reading, nil
+}
+
+func (a *mqlAwsKmsKey) getRotationStatus() (kmsRotationReading, error) {
 	if a.rotationStatusFetched {
 		return a.cachedRotationStatus, nil
 	}
@@ -390,63 +458,100 @@ func (a *mqlAwsKmsKey) getRotationStatus() (*kms.GetKeyRotationStatusOutput, err
 	ctx := context.Background()
 
 	resp, err := svc.GetKeyRotationStatus(ctx, &kms.GetKeyRotationStatusInput{KeyId: &keyArn})
+	reading, err := kmsRotationReadingFrom(resp, err)
 	if err != nil {
-		if Is400AccessDeniedError(err) {
-			a.rotationStatusFetched = true
-			return nil, nil
-		}
-		return nil, err
+		return kmsRotationReading{}, err
 	}
-	a.cachedRotationStatus = resp
+	if !reading.known {
+		log.Debug().Str("key", keyArn).Msg("access denied reading KMS key rotation status")
+	}
+	a.cachedRotationStatus = reading
 	a.rotationStatusFetched = true
-	return resp, nil
+	return reading, nil
 }
 
 func (a *mqlAwsKmsKey) keyRotationEnabled() (bool, error) {
-	resp, err := a.getRotationStatus()
+	reading, err := a.getRotationStatus()
 	if err != nil {
 		return false, err
 	}
-	if resp == nil {
-		return false, nil
+	if !reading.known {
+		return markKmsUnreadable(&a.KeyRotationEnabled)
 	}
-	return resp.KeyRotationEnabled, nil
+	return reading.enabled, nil
 }
 
 func (a *mqlAwsKmsKey) rotationPeriodInDays() (int64, error) {
-	resp, err := a.getRotationStatus()
+	reading, err := a.getRotationStatus()
 	if err != nil {
 		return 0, err
 	}
-	if resp == nil || resp.RotationPeriodInDays == nil {
-		return 0, nil
+	if !reading.known || reading.periodDays == nil {
+		return markKmsUnreadable(&a.RotationPeriodInDays)
 	}
-	return int64(*resp.RotationPeriodInDays), nil
+	return *reading.periodDays, nil
 }
 
 func (a *mqlAwsKmsKey) nextRotationAt() (*time.Time, error) {
-	resp, err := a.getRotationStatus()
+	reading, err := a.getRotationStatus()
 	if err != nil {
 		return nil, err
 	}
-	if resp == nil {
-		return nil, nil
+	if !reading.known {
+		return markKmsUnreadable(&a.NextRotationAt)
 	}
-	return resp.NextRotationDate, nil
+	return reading.nextRotationAt, nil
 }
 
 func (a *mqlAwsKmsKey) onDemandRotationStartedAt() (*time.Time, error) {
-	resp, err := a.getRotationStatus()
+	reading, err := a.getRotationStatus()
 	if err != nil {
 		return nil, err
 	}
-	if resp == nil {
-		return nil, nil
+	if !reading.known {
+		return markKmsUnreadable(&a.OnDemandRotationStartedAt)
 	}
-	return resp.OnDemandRotationStartDate, nil
+	return reading.onDemandRotationStartedAt, nil
 }
 
-func (a *mqlAwsKmsKey) getLastUsage() (*kms.GetKeyLastUsageOutput, error) {
+// kmsLastUsageReading is what lastUsageOperation and lastUsedAt publish.
+//
+// Both fields are null when the key has never been used and when the read was
+// refused. The two reasons stay separate here so callers, and a future field
+// that wants to report them apart, can still tell them apart.
+type kmsLastUsageReading struct {
+	// known is false when AWS refused GetKeyLastUsage.
+	known bool
+	// operation is nil when the key has not been used since KMS began tracking.
+	operation  *string
+	lastUsedAt *time.Time
+}
+
+// kmsLastUsageReadingFrom turns a GetKeyLastUsage answer into the reading the
+// last-usage fields publish.
+func kmsLastUsageReadingFrom(resp *kms.GetKeyLastUsageOutput, err error) (kmsLastUsageReading, error) {
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return kmsLastUsageReading{}, nil
+		}
+		return kmsLastUsageReading{}, err
+	}
+	if resp == nil {
+		return kmsLastUsageReading{}, nil
+	}
+
+	reading := kmsLastUsageReading{known: true}
+	if resp.KeyLastUsage == nil {
+		return reading, nil
+	}
+	reading.lastUsedAt = resp.KeyLastUsage.Timestamp
+	if op := string(resp.KeyLastUsage.Operation); op != "" {
+		reading.operation = &op
+	}
+	return reading, nil
+}
+
+func (a *mqlAwsKmsKey) getLastUsage() (kmsLastUsageReading, error) {
 	if a.lastUsageFetched {
 		return a.cachedLastUsage, nil
 	}
@@ -463,38 +568,45 @@ func (a *mqlAwsKmsKey) getLastUsage() (*kms.GetKeyLastUsageOutput, error) {
 	ctx := context.Background()
 
 	resp, err := svc.GetKeyLastUsage(ctx, &kms.GetKeyLastUsageInput{KeyId: &keyArn})
+	reading, err := kmsLastUsageReadingFrom(resp, err)
 	if err != nil {
-		if Is400AccessDeniedError(err) {
-			a.lastUsageFetched = true
-			return nil, nil
-		}
-		return nil, err
+		return kmsLastUsageReading{}, err
 	}
-	a.cachedLastUsage = resp
+	if !reading.known {
+		log.Debug().Str("key", keyArn).Msg("access denied reading KMS key last usage")
+	}
+	a.cachedLastUsage = reading
 	a.lastUsageFetched = true
-	return resp, nil
+	return reading, nil
 }
 
 func (a *mqlAwsKmsKey) lastUsageOperation() (string, error) {
-	resp, err := a.getLastUsage()
+	reading, err := a.getLastUsage()
 	if err != nil {
 		return "", err
 	}
-	if resp == nil || resp.KeyLastUsage == nil {
-		return "", nil
+	if !reading.known {
+		// GetKeyLastUsage was refused, so the last operation is unknown.
+		return markKmsUnreadable(&a.LastUsageOperation)
 	}
-	return string(resp.KeyLastUsage.Operation), nil
+	if reading.operation == nil {
+		// The key has not been used since KMS began tracking. There is no
+		// operation to name, and "" is outside the documented value set, so
+		// this reads null the way lastUsedAt already does.
+		return markKmsUnreadable(&a.LastUsageOperation)
+	}
+	return *reading.operation, nil
 }
 
 func (a *mqlAwsKmsKey) lastUsedAt() (*time.Time, error) {
-	resp, err := a.getLastUsage()
+	reading, err := a.getLastUsage()
 	if err != nil {
 		return nil, err
 	}
-	if resp == nil || resp.KeyLastUsage == nil {
-		return nil, nil
+	if !reading.known {
+		return markKmsUnreadable(&a.LastUsedAt)
 	}
-	return resp.KeyLastUsage.Timestamp, nil
+	return reading.lastUsedAt, nil
 }
 
 func (a *mqlAwsKmsKey) tags() (map[string]any, error) {
@@ -558,10 +670,10 @@ func (a *mqlAwsKmsKey) keyState() (string, error) {
 type mqlAwsKmsKeyInternal struct {
 	cachedKeyMetadata     *types.KeyMetadata
 	metadataLock          sync.Mutex
-	cachedRotationStatus  *kms.GetKeyRotationStatusOutput
+	cachedRotationStatus  kmsRotationReading
 	rotationStatusFetched bool
 	rotationStatusLock    sync.Mutex
-	cachedLastUsage       *kms.GetKeyLastUsageOutput
+	cachedLastUsage       kmsLastUsageReading
 	lastUsageFetched      bool
 	lastUsageLock         sync.Mutex
 }
@@ -838,12 +950,26 @@ func (a *mqlAwsKmsKey) policy() (string, error) {
 	ctx := context.Background()
 
 	resp, err := svc.GetKeyPolicy(ctx, &kms.GetKeyPolicyInput{KeyId: &keyArn})
+	return kmsPolicyOrUnreadable(&a.Policy, keyArn, resp, err)
+}
+
+// kmsPolicyOrUnreadable publishes a key policy document, or null when AWS
+// refused to disclose it.
+//
+// Every KMS key has a key policy, so "" can never be a truthful reading of one:
+// it is indistinguishable from a key whose policy grants a wildcard principal,
+// and it collapses through an empty statement list into isPublic:false. Any
+// other failure is a failure, not an answer.
+func kmsPolicyOrUnreadable(field *plugin.TValue[string], keyArn string, resp *kms.GetKeyPolicyOutput, err error) (string, error) {
 	if err != nil {
 		if Is400AccessDeniedError(err) {
 			log.Debug().Str("key", keyArn).Msg("access denied when retrieving KMS key policy")
-			return "", nil
+			return markKmsUnreadable(field)
 		}
 		return "", err
+	}
+	if resp == nil {
+		return markKmsUnreadable(field)
 	}
 	return convert.ToValue(resp.Policy), nil
 }
@@ -854,7 +980,34 @@ func (a *mqlAwsKmsKey) id() (string, error) {
 
 func (a *mqlAwsKmsKey) grants() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	return listKmsGrantsForKey(a.MqlRuntime, conn, a.Arn.Data, a.Region.Data)
+	grants, err := listKmsGrantsForKey(a.MqlRuntime, conn, a.Arn.Data, a.Region.Data)
+	return kmsGrantsOrUnreadable(&a.Grants, grants, err)
+}
+
+// kmsGrantsOrUnreadable publishes a grant list, or null when ListGrants was
+// refused for any key it covers.
+//
+// The grants such a key carries are unknown, and publishing the partial list
+// presents it as the complete one: a check reading "no grant allows X" would
+// pass on a key nobody was allowed to enumerate. Any other failure is returned
+// as the failure it is.
+func kmsGrantsOrUnreadable(field *plugin.TValue[[]any], grants []any, err error) ([]any, error) {
+	if errors.Is(err, errKmsGrantsUnreadable) {
+		return markKmsUnreadable(field)
+	}
+	return grants, err
+}
+
+// kmsListGrantsError classifies a ListGrants failure. A refusal becomes
+// errKmsGrantsUnreadable, which the grant accessors publish as null; anything
+// else stays the error it is, so a throttle or a network blip cannot be read as
+// a statement about the key.
+func kmsListGrantsError(keyArn string, err error) error {
+	if Is400AccessDeniedError(err) {
+		log.Debug().Str("keyArn", keyArn).Msg("access denied listing KMS grants")
+		return fmt.Errorf("%w for key %s: %w", errKmsGrantsUnreadable, keyArn, err)
+	}
+	return err
 }
 
 func listKmsGrantsForKey(runtime *plugin.Runtime, conn *connection.AwsConnection, keyArn, region string) ([]any, error) {
@@ -871,11 +1024,7 @@ func listKmsGrantsForKey(runtime *plugin.Runtime, conn *connection.AwsConnection
 	for paginator.HasMorePages() {
 		grantsResp, err := paginator.NextPage(ctx)
 		if err != nil {
-			if Is400AccessDeniedError(err) {
-				log.Debug().Str("keyArn", keyArn).Msg("access denied listing KMS grants")
-				return res, nil
-			}
-			return nil, err
+			return nil, kmsListGrantsError(keyArn, err)
 		}
 		for _, grant := range grantsResp.Grants {
 			operations := make([]any, len(grant.Operations))

--- a/providers/aws/resources/aws_kms_denied_reads_test.go
+++ b/providers/aws/resources/aws_kms_denied_reads_test.go
@@ -1,0 +1,514 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// kmsDeniedErr is the shape KMS answers with when a key policy withholds an
+// operation from the caller. Every test below routes through
+// Is400AccessDeniedError via this error rather than setting a "denied" flag by
+// hand, so a change to the classifier moves the tests with it.
+func kmsDeniedErr(operation string) error {
+	return &awshttp.ResponseError{
+		ResponseError: &smithyhttp.ResponseError{
+			Response: &smithyhttp.Response{Response: &http.Response{StatusCode: 400}},
+			Err: errors.New("AccessDeniedException: User is not authorized to perform " +
+				operation + " on this resource because the resource-based policy does not allow it"),
+		},
+	}
+}
+
+// kmsThrottleErr is a failure that is not a denial: it must never resolve to a
+// null field, because nothing about the key was established.
+func kmsThrottleErr() error {
+	return &awshttp.ResponseError{
+		ResponseError: &smithyhttp.ResponseError{
+			Response: &smithyhttp.Response{Response: &http.Response{StatusCode: 400}},
+			Err:      errors.New("ThrottlingException: Rate exceeded"),
+		},
+	}
+}
+
+func TestKmsDeniedErrIsClassifiedAsADenial(t *testing.T) {
+	assert.True(t, Is400AccessDeniedError(kmsDeniedErr("kms:GetKeyRotationStatus")),
+		"the fixture must be the shape the production classifier recognizes, or every test below proves nothing")
+	assert.False(t, Is400AccessDeniedError(kmsThrottleErr()),
+		"a throttle is not a denial")
+}
+
+func TestKmsRotationReadingFrom(t *testing.T) {
+	t.Run("a refused GetKeyRotationStatus is unknown, not rotation-off", func(t *testing.T) {
+		// alias/aws/acm answers this way to an account administrator, and it
+		// rotates. Reporting keyRotationEnabled:false here states the opposite
+		// of the truth about that key.
+		got, err := kmsRotationReadingFrom(nil, kmsDeniedErr("kms:GetKeyRotationStatus"))
+		require.NoError(t, err)
+		assert.False(t, got.known)
+		assert.Nil(t, got.periodDays)
+	})
+
+	t.Run("rotation on reports the period and the dates AWS gave", func(t *testing.T) {
+		next := time.Date(2027, 2, 1, 0, 0, 0, 0, time.UTC)
+		started := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)
+		period := int32(180)
+		got, err := kmsRotationReadingFrom(&kms.GetKeyRotationStatusOutput{
+			KeyRotationEnabled:        true,
+			RotationPeriodInDays:      &period,
+			NextRotationDate:          &next,
+			OnDemandRotationStartDate: &started,
+		}, nil)
+		require.NoError(t, err)
+		assert.True(t, got.known)
+		assert.True(t, got.enabled)
+		require.NotNil(t, got.periodDays)
+		assert.Equal(t, int64(180), *got.periodDays)
+		assert.Equal(t, &next, got.nextRotationAt)
+		assert.Equal(t, &started, got.onDemandRotationStartedAt)
+	})
+
+	t.Run("rotation off is a real false with no invented period", func(t *testing.T) {
+		// AWS omits RotationPeriodInDays whenever rotation is off. The reading
+		// must stay known so keyRotationEnabled publishes a measured false,
+		// while the period stays absent: 0 is not a rotation period.
+		got, err := kmsRotationReadingFrom(&kms.GetKeyRotationStatusOutput{
+			KeyRotationEnabled: false,
+		}, nil)
+		require.NoError(t, err)
+		assert.True(t, got.known)
+		assert.False(t, got.enabled)
+		assert.Nil(t, got.periodDays)
+		assert.Nil(t, got.nextRotationAt)
+	})
+
+	t.Run("a throttle is an error, not an answer", func(t *testing.T) {
+		_, err := kmsRotationReadingFrom(nil, kmsThrottleErr())
+		require.Error(t, err)
+	})
+}
+
+func TestKmsRotationFieldsPublishNullWhenDenied(t *testing.T) {
+	denied, err := kmsRotationReadingFrom(nil, kmsDeniedErr("kms:GetKeyRotationStatus"))
+	require.NoError(t, err)
+
+	key := &mqlAwsKmsKey{}
+	key.cachedRotationStatus = denied
+	key.rotationStatusFetched = true
+
+	enabled, err := key.keyRotationEnabled()
+	require.NoError(t, err)
+	assert.False(t, enabled)
+	assert.True(t, key.KeyRotationEnabled.IsNull(),
+		"a denied rotation read must publish null, never a measured false")
+
+	period, err := key.rotationPeriodInDays()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), period)
+	assert.True(t, key.RotationPeriodInDays.IsNull())
+
+	next, err := key.nextRotationAt()
+	require.NoError(t, err)
+	assert.Nil(t, next)
+	assert.True(t, key.NextRotationAt.IsNull())
+
+	onDemand, err := key.onDemandRotationStartedAt()
+	require.NoError(t, err)
+	assert.Nil(t, onDemand)
+	assert.True(t, key.OnDemandRotationStartedAt.IsNull())
+}
+
+func TestKmsRotationDisabledPublishesRealFalse(t *testing.T) {
+	// The counterpart of the test above: the two situations must stay
+	// distinguishable, so a key that genuinely does not rotate keeps reporting
+	// a measured false rather than being swept into null.
+	off, err := kmsRotationReadingFrom(&kms.GetKeyRotationStatusOutput{KeyRotationEnabled: false}, nil)
+	require.NoError(t, err)
+
+	key := &mqlAwsKmsKey{}
+	key.cachedRotationStatus = off
+	key.rotationStatusFetched = true
+
+	enabled, err := key.keyRotationEnabled()
+	require.NoError(t, err)
+	assert.False(t, enabled)
+	assert.False(t, key.KeyRotationEnabled.IsNull(),
+		"rotation that is genuinely off is a measured false, not an unknown")
+
+	// AWS reports no period for a key with rotation off, and 0 is not a
+	// rotation period.
+	period, err := key.rotationPeriodInDays()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), period)
+	assert.True(t, key.RotationPeriodInDays.IsNull(),
+		"an absent RotationPeriodInDays must be null, not a hard 0")
+}
+
+func TestKmsRotationEnabledPublishesTheReportedPeriod(t *testing.T) {
+	period := int32(180)
+	next := time.Date(2027, 2, 1, 0, 0, 0, 0, time.UTC)
+	on, err := kmsRotationReadingFrom(&kms.GetKeyRotationStatusOutput{
+		KeyRotationEnabled:   true,
+		RotationPeriodInDays: &period,
+		NextRotationDate:     &next,
+	}, nil)
+	require.NoError(t, err)
+
+	key := &mqlAwsKmsKey{}
+	key.cachedRotationStatus = on
+	key.rotationStatusFetched = true
+
+	enabled, err := key.keyRotationEnabled()
+	require.NoError(t, err)
+	assert.True(t, enabled)
+	assert.False(t, key.KeyRotationEnabled.IsNull())
+
+	got, err := key.rotationPeriodInDays()
+	require.NoError(t, err)
+	assert.Equal(t, int64(180), got)
+	assert.False(t, key.RotationPeriodInDays.IsNull())
+
+	at, err := key.nextRotationAt()
+	require.NoError(t, err)
+	assert.Equal(t, &next, at)
+	assert.False(t, key.NextRotationAt.IsNull())
+}
+
+func TestKmsLastUsageReadingFrom(t *testing.T) {
+	t.Run("a refused GetKeyLastUsage is unknown", func(t *testing.T) {
+		got, err := kmsLastUsageReadingFrom(nil, kmsDeniedErr("kms:GetKeyLastUsage"))
+		require.NoError(t, err)
+		assert.False(t, got.known)
+		assert.Nil(t, got.operation)
+	})
+
+	t.Run("a key that has never been used is known with no operation", func(t *testing.T) {
+		// This is the distinction the empty string erased: both cases publish
+		// null, but only one of them established anything about the key.
+		got, err := kmsLastUsageReadingFrom(&kms.GetKeyLastUsageOutput{}, nil)
+		require.NoError(t, err)
+		assert.True(t, got.known)
+		assert.Nil(t, got.operation)
+		assert.Nil(t, got.lastUsedAt)
+	})
+
+	t.Run("an empty operation string is treated as never used", func(t *testing.T) {
+		got, err := kmsLastUsageReadingFrom(&kms.GetKeyLastUsageOutput{
+			KeyLastUsage: &kmstypes.KeyLastUsageData{},
+		}, nil)
+		require.NoError(t, err)
+		assert.True(t, got.known)
+		assert.Nil(t, got.operation)
+	})
+
+	t.Run("a used key reports the operation and the timestamp", func(t *testing.T) {
+		used := time.Date(2026, 8, 20, 9, 30, 0, 0, time.UTC)
+		got, err := kmsLastUsageReadingFrom(&kms.GetKeyLastUsageOutput{
+			KeyLastUsage: &kmstypes.KeyLastUsageData{
+				Operation: kmstypes.KeyLastUsageTrackingOperationDecrypt,
+				Timestamp: &used,
+			},
+		}, nil)
+		require.NoError(t, err)
+		assert.True(t, got.known)
+		require.NotNil(t, got.operation)
+		assert.Equal(t, "Decrypt", *got.operation)
+		assert.Equal(t, &used, got.lastUsedAt)
+	})
+
+	t.Run("a throttle is an error, not an answer", func(t *testing.T) {
+		_, err := kmsLastUsageReadingFrom(nil, kmsThrottleErr())
+		require.Error(t, err)
+	})
+}
+
+func TestKmsLastUsageFieldsPublishNull(t *testing.T) {
+	t.Run("denied", func(t *testing.T) {
+		denied, err := kmsLastUsageReadingFrom(nil, kmsDeniedErr("kms:GetKeyLastUsage"))
+		require.NoError(t, err)
+
+		key := &mqlAwsKmsKey{}
+		key.cachedLastUsage = denied
+		key.lastUsageFetched = true
+
+		op, err := key.lastUsageOperation()
+		require.NoError(t, err)
+		assert.Equal(t, "", op)
+		assert.True(t, key.LastUsageOperation.IsNull(),
+			`a denied last-usage read must not publish "", which is outside the operation value set`)
+
+		at, err := key.lastUsedAt()
+		require.NoError(t, err)
+		assert.Nil(t, at)
+		assert.True(t, key.LastUsedAt.IsNull())
+	})
+
+	t.Run("never used", func(t *testing.T) {
+		never, err := kmsLastUsageReadingFrom(&kms.GetKeyLastUsageOutput{}, nil)
+		require.NoError(t, err)
+
+		key := &mqlAwsKmsKey{}
+		key.cachedLastUsage = never
+		key.lastUsageFetched = true
+
+		op, err := key.lastUsageOperation()
+		require.NoError(t, err)
+		assert.Equal(t, "", op)
+		assert.True(t, key.LastUsageOperation.IsNull())
+	})
+
+	t.Run("used", func(t *testing.T) {
+		used := time.Date(2026, 8, 20, 9, 30, 0, 0, time.UTC)
+		reading, err := kmsLastUsageReadingFrom(&kms.GetKeyLastUsageOutput{
+			KeyLastUsage: &kmstypes.KeyLastUsageData{
+				Operation: kmstypes.KeyLastUsageTrackingOperationGenerateDataKey,
+				Timestamp: &used,
+			},
+		}, nil)
+		require.NoError(t, err)
+
+		key := &mqlAwsKmsKey{}
+		key.cachedLastUsage = reading
+		key.lastUsageFetched = true
+
+		op, err := key.lastUsageOperation()
+		require.NoError(t, err)
+		assert.Equal(t, "GenerateDataKey", op)
+		assert.False(t, key.LastUsageOperation.IsNull())
+
+		at, err := key.lastUsedAt()
+		require.NoError(t, err)
+		assert.Equal(t, &used, at)
+		assert.False(t, key.LastUsedAt.IsNull())
+	})
+}
+
+func TestKmsPolicyOrUnreadable(t *testing.T) {
+	const keyArn = "arn:aws:kms:us-east-1:123456789012:key/7a4eb143-c07b-4e24-b0b7-f3abfdbbb2c2"
+
+	t.Run("a denied GetKeyPolicy publishes null", func(t *testing.T) {
+		key := &mqlAwsKmsKey{}
+		got, err := kmsPolicyOrUnreadable(&key.Policy, keyArn, nil, kmsDeniedErr("kms:GetKeyPolicy"))
+		require.NoError(t, err)
+		assert.Equal(t, "", got)
+		assert.True(t, key.Policy.IsNull(),
+			`every KMS key has a key policy, so "" can never be a truthful reading of one`)
+	})
+
+	t.Run("a policy that was read is published verbatim", func(t *testing.T) {
+		doc := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"kms:*","Resource":"*"}]}`
+		key := &mqlAwsKmsKey{}
+		got, err := kmsPolicyOrUnreadable(&key.Policy, keyArn, &kms.GetKeyPolicyOutput{Policy: &doc}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, doc, got)
+		assert.False(t, key.Policy.IsNull())
+	})
+
+	t.Run("a throttle is an error and leaves the field unset", func(t *testing.T) {
+		key := &mqlAwsKmsKey{}
+		_, err := kmsPolicyOrUnreadable(&key.Policy, keyArn, nil, kmsThrottleErr())
+		require.Error(t, err)
+		assert.False(t, key.Policy.IsNull())
+	})
+}
+
+// TestKmsDeniedPolicyLeavesIsPublicUnknown walks the whole collapse the fix
+// breaks: a denied GetKeyPolicy used to publish policy:"", which parsed to an
+// empty statement list, which statementsAllowPublic answered "not public" for.
+// The key whose policy names "Principal": "*" reported isPublic:false.
+func TestKmsDeniedPolicyLeavesIsPublicUnknown(t *testing.T) {
+	const keyArn = "arn:aws:kms:us-east-1:123456789012:key/7a4eb143-c07b-4e24-b0b7-f3abfdbbb2c2"
+	key := &mqlAwsKmsKey{Arn: setString(keyArn)}
+
+	_, err := kmsPolicyOrUnreadable(&key.Policy, keyArn, nil, kmsDeniedErr("kms:GetKeyPolicy"))
+	require.NoError(t, err)
+	require.True(t, key.Policy.IsNull())
+
+	stmts, err := key.policyStatements()
+	require.NoError(t, err)
+	assert.Nil(t, stmts)
+	assert.True(t, key.PolicyStatements.IsNull(),
+		"statements parsed from a policy nobody could read are unknown, not empty")
+
+	public, err := key.isPublic()
+	require.NoError(t, err)
+	assert.False(t, public)
+	assert.True(t, key.IsPublic.IsNull(),
+		"a key whose policy could not be read must never be reported as not public")
+}
+
+func TestResourceIsPublicOrUnknown(t *testing.T) {
+	wildcard := &mqlAwsIamPolicyStatement{
+		Effect:     setString("Allow"),
+		Principals: setMap(map[string]any{"AWS": []any{"*"}}),
+	}
+	scoped := &mqlAwsIamPolicyStatement{
+		Effect:     setString("Allow"),
+		Principals: setMap(map[string]any{"AWS": []any{"arn:aws:iam::123456789012:root"}}),
+	}
+
+	t.Run("a null statement list leaves isPublic null", func(t *testing.T) {
+		statements := plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull}
+		var field plugin.TValue[bool]
+		got, err := resourceIsPublicOrUnknown(&statements, &field)
+		require.NoError(t, err)
+		assert.False(t, got)
+		assert.True(t, field.IsNull())
+	})
+
+	t.Run("a statement list that was read and grants nobody is a real false", func(t *testing.T) {
+		// The regression guard on the fix: nulling the denied case must not
+		// sweep the measured "not public" case along with it.
+		statements := plugin.TValue[[]any]{Data: []any{scoped}, State: plugin.StateIsSet}
+		var field plugin.TValue[bool]
+		got, err := resourceIsPublicOrUnknown(&statements, &field)
+		require.NoError(t, err)
+		assert.False(t, got)
+		assert.False(t, field.IsNull())
+	})
+
+	t.Run("an empty statement list that was read is a real false", func(t *testing.T) {
+		statements := plugin.TValue[[]any]{Data: []any{}, State: plugin.StateIsSet}
+		var field plugin.TValue[bool]
+		got, err := resourceIsPublicOrUnknown(&statements, &field)
+		require.NoError(t, err)
+		assert.False(t, got)
+		assert.False(t, field.IsNull())
+	})
+
+	t.Run("a wildcard principal is public", func(t *testing.T) {
+		statements := plugin.TValue[[]any]{Data: []any{wildcard}, State: plugin.StateIsSet}
+		var field plugin.TValue[bool]
+		got, err := resourceIsPublicOrUnknown(&statements, &field)
+		require.NoError(t, err)
+		assert.True(t, got)
+		assert.False(t, field.IsNull())
+	})
+
+	t.Run("an error on the statement list is returned, not swallowed", func(t *testing.T) {
+		boom := errors.New("boom")
+		statements := plugin.TValue[[]any]{State: plugin.StateIsSet | plugin.StateIsNull, Error: boom}
+		var field plugin.TValue[bool]
+		_, err := resourceIsPublicOrUnknown(&statements, &field)
+		assert.ErrorIs(t, err, boom)
+	})
+}
+
+func TestKmsListGrantsError(t *testing.T) {
+	const keyArn = "arn:aws:kms:us-east-1:123456789012:key/7a4eb143-c07b-4e24-b0b7-f3abfdbbb2c2"
+
+	t.Run("a denial becomes the unreadable sentinel", func(t *testing.T) {
+		err := kmsListGrantsError(keyArn, kmsDeniedErr("kms:ListGrants"))
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errKmsGrantsUnreadable)
+		assert.Contains(t, err.Error(), keyArn)
+	})
+
+	t.Run("a throttle stays a plain failure", func(t *testing.T) {
+		err := kmsListGrantsError(keyArn, kmsThrottleErr())
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, errKmsGrantsUnreadable,
+			"only a refusal resolves to null; a throttle established nothing and must surface")
+	})
+
+	t.Run("no error stays no error", func(t *testing.T) {
+		assert.NoError(t, kmsListGrantsError(keyArn, nil))
+	})
+}
+
+func TestKmsGrantsOrUnreadable(t *testing.T) {
+	const keyArn = "arn:aws:kms:us-east-1:123456789012:key/7a4eb143-c07b-4e24-b0b7-f3abfdbbb2c2"
+
+	t.Run("a refused ListGrants publishes null, not a truncated list", func(t *testing.T) {
+		key := &mqlAwsKmsKey{}
+		got, err := kmsGrantsOrUnreadable(&key.Grants, nil,
+			kmsListGrantsError(keyArn, kmsDeniedErr("kms:ListGrants")))
+		require.NoError(t, err)
+		assert.Nil(t, got)
+		assert.True(t, key.Grants.IsNull(),
+			"a key with grants nobody may enumerate must not report an empty grant list")
+	})
+
+	t.Run("a partial page followed by a refusal is still null", func(t *testing.T) {
+		// The live shape: the first page listed grants, the second was refused.
+		// Publishing the first page presents it as the whole set.
+		key := &mqlAwsKmsKey{}
+		partial := []any{&mqlAwsKmsGrant{}, &mqlAwsKmsGrant{}}
+		got, err := kmsGrantsOrUnreadable(&key.Grants, partial,
+			kmsListGrantsError(keyArn, kmsDeniedErr("kms:ListGrants")))
+		require.NoError(t, err)
+		assert.Nil(t, got)
+		assert.True(t, key.Grants.IsNull())
+	})
+
+	t.Run("a list that was read is published", func(t *testing.T) {
+		key := &mqlAwsKmsKey{}
+		grants := []any{&mqlAwsKmsGrant{}, &mqlAwsKmsGrant{}}
+		got, err := kmsGrantsOrUnreadable(&key.Grants, grants, nil)
+		require.NoError(t, err)
+		assert.Len(t, got, 2)
+		assert.False(t, key.Grants.IsNull())
+	})
+
+	t.Run("a key with no grants is a real empty list", func(t *testing.T) {
+		key := &mqlAwsKmsKey{}
+		got, err := kmsGrantsOrUnreadable(&key.Grants, []any{}, nil)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+		assert.False(t, key.Grants.IsNull(),
+			"a key that genuinely has no grants must stay an empty list, not become null")
+	})
+
+	t.Run("a throttle surfaces as an error", func(t *testing.T) {
+		key := &mqlAwsKmsKey{}
+		_, err := kmsGrantsOrUnreadable(&key.Grants, nil, kmsListGrantsError(keyArn, kmsThrottleErr()))
+		require.Error(t, err)
+		assert.False(t, key.Grants.IsNull())
+	})
+
+	t.Run("one refused key nulls the account-wide list", func(t *testing.T) {
+		// aws.kms.grants joins its per-key failures, which is how the sentinel
+		// reaches the aggregate.
+		agg := &mqlAwsKms{}
+		joined := errors.Join(
+			kmsListGrantsError(keyArn, kmsDeniedErr("kms:ListGrants")),
+			errors.New("some other key was fine"),
+		)
+		got, err := kmsGrantsOrUnreadable(&agg.Grants, nil, joined)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+		assert.True(t, agg.Grants.IsNull())
+	})
+}
+
+func TestMarkKmsUnreadableSetsSetAndNull(t *testing.T) {
+	// GetOrCompute keeps a field the accessor set proactively, so the state has
+	// to carry both bits: StateIsSet alone caches the zero value as fact, and
+	// StateIsNull alone leaves the field looking unresolved.
+	var b plugin.TValue[bool]
+	got, err := markKmsUnreadable(&b)
+	require.NoError(t, err)
+	assert.False(t, got)
+	assert.True(t, b.IsSet())
+	assert.True(t, b.IsNull())
+
+	var i plugin.TValue[int64]
+	gotInt, err := markKmsUnreadable(&i)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), gotInt)
+	assert.True(t, i.IsSet())
+	assert.True(t, i.IsNull())
+}


### PR DESCRIPTION
Found by validating **all 69 fields** of `aws.kms` against a live account. Five fields report a confident answer when the underlying read was **refused** — an access-denied error folded into a nil return, then published as the zero value.

## This one does not need a contrived role

Every other defect in this class required a purpose-built least-privilege role to expose. This one does not.

**AWS-managed keys can deny `kms:GetKeyRotationStatus` through their own key policy, even to an account administrator.** `alias/aws/acm` does exactly that in a stock account:

```
$ aws kms get-key-rotation-status --key-id <acm key>
AccessDeniedException: User: arn:aws:iam::…:user/… is not authorized to perform:
kms:GetKeyRotationStatus ... because no resource-based policy allows the action
```

mql reported `keyRotationEnabled: false`, `rotationPeriodInDays: 0`. AWS-managed keys **do** rotate. **A rotation audit run with full admin credentials gets a wrong answer today.**

Rotation status now flows through a pure classifier, so a refusal is decided in one place and all four dependent fields publish null. Rotation that is genuinely disabled still yields a measured `false`.

## The key policy

**Every KMS key always has a key policy**, so the `""` this returned on a denial was never a truthful reading of any key — which makes it the cleanest instance of this class in the provider.

It nulls now. And because `policyStatementsFromDict` maps a null document to an **empty statement list**, and an empty statement list reports as **not public**, `policyStatements` nulls with it and `isPublic` goes through the null-aware `resourceIsPublicOrUnknown` helper:

| policy | `isPublic` |
|---|---|
| refused | **null** |
| read, grants nothing public | **false** |
| read, grants `*` | **true** |

## Also

- **`grants`** returned the partial slice on a denied `ListGrants` — a key with two real grants reported `[]` with nothing said otherwise.
- **`rotationPeriodInDays`** reported a hard `0` when AWS omits the value on a rotation-disabled key. Zero is not a possible rotation period.
- **`lastUsageOperation`** returned `""` both when `GetKeyLastUsage` was denied *and* when the key had genuinely never been used. `""` is outside the documented value set, so it was never a legal reading of either case. Both are null now and stay distinguishable in code — which also makes the field agree with `lastUsedAt`, already null for a never-used key.

## The precedent was already here

`tags()` handles the identical denial correctly via `markTagsUnreadable`, and `aliases()` surfaces the error. Only policy and rotation lied. This makes the file consistent with itself.

## Verified live, before and after, on the same keys

| check | before | after |
|---|---|---|
| `alias/aws/acm` (denies the call) — `keyRotationEnabled` | `false` | **`null`** |
| `alias/aws/acm` — `rotationPeriodInDays` | `0` | **`null`** |
| a key that **permits** the call | `true` / `365` | `true` / `365` — **no over-nulling** |
| wildcard-policy key — `isPublic` | `true` | `true`, 2 statements |
| aggregate `aws.kms.grants` under admin | 27 | **27 across 38 keys** |

That last row settles a design question rather than just passing: the aggregate list nulls if *any* key is refused, which risked rendering the field permanently useless in a real account. It does not fire under normal credentials, so the null only appears on a genuine refusal.

## Tests

14 tests, all routing a real `awshttp.ResponseError` through the production `Is400AccessDeniedError` rather than setting a "denied" flag — with `TestKmsDeniedErrIsClassifiedAsADenial` guarding the fixture itself, so the suite cannot pass on an error shape the classifier does not recognise. Every mutation produced a specific named failure, and every negative control is asserted: throttle still errors, read-and-empty still reports a real `false`, no grants still reports a real `[]`.

`aws.permissions.json` unchanged (1038); no client calls added.

## One judgment call to review

The aggregate `aws.kms.grants` goes null if any key in any region is refused, since a flat cross-key list has no way to say which part is missing. The measurement above shows it does not fire under normal credentials. If you would rather have partial-with-a-warning there, it is a one-line change in `mqlAwsKms.grants()`.
