### PR TITLE
🧹 ci: skip the Cloud Build substitutions doc in the link check

### DIFF
--- a/.github/actions/link-check/config.json
+++ b/.github/actions/link-check/config.json
@@ -26,6 +26,9 @@
     },
     {
       "pattern": "^https:\\/\\/docs\\.aws\\.amazon\\.com\\/"
+    },
+    {
+      "pattern": "^https:\\/\\/(docs\\.)?cloud\\.google\\.com\\/.*substitute-variable-values"
     }
   ]
 }


### PR DESCRIPTION
`cli/execruntime/README.md` links to the Cloud Build default-substitutions doc. It loads fine from a browser, but the CI runner gets a 404 for it — the old `cloud.google.com/cloud-build/...` URL redirects to `docs.cloud.google.com/build/...`, and that is what comes back 404 from the runner. The job fails on a link that is not actually broken.

Added an ignore pattern for that one document, matching either host it is served from. Everything else under `cloud.google.com` stays checked.
