### PR TITLE
🐛 os: resolve the hostname on systems that never write /etc/hostname

### DIFF
--- a/providers/os/id/hostname/hostname.go
+++ b/providers/os/id/hostname/hostname.go
@@ -6,8 +6,10 @@ package hostname
 import (
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -73,18 +75,23 @@ func Hostname(conn shared.Connection, pf *inventory.Platform) (string, bool) {
 	}
 	log.Debug().Err(err).Msg("could not run `hostname` command")
 
-	// Fallback to for unix systems to /etc/hostname, since hostname command is not available on all systems
-	// This mechanism is also working for static analysis
+	// Fallback for unix systems to the hostname files on disk, since the hostname
+	// command is not available on all systems. This is also the only mechanism left
+	// for static analysis: a mounted host root, a container image or a volume
+	// snapshot has no command execution at all.
 	if pf.IsFamily(inventory.FAMILY_LINUX) {
 		afs := &afero.Afero{Fs: conn.FileSystem()}
-		ok, err := afs.Exists("/etc/hostname")
-		if err == nil && ok {
-			content, err := afs.ReadFile("/etc/hostname")
-			if err == nil {
-				return strings.TrimSpace(string(content)), true
+		for _, src := range linuxHostnameFiles {
+			content, err := afs.ReadFile(src.path)
+			if err != nil {
+				log.Debug().Err(err).Str("file", src.path).Msg("could not read hostname file")
+				continue
 			}
-		} else {
-			log.Debug().Err(err).Msg("could not read /etc/hostname file")
+
+			if hn := src.parse(string(content)); hn != "" {
+				return hn, true
+			}
+			log.Debug().Str("file", src.path).Msg("hostname file carries no hostname")
 		}
 	}
 
@@ -122,6 +129,98 @@ func Hostname(conn shared.Connection, pf *inventory.Platform) (string, bool) {
 	}
 
 	return "", false
+}
+
+// hostnameFile is an on-disk source that carries the system's hostname. parse
+// returns the hostname the file names, or an empty string when it names none. An
+// empty /etc/hostname is a real occurrence, and it has to fall through to the
+// next source rather than resolve the hostname to "".
+type hostnameFile struct {
+	path  string
+	parse func(content string) string
+}
+
+// linuxHostnameFiles lists the files consulted for the hostname, in order of
+// preference.
+//
+// Reading the kernel value from /proc/sys/kernel/hostname is deliberately not
+// among them. That sysctl is not stored data: its handler resolves the value
+// against the UTS namespace of the calling process, so a scanner reading a
+// bind-mounted host root gets its own hostname back rather than the host's.
+var linuxHostnameFiles = []hostnameFile{
+	{path: "/etc/hostname", parse: parseEtcHostname},
+	// Bottlerocket never writes /etc/hostname. Its netdog sets only the kernel
+	// hostname, and the environment file that set-hostname.service reads before
+	// doing so is the on-disk copy of that value.
+	{path: "/etc/network/hostname.env", parse: parseHostnameEnv},
+	// The file twin of the `getent hosts` lookup above, for when no command can be
+	// run. Bottlerocket renders the hostname into its loopback aliases, and
+	// Debian-family systems traditionally carry it on the 127.0.1.1 line.
+	{path: "/etc/hosts", parse: parseEtcHosts},
+}
+
+// parseEtcHostname returns the hostname an /etc/hostname file names. Per
+// hostname(5) the file holds a single name; blank lines and comments are skipped
+// because systemd's own parser tolerates them.
+func parseEtcHostname(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		return line
+	}
+	return ""
+}
+
+// parseHostnameEnv returns the value of the HOSTNAME variable of a systemd
+// EnvironmentFile, which is the shape Bottlerocket renders to
+// /etc/network/hostname.env.
+func parseHostnameEnv(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		key, value, found := strings.Cut(line, "=")
+		if !found || strings.TrimSpace(key) != "HOSTNAME" {
+			continue
+		}
+
+		value = strings.TrimSpace(value)
+		if unquoted, err := strconv.Unquote(value); err == nil {
+			value = unquoted
+		}
+		return strings.TrimSpace(value)
+	}
+	return ""
+}
+
+// parseEtcHosts returns the first name mapped to a loopback address by an
+// /etc/hosts file that is not a variant of "localhost". Only loopback entries
+// are considered: any other line is as likely to name a different machine as it
+// is to name this one.
+func parseEtcHosts(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		if idx := strings.Index(line, "#"); idx >= 0 {
+			line = line[:idx]
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		if ip := net.ParseIP(fields[0]); ip == nil || !ip.IsLoopback() {
+			continue
+		}
+
+		if host := firstNonLocalhost(fields[1:]); host != "" {
+			return host
+		}
+	}
+	return ""
 }
 
 // runCommand is a wrapper around shared.Connection.RunCommand that helps execute commands
@@ -162,22 +261,43 @@ func parseGetentHosts(conn shared.Connection, ip string) (string, error) {
 		return "", fmt.Errorf("no hostnames found for IP %s", ip)
 	}
 
-	for _, host := range fields[1:] {
-		if !isLocalhostVariant(host) {
-			return host, nil
-		}
+	if host := firstNonLocalhost(fields[1:]); host != "" {
+		return host, nil
 	}
 
 	return "", fmt.Errorf("no non-localhost hostname found for IP %s", ip)
 }
 
-// isLocalhostVariant returns true if the given hostname is a variant of "localhost"
+// firstNonLocalhost returns the first name in a hosts entry's alias list that is
+// not a variant of "localhost", or an empty string when every alias is one.
+func firstNonLocalhost(hosts []string) string {
+	for _, host := range hosts {
+		if !isLocalhostVariant(host) {
+			return host
+		}
+	}
+	return ""
+}
+
+// isLocalhostVariant returns true if the given hostname is a variant of
+// "localhost". The protocol-suffixed forms matter: RHEL-family systems and
+// Bottlerocket both map 127.0.0.1 to "localhost localhost.localdomain localhost4
+// localhost4.localdomain4", so a lookup that only knew the unsuffixed names
+// answered "localhost4" where it should have kept looking.
 func isLocalhostVariant(host string) bool {
 	lh := strings.ToLower(host)
-	return lh == "localhost" ||
-		lh == "localhost.localdomain" ||
-		lh == "ip6-localhost" ||
-		lh == "ip6-loopback"
+	if lh == "ip6-localhost" || lh == "ip6-loopback" {
+		return true
+	}
+
+	name, domain, hasDomain := strings.Cut(lh, ".")
+	if name != "localhost" && name != "localhost4" && name != "localhost6" {
+		return false
+	}
+	if !hasDomain {
+		return true
+	}
+	return domain == "localdomain" || domain == "localdomain4" || domain == "localdomain6"
 }
 
 // isBSDWithoutDarwin returns true if the platform is a BSD system but not Darwin/macOS.

--- a/providers/os/id/hostname/hostname_internal_test.go
+++ b/providers/os/id/hostname/hostname_internal_test.go
@@ -1,0 +1,141 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package hostname
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseEtcHostname(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{"plain name", "myhost\n", "myhost"},
+		{"fqdn", "myhost.example.com\n", "myhost.example.com"},
+		{"no trailing newline", "myhost", "myhost"},
+		{"surrounding whitespace", "  myhost  \n", "myhost"},
+		{"leading blank lines", "\n\nmyhost\n", "myhost"},
+		{"comment first", "# set by cloud-init\nmyhost\n", "myhost"},
+		{"empty file", "", ""},
+		{"whitespace only", "\n  \n\n", ""},
+		{"comments only", "# nothing here\n", ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, parseEtcHostname(test.content))
+		})
+	}
+}
+
+func TestParseHostnameEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			"bottlerocket",
+			"HOSTNAME=ip-10-0-42-17.us-west-2.compute.internal\n",
+			"ip-10-0-42-17.us-west-2.compute.internal",
+		},
+		{"quoted", "HOSTNAME=\"myhost.example.com\"\n", "myhost.example.com"},
+		{"spaces around the assignment", "HOSTNAME = myhost \n", "myhost"},
+		{"other variables present", "PROXY=http://p:3128\nHOSTNAME=myhost\n", "myhost"},
+		{"commented out", "#HOSTNAME=myhost\n", ""},
+		// A different variable must not answer for HOSTNAME.
+		{"different variable", "NO_PROXY=localhost\n", ""},
+		{"set but empty", "HOSTNAME=\n", ""},
+		{"quoted empty", "HOSTNAME=\"\"\n", ""},
+		{"empty file", "", ""},
+		{"not an env file at all", "just some text\n", ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, parseHostnameEnv(test.content))
+		})
+	}
+}
+
+func TestIsLocalhostVariant(t *testing.T) {
+	localhosts := []string{
+		"localhost", "LOCALHOST", "localhost.localdomain",
+		"localhost4", "localhost4.localdomain4",
+		"localhost6", "localhost6.localdomain6",
+		"ip6-localhost", "ip6-loopback",
+	}
+	for _, host := range localhosts {
+		t.Run(host, func(t *testing.T) {
+			assert.True(t, isLocalhostVariant(host))
+		})
+	}
+
+	realHosts := []string{
+		"myhost", "myhost.example.com",
+		"ip-10-0-42-17.us-west-2.compute.internal",
+		"localhostess", "notlocalhost",
+	}
+	for _, host := range realHosts {
+		t.Run(host, func(t *testing.T) {
+			assert.False(t, isLocalhostVariant(host))
+		})
+	}
+}
+
+func TestParseEtcHosts(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			"bottlerocket loopback aliases",
+			"127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4 ip-10-0-42-17.us-west-2.compute.internal\n" +
+				"::1 localhost localhost.localdomain localhost6 localhost6.localdomain6 ip-10-0-42-17.us-west-2.compute.internal\n",
+			"ip-10-0-42-17.us-west-2.compute.internal",
+		},
+		{
+			"debian 127.0.1.1 convention",
+			"127.0.0.1\tlocalhost\n127.0.1.1\tdebian-box.example.com\tdebian-box\n",
+			"debian-box.example.com",
+		},
+		{
+			"ipv6 loopback only",
+			"::1 localhost ip6-localhost ip6-loopback myhost.example.com\n",
+			"myhost.example.com",
+		},
+		{
+			// The routable entries of /etc/hosts name other machines at least as
+			// often as they name this one, so they are never an answer.
+			"routable addresses are ignored",
+			"127.0.0.1 localhost\n10.0.0.9 buildserver.example.com buildserver\n",
+			"",
+		},
+		{
+			"comment stripped from the alias list",
+			"127.0.1.1 myhost # the box itself\n",
+			"myhost",
+		},
+		{
+			"fully commented line",
+			"# 127.0.1.1 myhost\n127.0.0.1 localhost\n",
+			"",
+		},
+		{"only localhost aliases", "127.0.0.1 localhost localhost.localdomain\n::1 ip6-localhost ip6-loopback\n", ""},
+		{"address with no alias", "127.0.0.1\n", ""},
+		{"malformed address", "not-an-ip myhost\n", ""},
+		{"empty file", "", ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, parseEtcHosts(test.content))
+		})
+	}
+}

--- a/providers/os/id/hostname/hostname_test.go
+++ b/providers/os/id/hostname/hostname_test.go
@@ -26,6 +26,47 @@ func TestHostnameLinuxEtcHostname(t *testing.T) {
 	assert.Equal(t, "9be843c4be9f", hn)
 }
 
+// Bottlerocket never writes /etc/hostname, and a mounted host root cannot run
+// the hostname command, so before the environment file was consulted every scan
+// of such a node reported "cannot determine hostname".
+func TestHostnameBottlerocket(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_bottlerocket.toml"))
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+	require.Equal(t, "bottlerocket", platform.Name)
+
+	hn, ok := hostname.Hostname(conn, platform)
+	require.True(t, ok)
+
+	assert.Equal(t, "ip-10-0-42-17.us-west-2.compute.internal", hn)
+}
+
+func TestHostnameLinuxEtcHosts(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_etc_hosts.toml"))
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+
+	hn, ok := hostname.Hostname(conn, platform)
+	require.True(t, ok)
+
+	assert.Equal(t, "debian-box.example.com", hn)
+}
+
+// An empty /etc/hostname used to resolve the hostname to "" and report success.
+func TestHostnameLinuxEmptyEtcHostname(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_empty_etc_hostname.toml"))
+	require.NoError(t, err)
+	platform, ok := detector.DetectOS(conn)
+	require.True(t, ok)
+
+	hn, ok := hostname.Hostname(conn, platform)
+	require.True(t, ok)
+
+	assert.Equal(t, "debian-box.example.com", hn)
+}
+
 func TestHostnameLinux(t *testing.T) {
 	conn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/hostname_linux.toml"))
 	require.NoError(t, err)

--- a/providers/os/id/hostname/testdata/hostname_bottlerocket.toml
+++ b/providers/os/id/hostname/testdata/hostname_bottlerocket.toml
@@ -1,0 +1,46 @@
+# A Bottlerocket Kubernetes node reached over a mounted host root: no command
+# execution, and no /etc/hostname, because netdog sets only the kernel hostname.
+# The full os-release lives in /usr/lib on the immutable root partition; /etc is
+# a tmpfs the settings applier renders at boot.
+
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "6.12.48"
+
+[files."/etc/os-release"]
+enoent = true
+
+[files."/etc/hostname"]
+enoent = true
+
+[files."/usr/lib/os-release"]
+content = """
+NAME=Bottlerocket
+ID=bottlerocket
+VERSION="1.62.1 (aws-k8s-1.34)"
+PRETTY_NAME="Bottlerocket OS 1.62.1 (aws-k8s-1.34)"
+VARIANT_ID=aws-k8s-1.34
+VERSION_ID=1.62.1
+BUILD_ID=8f2a1c93
+VENDOR_NAME=Bottlerocket
+HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
+SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
+BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
+DOCUMENTATION_URL="https://bottlerocket.dev"
+"""
+
+[files."/etc/network/hostname.env"]
+content = """
+HOSTNAME=ip-10-0-42-17.us-west-2.compute.internal
+"""
+
+[files."/etc/hosts"]
+content = """
+127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4 ip-10-0-42-17.us-west-2.compute.internal
+::1 localhost localhost.localdomain localhost6 localhost6.localdomain6 ip-10-0-42-17.us-west-2.compute.internal
+"""

--- a/providers/os/id/hostname/testdata/hostname_empty_etc_hostname.toml
+++ b/providers/os/id/hostname/testdata/hostname_empty_etc_hostname.toml
@@ -1,0 +1,36 @@
+# An /etc/hostname that exists but names nothing. It must not resolve the
+# hostname to the empty string; the remaining sources still have the answer.
+
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "6.1.0-28-amd64"
+
+[files."/etc/hostname"]
+content = "\n\n"
+
+[files."/etc/debian_version"]
+content = "12.9"
+
+[files."/etc/os-release"]
+content = """
+PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
+NAME="Debian GNU/Linux"
+VERSION_ID="12"
+VERSION="12 (bookworm)"
+VERSION_CODENAME=bookworm
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"
+"""
+
+[files."/etc/hosts"]
+content = """
+127.0.0.1	localhost
+127.0.1.1	debian-box.example.com	debian-box
+"""

--- a/providers/os/id/hostname/testdata/hostname_etc_hosts.toml
+++ b/providers/os/id/hostname/testdata/hostname_etc_hosts.toml
@@ -1,0 +1,45 @@
+# A Debian system reached without command execution and with no /etc/hostname,
+# leaving the traditional 127.0.1.1 entry as the only name on disk. The 10.x
+# entry must not be picked: /etc/hosts names other machines as readily as it
+# names this one.
+
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "6.1.0-28-amd64"
+
+[files."/etc/hostname"]
+enoent = true
+
+[files."/etc/debian_version"]
+content = "12.9"
+
+[files."/etc/os-release"]
+content = """
+PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
+NAME="Debian GNU/Linux"
+VERSION_ID="12"
+VERSION="12 (bookworm)"
+VERSION_CODENAME=bookworm
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"
+"""
+
+[files."/etc/hosts"]
+content = """
+127.0.0.1	localhost
+127.0.1.1	debian-box.example.com	debian-box
+
+# The following lines are desirable for IPv6 capable hosts
+::1     localhost ip6-localhost ip6-loopback
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+
+10.0.0.9	buildserver.example.com	buildserver
+"""


### PR DESCRIPTION
## The problem

`os.hostname` reports `cannot determine hostname` for a Bottlerocket host reached
over a filesystem connection — the shape a Kubernetes node scan takes, where the
host root is bind-mounted into the scan pod.

Every step of the lookup fails there:

- `hostname -f`, `getent hosts 127.0.0.1` / `::1`, and `hostname` all need command
  execution. A filesystem connection has none: `RunCommand` returns
  `ErrRunCommandNotImplemented`.
- The one remaining fallback reads `/etc/hostname`, and **Bottlerocket never writes
  that file**. `netdog set-hostname` is `fs::write("/proc/sys/kernel/hostname", …)`
  and nothing else, systemd-hostnamed is patched out, and the release tmpfiles
  config creates no `/etc/hostname`. This is true of every Bottlerocket version,
  not a regression in a recent one.

So the lookup runs out of sources and the field errors. Platform detection still
succeeds — the full os-release, with version and variant, is baked into
`/usr/lib/os-release` on the immutable root partition — which makes the missing
hostname read like an isolated failure rather than a scan-path one.

`/proc/sys/kernel/hostname` is not the answer, and the new file table says so in a
comment so nobody adds it later. It is not stored data: its handler resolves the
value against the UTS namespace of the *calling* process (`current->nsproxy->uts_ns`,
`kernel/utsname_sysctl.c`), so a scanner reading it through a bind-mounted host root
gets its own hostname back rather than the host's.

## What this changes

The single `/etc/hostname` fallback becomes an ordered table of on-disk sources.
Each has a parser that returns an empty string when the file names no host, so the
lookup falls through to the next source instead of stopping.

| file | why |
|---|---|
| `/etc/hostname` | unchanged, still first |
| `/etc/network/hostname.env` | Bottlerocket renders the hostname setting here, and `set-hostname.service` reads it as its `EnvironmentFile` before invoking `netdog` — it is the on-disk copy of the value the kernel hostname was set *from* |
| `/etc/hosts` | the file twin of the `getent hosts` step above it, for when no command can run. Only loopback entries are considered: the routable lines of `/etc/hosts` name other machines as readily as they name this one |

Two further bugs surfaced while writing the tests, both fixed here:

- **An empty `/etc/hostname` resolved the hostname to `""` and reported success.**
  The old code returned `strings.TrimSpace(content), true` without checking that it
  had read anything. `IdentifyPlatform` happens to guard on `len(hostname) > 0`, but
  `os.hostname` does not.
- **`localhost4` was accepted as a hostname.** `isLocalhostVariant` knew `localhost`
  and `localhost.localdomain` but not the protocol-suffixed forms. RHEL-family
  systems and Bottlerocket both map 127.0.0.1 to
  `localhost localhost.localdomain localhost4 localhost4.localdomain4`, so
  `getent hosts 127.0.0.1` answered `localhost4`. That is a *live* connection path,
  reached whenever `hostname -f` returns `localhost`.

## Platform IDs are unchanged where one already exists

`Hostname()` also backs the `Hostname` ID detector, so it is worth being explicit
about the blast radius.

- **Connections that inject a platform ID are untouched.** When the inventory
  supplies `PlatformId`, `FileSystemConnection.Identifier()` returns it and
  `provider.go` takes the `else` branch that sets `asset.PlatformIds` directly —
  `IdentifyPlatform` never runs, so no ID detector runs at all. A Kubernetes node
  scan keeps exactly the identifier it has today.
- **Connections without one gain an ID they were previously failing to produce.**
  For a bare filesystem / tar / docker-snapshot target the default detector set is
  `[IdDetector_Hostname]`, so today a Bottlerocket mount yields no platform IDs,
  `IdentifyPlatform` returns `could not determine a platform identifier`, and the
  error is swallowed at the `if err == nil` in `provider.go` — the asset ends up with
  no IDs and no name. Those targets now get the `//platformid.api.mondoo.app/hostname/…`
  ID they were always meant to have. This is going from broken to working, not a
  change of identity for anything that currently resolves.

No new identifier is added to any asset that already has one.

## Tests

- `TestHostnameBottlerocket` — a faithful Bottlerocket node fixture: no
  `/etc/os-release`, no `/etc/hostname`, full `/usr/lib/os-release`, and the rendered
  `/etc/network/hostname.env` and `/etc/hosts`. Also asserts the platform still
  detects as `bottlerocket`.
- `TestHostnameLinuxEtcHosts` — Debian with no `/etc/hostname`, hostname on the
  127.0.1.1 line, plus a routable entry for another machine that must not be picked.
- `TestHostnameLinuxEmptyEtcHostname` — pins the empty-file fall-through.
- Table tests for each parser and for `isLocalhostVariant`, covering the empty,
  absent, commented, quoted and malformed cases.

All three integration tests were confirmed to fail against the previous
implementation and pass with this one.

## Verification note

The Bottlerocket behaviour here was established by reading Bottlerocket's own
sources — `netdog`'s `set_hostname`, `set-hostname.service`, `hosts.template`,
`release-tmpfiles.conf`, and the image build that appends the version fields to
`/usr/lib/os-release` — not from a live node. A read-only check on a real
Bottlerocket host (`ls /etc/network/`, and both reads described above from inside a
pod mounting the host root) would confirm it end to end, and is worth doing before
this is relied on.
