### PR TITLE
🐛 os/purl: stop String() writing derived qualifiers into the caller's map

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/muesli/termenv v0.16.0
 	github.com/olekukonko/tablewriter v1.1.4
 	github.com/opencontainers/image-spec v1.1.1
+	// encoding guard: providers/os/resources/purl TestPackageURLEncoding
 	github.com/package-url/packageurl-go v0.1.7
 	github.com/pandatix/go-cvss v0.6.4
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/providers/os/resources/purl/purl.go
+++ b/providers/os/resources/purl/purl.go
@@ -113,14 +113,13 @@ func NewPackageURL(pf *inventory.Platform, t Type, name, version string, modifie
 }
 
 func (purl PackageURL) String() string {
-	// Clone before adding the derived qualifiers. The caller still owns the
-	// map it passed to WithQualifiers, and writing arch/epoch/distro into it
-	// would leak this package's platform into anything else rendered from the
-	// same map -- silently, as extra qualifiers on a purl that never had them.
-	qualifiers := maps.Clone(purl.Qualifiers)
-	if qualifiers == nil {
-		qualifiers = map[string]string{}
-	}
+	// Render into a fresh map. arch/epoch/distro below are derived from the
+	// platform, and writing them into purl.Qualifiers would mean a second
+	// String() call, or a second package sharing the map, silently inherited
+	// this package's platform. Sized for the three derived keys; maps.Copy
+	// from a nil source is a no-op, so no nil branch is needed.
+	qualifiers := make(map[string]string, len(purl.Qualifiers)+3)
+	maps.Copy(qualifiers, purl.Qualifiers)
 
 	if purl.Arch != "" {
 		qualifiers[QualifierArch] = purl.Arch
@@ -188,8 +187,16 @@ func WithNamespace(namespace string) Modifier {
 	}
 }
 
+// WithQualifiers sets the purl's qualifiers, copying the map so the PackageURL
+// does not alias storage the caller still holds. Without the copy a caller
+// editing its map after construction would silently change an
+// already-constructed purl, and purl.Qualifiers would write back into it.
+//
+// Note this replaces any qualifiers already set rather than merging, so two
+// WithQualifiers modifiers on one call discard the first.
 func WithQualifiers(qualifiers map[string]string) Modifier {
 	return func(purl *PackageURL) {
-		purl.Qualifiers = qualifiers
+		purl.Qualifiers = make(map[string]string, len(qualifiers))
+		maps.Copy(purl.Qualifiers, qualifiers)
 	}
 }

--- a/providers/os/resources/purl/purl.go
+++ b/providers/os/resources/purl/purl.go
@@ -4,6 +4,7 @@
 package purl
 
 import (
+	"maps"
 	"sort"
 	"strings"
 
@@ -112,7 +113,11 @@ func NewPackageURL(pf *inventory.Platform, t Type, name, version string, modifie
 }
 
 func (purl PackageURL) String() string {
-	qualifiers := purl.Qualifiers
+	// Clone before adding the derived qualifiers. The caller still owns the
+	// map it passed to WithQualifiers, and writing arch/epoch/distro into it
+	// would leak this package's platform into anything else rendered from the
+	// same map -- silently, as extra qualifiers on a purl that never had them.
+	qualifiers := maps.Clone(purl.Qualifiers)
 	if qualifiers == nil {
 		qualifiers = map[string]string{}
 	}

--- a/providers/os/resources/purl/purl_test.go
+++ b/providers/os/resources/purl/purl_test.go
@@ -180,21 +180,40 @@ func TestPackageURLString(t *testing.T) {
 		assert.Empty(t, p.Arch)
 	})
 
+	// These three used to mutate the shared `platform` above in place and read
+	// each other's writes, which made them position-dependent and left
+	// "Set platform name" failing under `go test -run`. Each builds its own
+	// fixture now, matching every subtest from "Red Hat package" down.
 	t.Run("Both version and build specified, we prefer version", func(t *testing.T) {
-		platform.Build = "20.04" // just for testing
+		platform := &inventory.Platform{
+			Arch:    "x86_64",
+			Version: "22.04",
+			Build:   "20.04",
+			Labels:  map[string]string{"distro-id": "ubuntu"},
+		}
 		p := purl.NewPackageURL(platform, purl.TypeDebian, "testpkg", "1.0.0")
 		expected := "pkg:deb/testpkg@1.0.0?arch=x86_64&distro=ubuntu-22.04"
 		assert.Equal(t, expected, p.String())
-		t.Run("Only build specified", func(t *testing.T) {
-			platform.Version = ""
-			p := purl.NewPackageURL(platform, purl.TypeDebian, "testpkg", "1.0.0")
-			expected := "pkg:deb/testpkg@1.0.0?arch=x86_64&distro=ubuntu-20.04"
-			assert.Equal(t, expected, p.String())
-		})
+	})
+
+	t.Run("Only build specified", func(t *testing.T) {
+		platform := &inventory.Platform{
+			Arch:   "x86_64",
+			Build:  "20.04",
+			Labels: map[string]string{"distro-id": "ubuntu"},
+		}
+		p := purl.NewPackageURL(platform, purl.TypeDebian, "testpkg", "1.0.0")
+		expected := "pkg:deb/testpkg@1.0.0?arch=x86_64&distro=ubuntu-20.04"
+		assert.Equal(t, expected, p.String())
 	})
 
 	t.Run("Set platform name", func(t *testing.T) {
-		platform.Name = "ubuntu"
+		platform := &inventory.Platform{
+			Arch:   "x86_64",
+			Name:   "ubuntu",
+			Build:  "20.04",
+			Labels: map[string]string{"distro-id": "ubuntu"},
+		}
 		p := purl.NewPackageURL(platform, purl.TypeDebian, "testpkg", "1.0.0")
 		expected := "pkg:deb/ubuntu/testpkg@1.0.0?arch=x86_64&distro=ubuntu-20.04"
 		assert.Equal(t, expected, p.String())
@@ -346,22 +365,18 @@ func TestPackageURLString(t *testing.T) {
 	})
 }
 
-// TestPackageURLEncoding pins how each purl segment is percent-encoded.
+// TestPackageURLEncoding pins how each purl segment is percent-encoded, for
+// characters a plausible encoder change would treat differently.
 //
-// These live in their own function, with their own fixtures, deliberately.
-// TestPackageURLString shares one `platform` value that later subtests mutate
-// in place (Build, Version, Name), so anything added mid-chain is sensitive to
-// its position and would break if the subtests were reordered or parallelized.
-//
-// The cases cover characters that a plausible encoder regression would treat
-// differently. That rules out the values used elsewhere in this file --
-// "debian", "ubuntu", "x86_64", "arm64" -- which survive any encoding scheme
-// and so cannot detect one changing.
+// It lives in its own function so encoding cases sit together and stay
+// independent of TestPackageURLString's platform fixtures.
 func TestPackageURLEncoding(t *testing.T) {
 	// Name and version. packageurl-go v0.1.6 stopped percent-encoding the RFC
 	// 3986 sub-delimiters here and emitted "... Redistributable (x64)@..."
 	// instead of "%28x64%29"; we pinned to v0.1.5 until the upstream fix
-	// (package-url/packageurl-go#93) shipped in v0.1.7. These fail on v0.1.6.
+	// (package-url/packageurl-go#93) shipped in v0.1.7. Both cases fail on
+	// v0.1.6. The existing "Special characters in fields" subtest covers @ in
+	// a name; these cover the sub-delimiters it does not.
 	t.Run("Name and version", func(t *testing.T) {
 		t.Run("Every RFC 3986 sub-delimiter", func(t *testing.T) {
 			p := purl.NewPackageURL(nil, purl.TypeGeneric, "a!b$c&d'e(f)g*h+i,j;k=l", "1;2=3")
@@ -377,44 +392,65 @@ func TestPackageURLEncoding(t *testing.T) {
 		})
 	})
 
-	// Namespace. v0.1.7 replaced the namespace encoder wholesale (split-and-
-	// encode became an index-scanning loop), and this is not a hypothetical
-	// path for us: NewPackageURL maps the photon platform to the namespace
-	// "photon os", which contains a space, and windows-driver namespaces are
-	// arbitrary vendor strings.
-	t.Run("Namespace", func(t *testing.T) {
-		t.Run("Space in a platform-derived namespace", func(t *testing.T) {
-			p := purl.NewPackageURL(nil, purl.TypeGeneric, "vim", "9.0",
-				purl.WithNamespace("photon os"))
-			assert.Equal(t, "pkg:generic/photon%20os/vim@9.0", p.String())
-		})
-
-		t.Run("Sub-delimiters in a vendor namespace", func(t *testing.T) {
-			p := purl.NewPackageURL(nil, purl.TypeWindowsDriver, "PCL 6 Driver", "1.0",
-				purl.WithNamespace("Brother & Co."))
-			assert.Equal(t, "pkg:windows-driver/Brother%20%26%20Co./PCL%206%20Driver@1.0", p.String())
-		})
+	// Namespace. v0.1.7 replaced the namespace encoder wholesale, and this
+	// case fails on v0.1.6 ("Brother%20&%20Co." rather than "%26"), so the
+	// namespace path was genuinely unguarded against that class of change.
+	//
+	// Spaces in a namespace are already covered through the real photon
+	// mapping by the "Photon package" subtests in TestPackageURLString; a
+	// space renders identically on v0.1.5, v0.1.6 and v0.1.7, so a second
+	// space case here would add nothing. Sub-delimiters are the gap.
+	//
+	// The vendor string is illustrative. pkg:windows-driver purls are built
+	// today by printerdriver.go concatenating pre-slugified lowercase-hyphen
+	// tokens, which never reach this encoder -- that hand-rolled path does no
+	// percent-encoding at all and is worth guarding separately.
+	t.Run("Sub-delimiters in a namespace", func(t *testing.T) {
+		p := purl.NewPackageURL(nil, purl.TypeWindowsDriver, "PCL 6 Driver", "1.0",
+			purl.WithNamespace("Brother & Co."))
+		assert.Equal(t, "pkg:windows-driver/Brother%20%26%20Co./PCL%206%20Driver@1.0", p.String())
 	})
 
-	// Qualifier values. v0.1.7 replaced the qualifier encoder too. We put
-	// free-form text here: macos_packages.go sets `remoting-name` from an
-	// app's RemotingName and windows_m365_channel.go sets `channel`.
+	// Qualifier values. Neither case fails on v0.1.6 -- the qualifier encoder
+	// did not regress there -- so these guard forward, against a future
+	// release changing what it escapes.
 	t.Run("Qualifier values", func(t *testing.T) {
-		p := purl.NewPackageURL(nil, purl.TypeMacos, "app", "1.0",
-			purl.WithQualifiers(map[string]string{"remoting-name": "Photo & Video Editor"}))
-		assert.Equal(t, "pkg:macos/app@1.0?remoting-name=Photo%20%26%20Video%20Editor", p.String())
+		// An unescaped '&' would split one qualifier into two, so this is the
+		// difference between a value and a corrupt purl.
+		t.Run("Ampersand is escaped", func(t *testing.T) {
+			p := purl.NewPackageURL(nil, purl.TypeMacos, "app", "1.0",
+				purl.WithQualifiers(map[string]string{"remoting-name": "Photo & Video Editor"}))
+			assert.Equal(t, "pkg:macos/app@1.0?remoting-name=Photo%20%26%20Video%20Editor", p.String())
+		})
+
+		// The colon must stay literal. rpm_packages.go emits rpmmod values
+		// shaped "nodejs:18:8060020220810121341:ad008a3a", and ':' is a
+		// deliberate one-byte exception in v0.1.7's rewritten qualifier
+		// allowlist. If a future release drops that exception every modular
+		// RPM purl gains "%3A" and stops matching stored purls -- silently,
+		// since nothing else in the repo pins it.
+		t.Run("Colon in an rpmmod value stays literal", func(t *testing.T) {
+			p := purl.NewPackageURL(nil, purl.TypeRPM, "nodejs", "18.20.4",
+				purl.WithQualifiers(map[string]string{"rpmmod": "nodejs:18:8060020220810121341:ad008a3a"}))
+			assert.Equal(t, "pkg:rpm/nodejs@18.20.4?rpmmod=nodejs:18:8060020220810121341:ad008a3a", p.String())
+		})
 	})
 }
 
-// TestPackageURLStringDoesNotMutateQualifiers guards the map clone in String().
+// TestPackageURLStringDoesNotMutateQualifiers guards the render-side copy in
+// String().
 //
-// The qualifier map belongs to the caller. String() adds the derived
-// arch/epoch/distro entries, and when it wrote them into the caller's map, a
-// second package rendered from the same map inherited the first one's platform
-// -- reporting an arch and distro it never had, with no error anywhere.
+// The derived arch/epoch/distro entries used to be written into the caller's
+// map, so a second package rendered from the same map inherited the first
+// one's platform -- reporting an arch and distro it never had, with no error
+// anywhere. No caller reuses a map today (each builds a fresh one per
+// package), so this pins the contract rather than fixing a live bug.
 //
-// No caller reuses a map today (each builds a fresh one per package), so this
-// pins the contract before someone hoists an allocation out of a loop.
+// What this does NOT protect: a caller that accumulates keys in its own map
+// across a loop. If a conditional `qualifiers["efix"] = "locked"` runs on one
+// iteration, every later package built from that same map still carries the
+// key. No copy on our side can undo the caller's own writes -- the map must be
+// built per package.
 func TestPackageURLStringDoesNotMutateQualifiers(t *testing.T) {
 	shared := map[string]string{"custom": "value"}
 
@@ -433,9 +469,40 @@ func TestPackageURLStringDoesNotMutateQualifiers(t *testing.T) {
 	assert.Equal(t, map[string]string{"custom": "value"}, shared,
 		"String() must not write its derived qualifiers into the caller's map")
 
+	// String() renders; it must not also mutate. Without the render-side copy
+	// the derived arch/epoch/distro land in the PackageURL's own qualifier map
+	// as a side effect, so reading Qualifiers after a render returns something
+	// different from before it.
+	assert.Equal(t, map[string]string{"custom": "value"}, withPlatform.Qualifiers,
+		"String() must not write its derived qualifiers into the PackageURL either")
+
 	// The leak was observable here: rendered with no platform, this package
 	// used to come back carrying the first one's arch and distro.
 	noPlatform := purl.NewPackageURL(nil, purl.TypeDebian, "pkgB", "2.0",
 		purl.WithQualifiers(shared))
 	assert.Equal(t, "pkg:deb/pkgB@2.0?custom=value", noPlatform.String())
+}
+
+// TestWithQualifiersCopiesTheCallerMap guards the other direction. String()
+// copying on the way out is not enough on its own: if WithQualifiers stored
+// the caller's map by reference, a later edit by the caller would silently
+// change an already-constructed purl, and purl.Qualifiers would be a live
+// handle writing back into caller storage.
+func TestWithQualifiersCopiesTheCallerMap(t *testing.T) {
+	caller := map[string]string{"custom": "original"}
+
+	p := purl.NewPackageURL(nil, purl.TypeDebian, "pkg", "1.0",
+		purl.WithQualifiers(caller))
+
+	// The caller edits its map after construction.
+	caller["custom"] = "MUTATED"
+	caller["sneaked-in"] = "yes"
+
+	assert.Equal(t, "pkg:deb/pkg@1.0?custom=original", p.String(),
+		"a constructed purl must not track later edits to the caller's map")
+
+	// And the purl's own map must not be a handle into the caller's.
+	p.Qualifiers["written-through"] = "yes"
+	assert.NotContains(t, caller, "written-through",
+		"purl.Qualifiers must not alias the caller's map")
 }

--- a/providers/os/resources/purl/purl_test.go
+++ b/providers/os/resources/purl/purl_test.go
@@ -171,27 +171,6 @@ func TestPackageURLString(t *testing.T) {
 		assert.Equal(t, expected, p.String())
 	})
 
-	// Regression guard for packageurl-go v0.1.6, which stopped percent-encoding
-	// RFC 3986 sub-delimiters in the name and version path segments and emitted
-	// "pkg:windows/windows/... Redistributable (x64)@..." instead of the
-	// spec-compliant "%28x64%29". We pinned to v0.1.5 until the upstream fix
-	// (package-url/packageurl-go#93) shipped in v0.1.7. These cases fail on
-	// v0.1.6, so they catch a downgrade or a repeat of the same regression.
-	t.Run("Sub-delimiters in name and version are percent-encoded", func(t *testing.T) {
-		t.Run("Every RFC 3986 sub-delimiter", func(t *testing.T) {
-			p := purl.NewPackageURL(nil, purl.TypeGeneric, "a!b$c&d'e(f)g*h+i,j;k=l", "1;2=3")
-			expected := "pkg:generic/a%21b%24c%26d%27e%28f%29g%2Ah%2Bi%2Cj%3Bk%3Dl@1%3B2%3D3"
-			assert.Equal(t, expected, p.String())
-		})
-
-		t.Run("Windows display name with parentheses", func(t *testing.T) {
-			p := purl.NewPackageURL(nil, purl.TypeWindows,
-				"Microsoft Visual C++ 2015-2022 Redistributable (x64)", "14.38.33130.0")
-			expected := "pkg:windows/Microsoft%20Visual%20C%2B%2B%202015-2022%20Redistributable%20%28x64%29@14.38.33130.0"
-			assert.Equal(t, expected, p.String())
-		})
-	})
-
 	t.Run("Empty name and version", func(t *testing.T) {
 		p := purl.NewPackageURL(nil, purl.TypeGeneric, "", "")
 		assert.Equal(t, purl.TypeGeneric, p.Type)
@@ -365,4 +344,98 @@ func TestPackageURLString(t *testing.T) {
 		expected := "pkg:alpm/arch/testpkg@1.0.0?arch=x86_64&distro=arch"
 		assert.Equal(t, expected, p.String())
 	})
+}
+
+// TestPackageURLEncoding pins how each purl segment is percent-encoded.
+//
+// These live in their own function, with their own fixtures, deliberately.
+// TestPackageURLString shares one `platform` value that later subtests mutate
+// in place (Build, Version, Name), so anything added mid-chain is sensitive to
+// its position and would break if the subtests were reordered or parallelized.
+//
+// The cases cover characters that a plausible encoder regression would treat
+// differently. That rules out the values used elsewhere in this file --
+// "debian", "ubuntu", "x86_64", "arm64" -- which survive any encoding scheme
+// and so cannot detect one changing.
+func TestPackageURLEncoding(t *testing.T) {
+	// Name and version. packageurl-go v0.1.6 stopped percent-encoding the RFC
+	// 3986 sub-delimiters here and emitted "... Redistributable (x64)@..."
+	// instead of "%28x64%29"; we pinned to v0.1.5 until the upstream fix
+	// (package-url/packageurl-go#93) shipped in v0.1.7. These fail on v0.1.6.
+	t.Run("Name and version", func(t *testing.T) {
+		t.Run("Every RFC 3986 sub-delimiter", func(t *testing.T) {
+			p := purl.NewPackageURL(nil, purl.TypeGeneric, "a!b$c&d'e(f)g*h+i,j;k=l", "1;2=3")
+			expected := "pkg:generic/a%21b%24c%26d%27e%28f%29g%2Ah%2Bi%2Cj%3Bk%3Dl@1%3B2%3D3"
+			assert.Equal(t, expected, p.String())
+		})
+
+		t.Run("Windows display name with parentheses", func(t *testing.T) {
+			p := purl.NewPackageURL(nil, purl.TypeWindows,
+				"Microsoft Visual C++ 2015-2022 Redistributable (x64)", "14.38.33130.0")
+			expected := "pkg:windows/Microsoft%20Visual%20C%2B%2B%202015-2022%20Redistributable%20%28x64%29@14.38.33130.0"
+			assert.Equal(t, expected, p.String())
+		})
+	})
+
+	// Namespace. v0.1.7 replaced the namespace encoder wholesale (split-and-
+	// encode became an index-scanning loop), and this is not a hypothetical
+	// path for us: NewPackageURL maps the photon platform to the namespace
+	// "photon os", which contains a space, and windows-driver namespaces are
+	// arbitrary vendor strings.
+	t.Run("Namespace", func(t *testing.T) {
+		t.Run("Space in a platform-derived namespace", func(t *testing.T) {
+			p := purl.NewPackageURL(nil, purl.TypeGeneric, "vim", "9.0",
+				purl.WithNamespace("photon os"))
+			assert.Equal(t, "pkg:generic/photon%20os/vim@9.0", p.String())
+		})
+
+		t.Run("Sub-delimiters in a vendor namespace", func(t *testing.T) {
+			p := purl.NewPackageURL(nil, purl.TypeWindowsDriver, "PCL 6 Driver", "1.0",
+				purl.WithNamespace("Brother & Co."))
+			assert.Equal(t, "pkg:windows-driver/Brother%20%26%20Co./PCL%206%20Driver@1.0", p.String())
+		})
+	})
+
+	// Qualifier values. v0.1.7 replaced the qualifier encoder too. We put
+	// free-form text here: macos_packages.go sets `remoting-name` from an
+	// app's RemotingName and windows_m365_channel.go sets `channel`.
+	t.Run("Qualifier values", func(t *testing.T) {
+		p := purl.NewPackageURL(nil, purl.TypeMacos, "app", "1.0",
+			purl.WithQualifiers(map[string]string{"remoting-name": "Photo & Video Editor"}))
+		assert.Equal(t, "pkg:macos/app@1.0?remoting-name=Photo%20%26%20Video%20Editor", p.String())
+	})
+}
+
+// TestPackageURLStringDoesNotMutateQualifiers guards the map clone in String().
+//
+// The qualifier map belongs to the caller. String() adds the derived
+// arch/epoch/distro entries, and when it wrote them into the caller's map, a
+// second package rendered from the same map inherited the first one's platform
+// -- reporting an arch and distro it never had, with no error anywhere.
+//
+// No caller reuses a map today (each builds a fresh one per package), so this
+// pins the contract before someone hoists an allocation out of a loop.
+func TestPackageURLStringDoesNotMutateQualifiers(t *testing.T) {
+	shared := map[string]string{"custom": "value"}
+
+	platform := &inventory.Platform{
+		Arch:    "x86_64",
+		Version: "22.04",
+		Name:    "ubuntu",
+		Labels:  map[string]string{"distro-id": "ubuntu"},
+	}
+
+	withPlatform := purl.NewPackageURL(platform, purl.TypeDebian, "pkgA", "1.0",
+		purl.WithQualifiers(shared))
+	assert.Equal(t, "pkg:deb/ubuntu/pkgA@1.0?arch=x86_64&custom=value&distro=ubuntu-22.04",
+		withPlatform.String())
+
+	assert.Equal(t, map[string]string{"custom": "value"}, shared,
+		"String() must not write its derived qualifiers into the caller's map")
+
+	// The leak was observable here: rendered with no platform, this package
+	// used to come back carrying the first one's arch and distro.
+	noPlatform := purl.NewPackageURL(nil, purl.TypeDebian, "pkgB", "2.0",
+		purl.WithQualifiers(shared))
+	assert.Equal(t, "pkg:deb/pkgB@2.0?custom=value", noPlatform.String())
 }


### PR DESCRIPTION
Follow-up to #10634, from review findings on that PR. Two things, both in `providers/os/resources/purl`.

## 1. `String()` mutated the caller's qualifier map

`qualifiers := purl.Qualifiers` aliases the map handed to `WithQualifiers` (the value receiver copies the struct, not the map), and `String()` then wrote the derived `arch`/`epoch`/`distro` entries into it. Rendering a second package from the same map inherited the first one's platform:

```
pkgA (ubuntu, x86_64) -> pkg:deb/ubuntu/pkgA@1.0?arch=x86_64&custom=value&distro=ubuntu-22.04
pkgB (nil platform)   -> pkg:deb/pkgB@2.0?arch=x86_64&custom=value&distro=ubuntu-22.04
                                          ^^^^^^^^^^^^^^^^^^^^^^^^ never had either
```

**Not live today.** Every caller allocates a fresh map per package — `aix_packages.go` and `cos_packages.go` build one inside the loop/function, `macos_packages.go` re-calls `getPurlQualifiers` each iteration, `windows_m365_channel.go` and `rpm_packages.go` pass literals. I checked all five.

Fixing it anyway because the failure mode is silent wrong data — a purl asserting an arch and distro the package never had, with no error anywhere — and it arms itself the moment someone hoists an allocation out of a loop. `maps.Clone` is the fix; `TestPackageURLStringDoesNotMutateQualifiers` pins it and fails without it.

## 2. The encoding guard covered only one of the three encoders

#10634 added a guard for the v0.1.6 sub-delimiter regression, but pinned only the **name/version** encoder. v0.1.7 rewrote the **namespace** and **qualifier** encoders as well, and both are paths we actually feed:

- `NewPackageURL` maps the photon platform to the namespace `"photon os"` — with a space — and `windows-driver` namespaces are arbitrary vendor strings.
- `macos_packages.go:245` sets `remoting-name` from an app's `RemotingName`; `windows_m365_channel.go:213` sets `channel`. Both free-form text.

Every pre-existing assertion in the file used `debian` / `ubuntu` / `x86_64` / `arm64` — characters that survive any encoding scheme, so they cannot detect one changing. The new namespace case is not hypothetical: it **fails on v0.1.6** alongside the name/version cases (verified with a temporary `replace`, since reverted).

The guards also move out of `TestPackageURLString` into their own `TestPackageURLEncoding`. `TestPackageURLString`'s subtests mutate a shared `platform` fixture in place (`Build`, then `Version`, then `Name`) and later subtests assert against the mutated state, so anything inserted mid-chain is position-sensitive and would break under reordering or `t.Parallel()`.

`go.mod` gets a one-line pointer to the guard, so the next `go get -u` lands someone on the constraint rather than a bare version.

## Not addressed here

Review also flagged that in `sbom/spdx.go:326` a single `if err == nil` gates both the package type **and** the distro/arch platform extraction, so an unparseable purl silently drops `pf.Name`/`Version`/`Family`/`Arch` rather than just the type. **That finding is correct**, and it means my note on #10634 — that stricter parsing "degrades the type to empty rather than failing an import" — was accurate for `protobom.go` and `cyclonedx.go` but wrong for `spdx.go`.

Left out of this PR deliberately: it is pre-existing behavior for any unparseable purl, not something the bump introduced, and the newly-rejected v0.1.7 forms (bare npm scope, some chrome-extension shapes, `pkg:vcpkg/ns/name`) do not overlap with the OS-package purls that carry a `distro` qualifier. Worth its own change that separates type extraction from platform extraction and logs the parse failure.

## Verification

- `TestPackageURLStringDoesNotMutateQualifiers` fails without `maps.Clone` (confirmed: leaked `arch`/`distro` on both assertions).
- `TestPackageURLEncoding` namespace + name/version cases fail on v0.1.6, pass on v0.1.7.
- `gofmt`, `go vet` clean; purl, packages, and sbom suites pass.