### PR TITLE
🐛 languages: read the project license from composer.json and Cargo.toml

### DIFF
--- a/providers/os/resources/languages/php/composerjson/extractor.go
+++ b/providers/os/resources/languages/php/composerjson/extractor.go
@@ -44,8 +44,12 @@ func (cj *composerJson) Root() *languages.Package {
 	}
 
 	return &languages.Package{
-		Name:         cj.Name,
-		Version:      cj.Version,
+		Name:    cj.Name,
+		Version: cj.Version,
+		// The project's own license, which is a different question from the
+		// licenses of what it requires. An array means a choice among them;
+		// LicenseExpression renders that as SPDX.
+		License:      languages.LicenseExpression(cj.License),
 		Purl:         php.NewPackageUrl(cj.Name, cj.Version),
 		Cpes:         php.NewCpes(cj.Name, cj.Version),
 		EvidenceList: php.NewEvidenceList(cj.evidence),

--- a/providers/os/resources/languages/php/composerjson/license_test.go
+++ b/providers/os/resources/languages/php/composerjson/license_test.go
@@ -1,0 +1,55 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package composerjson
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers/os/resources/languages"
+)
+
+func rootOf(t *testing.T, fixture string) *languages.Package {
+	t.Helper()
+	f, err := os.Open("./testdata/" + fixture)
+	require.NoError(t, err)
+	defer f.Close()
+
+	bom, err := (&Extractor{}).Parse(f, "composer.json")
+	require.NoError(t, err)
+	root := bom.Root()
+	require.NotNil(t, root)
+	return root
+}
+
+// The common form: one license, passed through as the manifest wrote it and
+// without acquiring parentheses it did not have.
+func TestComposerJsonReadsASingleLicense(t *testing.T) {
+	assert.Equal(t, "MIT", rootOf(t, "single-license.composer.json").License)
+}
+
+// Composer defines the array form as a DISJUNCTIVE license — the package is
+// offered under any one of them and the consumer chooses — which is SPDX's OR.
+// composer.lock renders the same field the same way, so a project and its
+// lockfile now answer this identically.
+func TestComposerJsonReadsADisjunctiveLicense(t *testing.T) {
+	assert.Equal(t, "(LGPL-2.1-only OR GPL-3.0-or-later)",
+		rootOf(t, "disjunctive-license.composer.json").License)
+}
+
+// A shape Composer does not define must not sink the manifest. The license is
+// unread — which is the honest answer — and the inventory still parses.
+func TestComposerJsonSurvivesALicenseItCannotRead(t *testing.T) {
+	root := rootOf(t, "odd-license.composer.json")
+	assert.Empty(t, root.License)
+	assert.Equal(t, "myvendor/odd", root.Name, "the rest of the manifest must still parse")
+}
+
+// A manifest that declares nothing reports nothing, distinct from one whose
+// license this could not render.
+func TestComposerJsonWithNoLicenseReportsNone(t *testing.T) {
+	assert.Empty(t, rootOf(t, "simple.composer.json").License)
+}

--- a/providers/os/resources/languages/php/composerjson/parser.go
+++ b/providers/os/resources/languages/php/composerjson/parser.go
@@ -3,6 +3,8 @@
 
 package composerjson
 
+import "encoding/json"
+
 // composerJson represents a parsed composer.json file.
 type composerJson struct {
 	Name        string            `json:"name"`
@@ -10,7 +12,40 @@ type composerJson struct {
 	Description string            `json:"description"`
 	Require     map[string]string `json:"require"`
 	RequireDev  map[string]string `json:"require-dev"`
+	License     composerLicense   `json:"license"`
 
 	// evidence is a list of file paths where the composer.json was found.
 	evidence []string `json:"-"`
+}
+
+// composerLicense is composer.json's `license`, which is either one license or
+// a list of them.
+//
+// The two forms mean different things and both are legal:
+//
+//	"license": "MIT"
+//	"license": ["LGPL-2.1-only", "GPL-3.0-or-later"]
+//
+// Composer defines the array as a DISJUNCTIVE license — the package is offered
+// under any one of them and the consumer chooses — which is why it is carried
+// as a list and rendered with languages.LicenseExpression rather than joined
+// here. composer.lock records the same field the same way, so a project and its
+// lockfile now answer the licence question identically instead of one of them
+// answering it at all.
+type composerLicense []string
+
+func (l *composerLicense) UnmarshalJSON(data []byte) error {
+	var slice []string
+	if err := json.Unmarshal(data, &slice); err == nil {
+		*l = slice
+		return nil
+	}
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		*l = []string{single}
+		return nil
+	}
+	// Any other shape states no license this can read. Leaving it empty keeps
+	// the rest of the manifest rather than failing the file over one field.
+	return nil
 }

--- a/providers/os/resources/languages/php/composerjson/testdata/disjunctive-license.composer.json
+++ b/providers/os/resources/languages/php/composerjson/testdata/disjunctive-license.composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "myvendor/choice",
+  "version": "2.0.0",
+  "license": ["LGPL-2.1-only", "GPL-3.0-or-later"],
+  "require": {
+    "monolog/monolog": "^3.0"
+  }
+}

--- a/providers/os/resources/languages/php/composerjson/testdata/odd-license.composer.json
+++ b/providers/os/resources/languages/php/composerjson/testdata/odd-license.composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "myvendor/odd",
+  "version": "3.0.0",
+  "license": {"type": "MIT"},
+  "require": {
+    "monolog/monolog": "^3.0"
+  }
+}

--- a/providers/os/resources/languages/php/composerjson/testdata/single-license.composer.json
+++ b/providers/os/resources/languages/php/composerjson/testdata/single-license.composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "myvendor/single",
+  "version": "1.0.0",
+  "license": "MIT",
+  "require": {
+    "monolog/monolog": "^3.0"
+  }
+}

--- a/providers/os/resources/languages/rust/cargotoml/extractor.go
+++ b/providers/os/resources/languages/rust/cargotoml/extractor.go
@@ -81,8 +81,12 @@ func (ct *cargoToml) Root() *languages.Package {
 	}
 
 	return &languages.Package{
-		Name:         ct.Package.Name,
-		Version:      ct.Package.Version,
+		Name:    ct.Package.Name,
+		Version: ct.Package.Version,
+		// The crate's own license. Cargo's `license` is already an SPDX
+		// expression, so it is carried through as written rather than
+		// rebuilt from parts.
+		License:      ct.Package.License,
 		Purl:         rust.NewPackageUrl(ct.Package.Name, ct.Package.Version),
 		Cpes:         rust.NewCpes(ct.Package.Name, ct.Package.Version),
 		EvidenceList: rust.NewEvidenceList(ct.evidence),

--- a/providers/os/resources/languages/rust/cargotoml/license_test.go
+++ b/providers/os/resources/languages/rust/cargotoml/license_test.go
@@ -1,0 +1,80 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cargotoml
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func parseFixture(t *testing.T, name string) (*cargoToml, error) {
+	t.Helper()
+	f, err := os.Open("./testdata/" + name)
+	require.NoError(t, err)
+	defer f.Close()
+
+	bom, err := (&Extractor{}).Parse(f, "Cargo.toml")
+	if err != nil {
+		return nil, err
+	}
+	return bom.(*cargoToml), nil
+}
+
+// Cargo's `license` is already an SPDX expression, so the crate's own license
+// is carried through as written. Before this it was not read at all and every
+// Rust project reported no license.
+func TestCargoTomlReadsTheCrateLicense(t *testing.T) {
+	ct, err := parseFixture(t, "licensed.Cargo.toml")
+	require.NoError(t, err)
+
+	root := ct.Root()
+	require.NotNil(t, root)
+	assert.Equal(t, "MIT OR Apache-2.0", root.License)
+}
+
+// license-file names a file, not a license. Reporting the path in a field
+// consumers read as an SPDX expression would be a wrong answer where an empty
+// one is the honest one.
+func TestCargoTomlDoesNotReadLicenseFileAsALicense(t *testing.T) {
+	ct, err := parseFixture(t, "license-file.Cargo.toml")
+	require.NoError(t, err)
+
+	root := ct.Root()
+	require.NotNil(t, root)
+	assert.Empty(t, root.License, "a path is not a license expression")
+	assert.Equal(t, "custom-terms", root.Name, "the rest of the manifest must still parse")
+}
+
+// TestCargoTomlParsesAWorkspaceMember is the regression this file exists for.
+//
+// A workspace member writes `version.workspace = true` — a TABLE where the
+// struct held a string — and decoding failed the whole FILE:
+//
+//	toml: (last key "package.version"): incompatible types: TOML value has type
+//	map[string]any; destination has type string
+//
+// So Parse returned an error and the crate reported no root, no dependencies and
+// no license: an empty inventory, not a missing version. Workspace inheritance
+// has been the standard Cargo layout since 1.64 and no fixture used it.
+func TestCargoTomlParsesAWorkspaceMember(t *testing.T) {
+	ct, err := parseFixture(t, "workspace-member.Cargo.toml")
+	require.NoError(t, err, "a workspace member must parse, not fail the file")
+
+	root := ct.Root()
+	require.NotNil(t, root, "the crate is still a package even when it inherits its version")
+	assert.Equal(t, "member", root.Name)
+
+	// Inherited values live in the workspace root manifest, which this parser
+	// was not given. Empty is the honest answer; a guess would be worse.
+	assert.Empty(t, root.Version, "an inherited version is unknown here, not invented")
+	assert.Empty(t, root.License, "an inherited license is unknown here, not invented")
+
+	// The point of not failing the file: the dependencies are still readable.
+	direct := ct.Direct()
+	require.Len(t, direct, 1)
+	assert.Equal(t, "serde", direct[0].Name)
+}

--- a/providers/os/resources/languages/rust/cargotoml/parser.go
+++ b/providers/os/resources/languages/rust/cargotoml/parser.go
@@ -29,9 +29,58 @@ type resolvedDep struct {
 
 // cargoPackageInfo represents the [package] section.
 type cargoPackageInfo struct {
-	Name    string `toml:"name"`
-	Version string `toml:"version"`
-	Edition string `toml:"edition"`
+	Name    string
+	Version string
+	Edition string
+	// License is the SPDX expression Cargo asks for in `license`. Its sibling
+	// `license-file` is deliberately not read: it names a file, and a path in a
+	// field consumers read as a license expression is worse than an empty one.
+	License string
+}
+
+// UnmarshalTOML reads [package] a field at a time so that a value Cargo allows
+// but this struct cannot hold does not sink the whole manifest.
+//
+// The shape that forced it is workspace inheritance. A member of a Cargo
+// workspace states
+//
+//	[package]
+//	name = "member"
+//	version.workspace = true
+//	license.workspace = true
+//
+// where the inherited fields are TABLES ({workspace = true}), not strings, and
+// the real values live in the workspace root manifest this extractor was not
+// given. Decoding straight into string fields failed the FILE:
+//
+//	toml: (last key "package.version"): incompatible types: TOML value has type
+//	map[string]any; destination has type string
+//
+// and Parse returned that error, so a workspace member reported no root, no
+// dependencies and no license at all — not a missing version, an empty
+// inventory. Workspace inheritance has been the standard layout since Cargo
+// 1.64, and no fixture here used it.
+//
+// An inherited field is left empty, which is the honest answer: the value is
+// stated in a file this parser does not have. Everything stated literally is
+// still read.
+func (p *cargoPackageInfo) UnmarshalTOML(v any) error {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	p.Name = tomlString(m["name"])
+	p.Version = tomlString(m["version"])
+	p.Edition = tomlString(m["edition"])
+	p.License = tomlString(m["license"])
+	return nil
+}
+
+// tomlString returns v when it is a string and "" for every other shape,
+// including the {workspace = true} table and a missing key.
+func tomlString(v any) string {
+	s, _ := v.(string)
+	return s
 }
 
 // cargoDep represents a dependency in table format.

--- a/providers/os/resources/languages/rust/cargotoml/testdata/license-file.Cargo.toml
+++ b/providers/os/resources/languages/rust/cargotoml/testdata/license-file.Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "custom-terms"
+version = "0.3.0"
+license-file = "LICENSE-CUSTOM"
+
+[dependencies]
+serde = "1.0"

--- a/providers/os/resources/languages/rust/cargotoml/testdata/licensed.Cargo.toml
+++ b/providers/os/resources/languages/rust/cargotoml/testdata/licensed.Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "licensed"
+version = "2.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+serde = "1.0"

--- a/providers/os/resources/languages/rust/cargotoml/testdata/workspace-member.Cargo.toml
+++ b/providers/os/resources/languages/rust/cargotoml/testdata/workspace-member.Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "member"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde = "1.0"


### PR DESCRIPTION
Two extractors never mapped the `license` field their manifest states, so every PHP and every Rust project reported no licence. One of them turned out to be hiding a larger bug.

## composer.json

`composer.lock`, describing the same project, already reported a licence. The two readings of one project disagreed because only one of them looked.

Composer states the field in two forms and both are legal:

```json
"license": "MIT"
"license": ["LGPL-2.1-only", "GPL-3.0-or-later"]
```

The array is a **disjunctive** licence — the package is offered under any one of them and the consumer chooses. That is SPDX's `OR`, which is exactly what `languages.LicenseExpression` renders and exactly what `composerlock` already feeds it, so the manifest and the lockfile now answer identically instead of one of them answering at all.

A shape Composer does not define leaves the licence unread rather than failing the manifest, matching `packageJsonLicense`: losing one field is better than losing the inventory.

## Cargo.toml — and the bug in front of it

Adding a `License` field alone would have been dead on arrival, because **a Cargo workspace member does not parse at all today**. A member inherits fields from the workspace root:

```toml
[package]
name = "member"
version.workspace = true
license.workspace = true
```

Those are **tables** (`{workspace = true}`), and `cargoPackageInfo` held them as strings, so `toml.Decode` failed the whole manifest:

```text
toml: (last key "package.version"): incompatible types: TOML value has type
map[string]any; destination has type string
```

`Parse` returned that error, so the crate reported **no root, no dependencies and no licence** — an empty inventory, not a missing version. Workspace inheritance has been the standard Cargo layout since 1.64 and no fixture here used it.

`[package]` is now read a field at a time through `UnmarshalTOML`. An inherited field is left empty, which is the honest answer: the value is stated in a file this parser was not given, and guessing would be worse than saying nothing. Everything stated literally is still read — the dependencies were never the problem.

`license` itself is already an SPDX expression, so it is carried through as written rather than rebuilt from parts. Its sibling `license-file` is deliberately **not** read: it names a file, and a path in a field consumers read as a licence expression is a wrong answer where an empty one is the honest one.

## Testing

New fixtures and tests in both packages, each verified to fail against the current behaviour rather than assumed to:

```text
--- FAIL: TestComposerJsonReadsASingleLicense
        expected: "MIT"
        actual  : ""
--- FAIL: TestComposerJsonReadsADisjunctiveLicense
        expected: "(LGPL-2.1-only OR GPL-3.0-or-later)"
        actual  : ""
--- FAIL: TestCargoTomlParsesAWorkspaceMember
        Received unexpected error:
        toml: (last key "package.license"): incompatible types: TOML value has
        type map[string]any; destination has type string
```

Coverage: the single and disjunctive forms, a shape Composer does not define, a manifest declaring nothing, `license-file` not being read as a licence, and the workspace member — which also asserts its dependencies still parse, since not failing the file is the whole point.

`go test ./providers/os/resources/languages/...` green.

## Follow-up

xgrep carries its own `composer.json` and `Cargo.toml` licence readers as a stopgap for exactly this gap, with a comment saying they stay until mql does it. They can go once this merges and the pin moves. Worth noting for whoever does it: mql renders `(MIT OR Apache-2.0)` parenthesised in file order where xgrep's local reader sorts and does not parenthesise, so the rendered value changes shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)