### PR TITLE
🐛 os: quote paths interpolated into PowerShell scripts

### DIFF
--- a/providers/os/connection/winrm/cat/cat.go
+++ b/providers/os/connection/winrm/cat/cat.go
@@ -5,7 +5,6 @@ package cat
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
 	"time"
@@ -34,9 +33,23 @@ func (cat *Fs) Name() string {
 	return "Winrm Cat FS"
 }
 
+// The two scripts below are handed to powershell as an encoded command
+// rather than as a quoted command line. A plain `powershell -c "... '<name>'"`
+// nests two parsers, the command line and then powershell itself, so a name
+// has to survive both. Encoding removes the outer layer entirely and
+// SingleQuote covers the inner one.
+
+func getContentScript(name string) string {
+	return powershell.Encode("Get-Content -LiteralPath " + powershell.SingleQuote(name))
+}
+
+func getItemScript(name string) string {
+	return powershell.Encode("Get-Item -LiteralPath " + powershell.SingleQuote(name) + " | ConvertTo-JSON")
+}
+
 func (cat *Fs) Open(name string) (afero.File, error) {
 	// NOTE: do not use type here since it does not work well with file names like 'C:\Program Files\New Text Document.txt'
-	cmd, err := cat.commandRunner.RunCommand(fmt.Sprintf("powershell -c \"Get-Content '%s'\"", name))
+	cmd, err := cat.commandRunner.RunCommand(getContentScript(name))
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +67,7 @@ func (cat *Fs) Open(name string) (afero.File, error) {
 }
 
 func (cat *Fs) Stat(name string) (os.FileInfo, error) {
-	cmd, err := cat.commandRunner.RunCommand(fmt.Sprintf("powershell -c \"Get-Item -LiteralPath '%s' | ConvertTo-JSON\"", name))
+	cmd, err := cat.commandRunner.RunCommand(getItemScript(name))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/os/connection/winrm/cat/cat_script_test.go
+++ b/providers/os/connection/winrm/cat/cat_script_test.go
@@ -1,0 +1,71 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cat
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/encoding/unicode"
+)
+
+// decodeCommand recovers the script from a `-EncodedCommand` command line.
+func decodeCommand(t *testing.T, command string) string {
+	t.Helper()
+
+	fields := strings.Fields(command)
+	require.Len(t, fields, 4, "expected an encoded command line, got %q", command)
+	assert.Equal(t, "-EncodedCommand", fields[2])
+
+	raw, err := base64.StdEncoding.DecodeString(fields[3])
+	require.NoError(t, err)
+
+	script, err := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).NewDecoder().Bytes(raw)
+	require.NoError(t, err)
+	return string(script)
+}
+
+func TestScriptsQuoteTheFileName(t *testing.T) {
+	tests := []struct {
+		name     string
+		file     string
+		expected string
+	}{
+		{
+			name:     "plain path",
+			file:     `C:\Windows\System32\drivers\etc\hosts`,
+			expected: `'C:\Windows\System32\drivers\etc\hosts'`,
+		},
+		{
+			name:     "path with spaces",
+			file:     `C:\Program Files\New Text Document.txt`,
+			expected: `'C:\Program Files\New Text Document.txt'`,
+		},
+		{
+			// a Windows file name may contain a single quote, and the
+			// command line layer used to need its own escaping on top
+			name:     "path with a quote",
+			file:     `C:\tmp\od'd.txt`,
+			expected: `'C:\tmp\od''d.txt'`,
+		},
+		{
+			name:     "path with a double quote",
+			file:     `C:\tmp\a"b.txt`,
+			expected: `'C:\tmp\a"b.txt'`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			content := decodeCommand(t, getContentScript(test.file))
+			assert.Contains(t, content, "Get-Content -LiteralPath "+test.expected)
+
+			item := decodeCommand(t, getItemScript(test.file))
+			assert.Contains(t, item, "Get-Item -LiteralPath "+test.expected+" | ConvertTo-JSON")
+		})
+	}
+}

--- a/providers/os/connection/winrm/cat/testdata/winrm.toml
+++ b/providers/os/connection/winrm/cat/testdata/winrm.toml
@@ -15,12 +15,14 @@ stdout="""
 [commands."powershell -c \"Get-WmiObject Win32_ComputerSystemProduct  | Select-Object -ExpandProperty UUID\""]
 stdout="EC2670D2-3D6E-2F4A-5C32-42C5931E1E1E"
 
-[commands."powershell -c \"Get-Content 'C:\\test.txt'\""]
+# Get-Content -LiteralPath 'C:\test.txt'
+[commands."powershell.exe -NoProfile -EncodedCommand JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsARwBlAHQALQBDAG8AbgB0AGUAbgB0ACAALQBMAGkAdABlAHIAYQBsAFAAYQB0AGgAIAAnAEMAOgBcAHQAZQBzAHQALgB0AHgAdAAnAA=="]
 stdout="""
 hi
 """
 
-[commands."powershell -c \"Get-Item -LiteralPath 'C:\\test.txt' | ConvertTo-JSON\""]
+# Get-Item -LiteralPath 'C:\test.txt' | ConvertTo-JSON
+[commands."powershell.exe -NoProfile -EncodedCommand JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsARwBlAHQALQBJAHQAZQBtACAALQBMAGkAdABlAHIAYQBsAFAAYQB0AGgAIAAnAEMAOgBcAHQAZQBzAHQALgB0AHgAdAAnACAAfAAgAEMAbwBuAHYAZQByAHQAVABvAC0ASgBTAE8ATgA="]
 stdout="""
 {
   "Name": "test.txt",
@@ -118,7 +120,8 @@ stdout="""
 }
 """
 
-[commands."powershell -c \"Get-Item -LiteralPath 'C:\\Windows' | ConvertTo-JSON\""]
+# Get-Item -LiteralPath 'C:\Windows' | ConvertTo-JSON
+[commands."powershell.exe -NoProfile -EncodedCommand JABQAHIAbwBnAHIAZQBzAHMAUAByAGUAZgBlAHIAZQBuAGMAZQA9ACcAUwBpAGwAZQBuAHQAbAB5AEMAbwBuAHQAaQBuAHUAZQAnADsARwBlAHQALQBJAHQAZQBtACAALQBMAGkAdABlAHIAYQBsAFAAYQB0AGgAIAAnAEMAOgBcAFcAaQBuAGQAbwB3AHMAJwAgAHwAIABDAG8AbgB2AGUAcgB0AFQAbwAtAEoAUwBPAE4A"]
 stdout="""
 {
   "Name": "Windows",

--- a/providers/os/registry/registrykey_powershell.go
+++ b/providers/os/registry/registrykey_powershell.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"go.mondoo.com/mql/providers/os/resources/powershell"
 )
 
 // isEmptyPowershellList reports whether the collection scripts produced no
@@ -50,7 +52,7 @@ func ParsePowershellRegistryKeyChildren(r io.Reader) ([]RegistryKeyChild, error)
 
 // RegistryKeyItem represents a registry key item and its properties
 const getRegistryKeyItemScript = `
-$path = '%s'
+$path = %s
 $reg = Get-Item ('Registry::' + $path)
 if ($reg -eq $null) {
   Write-Error "Could not find registry key"
@@ -78,12 +80,12 @@ ConvertTo-Json -Depth 3 -Compress $properties
 `
 
 func GetRegistryKeyItemScript(path string) string {
-	return fmt.Sprintf(getRegistryKeyItemScript, path)
+	return fmt.Sprintf(getRegistryKeyItemScript, powershell.SingleQuote(path))
 }
 
 // getRegistryKeyChildItemsScript represents a registry key item and its children
 const getRegistryKeyChildItemsScript = `
-$path = '%s'
+$path = %s
 $children = Get-ChildItem -Path ('Registry::' + $path) -rec -ea SilentlyContinue
 
 $properties = @()
@@ -100,5 +102,5 @@ ConvertTo-Json -compress $properties
 `
 
 func GetRegistryKeyChildItemsScript(path string) string {
-	return fmt.Sprintf(getRegistryKeyChildItemsScript, path)
+	return fmt.Sprintf(getRegistryKeyChildItemsScript, powershell.SingleQuote(path))
 }

--- a/providers/os/registry/registrykey_powershell_test.go
+++ b/providers/os/registry/registrykey_powershell_test.go
@@ -95,3 +95,48 @@ func TestWindowsRegistryEmptyListParsers(t *testing.T) {
 	_, err = ParsePowershellRegistryKeyChildren(strings.NewReader("{not json"))
 	assert.Error(t, err)
 }
+
+// pathAssignment returns the `$path = ...` line of a generated script.
+func pathAssignment(t *testing.T, script string) string {
+	t.Helper()
+	for _, line := range strings.Split(script, "\n") {
+		if strings.HasPrefix(line, "$path = ") {
+			return line
+		}
+	}
+	t.Fatalf("script has no $path assignment:\n%s", script)
+	return ""
+}
+
+func TestRegistryScriptsQuoteThePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "plain key",
+			path:     `HKLM\Software\Mondoo`,
+			expected: `$path = 'HKLM\Software\Mondoo'`,
+		},
+		{
+			// subkey names are read off the target and fed back into the
+			// next script, and a registry key name may contain a quote
+			name:     "key name with a quote",
+			path:     `HKLM\Software\od'd`,
+			expected: `$path = 'HKLM\Software\od''d'`,
+		},
+		{
+			name:     "quote followed by a statement separator",
+			path:     `HKLM\x'; whoami; '`,
+			expected: `$path = 'HKLM\x''; whoami; '''`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, pathAssignment(t, GetRegistryKeyItemScript(test.path)))
+			assert.Equal(t, test.expected, pathAssignment(t, GetRegistryKeyChildItemsScript(test.path)))
+		})
+	}
+}

--- a/providers/os/resources/powershell/encode.go
+++ b/providers/os/resources/powershell/encode.go
@@ -92,6 +92,15 @@ func SplitInvocation(cmd string) (argv []string, ok bool) {
 	return nil, false
 }
 
+// SingleQuote renders a value as a PowerShell single quoted string.
+// Single quoting is what makes a Windows path safe to interpolate: no escape
+// sequence is recognized inside it, so a backslash stays a backslash and a $
+// is not expanded. Only the quote character itself needs escaping, by
+// doubling it.
+func SingleQuote(v string) string {
+	return "'" + strings.ReplaceAll(v, "'", "''") + "'"
+}
+
 // Encode encodes a long powershell script as base64 and returns the wrapped command
 //
 // wraps a script to deactivate progress listener

--- a/providers/os/resources/powershell/quote_test.go
+++ b/providers/os/resources/powershell/quote_test.go
@@ -1,0 +1,34 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package powershell_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/providers/os/resources/powershell"
+)
+
+func TestSingleQuote(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"plain", `HKLM\Software\Mondoo`, `'HKLM\Software\Mondoo'`},
+		{"empty", "", "''"},
+		{"space", `C:\Program Files\app`, `'C:\Program Files\app'`},
+		{"trailing backslash stays literal", `C:\dir\`, `'C:\dir\'`},
+		{"dollar is not expanded", `C:\$env:SystemRoot`, `'C:\$env:SystemRoot'`},
+		{"quote is doubled", `key's name`, `'key''s name'`},
+		{"quote plus terminator", `x';whoami;'`, `'x'';whoami;'''`},
+		{"double quote needs no escape", `say "hi"`, `'say "hi"'`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, powershell.SingleQuote(test.value))
+		})
+	}
+}

--- a/providers/os/resources/windows/acl.go
+++ b/providers/os/resources/windows/acl.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"strconv"
 	"strings"
+
+	"go.mondoo.com/mql/providers/os/resources/powershell"
 )
 
 // AclScript builds the PowerShell that reads a filesystem object's
@@ -22,7 +24,7 @@ import (
 // [uint32] refuses outright with "Value was either too large or too small".
 func AclScript(path string) string {
 	return `$ErrorActionPreference='Stop'
-$p=` + quotePowerShellString(path) + `
+$p=` + powershell.SingleQuote(path) + `
 $a=Get-Acl -LiteralPath $p
 [ordered]@{
 Path=$p;Owner=[string]$a.Owner;Group=[string]$a.Group;Sddl=[string]$a.Sddl;Protected=$a.AreAccessRulesProtected
@@ -31,15 +33,6 @@ Access=@($a.Access|ForEach-Object{
 $s='';try{$s=[string]$_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value}catch{}
 [ordered]@{Identity=[string]$_.IdentityReference;Sid=$s;Type=[string]$_.AccessControlType;Rights=[string]$_.FileSystemRights;Mask=[int64][System.BitConverter]::ToUInt32([System.BitConverter]::GetBytes([int]$_.FileSystemRights),0);Inherited=$_.IsInherited;InheritanceFlags=[string]$_.InheritanceFlags;PropagationFlags=[string]$_.PropagationFlags}})
 }|ConvertTo-Json -Depth 5 -Compress`
-}
-
-// quotePowerShellString renders a value as a PowerShell single quoted string.
-// Single quoting is what makes a Windows path safe to interpolate: no escape
-// sequence is recognized inside it, so a backslash stays a backslash and a $
-// is not expanded. Only the quote character itself needs escaping, by
-// doubling it.
-func quotePowerShellString(v string) string {
-	return "'" + strings.ReplaceAll(v, "'", "''") + "'"
 }
 
 // Windows file access rights, as defined by the FileSystemRights enumeration
@@ -228,7 +221,7 @@ func ParseWindowsAcl(input io.Reader) (*WindowsAcl, error) {
 // generic bits is a negative number that [uint32] refuses outright.
 func AclAuditScript(path string) string {
 	return `$ErrorActionPreference='Stop'
-$p=` + quotePowerShellString(path) + `
+$p=` + powershell.SingleQuote(path) + `
 $a=Get-Acl -LiteralPath $p -Audit
 [ordered]@{
 Path=$p

--- a/providers/os/resources/windows/eventlog.go
+++ b/providers/os/resources/windows/eventlog.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"io"
 	"strings"
+
+	"go.mondoo.com/mql/providers/os/resources/powershell"
 )
 
 // errEmptyEventLogChannel is returned when the command produced no object at
@@ -40,7 +42,7 @@ var errEmptyEventLogChannel = errors.New("no Event Log channel information was r
 // disabled".
 func EventLogChannelScript(name string) string {
 	return `$ErrorActionPreference='Stop'
-$l=Get-WinEvent -ListLog ` + quotePowerShellString(name) + ` -ErrorAction Stop
+$l=Get-WinEvent -ListLog ` + powershell.SingleQuote(name) + ` -ErrorAction Stop
 [ordered]@{
 LogName=[string]$l.LogName
 IsEnabled=[bool]$l.IsEnabled


### PR DESCRIPTION
Two places interpolated a path into a PowerShell script without escaping it: the registry scripts (`$path = '%s'`, for both the key and the child-item variants) and the WinRM `cat` filesystem (`powershell -c "... '%s'"`). A Windows registry key name or file name is allowed to contain a quote, so in neither case did the value reliably arrive as the string it was meant to be. The WinRM one also nests two parsers — the command line and then PowerShell — so it needed escaping twice over.

`resources/windows` already had the right helper but kept it unexported in its own package, so it moved to the shared `os/resources/powershell` package as `SingleQuote` and all the call sites (registry, WinRM cat, `acl.go`, `eventlog.go`) now use the one implementation. The WinRM commands additionally go through `powershell.Encode`, which removes the outer quoting layer entirely: the command line carries a base64 script rather than a quoted one. `Open` picks up `-LiteralPath` at the same time, matching what `Stat` next to it already did.

Tests: a table for `SingleQuote`, one asserting the `$path` line of both registry scripts against literals, and one that decodes the WinRM encoded command back to its script. The three WinRM fixture keys are the commands themselves, so they were regenerated; each now carries a comment with the decoded script above it.
