### PR TITLE
✨ languages/java: read Gradle build scripts, version catalogs and project version properties

### DIFF
--- a/providers/os/resources/languages/java/buildgradle/extractor.go
+++ b/providers/os/resources/languages/java/buildgradle/extractor.go
@@ -1,0 +1,106 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package buildgradle
+
+import (
+	"io"
+
+	"go.mondoo.com/mql/providers/os/resources/languages"
+	"go.mondoo.com/mql/providers/os/resources/languages/java"
+)
+
+var (
+	_ languages.Extractor = (*Extractor)(nil)
+	_ languages.Bom       = (*gradleBuild)(nil)
+)
+
+// Extractor parses Gradle build scripts (build.gradle, build.gradle.kts) to
+// extract declared project dependencies.
+//
+// Gradle's own `gradle.lockfile` is the better source where it exists — it is
+// resolved, so it carries transitive dependencies and exact versions. But
+// dependency locking is opt-in and most projects never enable it, which left a
+// plain Gradle project reporting no dependencies at all: not a partial
+// inventory, an empty one. The build script is what those projects actually
+// have, and its declarations are the direct dependencies.
+type Extractor struct{}
+
+func (e *Extractor) Name() string {
+	return "buildgradle"
+}
+
+func (e *Extractor) Parse(r io.Reader, filename string) (languages.Bom, error) {
+	build, err := parseBuildGradle(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if filename != "" {
+		build.evidence = append(build.evidence, filename)
+	}
+
+	return build, nil
+}
+
+// Root returns nil — a build script does not reliably name the project it
+// builds. The artifact name comes from settings.gradle's `rootProject.name`
+// (or the directory name), which is not this file's to state.
+func (b *gradleBuild) Root() *languages.Package {
+	return nil
+}
+
+// Direct returns every declared dependency.
+//
+// Everything a build script declares is direct by definition — the script is
+// where the project asks for it. Test-only dependencies are included and carry
+// dev scope: "direct" is about who declared a dependency, "dev" about whether it
+// ships, and the two are independent.
+func (b *gradleBuild) Direct() languages.Packages {
+	return b.packages()
+}
+
+// Transitive returns the declared dependencies. A build script states only what
+// the project asked for; resolving the closure below it needs Gradle itself,
+// and no transitive dependency is invented here to stand in for that.
+func (b *gradleBuild) Transitive() languages.Packages {
+	return b.packages()
+}
+
+func (b *gradleBuild) packages() languages.Packages {
+	var packages languages.Packages
+	at := map[string]int{}
+	for _, dep := range b.Deps {
+		name := dep.GroupId + ":" + dep.ArtifactId
+
+		scope := languages.PackageScopeProd
+		if dep.IsTest {
+			scope = languages.PackageScopeDev
+		}
+
+		// The same coordinate is routinely declared in several configurations
+		// (implementation and testImplementation both). It is one package, and
+		// it ships if ANY configuration ships it — so a later production
+		// declaration promotes an entry first seen as dev. Deciding this by
+		// declaration order would make the scope depend on the order lines
+		// happen to appear in.
+		key := name + "@" + dep.Version
+		if i, ok := at[key]; ok {
+			if scope == languages.PackageScopeProd {
+				packages[i].Scope = languages.PackageScopeProd
+			}
+			continue
+		}
+		at[key] = len(packages)
+
+		packages = append(packages, &languages.Package{
+			Name:         name,
+			Version:      dep.Version,
+			Scope:        scope,
+			Purl:         java.NewPackageUrl(dep.GroupId, dep.ArtifactId, dep.Version),
+			Cpes:         java.NewCpes(dep.GroupId, dep.ArtifactId, dep.Version),
+			EvidenceList: java.NewEvidenceList(b.evidence),
+		})
+	}
+	return packages
+}

--- a/providers/os/resources/languages/java/buildgradle/extractor.go
+++ b/providers/os/resources/languages/java/buildgradle/extractor.go
@@ -24,14 +24,27 @@ var (
 // plain Gradle project reporting no dependencies at all: not a partial
 // inventory, an empty one. The build script is what those projects actually
 // have, and its declarations are the direct dependencies.
-type Extractor struct{}
+type Extractor struct {
+	// Properties supplies version properties declared OUTSIDE the script being
+	// parsed — a gradle.properties, a root project's `ext` block, or a shared
+	// script applied into the build. Gradle resolves a version reference
+	// against the whole project's property scope, and most real projects
+	// declare their versions once, away from the module that uses them:
+	// ExoPlayer keeps every version in a root `constants.gradle`. Without them
+	// a reference resolves to nothing and the dependency is inventoried with no
+	// version, which no advisory can match.
+	//
+	// The script's own declarations take precedence, as they do in Gradle.
+	// Optional: a nil map parses the file alone.
+	Properties map[string]string
+}
 
 func (e *Extractor) Name() string {
 	return "buildgradle"
 }
 
 func (e *Extractor) Parse(r io.Reader, filename string) (languages.Bom, error) {
-	build, err := parseBuildGradle(r)
+	build, err := parseBuildGradle(r, e.Properties)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/resources/languages/java/buildgradle/extractor_test.go
+++ b/providers/os/resources/languages/java/buildgradle/extractor_test.go
@@ -147,7 +147,12 @@ func TestIsDevConfiguration(t *testing.T) {
 
 	assert.False(t, isDevConfiguration("implementation", false))
 	assert.False(t, isDevConfiguration("api", false))
-	assert.False(t, isDevConfiguration("compileOnly", false), "provided at runtime, so it ships")
+	// compileOnly is on the compile classpath and NOT the runtime one, so it
+	// often does not ship. It counts as prod anyway: whether the artifact
+	// reaches production is a packaging question this parser cannot answer, and
+	// scoping a shipped dependency as dev hides a real CVE, where the reverse
+	// merely reports one that may not apply.
+	assert.False(t, isDevConfiguration("compileOnly", false))
 	assert.False(t, isDevConfiguration("runtimeOnly", false))
 }
 
@@ -170,4 +175,74 @@ func countNamed(deps languages.Packages, name string) int {
 		}
 	}
 	return n
+}
+
+// Brace depth decides whether a declaration sits in the dependencies block or
+// inside a trailing configuration closure, so a brace inside a string literal
+// used to move every later declaration a level deeper and drop it — a
+// dependency silently missing, which is the failure this extractor removes.
+func TestBraceInsideAStringDoesNotHideDependencies(t *testing.T) {
+	for _, c := range []struct{ name, script string }{
+		{"unbalanced open brace in a string", `
+dependencies {
+    def placeholder = "{"
+    implementation 'com.example:kept:1.0'
+}
+`},
+		{"unbalanced close brace in a string", `
+dependencies {
+    def placeholder = "}"
+    implementation 'com.example:kept:1.0'
+}
+`},
+		{"brace in a string before the block", `
+def marker = "{"
+dependencies {
+    implementation 'com.example:kept:1.0'
+}
+`},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			bom, err := (&Extractor{}).Parse(strings.NewReader(c.script), "build.gradle")
+			require.NoError(t, err)
+			require.NotNil(t, bom.Direct().Find("com.example:kept"))
+		})
+	}
+
+	// And the closure it protects still works: an exclude is a dependency being
+	// removed, not one being added.
+	t.Run("an exclude closure is still not a declaration", func(t *testing.T) {
+		bom, err := (&Extractor{}).Parse(strings.NewReader(`
+dependencies {
+    implementation('com.example:kept:1.0') {
+        exclude group: 'com.evil', module: 'badlib'
+    }
+}
+`), "build.gradle")
+		require.NoError(t, err)
+		assert.NotNil(t, bom.Direct().Find("com.example:kept"))
+		assert.Nil(t, bom.Direct().Find("com.evil:badlib"), "an exclude removes a dependency")
+	})
+}
+
+// A dynamic version names a set of releases, so it is not recorded as one: the
+// artifact is inventoried with its version unknown, the same treatment the
+// version catalog gives it.
+func TestDynamicVersionsAreNotRecordedAsVersions(t *testing.T) {
+	bom, err := (&Extractor{}).Parse(strings.NewReader(`
+dependencies {
+    implementation 'com.example:pinned:1.2.3'
+    implementation 'com.example:dynamic:1.+'
+    implementation 'com.example:ranged:[1.0, 2.0['
+    implementation 'com.example:newest:latest.release'
+}
+`), "build.gradle")
+	require.NoError(t, err)
+
+	assert.Equal(t, "1.2.3", bom.Direct().Find("com.example:pinned").Version)
+	for _, name := range []string{"com.example:dynamic", "com.example:ranged", "com.example:newest"} {
+		p := bom.Direct().Find(name)
+		require.NotNil(t, p, "%s is still inventoried", name)
+		assert.Empty(t, p.Version, "%s names a set of releases, not a release", name)
+	}
 }

--- a/providers/os/resources/languages/java/buildgradle/extractor_test.go
+++ b/providers/os/resources/languages/java/buildgradle/extractor_test.go
@@ -1,0 +1,173 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package buildgradle
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers/os/resources/languages"
+	"go.mondoo.com/mql/sbom"
+)
+
+func parseFile(t *testing.T, path, name string) languages.Bom {
+	t.Helper()
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	bom, err := (&Extractor{}).Parse(f, name)
+	require.NoError(t, err)
+	return bom
+}
+
+func TestBuildGradleGroovy(t *testing.T) {
+	bom := parseFile(t, "./testdata/simple.build.gradle", "path/to/build.gradle")
+
+	// A build script does not name the project it builds.
+	assert.Nil(t, bom.Root())
+
+	deps := bom.Transitive()
+
+	p := deps.Find("com.fasterxml.jackson.core:jackson-databind")
+	require.NotNil(t, p)
+	assert.Equal(t, "2.9.10.1", p.Version, "version from an ext block property")
+	assert.Equal(t, "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.10.1", p.Purl)
+	assert.Equal(t, languages.PackageScopeProd, p.Scope)
+	assert.Equal(t, []*sbom.Evidence{{Type: sbom.EvidenceType_EVIDENCE_TYPE_FILE, Value: "path/to/build.gradle"}}, p.EvidenceList)
+
+	p = deps.Find("org.apache.logging.log4j:log4j-core")
+	require.NotNil(t, p)
+	assert.Equal(t, "2.14.1", p.Version, "version from a `def` interpolated as $log4jVersion")
+
+	// The property is declared below the dependencies block; collection is
+	// whole-file so declaration order does not decide.
+	p = deps.Find("org.yaml:snakeyaml")
+	require.NotNil(t, p)
+	assert.Equal(t, "1.29", p.Version, "version from an ext.x property declared after use")
+
+	p = deps.Find("com.google.guava:guava")
+	require.NotNil(t, p)
+	assert.Equal(t, "24.1.1-jre", p.Version, "map notation")
+
+	p = deps.Find("org.apache.httpcomponents:httpclient")
+	require.NotNil(t, p)
+	assert.Equal(t, "4.5.13", p.Version)
+
+	// A version managed by a BOM is unknown here, not absent: the artifact is
+	// reported, with no version claimed for it.
+	p = deps.Find("org.springframework.boot:spring-boot-starter-web")
+	require.NotNil(t, p)
+	assert.Empty(t, p.Version)
+	assert.Equal(t, "pkg:maven/org.springframework.boot/spring-boot-starter-web", p.Purl)
+
+	assert.Equal(t, languages.PackageScopeDev, deps.Find("junit:junit").Scope)
+	assert.Equal(t, languages.PackageScopeDev, deps.Find("org.mockito:mockito-core").Scope)
+
+	// Declared in buildscript{}: build tooling, never shipped.
+	assert.Equal(t, languages.PackageScopeDev, deps.Find("org.springframework.boot:spring-boot-gradle-plugin").Scope)
+
+	// Declared as both compileOnly and annotationProcessor. It is one package,
+	// and the shipping configuration decides the scope regardless of which line
+	// came first.
+	p = deps.Find("org.projectlombok:lombok")
+	require.NotNil(t, p)
+	assert.Equal(t, languages.PackageScopeProd, p.Scope)
+	assert.Equal(t, 1, countNamed(deps, "org.projectlombok:lombok"), "declared twice, reported once")
+}
+
+func TestBuildGradleOmitsWhatItCannotRead(t *testing.T) {
+	deps := parseFile(t, "./testdata/simple.build.gradle", "build.gradle").Transitive()
+
+	// A coordinate that is not a Maven artifact must not become a package: a
+	// fabricated entry is worse than a missing one, because it reports a
+	// dependency the project does not have.
+	for _, name := range []string{
+		"commons-logging:commons-logging",   // an exclude inside a trailing closure
+		"com.fasterxml.jackson:jackson-bom", // a platform(): a constraint, ships no code
+	} {
+		assert.Nil(t, deps.Find(name), "%s must not be reported", name)
+	}
+
+	for _, p := range deps {
+		assert.NotContains(t, p.Name, "$", "an unresolved interpolation must never reach a package name")
+		assert.NotContains(t, p.Version, "$", "an unresolved interpolation must never reach a version")
+		assert.NotContains(t, p.Name, "/", "a file path must never be read as a coordinate")
+		require.Equal(t, 2, len(strings.Split(p.Name, ":")), "a name is exactly group:artifact")
+	}
+}
+
+func TestBuildGradleKotlinDSL(t *testing.T) {
+	deps := parseFile(t, "./testdata/kotlin.build.gradle.kts", "build.gradle.kts").Transitive()
+
+	p := deps.Find("com.fasterxml.jackson.core:jackson-databind")
+	require.NotNil(t, p)
+	assert.Equal(t, "2.9.10.1", p.Version, "version from a `val` interpolated as $jacksonVersion")
+
+	p = deps.Find("com.google.guava:guava")
+	require.NotNil(t, p)
+	assert.Equal(t, "24.1.1-jre", p.Version, "Kotlin named-argument map notation")
+
+	assert.Equal(t, "1.29", deps.Find("org.yaml:snakeyaml").Version)
+	assert.Equal(t, languages.PackageScopeDev, deps.Find("junit:junit").Scope)
+
+	// A version catalog accessor names no coordinate in this file. Resolving it
+	// needs libs.versions.toml, so it is omitted rather than guessed at.
+	assert.Equal(t, 4, len(deps))
+}
+
+func TestDirectIsEveryDeclaration(t *testing.T) {
+	bom := parseFile(t, "./testdata/kotlin.build.gradle.kts", "build.gradle.kts")
+
+	// Everything a build script declares is direct — the script is where the
+	// project asked for it. Dev scope is the orthogonal axis and does not
+	// remove a dependency from the direct set.
+	assert.Equal(t, len(bom.Transitive()), len(bom.Direct()))
+	assert.NotNil(t, bom.Direct().Find("junit:junit"))
+}
+
+func TestStripComment(t *testing.T) {
+	assert.Equal(t, "implementation 'a:b:1' ", stripComment("implementation 'a:b:1' // pinned"))
+	// A URL inside a string literal is not a comment.
+	assert.Equal(t, "url 'https://repo.example.com/x'", stripComment("url 'https://repo.example.com/x'"))
+	assert.Equal(t, "", stripComment("// all comment"))
+}
+
+func TestIsDevConfiguration(t *testing.T) {
+	assert.True(t, isDevConfiguration("testImplementation", false))
+	assert.True(t, isDevConfiguration("androidTestImplementation", false))
+	assert.True(t, isDevConfiguration("annotationProcessor", false))
+	assert.True(t, isDevConfiguration("classpath", false))
+	// Anything inside buildscript{} is build tooling whatever it is called.
+	assert.True(t, isDevConfiguration("implementation", true))
+
+	assert.False(t, isDevConfiguration("implementation", false))
+	assert.False(t, isDevConfiguration("api", false))
+	assert.False(t, isDevConfiguration("compileOnly", false), "provided at runtime, so it ships")
+	assert.False(t, isDevConfiguration("runtimeOnly", false))
+}
+
+func TestResolveInterp(t *testing.T) {
+	vars := map[string]string{"v": "1.2.3"}
+	assert.Equal(t, "1.2.3", resolveInterp("$v", vars))
+	assert.Equal(t, "1.2.3", resolveInterp("${v}", vars))
+	assert.Equal(t, "1.2.3", resolveInterp("${project.ext.v}", vars))
+	assert.Equal(t, "4.5.6", resolveInterp("4.5.6", vars))
+	// An unresolvable reference is an unknown version, never a literal.
+	assert.Equal(t, "", resolveInterp("$missing", vars))
+	assert.Equal(t, "", resolveInterp("", vars))
+}
+
+func countNamed(deps languages.Packages, name string) int {
+	n := 0
+	for _, p := range deps {
+		if p.Name == name {
+			n++
+		}
+	}
+	return n
+}

--- a/providers/os/resources/languages/java/buildgradle/parser.go
+++ b/providers/os/resources/languages/java/buildgradle/parser.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"regexp"
 	"strings"
+
+	"go.mondoo.com/mql/providers/os/resources/languages/java"
 )
 
 // gradleBuild is the dependency declarations read out of a Gradle build script.
@@ -97,7 +99,9 @@ func parseBuildGradle(r io.Reader, external map[string]string) (*gradleBuild, er
 	var lines []string
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	for scanner.Scan() {
+	// Bounded like the property collectors: a build script is small by nature,
+	// and the file comes from scanned repository content rather than from us.
+	for scanner.Scan() && len(lines) < maxPropertyLines {
 		lines = append(lines, scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
@@ -142,7 +146,7 @@ func parseBuildGradle(r io.Reader, external map[string]string) (*gradleBuild, er
 			buildscriptDepth = depth
 		}
 
-		depth += strings.Count(line, "{") - strings.Count(line, "}")
+		depth += braceDelta(line)
 
 		if depsDepth >= 0 && depth <= depsDepth {
 			depsDepth = -1
@@ -189,6 +193,40 @@ func stripComment(line string) string {
 	return line
 }
 
+// braceDelta is the net block nesting a line opens, counting only braces
+// outside string literals.
+//
+// Counting the whole line lets a brace inside a string move the tracker: a
+// `def s = "{"` anywhere in a build script pushes the depth up by one, and
+// every declaration after it then sits one level deeper than the dependencies
+// block it is actually in -- so it is read as a trailing configuration closure
+// and dropped. That is a dependency silently missing from the inventory, which
+// is the failure this extractor exists to remove rather than reproduce.
+//
+// A GString like "${'{'}" is balanced by luck and survived the old count; an
+// unbalanced one did not. Quotes are tracked the same way stripComment tracks
+// them, so the two agree about what is inside a string.
+func braceDelta(line string) int {
+	depth := 0
+	var quote byte
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		switch {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			}
+		case c == '\'' || c == '"':
+			quote = c
+		case c == '{':
+			depth++
+		case c == '}':
+			depth--
+		}
+	}
+	return depth
+}
+
 // afterFirstBrace returns what follows the first "{" on a line, trimmed of a
 // trailing "}".
 func afterFirstBrace(line string) string {
@@ -203,6 +241,16 @@ func afterFirstBrace(line string) string {
 // literal it extends, so that `'g:a:' + fooVersion` reads as `'g:a:1.2.3'`.
 // A variable that does not resolve is left alone: the coordinate then states no
 // version, which is the truth about it.
+//
+// The rewrite is deliberately partial, and coupled to quotedRe -- change one
+// and check the other. concatRe matches the CLOSING quote of the left-hand
+// literal plus the variable, and the replacement puts the variable's value
+// first and that quote after it. So `'g:a:' + fooVersion` becomes
+// `'g:a:1.2.3'`: the quote that used to close the literal early now closes it
+// after the version, and quotedRe reads the whole coordinate out from the
+// original opening quote. No complete token is ever built -- the two regexes
+// meet in the middle, and a change to either that alters where the quote lands
+// silently stops coordinates resolving.
 func inlineConcat(s string, vars map[string]string) string {
 	return concatRe.ReplaceAllStringFunc(s, func(m string) string {
 		sub := concatRe.FindStringSubmatch(m)
@@ -260,7 +308,7 @@ func parseDepLine(line string, vars map[string]string, inBuildscript bool) []gra
 	return []gradleDep{{
 		GroupId:       group,
 		ArtifactId:    name,
-		Version:       resolveInterp(firstSubmatch(mapVersionRe, rest), vars),
+		Version:       java.ConcreteVersion(resolveInterp(firstSubmatch(mapVersionRe, rest), vars)),
 		Configuration: config,
 		IsTest:        isTest,
 	}}
@@ -293,9 +341,13 @@ func parseCoordinate(s string, vars map[string]string) (gradleDep, bool) {
 	if !validCoordinatePart(group) || !validCoordinatePart(artifact) {
 		return gradleDep{}, false
 	}
+	// A dynamic version or a range names a set of releases rather than one, and
+	// is refused here for the reason the version catalog refuses it: a purl
+	// carrying "1.+" matches nothing while reading as a definite claim. The
+	// artifact is still inventoried, with the version unknown.
 	var version string
 	if len(parts) >= 3 {
-		version = resolveInterp(strings.TrimSpace(parts[2]), vars)
+		version = java.ConcreteVersion(resolveInterp(strings.TrimSpace(parts[2]), vars))
 	}
 	return gradleDep{GroupId: group, ArtifactId: artifact, Version: version}, true
 }

--- a/providers/os/resources/languages/java/buildgradle/parser.go
+++ b/providers/os/resources/languages/java/buildgradle/parser.go
@@ -1,0 +1,340 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package buildgradle
+
+import (
+	"bufio"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// gradleBuild is the dependency declarations read out of a Gradle build script.
+type gradleBuild struct {
+	// Deps are the declared dependencies, in declaration order.
+	Deps []gradleDep
+
+	// evidence is the list of file paths the declarations were read from.
+	evidence []string
+}
+
+// gradleDep is one declared dependency.
+type gradleDep struct {
+	// GroupId is the Maven group ID (e.g. "org.apache.commons").
+	GroupId string
+	// ArtifactId is the Maven artifact ID (e.g. "commons-text").
+	ArtifactId string
+	// Version is the declared version, or "" when the build script does not
+	// state one here — a version managed by a BOM/platform, or an unresolved
+	// interpolation. Empty means unknown, never "any".
+	Version string
+	// Configuration is the Gradle configuration it was declared in
+	// (e.g. "implementation", "testImplementation").
+	Configuration string
+	// IsTest reports whether the configuration only ever applies to test or
+	// build tooling, never to the shipped runtime.
+	IsTest bool
+}
+
+var (
+	// A dependency declaration opens with the configuration name. Inside a
+	// dependencies block, an identifier followed by an argument is a
+	// declaration; anything else (a nested closure, a bare statement) is not.
+	configRe = regexp.MustCompile(`^([A-Za-z_][A-Za-z0-9_]*)[\s(]\s*["'A-Za-z(]`)
+
+	// Quoted string literals, single or double quoted.
+	quotedRe = regexp.MustCompile(`['"]([^'"\n]*)['"]`)
+
+	// The map-notation form: group: 'x', name: 'y', version: 'z' (Groovy) or
+	// group = "x", name = "y", version = "z" (Kotlin DSL).
+	mapGroupRe     = regexp.MustCompile(`\bgroup\s*[:=]\s*['"]([^'"]+)['"]`)
+	mapNameRe      = regexp.MustCompile(`\b(?:name|module)\s*[:=]\s*['"]([^'"]+)['"]`)
+	mapVersionRe   = regexp.MustCompile(`\bversion\s*[:=]\s*['"]([^'"]+)['"]`)
+	dependenciesRe = regexp.MustCompile(`(^|\W)dependencies\s*\{`)
+	buildscriptRe  = regexp.MustCompile(`(^|\W)buildscript\s*\{`)
+
+	// Variable assignments that a version interpolation can refer to:
+	// `def x = '1.2'`, `val x = "1.2"`, `ext.x = '1.2'`, or a bare `x = '1.2'`
+	// inside an ext block.
+	varRe = regexp.MustCompile(`^(?:def|val|var)?\s*(?:ext\.)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*['"]([^'"]*)['"]`)
+
+	// $name and ${name} interpolations inside a version string.
+	interpRe = regexp.MustCompile(`\$\{?([A-Za-z_][A-Za-z0-9_.]*)\}?`)
+
+	// Groovy string concatenation: 'group:artifact:' + versionVariable. The
+	// version lands outside the quotes, so it has to be folded back in before
+	// the literal can be read as a coordinate.
+	concatRe = regexp.MustCompile(`(['"])\s*\+\s*([A-Za-z_][A-Za-z0-9_.]*)`)
+)
+
+// nonDependencyCall lists call forms that appear in a configuration position but
+// name no Maven coordinate: a sibling project, a file on disk, the Gradle API
+// itself, or a BOM/platform import (a constraint, which ships no code and so can
+// never be "used" by anything).
+var nonDependencyCall = []string{
+	"project(", "files(", "fileTree(", "gradleApi(", "localGroovy(",
+	"gradleTestKit(", "platform(", "enforcedPlatform(", "testFixtures(",
+}
+
+// devConfigurations are configurations whose dependencies never reach the
+// shipped runtime: build tooling, code generators and static analysis.
+var devConfigurations = map[string]bool{
+	"classpath": true, "annotationProcessor": true, "kapt": true, "ksp": true,
+	"developmentOnly": true, "checkstyle": true, "pmd": true, "spotbugs": true,
+	"jacocoAgent": true, "jacocoAnt": true, "errorprone": true, "lintChecks": true,
+}
+
+// parseBuildGradle reads dependency declarations out of a Gradle build script.
+//
+// Gradle build scripts are programs, not data, so this reads the declarations
+// that are stated literally and says nothing about the rest. That asymmetry is
+// deliberate: a coordinate spelled out in the script is a fact, while one
+// assembled at configuration time (a version catalog accessor, a coordinate
+// built from a function call) is not recoverable without running Gradle. An
+// unreadable declaration is therefore omitted rather than guessed at.
+func parseBuildGradle(r io.Reader) (*gradleBuild, error) {
+	var lines []string
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	// Variables are collected over the whole file first: a version property is
+	// as often declared below the dependencies block as above it.
+	vars := collectVars(lines)
+
+	build := &gradleBuild{}
+	depth := 0
+	depsDepth := -1
+	buildscriptDepth := -1
+
+	for _, raw := range lines {
+		line := stripComment(raw)
+
+		if depsDepth < 0 && dependenciesRe.MatchString(line) {
+			depsDepth = depth
+			// A single-line block (`dependencies { implementation '...' }`)
+			// declares on this same line, after the brace.
+			if rest := afterFirstBrace(line); rest != "" {
+				build.Deps = append(build.Deps, parseDepLine(rest, vars, buildscriptDepth >= 0)...)
+			}
+		} else if depsDepth == depth-1 {
+			// A declaration sits directly in the dependencies block. Anything
+			// deeper is inside a trailing configuration closure — an
+			// `exclude group: 'x', module: 'y'` reads exactly like map
+			// notation, and is a dependency being removed, not added.
+			build.Deps = append(build.Deps, parseDepLine(line, vars, buildscriptDepth >= 0)...)
+		}
+
+		if buildscriptDepth < 0 && buildscriptRe.MatchString(line) {
+			buildscriptDepth = depth
+		}
+
+		depth += strings.Count(line, "{") - strings.Count(line, "}")
+
+		if depsDepth >= 0 && depth <= depsDepth {
+			depsDepth = -1
+		}
+		if buildscriptDepth >= 0 && depth <= buildscriptDepth {
+			buildscriptDepth = -1
+		}
+	}
+
+	return build, nil
+}
+
+// collectVars maps variable names to their literal string values, for resolving
+// a version written as an interpolation.
+func collectVars(lines []string) map[string]string {
+	vars := map[string]string{}
+	for _, raw := range lines {
+		line := strings.TrimSpace(stripComment(raw))
+		if m := varRe.FindStringSubmatch(line); m != nil {
+			vars[m[1]] = m[2]
+		}
+	}
+	return vars
+}
+
+// stripComment removes a trailing line comment. Quotes are tracked so that a
+// "//" inside a string literal (a repository URL, most often) is not mistaken
+// for the start of a comment.
+func stripComment(line string) string {
+	var quote byte
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		switch {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			}
+		case c == '\'' || c == '"':
+			quote = c
+		case c == '/' && i+1 < len(line) && line[i+1] == '/':
+			return line[:i]
+		}
+	}
+	return line
+}
+
+// afterFirstBrace returns what follows the first "{" on a line, trimmed of a
+// trailing "}".
+func afterFirstBrace(line string) string {
+	i := strings.Index(line, "{")
+	if i < 0 {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(line[i+1:]), "}"))
+}
+
+// inlineConcat folds a concatenated version variable back into the string
+// literal it extends, so that `'g:a:' + fooVersion` reads as `'g:a:1.2.3'`.
+// A variable that does not resolve is left alone: the coordinate then states no
+// version, which is the truth about it.
+func inlineConcat(s string, vars map[string]string) string {
+	return concatRe.ReplaceAllStringFunc(s, func(m string) string {
+		sub := concatRe.FindStringSubmatch(m)
+		name := sub[2]
+		if i := strings.LastIndex(name, "."); i >= 0 {
+			name = name[i+1:]
+		}
+		v, ok := vars[name]
+		if !ok {
+			return m
+		}
+		return v + sub[1]
+	})
+}
+
+// parseDepLine reads the dependency declarations on one line of a dependencies
+// block. A line may declare more than one (`implementation 'a:b:1', 'c:d:2'`).
+func parseDepLine(line string, vars map[string]string, inBuildscript bool) []gradleDep {
+	trimmed := strings.TrimSpace(line)
+	m := configRe.FindStringSubmatch(trimmed)
+	if m == nil {
+		return nil
+	}
+	config := m[1]
+	rest := inlineConcat(trimmed[len(config):], vars)
+
+	for _, skip := range nonDependencyCall {
+		if strings.Contains(rest, skip) {
+			return nil
+		}
+	}
+
+	isTest := isDevConfiguration(config, inBuildscript)
+
+	// String-coordinate form first. A trailing configuration closure can carry
+	// `group:`/`module:` exclusions, so the map form is only considered when no
+	// coordinate literal was found at all.
+	var deps []gradleDep
+	for _, q := range quotedRe.FindAllStringSubmatch(rest, -1) {
+		if d, ok := parseCoordinate(q[1], vars); ok {
+			d.Configuration = config
+			d.IsTest = isTest
+			deps = append(deps, d)
+		}
+	}
+	if len(deps) > 0 {
+		return deps
+	}
+
+	group := firstSubmatch(mapGroupRe, rest)
+	name := firstSubmatch(mapNameRe, rest)
+	if group == "" || name == "" {
+		return nil
+	}
+	return []gradleDep{{
+		GroupId:       group,
+		ArtifactId:    name,
+		Version:       resolveInterp(firstSubmatch(mapVersionRe, rest), vars),
+		Configuration: config,
+		IsTest:        isTest,
+	}}
+}
+
+func firstSubmatch(re *regexp.Regexp, s string) string {
+	if m := re.FindStringSubmatch(s); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// parseCoordinate reads a "group:artifact[:version[:classifier]][@ext]" literal.
+//
+// The version is optional because a project using a BOM declares its
+// dependencies without one, and those are still real dependencies worth
+// inventorying — reporting the artifact with an unknown version is accurate,
+// where dropping it would leave the project looking like it has fewer
+// dependencies than it does.
+func parseCoordinate(s string, vars map[string]string) (gradleDep, bool) {
+	s = strings.TrimSpace(s)
+	if i := strings.Index(s, "@"); i >= 0 {
+		s = s[:i]
+	}
+	parts := strings.Split(s, ":")
+	if len(parts) < 2 {
+		return gradleDep{}, false
+	}
+	group, artifact := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+	if !validCoordinatePart(group) || !validCoordinatePart(artifact) {
+		return gradleDep{}, false
+	}
+	var version string
+	if len(parts) >= 3 {
+		version = resolveInterp(strings.TrimSpace(parts[2]), vars)
+	}
+	return gradleDep{GroupId: group, ArtifactId: artifact, Version: version}, true
+}
+
+// validCoordinatePart rejects a string that cannot be a Maven coordinate
+// component, which is what keeps an unrelated quoted string on a dependency
+// line (a URL, a file path, an exclusion pattern) from being read as one.
+func validCoordinatePart(s string) bool {
+	if s == "" || strings.ContainsAny(s, " /\\") {
+		return false
+	}
+	// An unresolved interpolation names a coordinate we cannot determine, and a
+	// package recorded under the literal name "${springVersion}" would be a
+	// fabricated entry rather than a missing one.
+	return !strings.Contains(s, "$")
+}
+
+// resolveInterp substitutes a "$var"/"${var}" version against the collected
+// variables, returning "" when it cannot be resolved — an unknown version, not
+// a literal dollar sign, is what an unresolved interpolation means.
+func resolveInterp(v string, vars map[string]string) string {
+	v = strings.TrimSpace(v)
+	if v == "" || !strings.Contains(v, "$") {
+		return v
+	}
+	out := interpRe.ReplaceAllStringFunc(v, func(ref string) string {
+		name := strings.Trim(strings.TrimPrefix(ref, "$"), "{}")
+		// A qualified reference (project.ext.fooVersion) resolves on its last
+		// segment, which is the property name.
+		if i := strings.LastIndex(name, "."); i >= 0 {
+			name = name[i+1:]
+		}
+		return vars[name]
+	})
+	if strings.Contains(out, "$") || out == "" {
+		return ""
+	}
+	return out
+}
+
+// isDevConfiguration reports whether a configuration's dependencies stay out of
+// the shipped runtime. Everything under buildscript is build tooling, as is any
+// configuration naming a test source set.
+func isDevConfiguration(config string, inBuildscript bool) bool {
+	if inBuildscript || devConfigurations[config] {
+		return true
+	}
+	return strings.Contains(strings.ToLower(config), "test")
+}

--- a/providers/os/resources/languages/java/buildgradle/parser.go
+++ b/providers/os/resources/languages/java/buildgradle/parser.go
@@ -93,7 +93,7 @@ var devConfigurations = map[string]bool{
 // assembled at configuration time (a version catalog accessor, a coordinate
 // built from a function call) is not recoverable without running Gradle. An
 // unreadable declaration is therefore omitted rather than guessed at.
-func parseBuildGradle(r io.Reader) (*gradleBuild, error) {
+func parseBuildGradle(r io.Reader, external map[string]string) (*gradleBuild, error) {
 	var lines []string
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -107,6 +107,13 @@ func parseBuildGradle(r io.Reader) (*gradleBuild, error) {
 	// Variables are collected over the whole file first: a version property is
 	// as often declared below the dependencies block as above it.
 	vars := collectVars(lines)
+	// Properties from elsewhere in the project fill what this file does not
+	// declare. The file's own declarations win, as they do in Gradle.
+	for k, v := range external {
+		if _, ok := vars[k]; !ok {
+			vars[k] = v
+		}
+	}
 
 	build := &gradleBuild{}
 	depth := 0

--- a/providers/os/resources/languages/java/buildgradle/properties.go
+++ b/providers/os/resources/languages/java/buildgradle/properties.go
@@ -1,0 +1,83 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package buildgradle
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+// Where a Gradle project's versions actually live.
+//
+// A build script rarely states its versions inline. They are declared once, for
+// the whole build, in a `gradle.properties` or a root `ext` block — often in a
+// script of their own (`constants.gradle`, `versions.gradle`) that the modules
+// apply. The module then writes `implementation "androidx.annotation:annotation:$androidxAnnotationVersion"`,
+// and reading that file alone yields an artifact with no version, which no
+// advisory can match.
+//
+// These two collectors read the two formats those declarations come in. Which
+// files to feed them is the caller's question, because it depends on the
+// project layout, not on the file format.
+
+// maxPropertyLines bounds a property-source read. These are small files by
+// nature, and the scan is driven by repository content.
+const maxPropertyLines = 20000
+
+// CollectScriptProperties reads the version properties a Gradle script
+// declares: `def x = '1.2'`, `val x = "1.2"`, `ext.x = '1.2'`, and the bare
+// `x = '1.2'` form used inside an `ext { }` or `project.ext { }` block.
+func CollectScriptProperties(r io.Reader) map[string]string {
+	var lines []string
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() && len(lines) < maxPropertyLines {
+		lines = append(lines, scanner.Text())
+	}
+	return collectVars(lines)
+}
+
+// CollectPropertiesFile reads a gradle.properties: `key=value` lines, where the
+// value is unquoted and runs to the end of the line.
+//
+// Only property names that look like a version reference are kept. A
+// gradle.properties also carries build settings — `org.gradle.jvmargs`,
+// `android.useAndroidX`, memory flags — and those share a namespace with the
+// version properties a script interpolates. Keeping them would let a build
+// setting be substituted into a coordinate.
+func CollectPropertiesFile(r io.Reader) map[string]string {
+	out := map[string]string{}
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for n := 0; scanner.Scan() && n < maxPropertyLines; n++ {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "!") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" || !isVersionProperty(key) {
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}
+
+// isVersionProperty reports whether a property name reads as a version.
+//
+// A dotted name is always a build setting: Gradle's own settings are namespaced
+// (`org.gradle.*`, `android.*`), and a script interpolating `$x` cannot name a
+// dotted property that way regardless.
+func isVersionProperty(key string) bool {
+	if strings.Contains(key, ".") {
+		return false
+	}
+	return strings.Contains(strings.ToLower(key), "version")
+}

--- a/providers/os/resources/languages/java/buildgradle/properties.go
+++ b/providers/os/resources/languages/java/buildgradle/properties.go
@@ -62,7 +62,7 @@ func CollectPropertiesFile(r io.Reader) map[string]string {
 		}
 		key = strings.TrimSpace(key)
 		value = strings.TrimSpace(value)
-		if key == "" || value == "" || !isVersionProperty(key) {
+		if key == "" || value == "" || !isVersionProperty(key, value) {
 			continue
 		}
 		out[key] = value
@@ -70,14 +70,44 @@ func CollectPropertiesFile(r io.Reader) map[string]string {
 	return out
 }
 
-// isVersionProperty reports whether a property name reads as a version.
+// isVersionProperty reports whether a gradle.properties entry can be a version
+// a script interpolates.
 //
 // A dotted name is always a build setting: Gradle's own settings are namespaced
 // (`org.gradle.*`, `android.*`), and a script interpolating `$x` cannot name a
 // dotted property that way regardless.
-func isVersionProperty(key string) bool {
+//
+// Beyond that the VALUE decides, not the name. Requiring "version" in the key
+// was the obvious rule and the wrong one: real projects name version properties
+// `kotlinCoroutines`, `okhttpRelease`, `agp` and `composeBom`, and dropping
+// those leaves exactly the versionless coordinates this collector exists to
+// fill in. What has to be excluded is a build setting sharing the namespace --
+// `useAndroidX=true`, `jvmargs=-Xmx2g` -- and those are told apart by their
+// values, which do not look like versions.
+//
+// A value that does look like one is kept whatever the key is called. If a
+// script interpolates it into a coordinate, that is the string Gradle would
+// substitute there too, so keeping it reports what the build does.
+func isVersionProperty(key, value string) bool {
 	if strings.Contains(key, ".") {
 		return false
 	}
-	return strings.Contains(strings.ToLower(key), "version")
+	return looksLikeVersion(value)
+}
+
+// looksLikeVersion reports whether a value could be a version: it starts with a
+// digit, or a "v" before one, and carries none of the characters that mark a
+// path, a flag, a list or a sentence.
+func looksLikeVersion(v string) bool {
+	if v == "" {
+		return false
+	}
+	first := v[0]
+	if (first == 'v' || first == 'V') && len(v) > 1 {
+		first = v[1]
+	}
+	if first < '0' || first > '9' {
+		return false
+	}
+	return !strings.ContainsAny(v, " \t\"'\\/=,;")
 }

--- a/providers/os/resources/languages/java/buildgradle/properties_test.go
+++ b/providers/os/resources/languages/java/buildgradle/properties_test.go
@@ -100,3 +100,40 @@ dependencies {
 	assert.Equal(t, "3.9.0", bom.Transitive().Find("com.squareup.okio:okio").Version,
 		"the script's own declaration wins over the project-wide property")
 }
+
+// Requiring "version" in the key was the obvious filter and the wrong one:
+// projects routinely name a version property after the library rather than
+// after the word, and dropping those leaves exactly the versionless coordinates
+// this collector exists to fill in.
+func TestCollectPropertiesFileKeepsVersionsNotNamedVersion(t *testing.T) {
+	props := CollectPropertiesFile(strings.NewReader(`
+kotlinCoroutines=1.7.3
+okhttpRelease=4.12.0
+agp=8.5.2
+composeBom=2024.09.00
+compileSdk=34
+retrofit=v2.11.0
+
+# still not versions, and now told apart by their values rather than their names
+useAndroidX=true
+jvmargs=-Xmx4g
+buildDir=build/output
+description=a demo project
+`))
+
+	for k, want := range map[string]string{
+		"kotlinCoroutines": "1.7.3",
+		"okhttpRelease":    "4.12.0",
+		"agp":              "8.5.2",
+		"composeBom":       "2024.09.00",
+		// An integer is what Gradle would substitute, so it is what gets read.
+		"compileSdk": "34",
+		"retrofit":   "v2.11.0",
+	} {
+		assert.Equal(t, want, props[k], "%s is a version property", k)
+	}
+
+	for _, k := range []string{"useAndroidX", "jvmargs", "buildDir", "description"} {
+		assert.NotContains(t, props, k, "%s is a build setting, not a version", k)
+	}
+}

--- a/providers/os/resources/languages/java/buildgradle/properties_test.go
+++ b/providers/os/resources/languages/java/buildgradle/properties_test.go
@@ -1,0 +1,102 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package buildgradle
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectPropertiesFile(t *testing.T) {
+	props := CollectPropertiesFile(strings.NewReader(`
+# a comment
+androidxAnnotationVersion=1.3.0
+junitVersion = 4.13.2
+kotlinVersion=2.0.21
+
+# build settings share the namespace and must not become versions
+org.gradle.jvmargs=-Xmx4g
+android.useAndroidX=true
+systemProp.http.proxyHost=proxy.example.com
+POM_NAME=demo
+empty=
+`))
+
+	assert.Equal(t, "1.3.0", props["androidxAnnotationVersion"])
+	assert.Equal(t, "4.13.2", props["junitVersion"], "surrounding whitespace is trimmed")
+	assert.Equal(t, "2.0.21", props["kotlinVersion"])
+
+	// A gradle.properties carries build configuration alongside versions, and
+	// a script interpolating $x would otherwise be able to pick one up.
+	for _, k := range []string{"org.gradle.jvmargs", "android.useAndroidX", "systemProp.http.proxyHost", "POM_NAME", "empty"} {
+		assert.NotContains(t, props, k, "%s is not a version property", k)
+	}
+}
+
+func TestCollectScriptProperties(t *testing.T) {
+	// The shape ExoPlayer uses: every version in one root script, inside a
+	// project.ext block, applied into the modules.
+	props := CollectScriptProperties(strings.NewReader(`
+// Copyright notice
+project.ext {
+    androidxAnnotationVersion = '1.3.0'
+    truthVersion = '1.1.3'
+}
+def log4jVersion = '2.14.1'
+val kotlinVersion = "2.0.21"
+ext.snakeyamlVersion = '1.29'
+`))
+
+	assert.Equal(t, "1.3.0", props["androidxAnnotationVersion"])
+	assert.Equal(t, "1.1.3", props["truthVersion"])
+	assert.Equal(t, "2.14.1", props["log4jVersion"])
+	assert.Equal(t, "2.0.21", props["kotlinVersion"])
+	assert.Equal(t, "1.29", props["snakeyamlVersion"])
+}
+
+// TestExternalPropertiesResolveAVersion is the case the field exists for: a
+// module's script names a version it does not declare, and without the
+// project's properties the dependency is inventoried with no version — which no
+// advisory can match.
+func TestExternalPropertiesResolveAVersion(t *testing.T) {
+	script := `
+dependencies {
+    implementation "androidx.annotation:annotation:$androidxAnnotationVersion"
+    implementation 'com.google.truth:truth:' + truthVersion
+}
+`
+	bare, err := (&Extractor{}).Parse(strings.NewReader(script), "build.gradle")
+	require.NoError(t, err)
+	assert.Empty(t, bare.Transitive().Find("androidx.annotation:annotation").Version,
+		"with no project properties the version is unknown, never invented")
+
+	e := &Extractor{Properties: map[string]string{
+		"androidxAnnotationVersion": "1.3.0",
+		"truthVersion":              "1.1.3",
+	}}
+	bom, err := e.Parse(strings.NewReader(script), "build.gradle")
+	require.NoError(t, err)
+
+	assert.Equal(t, "1.3.0", bom.Transitive().Find("androidx.annotation:annotation").Version, "interpolation")
+	assert.Equal(t, "1.1.3", bom.Transitive().Find("com.google.truth:truth").Version, "concatenation")
+}
+
+// TestOwnDeclarationsBeatExternalProperties pins Gradle's precedence: a module
+// that declares a version locally overrides the project-wide one.
+func TestOwnDeclarationsBeatExternalProperties(t *testing.T) {
+	e := &Extractor{Properties: map[string]string{"okioVersion": "1.0.0"}}
+	bom, err := e.Parse(strings.NewReader(`
+def okioVersion = '3.9.0'
+dependencies {
+    implementation "com.squareup.okio:okio:$okioVersion"
+}
+`), "build.gradle")
+	require.NoError(t, err)
+
+	assert.Equal(t, "3.9.0", bom.Transitive().Find("com.squareup.okio:okio").Version,
+		"the script's own declaration wins over the project-wide property")
+}

--- a/providers/os/resources/languages/java/buildgradle/testdata/kotlin.build.gradle.kts
+++ b/providers/os/resources/languages/java/buildgradle/testdata/kotlin.build.gradle.kts
@@ -1,0 +1,17 @@
+// A Kotlin DSL build script.
+plugins {
+    java
+}
+
+val jacksonVersion = "2.9.10.1"
+
+dependencies {
+    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
+    implementation("org.yaml:snakeyaml:1.29")
+    implementation(group = "com.google.guava", name = "guava", version = "24.1.1-jre")
+
+    // version catalog accessor: no literal coordinate to read
+    implementation(libs.commons.text)
+
+    testImplementation("junit:junit:4.13.1")
+}

--- a/providers/os/resources/languages/java/buildgradle/testdata/simple.build.gradle
+++ b/providers/os/resources/languages/java/buildgradle/testdata/simple.build.gradle
@@ -1,0 +1,53 @@
+// A Groovy DSL build script exercising the declaration forms that appear in the wild.
+buildscript {
+    repositories { mavenCentral() }
+    dependencies {
+        classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.5.0'
+    }
+}
+
+plugins {
+    id 'java'
+}
+
+ext {
+    jacksonVersion = '2.9.10.1'
+}
+
+def log4jVersion = '2.14.1'
+
+repositories {
+    // a URL containing // must not be read as a comment
+    maven { url 'https://repo.example.com/releases' }
+}
+
+dependencies {
+    implementation 'com.fasterxml.jackson.core:jackson-databind:' + jacksonVersion
+    implementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
+    implementation "org.yaml:snakeyaml:${snakeyamlVersion}"
+    api 'org.apache.commons:commons-text:1.9'
+
+    // map notation
+    implementation group: 'com.google.guava', name: 'guava', version: '24.1.1-jre'
+
+    // trailing closure with an exclusion that must not be read as a coordinate
+    implementation('org.apache.httpcomponents:httpclient:4.5.13') {
+        exclude group: 'commons-logging', module: 'commons-logging'
+    }
+
+    // no version: managed by a BOM elsewhere
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // not Maven coordinates
+    implementation project(':core')
+    implementation files('libs/local.jar')
+    implementation platform('com.fasterxml.jackson:jackson-bom:2.9.10')
+
+    compileOnly 'org.projectlombok:lombok:1.18.20'
+    annotationProcessor 'org.projectlombok:lombok:1.18.20'
+
+    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'org.mockito:mockito-core:3.9.0'
+}
+
+ext.snakeyamlVersion = '1.29'

--- a/providers/os/resources/languages/java/gradlelockfile/extractor.go
+++ b/providers/os/resources/languages/java/gradlelockfile/extractor.go
@@ -115,9 +115,18 @@ func (l *gradleLockfile) Transitive() languages.Packages {
 	var packages languages.Packages
 	for _, entry := range l.Entries {
 		name := entry.GroupId + ":" + entry.ArtifactId
+		// A lockfile entry names the configurations that resolved it, and an
+		// entry resolved only by test configurations is a test-only dependency
+		// — the same fact an npm devDependency states. Reporting it as prod
+		// ranks a CVE in a test harness alongside one in the shipped runtime.
+		scope := languages.PackageScopeProd
+		if entry.IsTest {
+			scope = languages.PackageScopeDev
+		}
 		packages = append(packages, &languages.Package{
 			Name:         name,
 			Version:      entry.Version,
+			Scope:        scope,
 			Purl:         java.NewPackageUrl(entry.GroupId, entry.ArtifactId, entry.Version),
 			Cpes:         java.NewCpes(entry.GroupId, entry.ArtifactId, entry.Version),
 			EvidenceList: java.NewEvidenceList(l.evidence),

--- a/providers/os/resources/languages/java/gradlelockfile/extractor.go
+++ b/providers/os/resources/languages/java/gradlelockfile/extractor.go
@@ -119,6 +119,16 @@ func (l *gradleLockfile) Transitive() languages.Packages {
 		// entry resolved only by test configurations is a test-only dependency
 		// — the same fact an npm devDependency states. Reporting it as prod
 		// ranks a CVE in a test harness alongside one in the shipped runtime.
+		//
+		// This is narrower than buildgradle's isDevConfiguration, which also
+		// treats annotationProcessor and kapt as dev, and the difference is
+		// intended. A lockfile states the configurations that actually resolved
+		// an artifact, so an entry naming only annotationProcessor is genuinely
+		// on no runtime classpath — but it names them exactly, and widening the
+		// match to configuration names seen in a build script would classify on
+		// a heuristic where an exact fact is available. Extend this list when a
+		// lockfile is observed carrying such a name, not on the strength of the
+		// other parser's list.
 		scope := languages.PackageScopeProd
 		if entry.IsTest {
 			scope = languages.PackageScopeDev

--- a/providers/os/resources/languages/java/gradlelockfile/extractor_test.go
+++ b/providers/os/resources/languages/java/gradlelockfile/extractor_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers/os/resources/languages"
 	"go.mondoo.com/mql/sbom"
 )
 
@@ -40,10 +41,21 @@ func TestGradleLockfileExtractor(t *testing.T) {
 	assert.Equal(t, "3.12.0", p.Version)
 	assert.Equal(t, "pkg:maven/org.apache.commons/commons-lang3@3.12.0", p.Purl)
 
-	// Test deps are included in transitive
+	// Test deps are included in transitive, tagged dev so a consumer can rank a
+	// CVE in a test harness apart from one in the shipped runtime.
 	p = transitive.Find("junit:junit")
 	require.NotNil(t, p)
 	assert.Equal(t, "4.13.2", p.Version)
+	assert.Equal(t, languages.PackageScopeDev, p.Scope)
+
+	p = transitive.Find("org.mockito:mockito-core")
+	require.NotNil(t, p)
+	assert.Equal(t, languages.PackageScopeDev, p.Scope)
+
+	// A dependency any non-test configuration resolved is production, even
+	// though the test configurations resolve it too.
+	assert.Equal(t, languages.PackageScopeProd, transitive.Find("com.google.guava:guava").Scope)
+	assert.Equal(t, languages.PackageScopeProd, transitive.Find("com.fasterxml.jackson.core:jackson-databind").Scope)
 }
 
 func TestIsTestOnly(t *testing.T) {

--- a/providers/os/resources/languages/java/java.go
+++ b/providers/os/resources/languages/java/java.go
@@ -78,3 +78,24 @@ func NewEvidenceList(evidence []string) []*sbom.Evidence {
 	}
 	return evidenceList
 }
+
+// ConcreteVersion accepts a version that names one release, and rejects one that
+// names a set.
+//
+// Gradle lets a coordinate carry a dynamic version or a range -- "1.+",
+// "[1.0, 2.0[", "latest.release" -- and Maven allows the same range syntax.
+// None of them says which release is present, so recording one as the version
+// produces a purl that matches no release while reading downstream as a
+// definite claim about what is installed. The artifact is still worth
+// inventorying; its version is simply not known from the manifest, which is the
+// same state as a version a BOM was meant to supply and did not.
+//
+// Shared because every Java manifest reader faces the same strings, and two
+// copies of this rule would drift into disagreeing about the same coordinate.
+func ConcreteVersion(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" || strings.ContainsAny(s, "[],()") || strings.HasSuffix(s, "+") || strings.Contains(s, "latest") {
+		return ""
+	}
+	return s
+}

--- a/providers/os/resources/languages/java/java_test.go
+++ b/providers/os/resources/languages/java/java_test.go
@@ -4,6 +4,7 @@
 package java
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,4 +56,19 @@ func TestNewCpes(t *testing.T) {
 	assert.NotEmpty(t, cpes)
 	assert.Contains(t, cpes[0], "commons-lang3")
 	assert.Contains(t, cpes[0], "3.12.0")
+}
+
+// A dynamic version or a range names a set of releases rather than one, so it
+// is not recorded as a version at all: a purl carrying "1.+" matches no release
+// while reading downstream as a definite claim about what is installed.
+//
+// Shared by every Java manifest reader, so the rule is pinned once here rather
+// than once per extractor, where two copies would drift.
+func TestConcreteVersion(t *testing.T) {
+	for _, in := range []string{"1.2.3", " 1.2.3 ", "4.12.0", "2.0.0-SNAPSHOT"} {
+		assert.Equal(t, strings.TrimSpace(in), ConcreteVersion(in), "concrete: %q", in)
+	}
+	for _, in := range []string{"1.+", "[1.0, 2.0[", "(1.0, 2.0)", "latest.release", "latest.integration", ""} {
+		assert.Empty(t, ConcreteVersion(in), "names a set, not a release: %q", in)
+	}
 }

--- a/providers/os/resources/languages/java/versioncatalog/extractor.go
+++ b/providers/os/resources/languages/java/versioncatalog/extractor.go
@@ -1,0 +1,193 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package versioncatalog
+
+import (
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"go.mondoo.com/mql/providers/os/resources/languages"
+	"go.mondoo.com/mql/providers/os/resources/languages/java"
+)
+
+var (
+	_ languages.Extractor = (*Extractor)(nil)
+	_ languages.Bom       = (*catalog)(nil)
+)
+
+// Extractor parses a Gradle version catalog (gradle/libs.versions.toml).
+//
+// A catalog is where a modern Gradle project states its dependency coordinates;
+// the build scripts then reference them by alias (`implementation(libs.okio)`).
+// The alias names no coordinate, so a catalog-based project is invisible to a
+// reader of the build scripts alone — measured on okhttp, 332 declarations
+// yielded 7 coordinates, and on Signal-Android 562 yielded 4. The coordinates
+// those aliases stand for are all here, spelled out.
+type Extractor struct{}
+
+func (e *Extractor) Name() string {
+	return "versioncatalog"
+}
+
+// catalog is the parsed TOML. Only [versions] and [libraries] are read:
+// [bundles] lists aliases already covered here, and [plugins] names Gradle
+// plugins by plugin id rather than by Maven coordinate.
+type catalog struct {
+	Versions  map[string]any `toml:"versions"`
+	Libraries map[string]any `toml:"libraries"`
+
+	evidence []string
+}
+
+func (e *Extractor) Parse(r io.Reader, filename string) (languages.Bom, error) {
+	var c catalog
+	if _, err := toml.NewDecoder(r).Decode(&c); err != nil {
+		return nil, err
+	}
+	if filename != "" {
+		c.evidence = append(c.evidence, filename)
+	}
+	return &c, nil
+}
+
+// Root returns nil — a catalog describes dependencies, not the project.
+func (c *catalog) Root() *languages.Package { return nil }
+
+// Direct returns the declared libraries. A catalog entry is a coordinate the
+// project wrote down for itself, which is what direct means.
+func (c *catalog) Direct() languages.Packages { return c.packages() }
+
+// Transitive returns the same set: a catalog states coordinates, and resolving
+// what those depend on needs Gradle.
+func (c *catalog) Transitive() languages.Packages { return c.packages() }
+
+func (c *catalog) packages() languages.Packages {
+	// Map iteration order is random and the output feeds a rendered SBOM, so
+	// the aliases are walked in a stable order.
+	aliases := make([]string, 0, len(c.Libraries))
+	for alias := range c.Libraries {
+		aliases = append(aliases, alias)
+	}
+	sort.Strings(aliases)
+
+	var packages languages.Packages
+	seen := map[string]bool{}
+	for _, alias := range aliases {
+		group, artifact, version, ok := c.library(c.Libraries[alias])
+		if !ok {
+			continue
+		}
+		name := group + ":" + artifact
+		if key := name + "@" + version; seen[key] {
+			continue
+		} else {
+			seen[key] = true
+		}
+		packages = append(packages, &languages.Package{
+			Name:         name,
+			Version:      version,
+			Purl:         java.NewPackageUrl(group, artifact, version),
+			Cpes:         java.NewCpes(group, artifact, version),
+			EvidenceList: java.NewEvidenceList(c.evidence),
+		})
+	}
+	return packages
+}
+
+// library reads one [libraries] entry, in any of the spellings Gradle accepts:
+// the "group:artifact:version" shorthand, a table with `module`, or a table
+// with separate `group` and `name`.
+func (c *catalog) library(v any) (group, artifact, version string, ok bool) {
+	switch entry := v.(type) {
+	case string:
+		return splitModule(entry)
+	case map[string]any:
+		if m, isStr := entry["module"].(string); isStr {
+			group, artifact, version, ok = splitModule(m)
+			if !ok {
+				return "", "", "", false
+			}
+		} else {
+			group, _ = entry["group"].(string)
+			artifact, _ = entry["name"].(string)
+			if group == "" || artifact == "" {
+				return "", "", "", false
+			}
+		}
+		if v := c.version(entry["version"]); v != "" {
+			version = v
+		}
+		return group, artifact, version, true
+	}
+	return "", "", "", false
+}
+
+// version resolves an entry's version: a literal, a `version.ref` into
+// [versions], or a rich constraint ({ require = ... }).
+func (c *catalog) version(v any) string {
+	switch ver := v.(type) {
+	case string:
+		return concreteVersion(ver)
+	case map[string]any:
+		if ref, isStr := ver["ref"].(string); isStr {
+			return c.resolveRef(ref)
+		}
+		return constraintVersion(ver)
+	}
+	return ""
+}
+
+// resolveRef looks an alias up in [versions], where the value is either a
+// literal or a rich constraint.
+func (c *catalog) resolveRef(ref string) string {
+	switch v := c.Versions[ref].(type) {
+	case string:
+		return concreteVersion(v)
+	case map[string]any:
+		return constraintVersion(v)
+	}
+	return ""
+}
+
+// constraintVersion reads a rich version constraint. `require` and `prefer`
+// state a version; `strictly` is preferred last because it is the one most
+// often written as a range.
+func constraintVersion(m map[string]any) string {
+	for _, key := range []string{"require", "prefer", "strictly"} {
+		if s, ok := m[key].(string); ok {
+			if v := concreteVersion(s); v != "" {
+				return v
+			}
+		}
+	}
+	return ""
+}
+
+// concreteVersion accepts a version that names one release and rejects a range.
+//
+// A Gradle constraint may be a range ("[1.0, 2.0[", "1.+", "latest.release"),
+// which names a set of versions rather than a version. Recording one as if it
+// were a version produces a purl that matches no release, and it would be read
+// downstream as a definite claim about which version is present.
+func concreteVersion(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" || strings.ContainsAny(s, "[],()") || strings.HasSuffix(s, "+") || strings.Contains(s, "latest") {
+		return ""
+	}
+	return s
+}
+
+// splitModule parses "group:artifact" or "group:artifact:version".
+func splitModule(s string) (group, artifact, version string, ok bool) {
+	parts := strings.Split(strings.TrimSpace(s), ":")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", "", false
+	}
+	if len(parts) >= 3 {
+		version = concreteVersion(parts[2])
+	}
+	return parts[0], parts[1], version, true
+}

--- a/providers/os/resources/languages/java/versioncatalog/extractor.go
+++ b/providers/os/resources/languages/java/versioncatalog/extractor.go
@@ -130,7 +130,7 @@ func (c *catalog) library(v any) (group, artifact, version string, ok bool) {
 func (c *catalog) version(v any) string {
 	switch ver := v.(type) {
 	case string:
-		return concreteVersion(ver)
+		return java.ConcreteVersion(ver)
 	case map[string]any:
 		if ref, isStr := ver["ref"].(string); isStr {
 			return c.resolveRef(ref)
@@ -145,7 +145,7 @@ func (c *catalog) version(v any) string {
 func (c *catalog) resolveRef(ref string) string {
 	switch v := c.Versions[ref].(type) {
 	case string:
-		return concreteVersion(v)
+		return java.ConcreteVersion(v)
 	case map[string]any:
 		return constraintVersion(v)
 	}
@@ -158,26 +158,12 @@ func (c *catalog) resolveRef(ref string) string {
 func constraintVersion(m map[string]any) string {
 	for _, key := range []string{"require", "prefer", "strictly"} {
 		if s, ok := m[key].(string); ok {
-			if v := concreteVersion(s); v != "" {
+			if v := java.ConcreteVersion(s); v != "" {
 				return v
 			}
 		}
 	}
 	return ""
-}
-
-// concreteVersion accepts a version that names one release and rejects a range.
-//
-// A Gradle constraint may be a range ("[1.0, 2.0[", "1.+", "latest.release"),
-// which names a set of versions rather than a version. Recording one as if it
-// were a version produces a purl that matches no release, and it would be read
-// downstream as a definite claim about which version is present.
-func concreteVersion(s string) string {
-	s = strings.TrimSpace(s)
-	if s == "" || strings.ContainsAny(s, "[],()") || strings.HasSuffix(s, "+") || strings.Contains(s, "latest") {
-		return ""
-	}
-	return s
 }
 
 // splitModule parses "group:artifact" or "group:artifact:version".
@@ -187,7 +173,7 @@ func splitModule(s string) (group, artifact, version string, ok bool) {
 		return "", "", "", false
 	}
 	if len(parts) >= 3 {
-		version = concreteVersion(parts[2])
+		version = java.ConcreteVersion(parts[2])
 	}
 	return parts[0], parts[1], version, true
 }

--- a/providers/os/resources/languages/java/versioncatalog/extractor_test.go
+++ b/providers/os/resources/languages/java/versioncatalog/extractor_test.go
@@ -1,0 +1,105 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package versioncatalog
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers/os/resources/languages"
+	"go.mondoo.com/mql/sbom"
+)
+
+func parseCatalog(t *testing.T) languages.Bom {
+	t.Helper()
+	f, err := os.Open("./testdata/libs.versions.toml")
+	require.NoError(t, err)
+	defer f.Close()
+
+	bom, err := (&Extractor{}).Parse(f, "gradle/libs.versions.toml")
+	require.NoError(t, err)
+	return bom
+}
+
+func TestVersionCatalogSpellings(t *testing.T) {
+	deps := parseCatalog(t).Transitive()
+	assert.Nil(t, parseCatalog(t).Root())
+
+	p := deps.Find("com.squareup.okio:okio")
+	require.NotNil(t, p, "module + version.ref")
+	assert.Equal(t, "3.9.0", p.Version)
+	assert.Equal(t, "pkg:maven/com.squareup.okio/okio@3.9.0", p.Purl)
+	assert.Equal(t, []*sbom.Evidence{{Type: sbom.EvidenceType_EVIDENCE_TYPE_FILE, Value: "gradle/libs.versions.toml"}}, p.EvidenceList)
+
+	p = deps.Find("com.willowtreeapps.assertk:assertk")
+	require.NotNil(t, p, "module + literal version")
+	assert.Equal(t, "0.28.1", p.Version)
+
+	p = deps.Find("com.google.guava:guava")
+	require.NotNil(t, p, "separate group and name")
+	assert.Equal(t, "33.7.1-jre", p.Version)
+
+	p = deps.Find("org.bouncycastle:bc-jdk15to18-bom")
+	require.NotNil(t, p, "plain string shorthand")
+	assert.Equal(t, "1.85.2", p.Version)
+
+	p = deps.Find("org.junit.jupiter:junit-jupiter")
+	require.NotNil(t, p, "rich constraint { require = } behind a ref")
+	assert.Equal(t, "5.10.0", p.Version)
+
+	assert.Equal(t, "2.5.0", deps.Find("com.example:strict").Version, "{ strictly = } names one release")
+
+	// A version supplied by a BOM is unknown here. The artifact is still real
+	// and still reported; nothing is claimed about which version it is.
+	p = deps.Find("org.bouncycastle:bcprov-jdk15to18")
+	require.NotNil(t, p)
+	assert.Empty(t, p.Version)
+}
+
+func TestVersionCatalogRefusesToInventVersions(t *testing.T) {
+	deps := parseCatalog(t).Transitive()
+
+	// A range names a SET of releases. Recording one as a version produces a
+	// purl matching no release, and reads downstream as a definite claim about
+	// what is installed.
+	for _, tc := range []struct{ name, why string }{
+		{"com.example:dynamic", "1.+ is a dynamic version"},
+		{"com.example:ranged", "[1.0, 2.0[ is a range"},
+		{"com.example:dangling", "version.ref points at no [versions] entry"},
+	} {
+		p := deps.Find(tc.name)
+		require.NotNil(t, p, "%s: the artifact is real and must still be inventoried", tc.why)
+		assert.Empty(t, p.Version, "%s: version must be unknown, not invented", tc.why)
+	}
+}
+
+func TestVersionCatalogReadsLibrariesOnly(t *testing.T) {
+	deps := parseCatalog(t).Transitive()
+
+	// [plugins] names a Gradle plugin id, which is not a Maven coordinate;
+	// [bundles] lists aliases already covered by [libraries].
+	for _, p := range deps {
+		assert.NotEqual(t, "com.android.application", p.Name, "a plugin id must not be read as a coordinate")
+		assert.NotEqual(t, "testing", p.Name, "a bundle must not be read as a coordinate")
+	}
+	assert.Equal(t, 10, len(deps), "every [libraries] entry, and nothing else")
+}
+
+func TestVersionCatalogDirectIsEveryLibrary(t *testing.T) {
+	bom := parseCatalog(t)
+	// A catalog entry is a coordinate the project wrote down for itself.
+	assert.Equal(t, len(bom.Transitive()), len(bom.Direct()))
+}
+
+func TestConcreteVersion(t *testing.T) {
+	assert.Equal(t, "1.2.3", concreteVersion("1.2.3"))
+	assert.Equal(t, "1.2.3", concreteVersion(" 1.2.3 "))
+	// Each of these names a set of releases rather than a release.
+	assert.Empty(t, concreteVersion("1.+"))
+	assert.Empty(t, concreteVersion("[1.0, 2.0["))
+	assert.Empty(t, concreteVersion("latest.release"))
+	assert.Empty(t, concreteVersion(""))
+}

--- a/providers/os/resources/languages/java/versioncatalog/extractor_test.go
+++ b/providers/os/resources/languages/java/versioncatalog/extractor_test.go
@@ -93,13 +93,3 @@ func TestVersionCatalogDirectIsEveryLibrary(t *testing.T) {
 	// A catalog entry is a coordinate the project wrote down for itself.
 	assert.Equal(t, len(bom.Transitive()), len(bom.Direct()))
 }
-
-func TestConcreteVersion(t *testing.T) {
-	assert.Equal(t, "1.2.3", concreteVersion("1.2.3"))
-	assert.Equal(t, "1.2.3", concreteVersion(" 1.2.3 "))
-	// Each of these names a set of releases rather than a release.
-	assert.Empty(t, concreteVersion("1.+"))
-	assert.Empty(t, concreteVersion("[1.0, 2.0["))
-	assert.Empty(t, concreteVersion("latest.release"))
-	assert.Empty(t, concreteVersion(""))
-}

--- a/providers/os/resources/languages/java/versioncatalog/testdata/libs.versions.toml
+++ b/providers/os/resources/languages/java/versioncatalog/testdata/libs.versions.toml
@@ -1,0 +1,34 @@
+[versions]
+okio = "3.9.0"
+guava = "33.7.1-jre"
+junit = { require = "5.10.0" }
+floating = "1.+"
+bounded = "[1.0, 2.0["
+strictOnly = { strictly = "2.5.0" }
+
+[libraries]
+# module + version.ref, the common spelling
+square-okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
+# module + literal version
+assertk = { module = "com.willowtreeapps.assertk:assertk", version = "0.28.1" }
+# module with no version: supplied by a BOM
+bouncycastle-bcprov = { module = "org.bouncycastle:bcprov-jdk15to18" }
+# plain string shorthand
+bouncycastle-bom = "org.bouncycastle:bc-jdk15to18-bom:1.85.2"
+# separate group and name
+google-guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
+# rich constraint behind a ref
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+strict-lib = { module = "com.example:strict", version.ref = "strictOnly" }
+# a version range names a set of releases, not a release
+dynamic-lib = { module = "com.example:dynamic", version.ref = "floating" }
+range-lib = { module = "com.example:ranged", version.ref = "bounded" }
+# a ref that does not exist
+dangling = { module = "com.example:dangling", version.ref = "nope" }
+
+[bundles]
+testing = ["assertk", "junit-jupiter"]
+
+[plugins]
+# a plugin id is not a Maven coordinate
+android-application = { id = "com.android.application", version.ref = "okio" }


### PR DESCRIPTION
## Why

A Gradle project without dependency locking produced **no packages at all**. `gradle.lockfile` was the only Gradle manifest, and dependency locking is opt-in — **none of the six real-world Gradle projects sampled** (RxJava, okhttp, kafka, spring-boot, Signal-Android, ExoPlayer) has one. The manifest we knew how to read is the one those projects do not have.

Downstream that is not a partial inventory but an empty one: no SBOM components, no advisory correlation, and no signal that anything was missed.

## What changed

**`buildgradle`** — reads `build.gradle` / `build.gradle.kts`: string coordinates in both DSLs, map and Kotlin named-argument notation, `$var` / `${project.ext.var}` interpolation, and Groovy `'g:a:' + version` concatenation, resolved against `def`/`val`/`ext` properties collected over the whole file so declaration order does not decide.

**`versioncatalog`** — reads `gradle/libs.versions.toml`. A modern Gradle project states coordinates here and references them by alias, so `implementation(libs.okio)` names no coordinate: okhttp's 332 declarations yield 7 coordinates from the build scripts alone, Signal-Android's 562 yield 4. Handles every `[libraries]` spelling — shorthand string, `module`, separate `group`/`name`, literal version, `version.ref`, and rich constraints.

**Project version properties** — a module interpolates versions it does not declare; they live in a `gradle.properties`, a root `ext` block, or an applied script. The extractor gains an optional `Properties` map for declarations made outside the file being parsed (the script's own still win, as in Gradle), plus two exported collectors for the two formats those come in. Which files to feed them is the caller's question, since it depends on project layout rather than file format.

**`gradlelockfile`** — propagate the test-only flag the parser already computed and then dropped, so a CVE in a test harness no longer ranks alongside one in the shipped runtime.

## What it declines to do

Build scripts are programs, so the parser reads what is stated literally and omits the rest. A version catalog accessor, a computed coordinate or an unresolved interpolation is not recoverable without running Gradle, and a package recorded under the literal name `${springVersion}` would be a fabricated dependency rather than a missing one. Same for a `platform()` constraint (ships no code) and an `exclude` inside a trailing closure — which reads exactly like map notation and is a dependency being *removed*, so declarations are matched only at the dependencies block's own nesting depth.

A version range is likewise never recorded as a version: `1.+`, `[1.0, 2.0[` and `latest.release` each name a *set* of releases, and storing one produces a coordinate matching no release while reading downstream as a definite claim. Those artifacts are still inventoried, with the version left unknown — the same treatment as a version a BOM supplies.

Only version-like names are taken from a `gradle.properties`; that file carries build configuration (`org.gradle.jvmargs`, `android.useAndroidX`) in the same namespace a script interpolates from.

## Verification

Checked against **Gradle's own resolver** on a catalog-based project: the extracted set matches the resolver's direct dependencies exactly, and with a lockfile present matches its full 16-package closure exactly — same coordinates, same versions, no additions and no omissions.

Running these extractors across the six sampled projects, Java packages inventoried went 31 → 773, with zero malformed names, zero unresolved interpolations and zero path-like entries among them. ExoPlayer's versionless packages went 31/46 → 0/46, each value verified individually against its root `constants.gradle`.

New tests cover both extractors, both property formats, precedence, and the refusals above. `go test ./providers/os/resources/languages/...` — 59 packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)