### PR TITLE
🐛 providers: unpack archive entries by their file name

### DIFF
--- a/providers/providers.go
+++ b/providers/providers.go
@@ -784,9 +784,13 @@ func InstallIO(reader io.ReadCloser, conf InstallConf) ([]*Provider, error) {
 	log.Debug().Str("path", tmpdir).Msg("unpacking providers")
 	files := map[string]struct{}{}
 	err = walkTarXz(reader, func(reader *tar.Reader, header *tar.Header) error {
-		files[header.Name] = struct{}{}
-		dst := filepath.Join(tmpdir, header.Name)
-		log.Debug().Str("name", header.Name).Str("dest", dst).Msg("unpacking file")
+		name, err := archiveFileName(header.Name)
+		if err != nil {
+			return err
+		}
+		files[name] = struct{}{}
+		dst := filepath.Join(tmpdir, name)
+		log.Debug().Str("name", name).Str("dest", dst).Msg("unpacking file")
 		writer, err := os.Create(dst)
 		if err != nil {
 			return err
@@ -924,6 +928,20 @@ func syncDir(path string) {
 	if err := dir.Sync(); err != nil {
 		log.Warn().Err(err).Str("path", path).Msg("failed to sync provider directory")
 	}
+}
+
+// archiveFileName returns the file name to unpack an archive entry to.
+// Provider archives are flat: the binary, the config and the schema all sit
+// at the top level, so every entry has to be a plain file name. Anything
+// carrying a directory component would let the archive pick where its
+// contents land, so it is rejected instead of unpacked.
+func archiveFileName(name string) (string, error) {
+	clean := filepath.Clean(filepath.FromSlash(name))
+	base := filepath.Base(clean)
+	if clean != base || base == "." || base == ".." || base == string(filepath.Separator) {
+		return "", errors.New("provider archive contains an unexpected file name: " + name)
+	}
+	return base, nil
 }
 
 func walkTarXz(reader io.Reader, callback func(reader *tar.Reader, header *tar.Header) error) error {

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"os"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
@@ -282,4 +283,57 @@ func TestTryProviderUpdateSchemaOnlyDownloadFails(t *testing.T) {
 	_, err := TryProviderUpdate(schemaOnly, UpdateProvidersConfig{Enabled: true})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "registry is down")
+}
+
+func TestArchiveFileName(t *testing.T) {
+	tests := []struct {
+		name     string
+		entry    string
+		expected string
+		wantErr  bool
+	}{
+		{"plain binary", "aws", "aws", false},
+		{"windows binary", "aws.exe", "aws.exe", false},
+		{"config", "aws.json", "aws.json", false},
+		{"schema", "aws.resources.json", "aws.resources.json", false},
+		{"leading dot slash", "./aws.json", "aws.json", false},
+		{"parent directory", "../aws.json", "", true},
+		{"nested parent directory", "../../etc/cron.d/mondoo", "", true},
+		{"subdirectory", "nested/aws.json", "", true},
+		{"absolute path", "/etc/cron.d/mondoo", "", true},
+		{"parent only", "..", "", true},
+		{"current directory", ".", "", true},
+		{"empty", "", "", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			res, err := archiveFileName(test.entry)
+			if test.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, res)
+		})
+	}
+}
+
+func TestInstallIORejectsPathsOutsideDestination(t *testing.T) {
+	// the unpack directory is created inside Dst, so an entry has to climb
+	// two levels to land outside of it
+	root := t.TempDir()
+	dst := filepath.Join(root, "providers")
+	escapee := filepath.Join(root, "escaped.json")
+
+	archive, err := buildTarXz(map[string][]byte{
+		"../../escaped.json": []byte(`{"name":"escaped"}`),
+	})
+	require.NoError(t, err)
+
+	_, err = InstallIO(io.NopCloser(bytes.NewReader(archive)), InstallConf{Dst: dst})
+	require.Error(t, err)
+
+	_, err = os.Stat(escapee)
+	assert.True(t, os.IsNotExist(err), "archive wrote outside the destination directory")
 }


### PR DESCRIPTION
Provider archives are flat: `bundleProvider` packs `<name>[.exe]`, `<name>.json` and `<name>.resources.json` at the top level, so every entry is a plain file name. The unpack loop joined the entry name onto the temp directory as-is, which meant an entry carrying a directory component picked its own destination instead of the installer picking it. The same name also feeds the provider name used to build the install path.

Entry names are now resolved once, up front: a plain file name is used as-is, anything else fails the install. `cli/selfupdate/archive.go` already does the equivalent. Added a table test for the name handling and an install test that pins that nothing lands outside the destination directory.
