### PR TITLE
🐛 os: quote directory paths in the cat filesystem listing

### DIFF
--- a/providers/os/connection/ssh/cat/cat_file.go
+++ b/providers/os/connection/ssh/cat/cat_file.go
@@ -114,7 +114,8 @@ func (f *File) Readdir(count int) (res []os.FileInfo, err error) {
 func (f *File) Readdirnames(n int) (names []string, err error) {
 	// TODO: input n is ignored
 
-	cmd, err := f.catfs.commandRunner.RunCommand("ls -1 '" + f.path + "'")
+	// we need shellquote to escape directory names with spaces or quotes
+	cmd, err := f.catfs.commandRunner.RunCommand(shellquote.Join("ls", "-1", f.path))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/connection/ssh/cat/cat_test.go
+++ b/providers/os/connection/ssh/cat/cat_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kballard/go-shellquote"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/llx"
@@ -100,6 +101,31 @@ func TestCatFsReusesStatHelper(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	assert.Equal(t, 1, countCommands(cw.commands, "sudo uname -s"))
+}
+
+func TestCatFsReaddirnamesQuotesPath(t *testing.T) {
+	fixture, _ := filepath.Abs("./testdata/cat.toml")
+	p, err := mock.New(0, &inventory.Asset{}, mock.WithPath(fixture))
+	require.NoError(t, err)
+
+	cw := &CommandWrapper{
+		commandRunner: p,
+		sudo:          shared.ParseSudo(map[string]*llx.Primitive{"sudo": llx.BoolPrimitive(true)}),
+	}
+
+	// directory names are read off the target and fed back into the listing
+	// command, so they have to survive as a single argument no matter what
+	// characters they contain
+	dir := `/home/vagrant/.ssh/od'd dir$(x)`
+
+	f := cat.NewFile(cat.New(cw), dir, false)
+	_, err = f.Readdirnames(-1)
+	require.NoError(t, err)
+
+	require.Len(t, cw.commands, 1)
+	args, err := shellquote.Split(cw.commands[0])
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sudo", "ls", "-1", dir}, args)
 }
 
 func countCommands(commands []string, target string) int {

--- a/providers/os/connection/ssh/cat/testdata/cat.toml
+++ b/providers/os/connection/ssh/cat/testdata/cat.toml
@@ -43,7 +43,7 @@ stdout = """0.4317.8180.0.0.1590420240.1590418792.?
 stdout = """0.271.41ed.0.0.1635245760.1635147499.?
 """
 
-[commands."sudo ls -1 '/etc/ssh'"]
+[commands."sudo ls -1 /etc/ssh"]
 stdout = """ssh_config
 ssh_config.d
 ssh_host_ecdsa_key


### PR DESCRIPTION
The `cat` filesystem builds shell commands for every file operation. `readContent` uses `shellquote.Join` for its `cat` command, but `Readdirnames` wrapped the path in single quotes by hand, so a directory name containing a quote or a space did not survive as a single argument.

Switched it to `shellquote.Join`, so both call sites in the file build their command the same way. Added a regression test that round-trips the built command back through `shellquote.Split` and asserts the path arrives as one argument; updated the listing fixture, whose key no longer needs quotes for a simple path.
