### PR TITLE
🐛 os/docker: quote the path in the container directory listing

### DIFF
--- a/providers/os/connection/docker/file.go
+++ b/providers/os/connection/docker/file.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kballard/go-shellquote"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 	"github.com/spf13/afero"
@@ -87,8 +88,16 @@ func (f *File) Readdir(count int) (res []os.FileInfo, err error) {
 	return f.catFs.ReadDir(f.path)
 }
 
+// listDirsCommand builds the command that lists the immediate subdirectories
+// of path. The container runs it through /bin/sh, so the path has to arrive
+// as a single argument whatever characters a directory name in the image
+// happens to contain.
+func listDirsCommand(path string) string {
+	return shellquote.Join("find", path, "-maxdepth", "1", "-type", "d")
+}
+
 func (f *File) Readdirnames(n int) ([]string, error) {
-	c, err := f.connection.RunCommand(fmt.Sprintf("find %s -maxdepth 1 -type d", f.path))
+	c, err := f.connection.RunCommand(listDirsCommand(f.path))
 	if err != nil {
 		return []string{}, err
 	}

--- a/providers/os/connection/docker/file_test.go
+++ b/providers/os/connection/docker/file_test.go
@@ -1,0 +1,34 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package docker
+
+import (
+	"testing"
+
+	"github.com/kballard/go-shellquote"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListDirsCommand(t *testing.T) {
+	// directory names come from the image, so they can contain anything a
+	// filename is allowed to contain
+	paths := []string{
+		"/etc",
+		"/opt/my app",
+		`/opt/od'd`,
+		`/opt/x'$(id)'`,
+		`/opt/"quoted"`,
+		"/opt/semi;colon",
+		"/opt/back\\slash",
+	}
+
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			args, err := shellquote.Split(listDirsCommand(path))
+			require.NoError(t, err)
+			assert.Equal(t, []string{"find", path, "-maxdepth", "1", "-type", "d"}, args)
+		})
+	}
+}


### PR DESCRIPTION
`Readdirnames` interpolated the path straight into its `find` command. The container runs that command through `/bin/sh`, so a directory name containing a space or a quote did not arrive as a single argument — the same shape as the `cat` filesystem fix in #10645.

The command is now built with `shellquote` and moved into a small helper, so it can be covered without a running container. The test round-trips the built command through `shellquote.Split` and asserts the path comes back as one argument for a handful of awkward names.
