### PR TITLE
🎉 aws-13.54.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/mql/providers/aws",
-	Version:         "13.53.3",
+	Version:         "13.54.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	// Throttling is per service and per region, and an organization scan spreads
 	// its calls over separate accounts, so the limits are rarely the binding


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.54.0)
- 🐛 aws: stop reporting Lambda state as empty and unlimited concurrency as zero (#10630)
- 🐛 aws: a refused EFS read must not report a file system as not public (#10627)
- 🐛 aws: a refused KMS read must not report rotation off or a key as not public (#10628)
- 🐛 aws: stop inventing SQS and SNS values that were never read (#10629)
- 🐛 aws: stop discovering terminated EC2 instances as scan targets (#10625)
- 🐛 aws/azure/gcp/oci: stop reporting unread exposure as "not public" (#10624)
- ✨ aws: replace opaque security dicts with typed sub-resources (#10570)
- ⭐ providers: harvest new fields from the 2026-08-31 SDK refresh (#10623)
- 🧹 Update deps for mql and providers 20260831 (#10615)
- 🧹 Update deps for mql and providers 20260828 (#10556)
- 🐛 aws: give every construction site a cache key it owns (#10582)
- 🐛 aws: init per-asset sub-resources for EMR encryption config and VPC encryption control (#10580)
- 🐛 aws: fix five data gaps that silently broke mondoo-aws-security checks (#10576)
- 🧹 providers: refresh SDK dependencies (#10546)
- 🐛 aws: report a real DynamoDB table identifier (#10505)
- 🐛 aws: stop dropping Condition blocks from IAM policy documents (#10503)
- 🐛 aws: give flow logs and RDS parameter groups a real identity (#10497)
- 🧹 deps: point go-scp at the mondoohq fork v1.0.4 (#10414)
- 🧹 deps: pin go-plugin past v1.8.0 to drop deprecated golang/protobuf (#10356)
- 🧹 Update deps for mql and providers 20260824 (#10346)
- 🧹 Update deps for mql and providers 20260824 (#10327)
- ✨ aws: close ten security-posture gaps, six on data already fetched (#10312)
- 🐛 aws: give WAF rate-based statements a real __id (#10288)
- 🧹 Update deps for mql and providers 20260821 (#10281)
- 🧹 migrate all providers to v14+ version-less ID style (#10268)
- ✨ aws: expose EKS certificate authority rotation, Batch Container Insights, and Redshift system table publishing (#10265)
- 🧹 Update deps for mql and providers 20260820 (#10261)
- 🧹 deprecate resources for cloud services the vendor has shut down (#10262)
- 🐛 aws: pick the EBS root volume by RootDeviceName, not by guessing (#10193)
- ✨ aws: expose centralized root access and trusted access on an organization (#10252)
- ✨ aws: expose the Organizations resource-based delegation policy (#10251)
- ✨ aws: expose access-log settings on a REST API Gateway stage (#10250)
- ✨ let providers declare a default scan parallelism (#10233)
- ✨ aws: reach the containing VPC from a subnet (#10231)
- 🧹 v14 -> non-versioned go-mod (#10234)
- 🐛 aws: read an automl job with the V2 describe, and fetch dynamodb's sse key (#10216)
- 🐛 aws: key a nat gateway address on the eni that was never in the key (#10213)
- 🐛 aws: stop three cloudwatch resources sharing one cache row (#10210)
- 🐛 aws: give inspector coverage rows and their children real identities (#10211)
- 🐛 aws: identify an autoscaling target by its dimension, and use the real arn (#10212)
- 🐛 aws: tell an automl job's input channels apart by position (#10214)
- 🐛 aws: scope vpn tunnel telemetry to its connection (#10215)
- 🐛 aws: list athena named queries from every workgroup, not just primary (#10209)
- 🐛 aws: paginate the direct connect listers instead of truncating at 100 (#10204)
- 🐛 aws: make a deleted application status check tell you it is deleted (#10205)
- 🐛 aws: list waf across every region and both scopes (#10208)
- 🐛 aws: report a log group that never expires as null retention, not zero (#10207)
- 🐛 aws: read cloudtrail advanced selectors through the resource field (#10206)
- 🐛 aws: read advanced event selectors in cloudtrail capturesAllManagementEvents (#10202)
- 🐛 aws: look up a secret's cloudformation stack in the secret's own region (#10203)
- 🐛 aws: count NotAction, NotResource and service wildcards as iam wildcards (#10201)
- 🐛 aws: decide elb enforcesTls from the encrypted protocols, not the plaintext ones (#10200)
- 🐛 aws: read a split default route as internet-reachable in subnet isPublic (#10199)
- 🐛 aws: nil-check the response bodies that siblings already nil-check (#10198)
- 🐛 aws: stop dereferencing the cache cluster id on the path that logs it (#10197)
- 🐛 aws: guard the iam responses that are already treated as optional (#10195)
- 🐛 aws: mark a purged codedeploy deployment null instead of returning a nil (#10196)
- 🐛 aws: stop dereferencing an absent config compliance recorded time (#10194)
- 🐛 aws: make the workdocs users lister able to return data (#10192)
- 🐛 aws: make the patch baseline detail fields reachable (#10191)
- 🐛 aws: resolve the cognito userPool reference by the arn its init accepts (#10190)
- 🐛 aws: stop the custom model init passing a field the schema does not have (#10188)
- 🐛 aws: read the lambda lookup args as values, not as their display form (#10189)
- 🐛 aws: stop the recovery point constructor passing fields the schema does not have (#10186)
- 🐛 aws: stop the firehose lister passing a field the schema does not have (#10187)
- 🐛 aws: stop the backup vault init passing a field the schema does not have (#10185)
- 🧹 aws: warn when the deprecated `ec2:tag:` discovery filters are used (#9994)
- ⭐ aws: report absence of an organization instead of failing (#10168)
- 🧹 Update deps for mql and providers 20260819 (#10167)
- ⭐ aws: expose nested virtualization on WorkSpaces (#10158)
- 🐛 aws: reject a regions filter the account cannot scan (#10105)
- 🐛 aws: honour the discovery tag filter for kms keys and secrets (#10106)
- 🐛 aws: report the credential report's root entry as having no IAM user (#10107)
- 🐛 aws: resolve a KMS alias instead of building an invalid key ARN (#10108)
- 🐛 aws: report no detail for the built-in Athena data catalog (#10109)
- 🐛 aws: keep the CloudTrail trails when a referenced role is deleted (#10111)
- 🐛 aws: keep the RDS subnets that resolve when one is deleted (#10104)
- 🐛 aws: report no state transition time for a running instance (#10103)
- 🐛 aws: stop nesting an ARN inside a patch baseline ARN (#10102)
- 🐛 aws: stop macieCoverage panicking on a bucket Macie does not track (#10101)
- 🐛 aws: give every instance block device its own cache key (#10100)
- 🐛 aws: tell the two sides of a VPC peering connection apart (#10099)
- 🧹 Update deps for mql and providers 20260818 (#10033)
- ⚡ aws: resolve IAM users and groups from the account list (#10044)
- 🌟 v14-pre (#10026)

---
Unblocks mondoohq/cnspec#3607: the new `mondoo-aws-security-organizations-centralized-root-access` check needs `aws.organization.enabledRootFeatures` (#10252), which is on main but not in any released aws provider — cnspec's lint compiles against the released 13.53.3 and fails with `cannot find field 'enabledRootFeatures'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)