### PR TITLE
🐛 aws: stop inventing SQS and SNS values that were never read

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -6074,7 +6074,12 @@ private aws.sns.topic @defaults("arn") {
   attributes() @maturity("deprecated") dict
   // Tags for the topic
   tags() map[string]string
-  // Signature version used for Amazon SNS message signing (1 or 2)
+  // Signature version used for Amazon SNS message signing
+  //
+  // Either 1 (SHA1 signatures) or 2 (SHA256 signatures). SNS omits the
+  // attribute on a topic that was never given an explicit signature
+  // version, and the service default of 1 is in force on such a topic, so
+  // that is what this field reports.
   signatureVersion() string
   // AWS account ID of the topic owner
   owner() string
@@ -6103,13 +6108,16 @@ private aws.sns.topic @defaults("arn") {
   // messages published to the topic, parsed from JSON. Top-level keys are
   // Name, Description, Version, and Statement, where each statement carries
   // DataDirection, DataIdentifier, and an Operation such as Audit,
-  // Deidentify, or Deny.
+  // Deidentify, or Deny. Null when the topic has no data protection policy
+  // and on FIFO topics, which do not support the feature at all.
   dataProtectionPolicy() dict
   // Active tracing configuration for X-Ray
   //
   // Either PassThrough (only messages that already carry a trace header
   // are traced) or Active (SNS generates a trace header for every
-  // published message).
+  // published message). SNS omits the attribute on a topic that was never
+  // given an explicit tracing mode, and the service default of PassThrough
+  // is in force on such a topic, so that is what this field reports.
   tracingConfig() string
   // Topic-level delivery policy
   //
@@ -6149,9 +6157,14 @@ private aws.sns.subscription @defaults("arn") {
   // Deprecated in favor of arn, topic, protocol, endpoint, owner,
   // confirmationWasAuthenticated, pendingConfirmation, rawMessageDelivery,
   // filterPolicy, filterPolicyScope, redrivePolicy, and deliveryPolicy. The
-  // complete set of subscription attributes as returned by SNS.
+  // set of subscription attributes as returned by SNS. Null for a
+  // subscription still awaiting confirmation, which has no ARN for SNS to
+  // answer an attribute request on.
   attributes() @maturity("deprecated") dict
   // Whether raw message delivery is enabled (no SNS metadata wrapper)
+  //
+  // Null for a subscription still awaiting confirmation, whose attributes
+  // SNS does not publish.
   rawMessageDelivery() bool
   // Message filter policy
   //
@@ -6161,7 +6174,11 @@ private aws.sns.subscription @defaults("arn") {
   // matching operators such as prefix, anything-but, or numeric ranges.
   // Empty when the subscription receives every message.
   filterPolicy() dict
-  // Scope of the filter policy: MessageAttributes or MessageBody
+  // Scope of the filter policy
+  //
+  // Either MessageAttributes or MessageBody, naming what `filterPolicy`
+  // matches against. Null for a subscription still awaiting confirmation,
+  // whose attributes SNS does not publish.
   filterPolicyScope() string
   // Dead-letter queue redrive policy
   //
@@ -6170,6 +6187,10 @@ private aws.sns.subscription @defaults("arn") {
   // the target queue. Empty when no dead-letter queue is configured.
   redrivePolicy() dict
   // Whether the subscription confirmation was authenticated
+  //
+  // Null for a subscription still awaiting confirmation: there has been no
+  // confirmation to authenticate, which is not the same as a confirmation
+  // that went unauthenticated.
   confirmationWasAuthenticated() bool
   // Subscription delivery policy
   //
@@ -6179,7 +6200,10 @@ private aws.sns.subscription @defaults("arn") {
   // sicklyRetryPolicy, throttlePolicy (maxReceivesPerSecond), and
   // guaranteed.
   deliveryPolicy() dict
-  // Whether the subscription is confirmed
+  // Whether the subscription is still awaiting confirmation
+  //
+  // True while the endpoint owner has not yet confirmed the subscription,
+  // in which case SNS holds no other attributes for it.
   pendingConfirmation() bool
 }
 
@@ -14229,7 +14253,12 @@ private aws.sqs.queue {
   kmsKey() aws.kms.key
   // Time when the queue was last modified
   lastModified() time
-  // Maximum amount of messages that can be received by the queue
+  // Receive attempts allowed before a message goes to the dead-letter queue
+  //
+  // The maxReceiveCount of the queue redrive policy: how many times a
+  // single message may be received without being deleted before SQS moves
+  // it to the dead-letter queue named by deadLetterQueue. Null when the
+  // queue has no redrive policy, because no such limit is configured on it.
   maxReceiveCount() int
   // Maximum message size for the queue
   maximumMessageSize() int
@@ -14239,7 +14268,11 @@ private aws.sqs.queue {
   receiveMessageWaitTimeSeconds() int
   // Region for the queue
   region string
-  // Whether SSE is enabled for the queue
+  // Whether SQS-managed server-side encryption (SSE-SQS) is enabled
+  //
+  // Covers SQS-managed encryption keys only. A queue encrypted with a
+  // customer-managed KMS key reports false here and names its key through
+  // kmsKey, so an encryption-at-rest audit has to read both fields.
   sqsManagedSseEnabled() bool
   // Type of queue: fifo or standard
   queueType() string

--- a/providers/aws/resources/aws_sns.go
+++ b/providers/aws/resources/aws_sns.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
+	"github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/transport/http"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
@@ -192,6 +193,18 @@ func (a *mqlAwsSnsTopic) fetchTopicAttributes() (map[string]string, error) {
 	return a.topicAtts, nil
 }
 
+// cachedFifoTopic reports whether the topic is FIFO, but only when the topic
+// attributes have already been read. known is false when nothing has been
+// fetched yet, so callers can decide whether the answer is worth an API call.
+func (a *mqlAwsSnsTopic) cachedFifoTopic() (isFifo bool, known bool) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	if !a.fetched {
+		return false, false
+	}
+	return a.topicAtts["FifoTopic"] == "true", true
+}
+
 func (a *mqlAwsSnsTopic) attributes() (any, error) {
 	atts, err := a.fetchTopicAttributes()
 	if err != nil {
@@ -200,12 +213,35 @@ func (a *mqlAwsSnsTopic) attributes() (any, error) {
 	return convert.JsonToDict(atts)
 }
 
+// SNS omits SignatureVersion and TracingConfig from GetTopicAttributes unless
+// the topic was explicitly configured with them, and the value in force on such
+// a topic is the documented service default: signature version 1, and
+// PassThrough tracing. Reporting the default rather than "" is a deliberate
+// departure from reporting only what was read: these are settings the service
+// applies to the topic right now, not evidence we failed to gather. Reporting
+// "" would put every never-configured topic outside the enum the field
+// documents, so `signatureVersion == "1"` would miss the majority of SigV1
+// topics.
+const (
+	snsDefaultSignatureVersion = "1"
+	snsDefaultTracingConfig    = "PassThrough"
+)
+
+// snsAttributeOrDefault returns the attribute SNS reported, or the service
+// default in force when SNS omitted it.
+func snsAttributeOrDefault(atts map[string]string, name string, def string) string {
+	if v := atts[name]; v != "" {
+		return v
+	}
+	return def
+}
+
 func (a *mqlAwsSnsTopic) signatureVersion() (string, error) {
 	atts, err := a.fetchTopicAttributes()
 	if err != nil {
 		return "", err
 	}
-	return atts["SignatureVersion"], nil
+	return snsAttributeOrDefault(atts, "SignatureVersion", snsDefaultSignatureVersion), nil
 }
 
 func (a *mqlAwsSnsTopic) owner() (string, error) {
@@ -333,8 +369,12 @@ func (a *mqlAwsSnsTopic) subscriptions() ([]any, error) {
 type mqlAwsSnsSubscriptionInternal struct {
 	cacheTopicArn *string
 	fetched       bool
-	attrs         map[string]string
-	lock          sync.Mutex
+	// unconfirmed marks a subscription whose ARN is the literal
+	// "PendingConfirmation" placeholder. SNS has no attributes to give for
+	// one, so attrs stays nil and every attribute-backed field reads null.
+	unconfirmed bool
+	attrs       map[string]string
+	lock        sync.Mutex
 }
 
 func (a *mqlAwsSnsSubscription) topic() (*mqlAwsSnsTopic, error) {
@@ -365,12 +405,16 @@ func (a *mqlAwsSnsSubscription) fetchAttributes() (map[string]string, error) {
 	arnVal := a.Arn.Data
 
 	// Unconfirmed subscriptions have ARN set to "PendingConfirmation" which is
-	// not a valid ARN. GetSubscriptionAttributes will reject it, so return
-	// a minimal attribute map with the pending status instead.
+	// not a valid ARN. GetSubscriptionAttributes will reject it, so no
+	// attribute was ever read for this subscription. Return no attributes
+	// rather than a synthesized map: fabricating one would report
+	// confirmationWasAuthenticated as a measured false ("not authenticated")
+	// when the truth is that the subscription is not yet confirmed.
 	if !arn.IsARN(arnVal) {
 		a.fetched = true
-		a.attrs = map[string]string{"PendingConfirmation": "true"}
-		return a.attrs, nil
+		a.unconfirmed = true
+		a.attrs = nil
+		return nil, nil
 	}
 
 	regionVal := a.Region.Data
@@ -391,10 +435,23 @@ func (a *mqlAwsSnsSubscription) fetchAttributes() (map[string]string, error) {
 	return a.attrs, nil
 }
 
+// isUnconfirmed reports whether the subscription is still awaiting
+// confirmation, in which case SNS holds no attributes for it and every
+// attribute-backed field must read null rather than a zero value.
+func (a *mqlAwsSnsSubscription) isUnconfirmed() bool {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	return a.unconfirmed
+}
+
 func (a *mqlAwsSnsSubscription) attributes() (any, error) {
 	attrs, err := a.fetchAttributes()
 	if err != nil {
 		return nil, err
+	}
+	if a.isUnconfirmed() {
+		a.Attributes.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
 	}
 	return convert.JsonToDict(attrs)
 }
@@ -403,6 +460,10 @@ func (a *mqlAwsSnsSubscription) rawMessageDelivery() (bool, error) {
 	attrs, err := a.fetchAttributes()
 	if err != nil {
 		return false, err
+	}
+	if a.isUnconfirmed() {
+		a.RawMessageDelivery.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
 	}
 	return attrs["RawMessageDelivery"] == "true", nil
 }
@@ -428,6 +489,10 @@ func (a *mqlAwsSnsSubscription) filterPolicyScope() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if a.isUnconfirmed() {
+		a.FilterPolicyScope.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
 	return attrs["FilterPolicyScope"], nil
 }
 
@@ -451,6 +516,12 @@ func (a *mqlAwsSnsSubscription) confirmationWasAuthenticated() (bool, error) {
 	attrs, err := a.fetchAttributes()
 	if err != nil {
 		return false, err
+	}
+	if a.isUnconfirmed() {
+		// Not "the confirmation was unauthenticated": there has been no
+		// confirmation to authenticate yet.
+		a.ConfirmationWasAuthenticated.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
 	}
 	return attrs["ConfirmationWasAuthenticated"] == "true", nil
 }
@@ -476,6 +547,11 @@ func (a *mqlAwsSnsSubscription) pendingConfirmation() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	// A "PendingConfirmation" placeholder ARN is itself the answer: the
+	// subscription exists and is unconfirmed. This one stays a measured true.
+	if a.isUnconfirmed() {
+		return true, nil
+	}
 	return attrs["PendingConfirmation"] == "true", nil
 }
 
@@ -500,7 +576,7 @@ func (a *mqlAwsSnsTopic) tracingConfig() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return atts["TracingConfig"], nil
+	return snsAttributeOrDefault(atts, "TracingConfig", snsDefaultTracingConfig), nil
 }
 
 func (a *mqlAwsSnsTopic) displayName() (string, error) {
@@ -527,7 +603,32 @@ func (a *mqlAwsSnsTopic) deliveryPolicy() (any, error) {
 	return convert.JsonToDict(result)
 }
 
+// isSnsOperationUnsupported reports whether SNS answered that the operation
+// does not apply to this topic. SNS rejects GetDataProtectionPolicy on a FIFO
+// topic with a 400 InvalidAction ("Operation (GetDataProtectionPolicy) is not
+// supported on FIFO topics"), which says the field does not exist for that
+// topic rather than that the read failed.
+//
+// Deliberately narrow: it matches the InvalidAction code alone and never a
+// denial or a throttle, so an AccessDenied still surfaces as an error instead
+// of becoming a silent null.
+func isSnsOperationUnsupported(err error) bool {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return apiErr.ErrorCode() == "InvalidAction"
+}
+
 func (a *mqlAwsSnsTopic) dataProtectionPolicy() (any, error) {
+	// FIFO topics have no data protection policy, and SNS rejects the call
+	// rather than answering it. When the topic attributes are already in hand
+	// the FIFO answer is free, so skip a call that can only fail.
+	if isFifo, known := a.cachedFifoTopic(); known && isFifo {
+		a.DataProtectionPolicy.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	svc := conn.Sns(a.Region.Data)
 	ctx := context.Background()
@@ -538,15 +639,22 @@ func (a *mqlAwsSnsTopic) dataProtectionPolicy() (any, error) {
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
+			a.DataProtectionPolicy.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		if isSnsOperationUnsupported(err) {
+			a.DataProtectionPolicy.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
 		}
 		var respErr *http.ResponseError
 		if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
+			a.DataProtectionPolicy.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
 		}
 		return nil, err
 	}
 	if resp.DataProtectionPolicy == nil || *resp.DataProtectionPolicy == "" {
+		a.DataProtectionPolicy.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
 	var policy map[string]any

--- a/providers/aws/resources/aws_sns_test.go
+++ b/providers/aws/resources/aws_sns_test.go
@@ -1,0 +1,250 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// snsTopicWithAttributes builds a topic whose attribute fetch is already
+// satisfied, so the accessors under test run without a connection.
+func snsTopicWithAttributes(atts map[string]string) *mqlAwsSnsTopic {
+	topic := &mqlAwsSnsTopic{
+		Arn:    plugin.TValue[string]{Data: "arn:aws:sns:us-east-1:123456789012:MyTopic", State: plugin.StateIsSet},
+		Region: plugin.TValue[string]{Data: "us-east-1", State: plugin.StateIsSet},
+	}
+	topic.fetched = true
+	topic.topicAtts = atts
+	return topic
+}
+
+// SNS omits SignatureVersion unless the topic was explicitly configured, and
+// the default in force is 1. Reporting "" put every never-configured topic
+// outside the documented enum, so `signatureVersion == "1"` missed most SigV1
+// topics.
+func TestSnsTopicSignatureVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		atts map[string]string
+		want string
+	}{
+		{
+			name: "absent means the service default of 1",
+			atts: map[string]string{"TopicArn": "arn:aws:sns:us-east-1:123456789012:MyTopic"},
+			want: "1",
+		},
+		{
+			name: "explicitly set to 1",
+			atts: map[string]string{"SignatureVersion": "1"},
+			want: "1",
+		},
+		{
+			name: "explicitly set to 2 is never overridden by the default",
+			atts: map[string]string{"SignatureVersion": "2"},
+			want: "2",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			topic := snsTopicWithAttributes(test.atts)
+			got, err := topic.signatureVersion()
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestSnsTopicTracingConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		atts map[string]string
+		want string
+	}{
+		{
+			name: "absent means the service default of PassThrough",
+			atts: map[string]string{"TopicArn": "arn:aws:sns:us-east-1:123456789012:MyTopic"},
+			want: "PassThrough",
+		},
+		{
+			name: "explicitly set to PassThrough",
+			atts: map[string]string{"TracingConfig": "PassThrough"},
+			want: "PassThrough",
+		},
+		{
+			name: "explicitly set to Active is never overridden by the default",
+			atts: map[string]string{"TracingConfig": "Active"},
+			want: "Active",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			topic := snsTopicWithAttributes(test.atts)
+			got, err := topic.tracingConfig()
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestIsSnsOperationUnsupported(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			// The exact answer every FIFO topic gives, in every account and
+			// every region.
+			name: "get data protection policy on a fifo topic",
+			err: &smithy.GenericAPIError{
+				Code:    "InvalidAction",
+				Message: "Operation (GetDataProtectionPolicy) is not supported on FIFO topics",
+			},
+			want: true,
+		},
+		{
+			// Must stay an error: a denial leaves the policy unknown and must
+			// never become a silent null.
+			name: "access denied is still an error",
+			err:  &smithy.GenericAPIError{Code: "AuthorizationError", Message: "User is not authorized to perform: SNS:GetDataProtectionPolicy"},
+			want: false,
+		},
+		{
+			name: "not found is still an error here",
+			err:  &smithy.GenericAPIError{Code: "NotFound", Message: "Topic does not exist"},
+			want: false,
+		},
+		{
+			name: "a throttle is still an error",
+			err:  &smithy.GenericAPIError{Code: "Throttling", Message: "Rate exceeded"},
+			want: false,
+		},
+		{
+			// A transport failure carries no API error and must never be read
+			// as "this topic has no data protection policy".
+			name: "a transport error is not an api error",
+			err:  errors.New("dial tcp: lookup sns.us-east-1.amazonaws.com: no such host"),
+			want: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, isSnsOperationUnsupported(test.err))
+		})
+	}
+}
+
+// A FIFO topic has no data protection policy and SNS rejects the call, so the
+// field reads null. It used to error on every FIFO topic in every region.
+func TestSnsTopicDataProtectionPolicyIsNullOnFifoTopic(t *testing.T) {
+	topic := snsTopicWithAttributes(map[string]string{"FifoTopic": "true"})
+
+	policy, err := topic.dataProtectionPolicy()
+	require.NoError(t, err)
+	assert.Nil(t, policy)
+	assert.True(t, topic.DataProtectionPolicy.IsSet(), "field must be marked resolved")
+	assert.True(t, topic.DataProtectionPolicy.IsNull(), "a fifo topic must read null, not error")
+}
+
+func TestSnsTopicCachedFifoTopic(t *testing.T) {
+	fifo, known := snsTopicWithAttributes(map[string]string{"FifoTopic": "true"}).cachedFifoTopic()
+	assert.True(t, known)
+	assert.True(t, fifo)
+
+	standard, known := snsTopicWithAttributes(map[string]string{}).cachedFifoTopic()
+	assert.True(t, known)
+	assert.False(t, standard)
+
+	// Nothing fetched yet, so the caller must not skip the API call on the
+	// strength of a false it never read.
+	unfetched := &mqlAwsSnsTopic{}
+	_, known = unfetched.cachedFifoTopic()
+	assert.False(t, known)
+}
+
+// A subscription that has not been confirmed carries the literal
+// "PendingConfirmation" placeholder instead of an ARN, so SNS has no
+// attributes to give for it. Those fields used to be synthesized: a reader saw
+// confirmationWasAuthenticated:false ("not authenticated") when the truth was
+// "not yet confirmed".
+func TestSnsPendingSubscriptionReportsNullNotFalse(t *testing.T) {
+	sub := &mqlAwsSnsSubscription{
+		Arn:      plugin.TValue[string]{Data: "PendingConfirmation", State: plugin.StateIsSet},
+		Protocol: plugin.TValue[string]{Data: "email", State: plugin.StateIsSet},
+		Region:   plugin.TValue[string]{Data: "us-east-1", State: plugin.StateIsSet},
+	}
+
+	raw, err := sub.rawMessageDelivery()
+	require.NoError(t, err)
+	assert.False(t, raw)
+	assert.True(t, sub.RawMessageDelivery.IsNull(), "rawMessageDelivery was never read")
+
+	authed, err := sub.confirmationWasAuthenticated()
+	require.NoError(t, err)
+	assert.False(t, authed)
+	assert.True(t, sub.ConfirmationWasAuthenticated.IsNull(), "there is no confirmation to authenticate yet")
+
+	scope, err := sub.filterPolicyScope()
+	require.NoError(t, err)
+	assert.Empty(t, scope)
+	assert.True(t, sub.FilterPolicyScope.IsNull(), "filterPolicyScope was never read")
+
+	attrs, err := sub.attributes()
+	require.NoError(t, err)
+	assert.Nil(t, attrs, "attributes must not be a fabricated one-key map")
+	assert.True(t, sub.Attributes.IsNull())
+
+	// The one fact we do know stays a measured true.
+	pending, err := sub.pendingConfirmation()
+	require.NoError(t, err)
+	assert.True(t, pending)
+	assert.False(t, sub.PendingConfirmation.IsNull(), "pendingConfirmation is measured, not null")
+}
+
+// The confirmed path must keep reporting what SNS returned.
+func TestSnsConfirmedSubscriptionReportsAttributes(t *testing.T) {
+	sub := &mqlAwsSnsSubscription{
+		Arn:    plugin.TValue[string]{Data: "arn:aws:sns:us-east-1:123456789012:MyTopic:5b9f3f4a-1c2d-4e5f-8a9b-0c1d2e3f4a5b", State: plugin.StateIsSet},
+		Region: plugin.TValue[string]{Data: "us-east-1", State: plugin.StateIsSet},
+	}
+	sub.fetched = true
+	sub.attrs = map[string]string{
+		"RawMessageDelivery":           "true",
+		"ConfirmationWasAuthenticated": "true",
+		"FilterPolicyScope":            "MessageBody",
+		"PendingConfirmation":          "false",
+	}
+
+	raw, err := sub.rawMessageDelivery()
+	require.NoError(t, err)
+	assert.True(t, raw)
+	assert.False(t, sub.RawMessageDelivery.IsNull())
+
+	authed, err := sub.confirmationWasAuthenticated()
+	require.NoError(t, err)
+	assert.True(t, authed)
+	assert.False(t, sub.ConfirmationWasAuthenticated.IsNull())
+
+	scope, err := sub.filterPolicyScope()
+	require.NoError(t, err)
+	assert.Equal(t, "MessageBody", scope)
+	assert.False(t, sub.FilterPolicyScope.IsNull())
+
+	pending, err := sub.pendingConfirmation()
+	require.NoError(t, err)
+	assert.False(t, pending)
+
+	attrs, err := sub.attributes()
+	require.NoError(t, err)
+	assert.False(t, sub.Attributes.IsNull())
+	dict, ok := attrs.(map[string]any)
+	require.True(t, ok, "attributes must serialize to a map")
+	assert.Equal(t, "MessageBody", dict["FilterPolicyScope"])
+}

--- a/providers/aws/resources/aws_sqs.go
+++ b/providers/aws/resources/aws_sqs.go
@@ -357,7 +357,37 @@ func (a *mqlAwsSqsQueue) lastModified() (*time.Time, error) {
 
 type redrivePolicy struct {
 	DeadLetterTargetArn string `json:"deadLetterTargetArn,omitempty"`
-	MaxReceiveCount     int    `json:"maxReceiveCount,omitempty"`
+	// Kept raw so an absent key stays absent. A queue with no redrive policy
+	// has no maxReceiveCount at all, which is not the same as a count of 0.
+	// The raw form also absorbs the quoted-number spelling the console has
+	// historically written.
+	MaxReceiveCount json.RawMessage `json:"maxReceiveCount,omitempty"`
+}
+
+// parseRedriveMaxReceiveCount returns the per-message receive-attempt count a
+// queue's RedrivePolicy attribute sets before a message is moved to the
+// dead-letter queue.
+//
+// ok is false when the queue carries no redrive policy, or carries one without
+// a maxReceiveCount: that queue has no receive-attempt limit, so a count of 0
+// would report a limit that was never configured.
+func parseRedriveMaxReceiveCount(redrivePolicyAttr string) (int64, bool, error) {
+	if redrivePolicyAttr == "" {
+		return 0, false, nil
+	}
+	var r redrivePolicy
+	if err := json.Unmarshal([]byte(redrivePolicyAttr), &r); err != nil {
+		return 0, false, err
+	}
+	raw := strings.TrimSpace(string(r.MaxReceiveCount))
+	if raw == "" || raw == "null" {
+		return 0, false, nil
+	}
+	count, err := strconv.ParseInt(strings.Trim(raw, `"`), 10, 64)
+	if err != nil {
+		return 0, false, fmt.Errorf("invalid maxReceiveCount %s in sqs redrive policy: %w", raw, err)
+	}
+	return count, true, nil
 }
 
 func (a *mqlAwsSqsQueue) maxReceiveCount() (int64, error) {
@@ -365,16 +395,15 @@ func (a *mqlAwsSqsQueue) maxReceiveCount() (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	c := atts["RedrivePolicy"]
-	if c == "" {
-		return 0, nil
-	}
-	var r redrivePolicy
-	err = json.Unmarshal([]byte(c), &r)
+	count, ok, err := parseRedriveMaxReceiveCount(atts["RedrivePolicy"])
 	if err != nil {
 		return 0, err
 	}
-	return int64(r.MaxReceiveCount), nil
+	if !ok {
+		a.MaxReceiveCount.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return count, nil
 }
 
 func (a *mqlAwsSqsQueue) maximumMessageSize() (int64, error) {
@@ -413,6 +442,10 @@ func (a *mqlAwsSqsQueue) receiveMessageWaitTimeSeconds() (int64, error) {
 	return int64(c), nil
 }
 
+// sqsManagedSseEnabled reports the SqsManagedSseEnabled attribute, which
+// covers SQS-managed server-side encryption (SSE-SQS) only. A queue encrypted
+// with a customer-managed KMS key reports false here and names its key through
+// kmsKey, so this is not an "is the queue encrypted" answer on its own.
 func (a *mqlAwsSqsQueue) sqsManagedSseEnabled() (bool, error) {
 	atts, err := a.fetchAttributes()
 	if err != nil {

--- a/providers/aws/resources/aws_sqs_test.go
+++ b/providers/aws/resources/aws_sqs_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 )
 
 func TestSqsQueueName(t *testing.T) {
@@ -49,4 +51,126 @@ func TestRegionFromSqsQueueURL(t *testing.T) {
 			assert.Equal(t, test.expected, regionFromSqsQueueURL(test.queueURL))
 		})
 	}
+}
+
+func TestParseRedriveMaxReceiveCount(t *testing.T) {
+	tests := []struct {
+		name      string
+		attr      string
+		wantCount int64
+		wantOk    bool
+		wantErr   bool
+	}{
+		{
+			// 10 of 11 live queues looked like this. The queue has no
+			// receive-attempt limit, so there is no number to report.
+			name:   "no redrive policy at all",
+			attr:   "",
+			wantOk: false,
+		},
+		{
+			name:      "redrive policy set",
+			attr:      `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:123456789012:dlq","maxReceiveCount":7}`,
+			wantCount: 7,
+			wantOk:    true,
+		},
+		{
+			// The console has written the count as a quoted number.
+			name:      "count written as a string",
+			attr:      `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:123456789012:dlq","maxReceiveCount":"7"}`,
+			wantCount: 7,
+			wantOk:    true,
+		},
+		{
+			name:      "a real limit of one is not absence",
+			attr:      `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:123456789012:dlq","maxReceiveCount":1}`,
+			wantCount: 1,
+			wantOk:    true,
+		},
+		{
+			name:   "policy without a maxReceiveCount",
+			attr:   `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:123456789012:dlq"}`,
+			wantOk: false,
+		},
+		{
+			name:   "explicit json null",
+			attr:   `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:123456789012:dlq","maxReceiveCount":null}`,
+			wantOk: false,
+		},
+		{
+			name:    "malformed json is an error, not an absence",
+			attr:    `{"maxReceiveCount":`,
+			wantErr: true,
+		},
+		{
+			name:    "non-numeric count is an error, not an absence",
+			attr:    `{"maxReceiveCount":"many"}`,
+			wantErr: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			count, ok, err := parseRedriveMaxReceiveCount(test.attr)
+			if test.wantErr {
+				assert.Error(t, err)
+				assert.False(t, ok)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.wantOk, ok)
+			assert.Equal(t, test.wantCount, count)
+		})
+	}
+}
+
+// sqsQueueWithAttributes builds a queue whose attribute fetch is already
+// satisfied, so the accessors under test run without a connection.
+func sqsQueueWithAttributes(atts map[string]string) *mqlAwsSqsQueue {
+	q := &mqlAwsSqsQueue{
+		Url:    plugin.TValue[string]{Data: "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue", State: plugin.StateIsSet},
+		Region: plugin.TValue[string]{Data: "us-east-1", State: plugin.StateIsSet},
+	}
+	q.fetched = true
+	q.queueAtts = atts
+	return q
+}
+
+// A queue with no redrive policy has no maxReceiveCount attribute at all.
+// Reporting 0 made `maxReceiveCount >= 3` fail on queues that never had the
+// setting, and `maxReceiveCount < 100` pass as though it had been measured.
+func TestSqsQueueMaxReceiveCountIsNullWithoutRedrivePolicy(t *testing.T) {
+	q := sqsQueueWithAttributes(map[string]string{
+		"QueueArn":          "arn:aws:sqs:us-east-1:123456789012:MyQueue",
+		"VisibilityTimeout": "30",
+	})
+
+	count, err := q.maxReceiveCount()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+	assert.True(t, q.MaxReceiveCount.IsSet(), "field must be marked resolved")
+	assert.True(t, q.MaxReceiveCount.IsNull(), "absent redrive policy must read null, not 0")
+}
+
+func TestSqsQueueMaxReceiveCountReportsConfiguredLimit(t *testing.T) {
+	q := sqsQueueWithAttributes(map[string]string{
+		"RedrivePolicy": `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:123456789012:dlq","maxReceiveCount":7}`,
+	})
+
+	count, err := q.maxReceiveCount()
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), count)
+	assert.False(t, q.MaxReceiveCount.IsNull(), "a configured limit must not read null")
+}
+
+// A queue whose redrive policy really sets 0 attempts is a measured 0 and must
+// stay distinguishable from the absent case above.
+func TestSqsQueueMaxReceiveCountZeroIsNotNull(t *testing.T) {
+	q := sqsQueueWithAttributes(map[string]string{
+		"RedrivePolicy": `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:123456789012:dlq","maxReceiveCount":0}`,
+	})
+
+	count, err := q.maxReceiveCount()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+	assert.False(t, q.MaxReceiveCount.IsNull(), "a measured 0 must not read null")
 }


### PR DESCRIPTION
Found by validating **all 57 fields** of `aws.sqs` and `aws.sns` against a live account. Seven defects — none of which errored. Each returned a plausible value that was never measured.

## `dataProtectionPolicy` errors on every FIFO topic, everywhere

`GetDataProtectionPolicy` is not supported on FIFO topics and returns `400 InvalidAction`, but only access-denied and 404 were swallowed. Every FIFO topic in every account and region produced a field error.

The field does not exist for FIFO topics, so it reads **null** now. The gate takes its answer from topic attributes already in hand where possible, so no extra API call is made, and the swallow is deliberately narrow — an authorization error, a not-found and a throttle all still surface.

## `maxReceiveCount` invents a `0`

A queue with no redrive policy has **no `RedrivePolicy` attribute at all**, but mql reported `0` as a measured value on 10 of 11 queues. Both directions of check were wrong from the same input:

- `maxReceiveCount >= 3` — **failed** on queues that have no such setting
- `maxReceiveCount < 100` — **passed** as though measured

Null now, while a genuinely configured `0` stays a measured `0`. The decode also stopped treating an absent key as zero, and now tolerates the quoted-number spelling the console has historically written, which previously errored the field outright.

## `signatureVersion` / `tracingConfig` — a deliberate exception, flagged for review

Both returned `""` whenever the attribute was absent, which is most topics, since SNS omits them unless explicitly set. `""` is outside the value set both fields document — and it meant **`signatureVersion == "1"`, the check that finds the weaker setting, missed every topic never explicitly configured.**

They now report the documented service default, and an explicitly set value still wins.

**This is a deliberate departure from "a value that was not read must not be asserted."** These are not unread evidence: the topic *is* signing with version 1 right now, and that fact is established by AWS's documented default. Reporting null would leave the audit check just as broken and additionally break `!= "2"`.

The line I drew against the next defect: an unconfirmed subscription's `confirmationWasAuthenticated` has **no true value at all**, whereas a topic's signature version does. Same principle, opposite answers, for a reason — worth a reviewer's eye.

## Pending subscriptions had their attributes synthesized

For a subscription still awaiting confirmation, `fetchAttributes` fabricated a one-key map, so `rawMessageDelivery`, `confirmationWasAuthenticated`, `filterPolicyScope` and `attributes` were reported as fact although nothing was read. `confirmationWasAuthenticated: false` read as *"not authenticated"* when the truth is *"not yet confirmed"*.

Those four are null now. `pendingConfirmation` stays a measured `true` — the placeholder ARN is itself the evidence.

## Two doc comments that would mislead an audit

- **`sqsManagedSseEnabled`** said *"whether SSE is enabled for the queue"* but reports **SQS-managed SSE only**. A queue encrypted with a customer-managed key correctly reads `false` and, read against that sentence, looks unencrypted.
- **`maxReceiveCount`** described itself as a message limit rather than the redrive receive-attempt count.

Also corrected while in there: `subscription.pendingConfirmation` was documented as the **exact inverse** of what it returns.

## Verified live, before and after

| check | before | after |
|---|---|---|
| FIFO topic `dataProtectionPolicy` | **error** | **null** |
| 10 queues with no redrive policy | `0` | **null** |
| the one queue **with** a redrive policy | `7` | `7` |
| unset `signatureVersion` / `tracingConfig` | `""` / `""` | **`"1"` / `"PassThrough"`** |
| explicitly set to `2` / `Active` | `"2"` / `"Active"` | unchanged |

## Tests

Nine mutations, each producing a specific named failure, then reverted — including two negative controls that guard against over-correcting: a configured `0` must stay a measured `0`, and a **confirmed** subscription must still report its real attributes rather than null.

`aws.lr` doc edits regenerate cleanly; `aws.lr.versions` unchanged, as doc-only edits need no version bump.

## Coverage note

`dataProtectionPolicy`'s non-empty JSON parse path is **unproven** — `PutDataProtectionPolicy` is rejected account-wide ("not supported in this region") in both us-west-2 and us-east-1. The empty path and the FIFO-error path are both proven. Stating it rather than implying full coverage.

## Not included

Two coverage gaps I found but deliberately left out, since they are new schema fields rather than fixes: `aws.sqs.queue` has no `externalAccessFindings` even though Access Analyzer flagged the public **queue** alongside the topic and S3/IAM/KMS/SNS all expose it, and no `kmsDataKeyReusePeriodSeconds`.
