### PR TITLE
🟢 os: give the rpm probe test a name of its own

### DIFF
--- a/providers/os/resources/packages/resolve_pkg_managers_test.go
+++ b/providers/os/resources/packages/resolve_pkg_managers_test.go
@@ -36,15 +36,17 @@ func managerNames(pms []OperatingSystemPkgManager) []string {
 	return names
 }
 
-// CBL-Mariner 2.0 reports ID=mariner with family ["linux","unix","os"]. It is
-// not in the redhat family and no case names it, so before the filesystem
-// probe it matched nothing and packages errored on a host with 69 rpms in a
-// healthy /var/lib/rpm.
-func TestResolveSystemPkgManagersMariner(t *testing.T) {
+// The rpm database still lives under /var/lib/rpm on most rpm distros. CBL-Mariner
+// 2.0 was the host that exposed the gap: it reports ID=mariner with family
+// ["linux","unix","os"], so it is not in the redhat family, and before the probe
+// no case named it and packages errored on a host with 69 rpms on disk. Mariner
+// itself is now claimed by name, so it no longer reaches this branch and cannot
+// stand in for it. The path is covered here instead, on a distro nobody has
+// named, which is the case the probe exists to serve.
+func TestResolveSystemPkgManagersUnknownRpmVarLibPath(t *testing.T) {
 	conn := newProbeConn(t, &inventory.Platform{
-		Name:    "mariner",
-		Version: "2.0",
-		Family:  []string{"linux", "unix", "os"},
+		Name:   "someotherrpmdistro",
+		Family: []string{"linux", "unix", "os"},
 	}, "/var/lib/rpm")
 
 	pms, err := ResolveSystemPkgManagers(conn)


### PR DESCRIPTION
`main` does not compile under `go test`. Two PRs fixed the same CBL-Mariner report a day apart and each shipped a test called `TestResolveSystemPkgManagersMariner`:

- #10607 added a `Name == "mariner"` case to the switch, with `mariner_test.go`
- #10605 added a filesystem probe to the plain-linux branch, with `resolve_pkg_managers_test.go`

They touched different files, so both merged cleanly and both were green on their own branches. Together they redeclare the symbol:

```
resources/packages/resolve_pkg_managers_test.go:43:6: TestResolveSystemPkgManagersMariner redeclared in this block
	resources/packages/mariner_test.go:20:6: other declaration of TestResolveSystemPkgManagersMariner
```

The `packages` test binary does not build, so `golangci-lint` fails typecheck and `go-test-providers` fails on **every open PR**, not just the one that surfaced it.

## Why renaming was not enough

The switch runs the named case before the plain-linux branch, so `mariner` never reaches the probe. The probe test kept its assertions but stopped covering the probe. Deleting the entire rpm probe block leaves it passing:

```
--- PASS: TestProbeMarinerTMP        # probe deleted, still green
--- FAIL: TestResolveSystemPkgManagersRpmSysimagePath
```

It also left the `/var/lib/rpm` probe entry uncovered — the only other probe test reads `/usr/lib/sysimage/rpm`. Dropping `/var/lib/rpm` from `rpmPaths` passed the full suite.

## Change

Point the test at the case the probe exists to serve, an rpm distro nobody has named, and name it for the path it covers. No production code changes. Mariner stays covered by `mariner_test.go`, which drives it through the named case against a real rpm fixture.

## Test plan

- `go vet ./resources/packages/` clean; full package suite passes
- `golangci-lint run ./resources/packages/...` — 0 issues
- Mutation check: dropping `/var/lib/rpm` from `rpmPaths` now fails `TestResolveSystemPkgManagersUnknownRpmVarLibPath`, and passed before this change
