### PR TITLE
🐛 aws: stop reporting Lambda state as empty and unlimited concurrency as zero

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -18181,7 +18181,10 @@ private aws.lambda.function.version @defaults("arn version") {
   // Lifecycle state of this version
   //
   // One of Active, Inactive, Pending, or Failed. Null when the state could not
-  // be read.
+  // be read. ListVersionsByFunction does not carry the state, so reading this
+  // field costs one GetFunctionConfiguration call per version, and a query
+  // shaped like functions { versions { state } } scales with the total number
+  // of versions in the account.
   state() string
 }
 

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -17960,9 +17960,9 @@ private aws.lambda.runtimeManagementConfig @defaults("updateRuntimeOn") {
   updateRuntimeOn string
   // Managed runtime version the function is pinned to
   //
-  // Set only when updateRuntimeOn is Manual. Distinct from the function's own
-  // runtimeVersionArn, which reports the build the function is running right
-  // now whether or not it is pinned.
+  // Set only when updateRuntimeOn is Manual, and null otherwise. Distinct from
+  // the function's own runtimeVersionArn, which reports the build the function
+  // is running right now whether or not it is pinned.
   runtimeVersionArn string
 }
 
@@ -17974,9 +17974,16 @@ private aws.lambda.function @defaults("arn") {
   name string
   // Runtime environment for the function
   runtime string
-  // Concurrency limit for the function
+  // Reserved concurrency limit for the function
+  //
+  // The share of the account's concurrency pool set aside for this function.
+  // A value of 0 is a real setting that throttles the function so it cannot be
+  // invoked at all. Null means no reservation is configured, so the function
+  // draws on the account's unreserved pool.
   concurrency() int
   // Target ARN of the dead-letter queue config
+  //
+  // Null when the function has no dead-letter queue configured.
   dlqTargetArn string
   // Recursive loop detection mode, either "Allow" or "Terminate"
   recursiveLoop() string
@@ -18035,7 +18042,7 @@ private aws.lambda.function @defaults("arn") {
   revisionId string
   // ARN of the resolved managed runtime version the function runs on
   //
-  // Identifies the exact patched build of the managed runtime, distinct from runtimeManagementConfig, which only reports the update mode. Empty for OS-only runtimes and container-image functions.
+  // Identifies the exact patched build of the managed runtime, distinct from runtimeManagementConfig, which only reports the update mode. Empty for OS-only runtimes and container-image functions, and null when the function configuration could not be read.
   runtimeVersionArn() string
   // Human-readable description of the function
   description string
@@ -18049,16 +18056,29 @@ private aws.lambda.function @defaults("arn") {
   // configured. NONE means the function URL is publicly invocable without
   // authentication.
   urlConfigAuthType() string
-  // Current state of the function (Active, Inactive, Pending, Failed, Deactivating, Deactivated, ActiveNonInvocable, Deleting)
-  state string
+  // Current state of the function
+  //
+  // One of Active, Inactive, Pending, Failed, Deactivating, Deactivated,
+  // ActiveNonInvocable, or Deleting. Only Active and ActiveNonInvocable
+  // functions can be invoked. Null when the state could not be read.
+  state() string
   // Size of the function deployment package in bytes
   codeSize int
   // Reason for the function's current state
-  stateReason string
-  // Status of the last function update (Successful, Failed, InProgress)
-  lastUpdateStatus string
+  //
+  // Null when the function is in a state AWS gives no reason for, which is the
+  // usual case for a healthy Active function.
+  stateReason() string
+  // Status of the last function update
+  //
+  // One of Successful, Failed, or InProgress. Null when the status could not
+  // be read.
+  lastUpdateStatus() string
   // Reason for the last update status
-  lastUpdateStatusReason string
+  //
+  // Null when AWS gives no reason, which is the usual case after a successful
+  // update.
+  lastUpdateStatusReason() string
   // KMS key used to encrypt environment variables
   kmsKey() aws.kms.key
   // Environment variables configured for the function
@@ -18158,8 +18178,11 @@ private aws.lambda.function.version @defaults("arn version") {
   timeout int
   // When this version was last modified
   lastModifiedAt time
-  // State: Active, Inactive, Pending, Failed
-  state string
+  // Lifecycle state of this version
+  //
+  // One of Active, Inactive, Pending, or Failed. Null when the state could not
+  // be read.
+  state() string
 }
 
 // AWS Lambda function URL configuration
@@ -18257,6 +18280,9 @@ private aws.lambda.eventSourceMapping @defaults("uuid eventSourceArn") {
   // UUID of the event source mapping
   uuid string
   // Amazon Resource Name (ARN) of the event source mapping
+  //
+  // Reported by the API. Composed from the region, account, and UUID only for
+  // a response that names no ARN.
   arn() string
   // ARN of the event source
   eventSourceArn string
@@ -18273,6 +18299,8 @@ private aws.lambda.eventSourceMapping @defaults("uuid eventSourceArn") {
   // Maximum time in seconds to gather records before invoking the function
   maximumBatchingWindowInSeconds int
   // Number of batches to process concurrently from each shard
+  //
+  // Between 1 and 10. Null for a source that does not use shards, such as SQS.
   parallelizationFactor int
   // Maximum number of retry attempts (-1 for infinite)
   maximumRetryAttempts int
@@ -18289,10 +18317,18 @@ private aws.lambda.eventSourceMapping @defaults("uuid eventSourceArn") {
   // Amazon MQ broker destination queues
   queues []string
   // Duration in seconds of the tumbling window
+  //
+  // Between 0 and 900. Null when the mapping does not aggregate records into
+  // windows.
   tumblingWindowInSeconds int
-  // Position in stream to start reading: AT_TIMESTAMP, LATEST, TRIM_HORIZON
+  // Position in stream to start reading
+  //
+  // One of AT_TIMESTAMP, LATEST, or TRIM_HORIZON. Null for a source that has
+  // no reading position, such as SQS.
   startingPosition string
   // ARN of the on-failure destination
+  //
+  // Null when the mapping has no on-failure destination configured.
   onFailureDestinationArn string
   // Event filtering criteria
   //
@@ -18301,6 +18337,9 @@ private aws.lambda.eventSourceMapping @defaults("uuid eventSourceArn") {
   // are discarded before the function is invoked.
   filterCriteria dict
   // Maximum concurrency for SQS event sources
+  //
+  // Between 2 and 1000. Null when no maximum is configured, leaving the
+  // mapping to scale on the default schedule.
   maximumConcurrency int
 }
 

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -153000,7 +153000,9 @@ func (c *mqlAwsLambdaFunction) GetUrlConfigAuthType() *plugin.TValue[string] {
 }
 
 func (c *mqlAwsLambdaFunction) GetState() *plugin.TValue[string] {
-	return &c.State
+	return plugin.GetOrCompute[string](&c.State, func() (string, error) {
+		return c.state()
+	})
 }
 
 func (c *mqlAwsLambdaFunction) GetCodeSize() *plugin.TValue[int64] {
@@ -153008,15 +153010,21 @@ func (c *mqlAwsLambdaFunction) GetCodeSize() *plugin.TValue[int64] {
 }
 
 func (c *mqlAwsLambdaFunction) GetStateReason() *plugin.TValue[string] {
-	return &c.StateReason
+	return plugin.GetOrCompute[string](&c.StateReason, func() (string, error) {
+		return c.stateReason()
+	})
 }
 
 func (c *mqlAwsLambdaFunction) GetLastUpdateStatus() *plugin.TValue[string] {
-	return &c.LastUpdateStatus
+	return plugin.GetOrCompute[string](&c.LastUpdateStatus, func() (string, error) {
+		return c.lastUpdateStatus()
+	})
 }
 
 func (c *mqlAwsLambdaFunction) GetLastUpdateStatusReason() *plugin.TValue[string] {
-	return &c.LastUpdateStatusReason
+	return plugin.GetOrCompute[string](&c.LastUpdateStatusReason, func() (string, error) {
+		return c.lastUpdateStatusReason()
+	})
 }
 
 func (c *mqlAwsLambdaFunction) GetKmsKey() *plugin.TValue[*mqlAwsKmsKey] {
@@ -153344,7 +153352,9 @@ func (c *mqlAwsLambdaFunctionVersion) GetLastModifiedAt() *plugin.TValue[*time.T
 }
 
 func (c *mqlAwsLambdaFunctionVersion) GetState() *plugin.TValue[string] {
-	return &c.State
+	return plugin.GetOrCompute[string](&c.State, func() (string, error) {
+		return c.state()
+	})
 }
 
 // mqlAwsLambdaFunctionUrlConfig for the aws.lambda.function.urlConfig resource

--- a/providers/aws/resources/aws_guardduty.go
+++ b/providers/aws/resources/aws_guardduty.go
@@ -398,24 +398,39 @@ func parseAwsTimestampPtr(value *string) *time.Time {
 	return parseAwsTimestamp(*value)
 }
 
+// awsTimestampLayouts lists every shape a string timestamp arrives in from the
+// AWS APIs that hand back timestamps as strings instead of typed times. They
+// are tried in order; the first that parses wins.
+var awsTimestampLayouts = []string{
+	// The common case, e.g. "2026-04-09T05:40:04Z" or "2026-04-09T05:40:04+00:00".
+	time.RFC3339,
+	// Some AWS APIs (e.g., Lambda layers) return timestamps with a non-RFC3339
+	// timezone offset like "2026-04-12T18:11:01.019+0000" (missing colon).
+	"2006-01-02T15:04:05.000-0700",
+	// The same offset shape without fractional seconds, e.g. Lambda provisioned
+	// concurrency: "2026-08-31T20:11:24+0000". The layout above demands the
+	// fractional part, so this form needs its own entry.
+	"2006-01-02T15:04:05-0700",
+	// Some AWS APIs (e.g., EC2 Verified Access) return timestamps without
+	// timezone info like "2026-04-09T05:40:04". Read as UTC in that case.
+	"2006-01-02T15:04:05",
+}
+
 func parseAwsTimestamp(value string) *time.Time {
-	timestamp, err := time.Parse(time.RFC3339, value)
-	if err != nil {
-		// Some AWS APIs (e.g., Lambda layers) return timestamps with non-RFC3339
-		// timezone offset like "2026-04-12T18:11:01.019+0000" (missing colon).
-		timestamp, err = time.Parse("2006-01-02T15:04:05.000-0700", value)
+	for _, layout := range awsTimestampLayouts {
+		timestamp, err := time.Parse(layout, value)
 		if err != nil {
-			// Some AWS APIs (e.g., EC2 Verified Access) return timestamps without
-			// timezone info like "2026-04-09T05:40:04". Parse as UTC in that case.
-			timestamp, err = time.Parse("2006-01-02T15:04:05", value)
-			if err != nil {
-				log.Warn().Err(err).Str("timestamp", value).Msg("failed to parse timestamp")
-				return nil
-			}
+			continue
+		}
+		// A layout carrying no zone parses into UTC already; normalizing keeps
+		// the location explicit rather than the zero Location value.
+		if layout == "2006-01-02T15:04:05" {
 			timestamp = timestamp.UTC()
 		}
+		return &timestamp
 	}
-	return &timestamp
+	log.Warn().Str("timestamp", value).Msg("failed to parse timestamp")
+	return nil
 }
 
 func (a *mqlAwsGuarddutyDetector) featureConfigurations() ([]any, error) {

--- a/providers/aws/resources/aws_guardduty_test.go
+++ b/providers/aws/resources/aws_guardduty_test.go
@@ -137,3 +137,90 @@ func TestParseGuardDutyTimestamp(t *testing.T) {
 		assert.Nil(t, parseGuardDutyTimestamp(strPtr("not-a-timestamp")))
 	})
 }
+
+// TestParseAwsTimestampLayouts walks every layout the helper accepts, one case
+// per entry in awsTimestampLayouts. The "+0000" form without fractional
+// seconds is the one Lambda provisioned concurrency returns; before it was
+// added, the layout ahead of it demanded a fractional part, every other layout
+// rejected the offset, and lastModified read null on every provisioned
+// concurrency config in every account.
+func TestParseAwsTimestampLayouts(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		input  string
+		hour   int
+		minute int
+		second int
+		// offsetSeconds is the zone offset the parsed value must carry.
+		offsetSeconds int
+	}{
+		{
+			name:   "RFC3339",
+			input:  "2026-08-31T20:11:24Z",
+			hour:   20,
+			minute: 11,
+			second: 24,
+		},
+		{
+			name:   "numeric offset with fractional seconds",
+			input:  "2026-08-31T20:11:24.019+0000",
+			hour:   20,
+			minute: 11,
+			second: 24,
+		},
+		{
+			name:   "numeric offset without fractional seconds",
+			input:  "2026-08-31T20:11:24+0000",
+			hour:   20,
+			minute: 11,
+			second: 24,
+		},
+		{
+			name:          "negative numeric offset without fractional seconds",
+			input:         "2026-08-31T13:11:24-0700",
+			hour:          13,
+			minute:        11,
+			second:        24,
+			offsetSeconds: -7 * 60 * 60,
+		},
+		{
+			name:   "no timezone",
+			input:  "2026-08-31T20:11:24",
+			hour:   20,
+			minute: 11,
+			second: 24,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := parseAwsTimestamp(tc.input)
+			require.NotNil(t, ts, "layout for %q must parse", tc.input)
+			assert.Equal(t, 2026, ts.Year())
+			assert.Equal(t, time.August, ts.Month())
+			assert.Equal(t, 31, ts.Day())
+			assert.Equal(t, tc.hour, ts.Hour())
+			assert.Equal(t, tc.minute, ts.Minute())
+			assert.Equal(t, tc.second, ts.Second())
+
+			_, offset := ts.Zone()
+			assert.Equal(t, tc.offsetSeconds, offset)
+
+			// Every case above names the same instant, so they must all
+			// normalize to the same UTC time.
+			assert.Equal(t, "2026-08-31T20:11:24Z", ts.UTC().Format(time.RFC3339))
+		})
+	}
+}
+
+// TestParseAwsTimestampRejectsGarbage pins that widening the layout list did
+// not turn the helper into something that accepts anything.
+func TestParseAwsTimestampRejectsGarbage(t *testing.T) {
+	for _, input := range []string{
+		"",
+		"not-a-timestamp",
+		"2026-08-31",
+		"2026-08-31 20:11:24",
+		"2026-08-31T20:11:24+00",
+	} {
+		assert.Nil(t, parseAwsTimestamp(input), "must not parse %q", input)
+	}
+}

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -291,7 +292,7 @@ func newLambdaFunctionResource(runtime *plugin.Runtime, region string, accountID
 	// accessors to read them.
 	if status := lambdaStatusFromConfiguration(&function); status != nil {
 		f.status = status
-		f.statusFetched = true
+		f.statusFetched.Store(true)
 	}
 	f.cacheRoleArn = function.Role
 	f.region = region
@@ -436,7 +437,7 @@ type mqlAwsLambdaFunctionInternal struct {
 	runtimeMgmtResp *lambda.GetRuntimeManagementConfigOutput
 	runtimeMgmtErr  error
 
-	statusFetched bool
+	statusFetched atomic.Bool
 	statusLock    sync.Mutex
 	status        *lambdaFunctionStatus
 }
@@ -550,12 +551,12 @@ func nullOnEmpty(field *plugin.TValue[string], value string) (string, error) {
 // it. A 404 or an access denial leaves the status absent, so those fields read
 // as null rather than as an empty string.
 func (a *mqlAwsLambdaFunction) fetchStatus() (*lambdaFunctionStatus, error) {
-	if a.statusFetched {
+	if a.statusFetched.Load() {
 		return a.status, nil
 	}
 	a.statusLock.Lock()
 	defer a.statusLock.Unlock()
-	if a.statusFetched {
+	if a.statusFetched.Load() {
 		return a.status, nil
 	}
 
@@ -568,18 +569,18 @@ func (a *mqlAwsLambdaFunction) fetchStatus() (*lambdaFunctionStatus, error) {
 	if err != nil {
 		var respErr *http.ResponseError
 		if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
-			a.statusFetched = true
+			a.statusFetched.Store(true)
 			return nil, nil
 		}
 		if Is400AccessDeniedError(err) {
-			a.statusFetched = true
+			a.statusFetched.Store(true)
 			return nil, nil
 		}
 		return nil, err
 	}
 
 	a.status = lambdaStatusFromConfigurationOutput(resp)
-	a.statusFetched = true
+	a.statusFetched.Store(true)
 	return a.status, nil
 }
 
@@ -1788,6 +1789,10 @@ func (a *mqlAwsLambdaFunctionVersion) state() (string, error) {
 		return "", nil
 	}
 
+	// One call per version, and there is no cheaper shape: ListVersionsByFunction
+	// omits State, which is the defect this accessor exists to fix, and Lambda
+	// offers no batch equivalent. GetOrCompute caches the result per version
+	// resource, so the cost is one call per version read, not per access.
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	svc := conn.Lambda(region)
 	resp, err := svc.GetFunctionConfiguration(context.Background(), &lambda.GetFunctionConfigurationInput{

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -149,9 +149,11 @@ func getLambdaArn(name string, region string, accountId string) string {
 // that the lazy accessors depend on. Shared by the list path and the targeted
 // init lookup.
 func newLambdaFunctionResource(runtime *plugin.Runtime, region string, accountID string, function lambdatypes.FunctionConfiguration) (*mqlAwsLambdaFunction, error) {
-	var dlqTarget string
+	// A function with no dead-letter config has no target ARN; reporting ""
+	// would assert "not configured" as a measured value.
+	var dlqTarget *string
 	if function.DeadLetterConfig != nil {
-		dlqTarget = convert.ToValue(function.DeadLetterConfig.TargetArn)
+		dlqTarget = function.DeadLetterConfig.TargetArn
 	}
 
 	// Convert architectures to []any
@@ -239,7 +241,7 @@ func newLambdaFunctionResource(runtime *plugin.Runtime, region string, accountID
 		"arn":                         llx.StringDataPtr(function.FunctionArn),
 		"name":                        llx.StringDataPtr(function.FunctionName),
 		"runtime":                     llx.StringData(string(function.Runtime)),
-		"dlqTargetArn":                llx.StringData(dlqTarget),
+		"dlqTargetArn":                llx.StringDataPtr(dlqTarget),
 		"region":                      llx.StringData(region),
 		"architectures":               llx.ArrayData(architectures, types.String),
 		"ephemeralStorageSize":        llx.IntData(ephemeralStorageSize),
@@ -252,11 +254,7 @@ func newLambdaFunctionResource(runtime *plugin.Runtime, region string, accountID
 		"revisionId":                  llx.StringDataPtr(function.RevisionId),
 		"description":                 llx.StringDataPtr(function.Description),
 		"lastModifiedAt":              llx.TimeDataPtr(lastModifiedAt),
-		"state":                       llx.StringData(string(function.State)),
 		"codeSize":                    llx.IntData(function.CodeSize),
-		"stateReason":                 llx.StringDataPtr(function.StateReason),
-		"lastUpdateStatus":            llx.StringData(string(function.LastUpdateStatus)),
-		"lastUpdateStatusReason":      llx.StringDataPtr(function.LastUpdateStatusReason),
 		"environment":                 llx.MapData(envVars, types.String),
 		"snapStartApplyOn":            llx.StringData(snapStartApplyOn),
 		"snapStartOptimizationStatus": llx.StringData(snapStartOptimizationStatus),
@@ -287,6 +285,14 @@ func newLambdaFunctionResource(runtime *plugin.Runtime, region string, accountID
 	}
 	mqlFunc.(*mqlAwsLambdaFunction).cacheKmsKeyArn = convert.ToValue(function.KMSKeyArn)
 	f := mqlFunc.(*mqlAwsLambdaFunction)
+	// A GetFunction lookup already carries the lifecycle fields, so seeding the
+	// memo here spares that path the extra GetFunctionConfiguration call. A
+	// ListFunctions summary carries none of them and seeds nothing, leaving the
+	// accessors to read them.
+	if status := lambdaStatusFromConfiguration(&function); status != nil {
+		f.status = status
+		f.statusFetched = true
+	}
 	f.cacheRoleArn = function.Role
 	f.region = region
 	f.accountID = accountID
@@ -429,6 +435,184 @@ type mqlAwsLambdaFunctionInternal struct {
 	runtimeMgmtOnce sync.Once
 	runtimeMgmtResp *lambda.GetRuntimeManagementConfigOutput
 	runtimeMgmtErr  error
+
+	statusFetched bool
+	statusLock    sync.Mutex
+	status        *lambdaFunctionStatus
+}
+
+// lambdaFunctionStatus carries the lifecycle values that only a per-function
+// configuration lookup reports. The ListFunctions summary omits every one of
+// them, so a function reached through the list has to read them separately.
+type lambdaFunctionStatus struct {
+	state                  string
+	stateReason            *string
+	lastUpdateStatus       string
+	lastUpdateStatusReason *string
+	runtimeVersionArn      *string
+}
+
+// State reports the function lifecycle state, empty when nothing was read.
+func (s *lambdaFunctionStatus) State() string {
+	if s == nil {
+		return ""
+	}
+	return s.state
+}
+
+// StateReason reports why the function is in its current state, empty when
+// nothing was read or AWS gave no reason.
+func (s *lambdaFunctionStatus) StateReason() string {
+	if s == nil {
+		return ""
+	}
+	return convert.ToValue(s.stateReason)
+}
+
+// LastUpdateStatus reports the outcome of the most recent update, empty when
+// nothing was read.
+func (s *lambdaFunctionStatus) LastUpdateStatus() string {
+	if s == nil {
+		return ""
+	}
+	return s.lastUpdateStatus
+}
+
+// LastUpdateStatusReason reports why the most recent update ended the way it
+// did, empty when nothing was read or AWS gave no reason.
+func (s *lambdaFunctionStatus) LastUpdateStatusReason() string {
+	if s == nil {
+		return ""
+	}
+	return convert.ToValue(s.lastUpdateStatusReason)
+}
+
+// RuntimeVersionArn reports the patched managed-runtime build the function
+// runs on, empty when nothing was read or the runtime has no versioned build.
+func (s *lambdaFunctionStatus) RuntimeVersionArn() string {
+	if s == nil {
+		return ""
+	}
+	return convert.ToValue(s.runtimeVersionArn)
+}
+
+// lambdaStatusFromConfiguration reads the lifecycle values off a function
+// configuration, returning nil when the configuration carries none of them.
+// ListFunctions returns a summary with State, StateReason, LastUpdateStatus,
+// LastUpdateStatusReason and RuntimeVersionConfig all absent; treating that
+// summary as a status would report "" for every function in every account.
+// A real configuration always names a state.
+func lambdaStatusFromConfiguration(cfg *lambdatypes.FunctionConfiguration) *lambdaFunctionStatus {
+	if cfg == nil || cfg.State == "" {
+		return nil
+	}
+	status := &lambdaFunctionStatus{
+		state:                  string(cfg.State),
+		stateReason:            cfg.StateReason,
+		lastUpdateStatus:       string(cfg.LastUpdateStatus),
+		lastUpdateStatusReason: cfg.LastUpdateStatusReason,
+	}
+	if cfg.RuntimeVersionConfig != nil {
+		status.runtimeVersionArn = cfg.RuntimeVersionConfig.RuntimeVersionArn
+	}
+	return status
+}
+
+// lambdaStatusFromConfigurationOutput reads the lifecycle values off a
+// GetFunctionConfiguration response, which flattens the same fields the
+// FunctionConfiguration struct nests.
+func lambdaStatusFromConfigurationOutput(resp *lambda.GetFunctionConfigurationOutput) *lambdaFunctionStatus {
+	if resp == nil {
+		return nil
+	}
+	return lambdaStatusFromConfiguration(&lambdatypes.FunctionConfiguration{
+		State:                  resp.State,
+		StateReason:            resp.StateReason,
+		LastUpdateStatus:       resp.LastUpdateStatus,
+		LastUpdateStatusReason: resp.LastUpdateStatusReason,
+		RuntimeVersionConfig:   resp.RuntimeVersionConfig,
+	})
+}
+
+// nullOnEmpty reports value, marking the field null when the value is empty.
+// The callers read values that AWS either names or omits entirely, so an empty
+// string means the value was never read and must not be asserted as measured.
+func nullOnEmpty(field *plugin.TValue[string], value string) (string, error) {
+	if value == "" {
+		field.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
+	return value, nil
+}
+
+// fetchStatus resolves the lifecycle values a ListFunctions summary omits,
+// with one GetFunctionConfiguration call shared by every field derived from
+// it. A 404 or an access denial leaves the status absent, so those fields read
+// as null rather than as an empty string.
+func (a *mqlAwsLambdaFunction) fetchStatus() (*lambdaFunctionStatus, error) {
+	if a.statusFetched {
+		return a.status, nil
+	}
+	a.statusLock.Lock()
+	defer a.statusLock.Unlock()
+	if a.statusFetched {
+		return a.status, nil
+	}
+
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Lambda(a.Region.Data)
+	funcName := a.Name.Data
+	resp, err := svc.GetFunctionConfiguration(context.Background(), &lambda.GetFunctionConfigurationInput{
+		FunctionName: &funcName,
+	})
+	if err != nil {
+		var respErr *http.ResponseError
+		if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
+			a.statusFetched = true
+			return nil, nil
+		}
+		if Is400AccessDeniedError(err) {
+			a.statusFetched = true
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	a.status = lambdaStatusFromConfigurationOutput(resp)
+	a.statusFetched = true
+	return a.status, nil
+}
+
+func (a *mqlAwsLambdaFunction) state() (string, error) {
+	status, err := a.fetchStatus()
+	if err != nil {
+		return "", err
+	}
+	return nullOnEmpty(&a.State, status.State())
+}
+
+func (a *mqlAwsLambdaFunction) stateReason() (string, error) {
+	status, err := a.fetchStatus()
+	if err != nil {
+		return "", err
+	}
+	return nullOnEmpty(&a.StateReason, status.StateReason())
+}
+
+func (a *mqlAwsLambdaFunction) lastUpdateStatus() (string, error) {
+	status, err := a.fetchStatus()
+	if err != nil {
+		return "", err
+	}
+	return nullOnEmpty(&a.LastUpdateStatus, status.LastUpdateStatus())
+}
+
+func (a *mqlAwsLambdaFunction) lastUpdateStatusReason() (string, error) {
+	status, err := a.fetchStatus()
+	if err != nil {
+		return "", err
+	}
+	return nullOnEmpty(&a.LastUpdateStatusReason, status.LastUpdateStatusReason())
 }
 
 // fetchImageData resolves the container image URIs for Image package type
@@ -639,14 +823,24 @@ func (a *mqlAwsLambdaFunction) concurrency() (int64, error) {
 	functionConcurrency, err := svc.GetFunctionConcurrency(ctx, &lambda.GetFunctionConcurrencyInput{FunctionName: &funcName})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
+			a.Concurrency.State = plugin.StateIsSet | plugin.StateIsNull
 			return 0, nil
 		}
 		return 0, errors.Wrap(err, "could not gather aws lambda function concurrency")
 	}
-	if functionConcurrency.ReservedConcurrentExecutions == nil {
+	return reservedConcurrency(&a.Concurrency, functionConcurrency.ReservedConcurrentExecutions)
+}
+
+// reservedConcurrency reports a function's reserved concurrency, keeping an
+// absent reservation distinct from a reservation of zero. They are opposite
+// postures: no reservation draws on the account's unreserved pool, while a
+// reservation of zero throttles the function so it cannot be invoked at all.
+func reservedConcurrency(field *plugin.TValue[int64], reserved *int32) (int64, error) {
+	if reserved == nil {
+		field.State = plugin.StateIsSet | plugin.StateIsNull
 		return 0, nil
 	}
-	return int64(*functionConcurrency.ReservedConcurrentExecutions), nil
+	return int64(*reserved), nil
 }
 
 func (a *mqlAwsLambdaFunction) policy() (any, error) {
@@ -1054,9 +1248,31 @@ func (a *mqlAwsLambda) getEventSourceMappings(conn *connection.AwsConnection) []
 // createEventSourceMappingResource creates an aws.lambda.eventSourceMapping resource from SDK data.
 // Shared between top-level listing and per-function listing to ensure cache reuse via UUID-based __id.
 func createEventSourceMappingResource(runtime *plugin.Runtime, esm lambdatypes.EventSourceMappingConfiguration, region string) (*mqlAwsLambdaEventSourceMapping, error) {
-	var onFailureDestinationArn string
+	args, err := eventSourceMappingArgs(esm, region)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := CreateResource(runtime, "aws.lambda.eventSourceMapping", args)
+	if err != nil {
+		return nil, err
+	}
+	mqlEsm := res.(*mqlAwsLambdaEventSourceMapping)
+	mqlEsm.cacheFunctionArn = convert.ToValue(esm.FunctionArn)
+	mqlEsm.cacheArn = convert.ToValue(esm.EventSourceMappingArn)
+	return mqlEsm, nil
+}
+
+// eventSourceMappingArgs maps an SDK event source mapping into resource
+// arguments. Settings the mapping does not carry stay null: zero is outside
+// the valid range of parallelizationFactor (1-10) and maximumConcurrency
+// (2-1000), so reporting it would name a value that cannot exist. The -1
+// fallbacks on maximumRetryAttempts and maximumRecordAgeInSeconds are the
+// documented "retry forever" and "no maximum age" sentinels, not stand-ins.
+func eventSourceMappingArgs(esm lambdatypes.EventSourceMappingConfiguration, region string) (map[string]*llx.RawData, error) {
+	var onFailureDestinationArn *string
 	if esm.DestinationConfig != nil && esm.DestinationConfig.OnFailure != nil {
-		onFailureDestinationArn = convert.ToValue(esm.DestinationConfig.OnFailure.Destination)
+		onFailureDestinationArn = esm.DestinationConfig.OnFailure.Destination
 	}
 
 	filterCriteria, err := convert.JsonToDict(esm.FilterCriteria)
@@ -1064,40 +1280,41 @@ func createEventSourceMappingResource(runtime *plugin.Runtime, esm lambdatypes.E
 		return nil, err
 	}
 
-	var maximumConcurrency int64
-	if esm.ScalingConfig != nil && esm.ScalingConfig.MaximumConcurrency != nil {
-		maximumConcurrency = int64(*esm.ScalingConfig.MaximumConcurrency)
+	var maximumConcurrency *int32
+	if esm.ScalingConfig != nil {
+		maximumConcurrency = esm.ScalingConfig.MaximumConcurrency
 	}
 
-	res, err := CreateResource(runtime, "aws.lambda.eventSourceMapping",
-		map[string]*llx.RawData{
-			"__id":                           llx.StringDataPtr(esm.UUID),
-			"uuid":                           llx.StringDataPtr(esm.UUID),
-			"eventSourceArn":                 llx.StringDataPtr(esm.EventSourceArn),
-			"region":                         llx.StringData(region),
-			"state":                          llx.StringDataPtr(esm.State),
-			"stateTransitionReason":          llx.StringDataPtr(esm.StateTransitionReason),
-			"batchSize":                      llx.IntDataDefault(esm.BatchSize, 0),
-			"maximumBatchingWindowInSeconds": llx.IntDataDefault(esm.MaximumBatchingWindowInSeconds, 0),
-			"parallelizationFactor":          llx.IntDataDefault(esm.ParallelizationFactor, 0),
-			"maximumRetryAttempts":           llx.IntDataDefault(esm.MaximumRetryAttempts, -1),
-			"maximumRecordAgeInSeconds":      llx.IntDataDefault(esm.MaximumRecordAgeInSeconds, -1),
-			"bisectBatchOnFunctionError":     llx.BoolDataPtr(esm.BisectBatchOnFunctionError),
-			"lastModified":                   llx.TimeDataPtr(esm.LastModified),
-			"lastProcessingResult":           llx.StringDataPtr(esm.LastProcessingResult),
-			"topics":                         llx.ArrayData(toInterfaceArr(esm.Topics), types.String),
-			"queues":                         llx.ArrayData(toInterfaceArr(esm.Queues), types.String),
-			"tumblingWindowInSeconds":        llx.IntDataDefault(esm.TumblingWindowInSeconds, 0),
-			"startingPosition":               llx.StringData(string(esm.StartingPosition)),
-			"onFailureDestinationArn":        llx.StringData(onFailureDestinationArn),
-			"filterCriteria":                 llx.DictData(filterCriteria),
-			"maximumConcurrency":             llx.IntData(maximumConcurrency),
-		})
-	if err != nil {
-		return nil, err
+	// StartingPosition is only meaningful for stream and Kafka sources; an SQS
+	// mapping has none, and "" is not one of its documented values.
+	startingPosition := llx.NilData
+	if esm.StartingPosition != "" {
+		startingPosition = llx.StringData(string(esm.StartingPosition))
 	}
-	res.(*mqlAwsLambdaEventSourceMapping).cacheFunctionArn = convert.ToValue(esm.FunctionArn)
-	return res.(*mqlAwsLambdaEventSourceMapping), nil
+
+	return map[string]*llx.RawData{
+		"__id":                           llx.StringDataPtr(esm.UUID),
+		"uuid":                           llx.StringDataPtr(esm.UUID),
+		"eventSourceArn":                 llx.StringDataPtr(esm.EventSourceArn),
+		"region":                         llx.StringData(region),
+		"state":                          llx.StringDataPtr(esm.State),
+		"stateTransitionReason":          llx.StringDataPtr(esm.StateTransitionReason),
+		"batchSize":                      llx.IntDataDefault(esm.BatchSize, 0),
+		"maximumBatchingWindowInSeconds": llx.IntDataDefault(esm.MaximumBatchingWindowInSeconds, 0),
+		"parallelizationFactor":          llx.IntDataPtr(esm.ParallelizationFactor),
+		"maximumRetryAttempts":           llx.IntDataDefault(esm.MaximumRetryAttempts, -1),
+		"maximumRecordAgeInSeconds":      llx.IntDataDefault(esm.MaximumRecordAgeInSeconds, -1),
+		"bisectBatchOnFunctionError":     llx.BoolDataPtr(esm.BisectBatchOnFunctionError),
+		"lastModified":                   llx.TimeDataPtr(esm.LastModified),
+		"lastProcessingResult":           llx.StringDataPtr(esm.LastProcessingResult),
+		"topics":                         llx.ArrayData(toInterfaceArr(esm.Topics), types.String),
+		"queues":                         llx.ArrayData(toInterfaceArr(esm.Queues), types.String),
+		"tumblingWindowInSeconds":        llx.IntDataPtr(esm.TumblingWindowInSeconds),
+		"startingPosition":               startingPosition,
+		"onFailureDestinationArn":        llx.StringDataPtr(onFailureDestinationArn),
+		"filterCriteria":                 llx.DictData(filterCriteria),
+		"maximumConcurrency":             llx.IntDataPtr(maximumConcurrency),
+	}, nil
 }
 
 func (a *mqlAwsLambdaEventSourceMapping) id() (string, error) {
@@ -1106,9 +1323,23 @@ func (a *mqlAwsLambdaEventSourceMapping) id() (string, error) {
 
 const lambdaEventSourceMappingArnPattern = "arn:aws:lambda:%s:%s:event-source-mapping:%s"
 
+// eventSourceMappingArn prefers the ARN the API returns. The composed fallback
+// hardcodes the `aws` partition, which is wrong in GovCloud (`aws-us-gov`) and
+// China (`aws-cn`); it is kept only for a response that names no ARN.
+func eventSourceMappingArn(sdkArn string, region string, accountID string, uuid string) string {
+	if sdkArn != "" {
+		return sdkArn
+	}
+	return fmt.Sprintf(lambdaEventSourceMappingArnPattern, region, accountID, uuid)
+}
+
 func (a *mqlAwsLambdaEventSourceMapping) arn() (string, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	return fmt.Sprintf(lambdaEventSourceMappingArnPattern, a.Region.Data, conn.AccountId(), a.Uuid.Data), nil
+	accountID := ""
+	if a.cacheArn == "" {
+		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+		accountID = conn.AccountId()
+	}
+	return eventSourceMappingArn(a.cacheArn, a.Region.Data, accountID, a.Uuid.Data), nil
 }
 
 func (a *mqlAwsLambdaEventSourceMapping) function() (*mqlAwsLambdaFunction, error) {
@@ -1376,33 +1607,19 @@ func (a *mqlAwsLambdaFunction) eventInvokeConfig() (any, error) {
 
 // runtimeVersionArn resolves the exact patched managed-runtime build the
 // function runs on. The ListFunctions summary omits RuntimeVersionConfig, so
-// this is fetched per function via GetFunctionConfiguration.
+// it shares the per-function configuration lookup with the lifecycle fields.
+// It stays empty for runtimes that have no versioned build, and reads null
+// when the configuration could not be read at all.
 func (a *mqlAwsLambdaFunction) runtimeVersionArn() (string, error) {
-	funcName := a.Name.Data
-	region := a.Region.Data
-	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-
-	svc := conn.Lambda(region)
-	ctx := context.Background()
-
-	resp, err := svc.GetFunctionConfiguration(ctx, &lambda.GetFunctionConfigurationInput{
-		FunctionName: &funcName,
-	})
+	status, err := a.fetchStatus()
 	if err != nil {
-		var respErr *http.ResponseError
-		if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
-			return "", nil
-		}
-		if Is400AccessDeniedError(err) {
-			return "", nil
-		}
 		return "", err
 	}
-
-	if resp.RuntimeVersionConfig != nil {
-		return convert.ToValue(resp.RuntimeVersionConfig.RuntimeVersionArn), nil
+	if status == nil {
+		a.RuntimeVersionArn.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
 	}
-	return "", nil
+	return status.RuntimeVersionArn(), nil
 }
 
 func (a *mqlAwsLambdaFunction) runtimeManagementConfig() (any, error) {
@@ -1473,15 +1690,24 @@ func (a *mqlAwsLambdaFunction) runtimeManagement() (*mqlAwsLambdaRuntimeManageme
 		a.RuntimeManagement.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	res, err := CreateResource(a.MqlRuntime, "aws.lambda.runtimeManagementConfig", map[string]*llx.RawData{
-		"__id":              llx.StringData(a.Arn.Data + "/runtimeManagementConfig"),
-		"updateRuntimeOn":   llx.StringData(string(resp.UpdateRuntimeOn)),
-		"runtimeVersionArn": llx.StringData(convert.ToValue(resp.RuntimeVersionArn)),
-	})
+	res, err := CreateResource(a.MqlRuntime, "aws.lambda.runtimeManagementConfig",
+		runtimeManagementArgs(a.Arn.Data, resp))
 	if err != nil {
 		return nil, err
 	}
 	return res.(*mqlAwsLambdaRuntimeManagementConfig), nil
+}
+
+// runtimeManagementArgs maps a runtime management response into resource
+// arguments. AWS omits the pinned version for a function on Auto updates, so
+// runtimeVersionArn stays null there rather than claiming an empty ARN, which
+// is what the deprecated dict this resource replaces already did.
+func runtimeManagementArgs(functionArn string, resp *lambda.GetRuntimeManagementConfigOutput) map[string]*llx.RawData {
+	return map[string]*llx.RawData{
+		"__id":              llx.StringData(functionArn + "/runtimeManagementConfig"),
+		"updateRuntimeOn":   llx.StringData(string(resp.UpdateRuntimeOn)),
+		"runtimeVersionArn": llx.StringDataPtr(resp.RuntimeVersionArn),
+	}
 }
 
 // ==================== Types ====================
@@ -1527,7 +1753,6 @@ func (a *mqlAwsLambdaFunction) versions() ([]any, error) {
 					"memorySize":     llx.IntDataDefault(v.MemorySize, 0),
 					"timeout":        llx.IntDataDefault(v.Timeout, 3),
 					"lastModifiedAt": llx.TimeDataPtr(lastModifiedAt),
-					"state":          llx.StringData(string(v.State)),
 				})
 			if err != nil {
 				return nil, err
@@ -1540,6 +1765,47 @@ func (a *mqlAwsLambdaFunction) versions() ([]any, error) {
 
 func (a *mqlAwsLambdaFunctionVersion) id() (string, error) {
 	return a.Arn.Data, nil
+}
+
+// lambdaRegionFromArn pulls the region out of a Lambda ARN, returning "" when
+// the value is not a parseable ARN.
+func lambdaRegionFromArn(value string) string {
+	parsed, err := arn.Parse(value)
+	if err != nil {
+		return ""
+	}
+	return parsed.Region
+}
+
+// state resolves the version's lifecycle state. ListVersionsByFunction omits
+// State on every entry it returns, so the version is read by its own
+// qualified ARN. It reads null when the state could not be read at all.
+func (a *mqlAwsLambdaFunctionVersion) state() (string, error) {
+	versionArn := a.Arn.Data
+	region := lambdaRegionFromArn(versionArn)
+	if region == "" {
+		a.State.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
+
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Lambda(region)
+	resp, err := svc.GetFunctionConfiguration(context.Background(), &lambda.GetFunctionConfigurationInput{
+		FunctionName: &versionArn,
+	})
+	if err != nil {
+		var respErr *http.ResponseError
+		if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
+			a.State.State = plugin.StateIsSet | plugin.StateIsNull
+			return "", nil
+		}
+		if Is400AccessDeniedError(err) {
+			a.State.State = plugin.StateIsSet | plugin.StateIsNull
+			return "", nil
+		}
+		return "", err
+	}
+	return nullOnEmpty(&a.State, string(resp.State))
 }
 
 // ==================== Per-Layer Versions ====================
@@ -1604,4 +1870,5 @@ func (a *mqlAwsLambdaLayerVersion) id() (string, error) {
 
 type mqlAwsLambdaEventSourceMappingInternal struct {
 	cacheFunctionArn string
+	cacheArn         string
 }

--- a/providers/aws/resources/aws_lambda_test.go
+++ b/providers/aws/resources/aws_lambda_test.go
@@ -6,9 +6,14 @@ package resources
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/types"
 )
 
 func TestGetLambdaArn(t *testing.T) {
@@ -67,4 +72,378 @@ func TestGetLambdaArnFromRawDataArgs(t *testing.T) {
 	assert.Equal(t,
 		"arn:aws:lambda:us-east-1:123456789012:function:my-function",
 		getLambdaArn(name, region, "123456789012"))
+}
+
+// TestLambdaStatusFromConfiguration pins the difference between a
+// ListFunctions summary and a real function configuration. ListFunctions
+// returns none of the lifecycle fields, so reading them off a summary reported
+// "" as a measured state for every function in every account, and
+// `functions.all(state == "Active")` failed everywhere.
+func TestLambdaStatusFromConfiguration(t *testing.T) {
+	t.Run("nil configuration carries no status", func(t *testing.T) {
+		assert.Nil(t, lambdaStatusFromConfiguration(nil))
+	})
+
+	t.Run("ListFunctions summary carries no status", func(t *testing.T) {
+		// The shape ListFunctions actually returns: identity and code
+		// settings, no lifecycle fields at all.
+		summary := lambdatypes.FunctionConfiguration{
+			FunctionName: aws.String("my-function"),
+			FunctionArn:  aws.String("arn:aws:lambda:us-east-1:123456789012:function:my-function"),
+			Runtime:      lambdatypes.RuntimePython313,
+			MemorySize:   aws.Int32(128),
+		}
+		assert.Nil(t, lambdaStatusFromConfiguration(&summary))
+	})
+
+	t.Run("GetFunction configuration carries the status", func(t *testing.T) {
+		cfg := lambdatypes.FunctionConfiguration{
+			FunctionName:     aws.String("my-function"),
+			State:            lambdatypes.StateActive,
+			LastUpdateStatus: lambdatypes.LastUpdateStatusSuccessful,
+			RuntimeVersionConfig: &lambdatypes.RuntimeVersionConfig{
+				RuntimeVersionArn: aws.String("arn:aws:lambda:us-east-1::runtime:abc123"),
+			},
+		}
+		status := lambdaStatusFromConfiguration(&cfg)
+		require.NotNil(t, status)
+		assert.Equal(t, "Active", status.State())
+		assert.Equal(t, "Successful", status.LastUpdateStatus())
+		assert.Equal(t, "arn:aws:lambda:us-east-1::runtime:abc123", status.RuntimeVersionArn())
+		// AWS names no reason for a healthy function.
+		assert.Equal(t, "", status.StateReason())
+		assert.Equal(t, "", status.LastUpdateStatusReason())
+	})
+
+	t.Run("failed function reports its reasons", func(t *testing.T) {
+		cfg := lambdatypes.FunctionConfiguration{
+			State:                  lambdatypes.StateFailed,
+			StateReason:            aws.String("The function is missing its VPC configuration"),
+			LastUpdateStatus:       lambdatypes.LastUpdateStatusFailed,
+			LastUpdateStatusReason: aws.String("ENI limit exceeded"),
+		}
+		status := lambdaStatusFromConfiguration(&cfg)
+		require.NotNil(t, status)
+		assert.Equal(t, "Failed", status.State())
+		assert.Equal(t, "The function is missing its VPC configuration", status.StateReason())
+		assert.Equal(t, "Failed", status.LastUpdateStatus())
+		assert.Equal(t, "ENI limit exceeded", status.LastUpdateStatusReason())
+	})
+}
+
+func TestLambdaStatusFromConfigurationOutput(t *testing.T) {
+	t.Run("flattened response carries the status", func(t *testing.T) {
+		resp := &lambda.GetFunctionConfigurationOutput{
+			State:            lambdatypes.StateInactive,
+			StateReason:      aws.String("Function is idle"),
+			LastUpdateStatus: lambdatypes.LastUpdateStatusInProgress,
+			RuntimeVersionConfig: &lambdatypes.RuntimeVersionConfig{
+				RuntimeVersionArn: aws.String("arn:aws:lambda:eu-west-1::runtime:def456"),
+			},
+		}
+		status := lambdaStatusFromConfigurationOutput(resp)
+		require.NotNil(t, status)
+		assert.Equal(t, "Inactive", status.State())
+		assert.Equal(t, "Function is idle", status.StateReason())
+		assert.Equal(t, "InProgress", status.LastUpdateStatus())
+		assert.Equal(t, "arn:aws:lambda:eu-west-1::runtime:def456", status.RuntimeVersionArn())
+	})
+
+	t.Run("nil response carries no status", func(t *testing.T) {
+		assert.Nil(t, lambdaStatusFromConfigurationOutput(nil))
+	})
+}
+
+// TestLambdaFunctionStatusAccessorsReportNullWhenUnread covers the branch the
+// 404 and access-denied paths land in: the lookup ran and returned nothing, so
+// every field derived from it has to read null rather than "".
+func TestLambdaFunctionStatusAccessorsReportNullWhenUnread(t *testing.T) {
+	newUnread := func() *mqlAwsLambdaFunction {
+		fn := &mqlAwsLambdaFunction{}
+		// What fetchStatus leaves behind on a 404 or an access denial.
+		fn.statusFetched = true
+		return fn
+	}
+
+	t.Run("state", func(t *testing.T) {
+		fn := newUnread()
+		v, err := fn.state()
+		require.NoError(t, err)
+		assert.Equal(t, "", v)
+		assert.True(t, fn.State.IsSet())
+		assert.True(t, fn.State.IsNull())
+	})
+
+	t.Run("stateReason", func(t *testing.T) {
+		fn := newUnread()
+		v, err := fn.stateReason()
+		require.NoError(t, err)
+		assert.Equal(t, "", v)
+		assert.True(t, fn.StateReason.IsSet())
+		assert.True(t, fn.StateReason.IsNull())
+	})
+
+	t.Run("lastUpdateStatus", func(t *testing.T) {
+		fn := newUnread()
+		v, err := fn.lastUpdateStatus()
+		require.NoError(t, err)
+		assert.Equal(t, "", v)
+		assert.True(t, fn.LastUpdateStatus.IsSet())
+		assert.True(t, fn.LastUpdateStatus.IsNull())
+	})
+
+	t.Run("lastUpdateStatusReason", func(t *testing.T) {
+		fn := newUnread()
+		v, err := fn.lastUpdateStatusReason()
+		require.NoError(t, err)
+		assert.Equal(t, "", v)
+		assert.True(t, fn.LastUpdateStatusReason.IsSet())
+		assert.True(t, fn.LastUpdateStatusReason.IsNull())
+	})
+
+	t.Run("runtimeVersionArn", func(t *testing.T) {
+		fn := newUnread()
+		v, err := fn.runtimeVersionArn()
+		require.NoError(t, err)
+		assert.Equal(t, "", v)
+		assert.True(t, fn.RuntimeVersionArn.IsSet())
+		assert.True(t, fn.RuntimeVersionArn.IsNull())
+	})
+}
+
+// TestLambdaFunctionStatusAccessorsReadSeededStatus exercises the accessors
+// against a status seeded the way newLambdaFunctionResource seeds it from a
+// GetFunction lookup, so no configuration call is needed.
+func TestLambdaFunctionStatusAccessorsReadSeededStatus(t *testing.T) {
+	cfg := lambdatypes.FunctionConfiguration{
+		State:            lambdatypes.StateActive,
+		LastUpdateStatus: lambdatypes.LastUpdateStatusSuccessful,
+	}
+
+	fn := &mqlAwsLambdaFunction{}
+	if status := lambdaStatusFromConfiguration(&cfg); status != nil {
+		fn.status = status
+		fn.statusFetched = true
+	}
+
+	state, err := fn.state()
+	require.NoError(t, err)
+	assert.Equal(t, "Active", state)
+	assert.False(t, fn.State.IsNull())
+
+	lastUpdate, err := fn.lastUpdateStatus()
+	require.NoError(t, err)
+	assert.Equal(t, "Successful", lastUpdate)
+	assert.False(t, fn.LastUpdateStatus.IsNull())
+
+	// A healthy function has no reason, and an absent reason is null.
+	reason, err := fn.stateReason()
+	require.NoError(t, err)
+	assert.Equal(t, "", reason)
+	assert.True(t, fn.StateReason.IsNull())
+}
+
+func TestNullOnEmpty(t *testing.T) {
+	t.Run("empty value marks the field null", func(t *testing.T) {
+		var field plugin.TValue[string]
+		v, err := nullOnEmpty(&field, "")
+		require.NoError(t, err)
+		assert.Equal(t, "", v)
+		assert.True(t, field.IsSet())
+		assert.True(t, field.IsNull())
+	})
+
+	t.Run("real value passes through untouched", func(t *testing.T) {
+		var field plugin.TValue[string]
+		v, err := nullOnEmpty(&field, "Active")
+		require.NoError(t, err)
+		assert.Equal(t, "Active", v)
+		assert.False(t, field.IsNull())
+	})
+}
+
+// TestReservedConcurrency pins the distinction a hard 0 destroyed: a reserved
+// concurrency of 0 throttles the function so it cannot be invoked, while no
+// reservation lets it draw on the account's unreserved pool. Reporting 0 for
+// both inverted the security posture of every unreserved function.
+func TestReservedConcurrency(t *testing.T) {
+	t.Run("absent reservation reads null", func(t *testing.T) {
+		var field plugin.TValue[int64]
+		v, err := reservedConcurrency(&field, nil)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), v)
+		assert.True(t, field.IsSet())
+		assert.True(t, field.IsNull())
+	})
+
+	t.Run("explicit zero reads as a real zero", func(t *testing.T) {
+		var field plugin.TValue[int64]
+		v, err := reservedConcurrency(&field, aws.Int32(0))
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), v)
+		assert.False(t, field.IsNull())
+	})
+
+	t.Run("the two are distinguishable", func(t *testing.T) {
+		var absent, throttled plugin.TValue[int64]
+		absentVal, err := reservedConcurrency(&absent, nil)
+		require.NoError(t, err)
+		throttledVal, err := reservedConcurrency(&throttled, aws.Int32(0))
+		require.NoError(t, err)
+
+		assert.Equal(t, absentVal, throttledVal)
+		assert.NotEqual(t, absent.IsNull(), throttled.IsNull())
+	})
+
+	t.Run("a real reservation passes through", func(t *testing.T) {
+		var field plugin.TValue[int64]
+		v, err := reservedConcurrency(&field, aws.Int32(50))
+		require.NoError(t, err)
+		assert.Equal(t, int64(50), v)
+		assert.False(t, field.IsNull())
+	})
+}
+
+// TestEventSourceMappingArn pins that the ARN comes from the API. The composed
+// fallback hardcodes the `aws` partition, which names a resource that does not
+// exist in GovCloud or China.
+func TestEventSourceMappingArn(t *testing.T) {
+	t.Run("uses the ARN the API reports", func(t *testing.T) {
+		sdkArn := "arn:aws-us-gov:lambda:us-gov-west-1:123456789012:event-source-mapping:8bd1f2a4-1c3e-4d5f-9a0b-1c2d3e4f5a6b"
+		got := eventSourceMappingArn(sdkArn, "us-gov-west-1", "123456789012",
+			"8bd1f2a4-1c3e-4d5f-9a0b-1c2d3e4f5a6b")
+		assert.Equal(t, sdkArn, got)
+	})
+
+	t.Run("composes only when the API names no ARN", func(t *testing.T) {
+		got := eventSourceMappingArn("", "us-east-1", "123456789012",
+			"8bd1f2a4-1c3e-4d5f-9a0b-1c2d3e4f5a6b")
+		assert.Equal(t,
+			"arn:aws:lambda:us-east-1:123456789012:event-source-mapping:8bd1f2a4-1c3e-4d5f-9a0b-1c2d3e4f5a6b",
+			got)
+	})
+}
+
+func TestLambdaRegionFromArn(t *testing.T) {
+	t.Run("qualified version ARN", func(t *testing.T) {
+		assert.Equal(t, "eu-central-1",
+			lambdaRegionFromArn("arn:aws:lambda:eu-central-1:123456789012:function:my-function:3"))
+	})
+
+	t.Run("unqualified function ARN", func(t *testing.T) {
+		assert.Equal(t, "us-east-1",
+			lambdaRegionFromArn("arn:aws:lambda:us-east-1:123456789012:function:my-function"))
+	})
+
+	t.Run("non-ARN value has no region", func(t *testing.T) {
+		assert.Equal(t, "", lambdaRegionFromArn("my-function"))
+	})
+}
+
+// rawDataIsNull reports whether a resource argument was handed over as null.
+func rawDataIsNull(t *testing.T, args map[string]*llx.RawData, key string) bool {
+	t.Helper()
+	raw, ok := args[key]
+	require.True(t, ok, "argument %q missing", key)
+	return raw.Type == types.Nil
+}
+
+// TestEventSourceMappingArgsAbsentSettings pins that settings an SQS mapping
+// does not carry stay null. Zero is outside the valid range of
+// parallelizationFactor (1-10) and maximumConcurrency (2-1000), so reporting
+// it named a value that cannot exist.
+func TestEventSourceMappingArgsAbsentSettings(t *testing.T) {
+	// The shape an SQS mapping comes back as: no shards, no window, no scaling
+	// config, no starting position, no on-failure destination.
+	esm := lambdatypes.EventSourceMappingConfiguration{
+		UUID:                  aws.String("8bd1f2a4-1c3e-4d5f-9a0b-1c2d3e4f5a6b"),
+		EventSourceArn:        aws.String("arn:aws:sqs:us-east-1:123456789012:my-queue"),
+		FunctionArn:           aws.String("arn:aws:lambda:us-east-1:123456789012:function:my-function"),
+		EventSourceMappingArn: aws.String("arn:aws:lambda:us-east-1:123456789012:event-source-mapping:8bd1f2a4-1c3e-4d5f-9a0b-1c2d3e4f5a6b"),
+		State:                 aws.String("Enabled"),
+		BatchSize:             aws.Int32(10),
+	}
+
+	args, err := eventSourceMappingArgs(esm, "us-east-1")
+	require.NoError(t, err)
+
+	assert.True(t, rawDataIsNull(t, args, "parallelizationFactor"))
+	assert.True(t, rawDataIsNull(t, args, "tumblingWindowInSeconds"))
+	assert.True(t, rawDataIsNull(t, args, "maximumConcurrency"))
+	assert.True(t, rawDataIsNull(t, args, "startingPosition"))
+	assert.True(t, rawDataIsNull(t, args, "onFailureDestinationArn"))
+
+	// -1 is the documented "retry forever" / "no maximum age" sentinel, not a
+	// stand-in for an unread value.
+	assert.Equal(t, int64(-1), args["maximumRetryAttempts"].Value)
+	assert.Equal(t, int64(-1), args["maximumRecordAgeInSeconds"].Value)
+	assert.Equal(t, int64(10), args["batchSize"].Value)
+	assert.Equal(t, "Enabled", args["state"].Value)
+}
+
+// TestEventSourceMappingArgsReportedSettings pins that a mapping that does
+// carry these settings reports them, so the null handling above cannot be
+// satisfied by dropping the values altogether.
+func TestEventSourceMappingArgsReportedSettings(t *testing.T) {
+	esm := lambdatypes.EventSourceMappingConfiguration{
+		UUID:                    aws.String("11111111-2222-3333-4444-555555555555"),
+		EventSourceArn:          aws.String("arn:aws:kinesis:us-east-1:123456789012:stream/my-stream"),
+		ParallelizationFactor:   aws.Int32(4),
+		TumblingWindowInSeconds: aws.Int32(30),
+		StartingPosition:        lambdatypes.EventSourcePositionTrimHorizon,
+		ScalingConfig:           &lambdatypes.ScalingConfig{MaximumConcurrency: aws.Int32(20)},
+		DestinationConfig: &lambdatypes.DestinationConfig{
+			OnFailure: &lambdatypes.OnFailure{
+				Destination: aws.String("arn:aws:sqs:us-east-1:123456789012:dlq"),
+			},
+		},
+	}
+
+	args, err := eventSourceMappingArgs(esm, "us-east-1")
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(4), args["parallelizationFactor"].Value)
+	assert.Equal(t, int64(30), args["tumblingWindowInSeconds"].Value)
+	assert.Equal(t, int64(20), args["maximumConcurrency"].Value)
+	assert.Equal(t, "TRIM_HORIZON", args["startingPosition"].Value)
+	assert.Equal(t, "arn:aws:sqs:us-east-1:123456789012:dlq", args["onFailureDestinationArn"].Value)
+}
+
+// TestEventSourceMappingArgsZeroTumblingWindow pins that a window AWS actually
+// reports as 0 stays a measured 0, so the null handling does not swallow a
+// real value. 0 is inside the documented range for this field.
+func TestEventSourceMappingArgsZeroTumblingWindow(t *testing.T) {
+	esm := lambdatypes.EventSourceMappingConfiguration{
+		UUID:                    aws.String("11111111-2222-3333-4444-555555555555"),
+		TumblingWindowInSeconds: aws.Int32(0),
+	}
+
+	args, err := eventSourceMappingArgs(esm, "us-east-1")
+	require.NoError(t, err)
+
+	assert.False(t, rawDataIsNull(t, args, "tumblingWindowInSeconds"))
+	assert.Equal(t, int64(0), args["tumblingWindowInSeconds"].Value)
+}
+
+// TestRuntimeManagementArgs pins that the pinned-version ARN is null for a
+// function on automatic runtime updates. The deprecated dict left the key out
+// entirely, so its typed replacement asserting "" was weaker than the field it
+// replaces.
+func TestRuntimeManagementArgs(t *testing.T) {
+	t.Run("automatic updates pin no version", func(t *testing.T) {
+		args := runtimeManagementArgs("arn:aws:lambda:us-east-1:123456789012:function:my-function",
+			&lambda.GetRuntimeManagementConfigOutput{UpdateRuntimeOn: lambdatypes.UpdateRuntimeOnAuto})
+		assert.Equal(t, "Auto", args["updateRuntimeOn"].Value)
+		assert.True(t, rawDataIsNull(t, args, "runtimeVersionArn"))
+	})
+
+	t.Run("manual updates report the pinned version", func(t *testing.T) {
+		args := runtimeManagementArgs("arn:aws:lambda:us-east-1:123456789012:function:my-function",
+			&lambda.GetRuntimeManagementConfigOutput{
+				UpdateRuntimeOn:   lambdatypes.UpdateRuntimeOnManual,
+				RuntimeVersionArn: aws.String("arn:aws:lambda:us-east-1::runtime:abc123"),
+			})
+		assert.Equal(t, "Manual", args["updateRuntimeOn"].Value)
+		assert.Equal(t, "arn:aws:lambda:us-east-1::runtime:abc123", args["runtimeVersionArn"].Value)
+	})
 }

--- a/providers/aws/resources/aws_lambda_test.go
+++ b/providers/aws/resources/aws_lambda_test.go
@@ -161,7 +161,7 @@ func TestLambdaFunctionStatusAccessorsReportNullWhenUnread(t *testing.T) {
 	newUnread := func() *mqlAwsLambdaFunction {
 		fn := &mqlAwsLambdaFunction{}
 		// What fetchStatus leaves behind on a 404 or an access denial.
-		fn.statusFetched = true
+		fn.statusFetched.Store(true)
 		return fn
 	}
 
@@ -223,7 +223,7 @@ func TestLambdaFunctionStatusAccessorsReadSeededStatus(t *testing.T) {
 	fn := &mqlAwsLambdaFunction{}
 	if status := lambdaStatusFromConfiguration(&cfg); status != nil {
 		fn.status = status
-		fn.statusFetched = true
+		fn.statusFetched.Store(true)
 	}
 
 	state, err := fn.state()


### PR DESCRIPTION
Found by validating **all 154 fields** of `aws.lambda` against a live account. Seven defects.

## `state` was `""` for every function in every account

`ListFunctions` does not return `State`, `StateReason`, `LastUpdateStatus` or `LastUpdateStatusReason`, but the list path mapped them anyway. The same function reached two ways disagreed:

| path | `state` | `lastUpdateStatus` |
|---|---|---|
| `aws.lambda.functions` | `""` | `""` |
| `aws.lambda.function(arn:)` | `"Active"` | `"Successful"` |
| `aws get-function-configuration` | `"Active"` | `"Successful"` |

So `functions.all(state == "Active")` **failed fleet-wide**, and `""` is not one of the values the field documents. `version.state` had the same cause — `ListVersionsByFunction` omits `State` too.

These five are computed now, behind a memoized `GetFunctionConfiguration`.

**The cost is lower than it looks.** `runtimeVersionArn` was already making that exact call per function, so it was folded into the same fetch — a query touching both now makes **one** call where it used to make two. The init path seeds the memo when the source configuration already carries a state, so the `GetFunction`-backed lookup makes no second call, and discovery reads none of these fields, so asset discovery is untouched.

Worth knowing before release: a policy reading `functions { state }` across a large account now makes one `GetFunctionConfiguration` per function. That is unavoidable for a correct answer — the data simply is not in `ListFunctions` — but it is a real change in scan cost.

## `concurrency` conflated opposite security postures

A reserved concurrency of **0 means the function is fully throttled and cannot be invoked**. An **absent** reservation means no limit at all. Both reported `0`.

Absent reads null now; a configured `0` stays a measured `0`.

## `provisionedConcurrencyConfig.lastModified` could never be read

AWS returns `2026-08-31T20:11:24+0000`. `parseAwsTimestamp` tried RFC3339, a layout **requiring** fractional seconds, and one with no offset at all — so every provisioned concurrency config in every account logged a parse failure and reported null.

The no-fraction numeric-offset layout is in the chain now, with a test per layout **and** one asserting the parser still rejects garbage, since widening a fallback list is how a parser quietly becomes accept-anything.

## Also

- **`eventSourceMapping.arn`** composed an `arn:aws:` string by hand although the SDK returns `EventSourceMappingArn` — wrong in GovCloud and China. Reads the API value now.
- **`runtimeManagement.runtimeVersionArn`** asserted `""` for functions on automatic updates, where the **deprecated** dict it replaces correctly omits the key. The typed successor was weaker than the thing it replaced.
- **Event source mapping settings reported `0` for values AWS never sent.** `parallelizationFactor` (1–10), `tumblingWindowInSeconds` and `maximumConcurrency` (2–1000) all document ranges that exclude `0`, so the value could not exist. Null when absent; a real `0` still passes through where `0` is in range. `startingPosition`, `onFailureDestinationArn` and `dlqTargetArn` likewise, since none has an empty member.

`maximumRetryAttempts: -1` and `maximumRecordAgeInSeconds: -1` were left alone — those genuinely are the documented "infinite" sentinel, and the code now says so.

## Verified live, before and after

All seven functions went from `state: ""` to `Active` / `Successful`, **read through the list path**.

The concurrency triple, against `get-function-concurrency` as ground truth:

| function | AWS | mql |
|---|---|---|
| explicit reservation of 0 (throttled) | `{"ReservedConcurrentExecutions":0}` | **`0`** |
| reservation of 5 | `{"ReservedConcurrentExecutions":5}` | **`5`** |
| no reservation | `{}` | **`null`** |

I created the explicit-zero case specifically for this, since the account had none — proving the fix distinguishes the two rather than merely nulling everything.

## Schema

Four `aws.lambda.function` fields and `version.state` moved from stored to computed. **No field names changed**, so the existing `.lr.versions` entries still apply and regeneration is byte-identical to the committed file — no version bump needed. No `.lr` field types changed. `aws.permissions.json` is unchanged at 1038; `lambda:GetFunctionConfiguration` was already there from `runtimeVersionArn`.

## Tests

13 mutations, each caught by a specific named test, each reverted. Every decision was extracted into a pure function the tests reach through the real path rather than by hand-setting internal state.

## Exposure fields untouched

`isPublic`, `allowsPublicAccess` and `urlConfig` all validated **correct** during the sweep, including a function whose only public grant is AWS's auto-generated function-URL policy (confirmed with `curl` returning HTTP 200 unauthenticated) and condition-scoped wildcards not being over-reported. Deliberately not changed.

## Two judgment calls to review

1. **`runtimeVersionArn` keeps `""` for read-and-absent.** When the configuration *was* read but `RuntimeVersionConfig` is nil — OS-only and container-image runtimes — it still reports `""`, which is the shipped documented behaviour a policy may compare against. It reports null only when the configuration could not be read. Changing both would go beyond the defect.
2. **Three paths are unit-tested but not live-verified**: `dlqTargetArn` null, and the two access-denied null branches on `concurrency()` and version `state()`. Reaching `dlqTargetArn` from a test would have meant a ~100-line refactor of a creator that is not otherwise changing.
