### PR TITLE
🐛 os/powershell: create the staged script file rather than reuse one

### DIFF
--- a/providers/os/resources/iis.go
+++ b/providers/os/resources/iis.go
@@ -105,7 +105,7 @@ func (i *mqlIis) runCollection() (*windows.IisData, error) {
 	}
 
 	// The collection script is far too long to travel on a command line:
-	// 13,849 characters, 37,078 once Encode has widened it to UTF-16 and base64
+	// 18,545 characters, 49,554 once Encode has widened it to UTF-16 and base64
 	// encoded it, against a ceiling of about 32k over SSH and 8,191 over WinRM.
 	// Passed as an encoded command it is rejected by the target before
 	// PowerShell runs, and the non-zero exit with empty stdout reads as "IIS is

--- a/providers/os/resources/powershell/scriptlength_test.go
+++ b/providers/os/resources/powershell/scriptlength_test.go
@@ -61,11 +61,12 @@ var knownOverCap = map[string]string{
 // passed to powershell.Stage somewhere in the tree. The last one is the point:
 // it makes the exemption a statement about code rather than a note.
 var stagedScripts = map[string]string{
-	// 13,849 characters, 37,078 encoded — over both ceilings and not
-	// compactable: the shared prelude alone (install guard, section lists,
-	// ConvertTo-PlainElement, Get-SectionMap) is 7,060 characters, so splitting
-	// it into round trips leaves every one of them over the WinRM cap. It is
-	// staged by providers/os/resources/iis.go and run with -File.
+	// 18,545 characters, 49,554 encoded — over both ceilings and not
+	// compactable: the prelude every scope needs (install guard, section lists
+	// and helpers, everything above Get-ScopeConfiguration) is 11,553 characters
+	// on its own, so splitting the script into round trips leaves every one of
+	// them over the WinRM cap. It is staged by providers/os/resources/iis.go and
+	// run with -File.
 	"providers/os/resources/windows/iis.go:IIS_CONFIGURATION": "staged as a file by the iis resource and run with -File",
 }
 

--- a/providers/os/resources/powershell/stage.go
+++ b/providers/os/resources/powershell/stage.go
@@ -70,6 +70,9 @@ type StagedScript struct {
 
 	conn    shared.Connection
 	written bool
+	// viaFS records that the write went through the connection's filesystem,
+	// which is also the cheapest way to take it off again.
+	viaFS bool
 }
 
 // stagedDir picks the staging directory from the asset's platform.
@@ -158,6 +161,7 @@ func Stage(conn shared.Connection, name, script string) (*StagedScript, error) {
 
 	if err := writeViaFileSystem(conn, path, script); err == nil {
 		staged.written = true
+		staged.viaFS = true
 		return staged, nil
 	} else {
 		log.Debug().Err(err).Str("path", path).
@@ -188,24 +192,44 @@ func writeViaFileSystem(conn shared.Connection, path, script string) error {
 	if fs == nil {
 		return errors.New("connection has no filesystem")
 	}
-	// Clear a leftover from an interrupted scan, then create the file rather
-	// than open whatever is at the path. The staging directory is writable by
-	// every local user and the name is derived from the script, so the path is
-	// knowable before a scan runs; O_EXCL makes a file that is already there a
-	// failure instead of something this write goes through. Nothing is lost by
-	// failing: the caller falls back to the chunked write, which creates the
-	// file the same way.
-	if err := fs.Remove(path); err != nil && !os.IsNotExist(err) {
-		log.Debug().Err(err).Str("path", path).
-			Msg("powershell> could not clear the staging path before writing")
-	}
-
-	// PowerShell reads a BOM-less UTF-8 file fine, and every script staged this
-	// way is ASCII in practice. CRLF is not required by -File.
+	// Create the file rather than open whatever is at the path. The staging
+	// directory is writable by every local user and the name is derived from the
+	// script, so the path is knowable before a scan runs; O_EXCL makes a file
+	// that is already there a failure instead of something this write goes
+	// through. Nothing is lost by failing: the caller falls back to the chunked
+	// write, which creates the file the same way.
+	//
+	// The create comes first and the delete only after it fails, rather than the
+	// other way around, because the path is free on every scan that was not
+	// interrupted. Over sftp clearing it first would spend two round trips
+	// deleting nothing: pkg/sftp's Remove tries the file, then the directory,
+	// before it can say the path does not exist.
+	//
+	// The retry is deliberately not gated on the error meaning "already exists".
+	// Over sftp that gate would never open: SFTP v3 has no status code for it,
+	// so a server answers EEXIST with SSH_FX_FAILURE and pkg/sftp passes it
+	// through untranslated, leaving os.IsExist false on the one transport this
+	// matters for. A failure that deleting cannot fix simply fails the second
+	// create too. Re-planting the path between the two is not a way in
+	// either — that is what the second O_EXCL is for.
 	f, err := fs.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		if rmErr := fs.Remove(path); rmErr != nil {
+			// Report why the create failed, not why the speculative delete did.
+			return err
+		}
+		f, err = fs.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	}
 	if err != nil {
 		return err
 	}
+
+	// No BOM and no CRLF: -File needs neither, and every byte a staged script
+	// puts in a *value* is ASCII today. That last part is a constraint, not an
+	// observation — PowerShell 5.1 decodes a BOM-less file with the ANSI
+	// codepage, so a non-ASCII character in an emitted string would arrive
+	// mangled where the -EncodedCommand path would have carried it intact. The
+	// em dashes in iis.ps1 are all inside comments, where that does not show.
 	if _, err := f.Write([]byte(script)); err != nil {
 		f.Close()
 		return err
@@ -323,6 +347,22 @@ func (s *StagedScript) Remove() {
 		return
 	}
 	s.written = false
+
+	// A script that went on through the filesystem comes off the same way. The
+	// command below starts a powershell.exe on the target, which is the most
+	// expensive single step in staging, to delete a file the connection can
+	// unlink in one request.
+	if s.viaFS {
+		if fs := s.conn.FileSystem(); fs != nil {
+			err := fs.Remove(s.Path)
+			if err == nil {
+				return
+			}
+			log.Debug().Err(err).Str("path", s.Path).
+				Msg("powershell> could not unlink the staged script, falling back to a command")
+		}
+	}
+
 	err := runOne(s.conn, psCommand(
 		fmt.Sprintf("Remove-Item -Force -ErrorAction SilentlyContinue '%s'", s.Path),
 		fmt.Sprintf("-not (Test-Path '%s')", s.Path)))

--- a/providers/os/resources/powershell/stage.go
+++ b/providers/os/resources/powershell/stage.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -187,9 +188,21 @@ func writeViaFileSystem(conn shared.Connection, path, script string) error {
 	if fs == nil {
 		return errors.New("connection has no filesystem")
 	}
+	// Clear a leftover from an interrupted scan, then create the file rather
+	// than open whatever is at the path. The staging directory is writable by
+	// every local user and the name is derived from the script, so the path is
+	// knowable before a scan runs; O_EXCL makes a file that is already there a
+	// failure instead of something this write goes through. Nothing is lost by
+	// failing: the caller falls back to the chunked write, which creates the
+	// file the same way.
+	if err := fs.Remove(path); err != nil && !os.IsNotExist(err) {
+		log.Debug().Err(err).Str("path", path).
+			Msg("powershell> could not clear the staging path before writing")
+	}
+
 	// PowerShell reads a BOM-less UTF-8 file fine, and every script staged this
 	// way is ASCII in practice. CRLF is not required by -File.
-	f, err := fs.Create(path)
+	f, err := fs.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		return err
 	}
@@ -216,13 +229,16 @@ func writeViaCommand(conn shared.Connection, path, script string) error {
 	tmp := path + ".b64"
 
 	// Fresh file per run: an interrupted earlier scan could otherwise leave a
-	// partial payload that this one silently appends to. The hashed name makes
-	// that unlikely rather than impossible.
+	// partial payload that this one silently appends to. New-Item without
+	// -Force is the exclusive create - it fails rather than reusing whatever is
+	// at the path, which matters because the staging directory is writable by
+	// every local user and the name is derived from the script. The attribute
+	// test is 0x400, FILE_ATTRIBUTE_REPARSE_POINT: a link at the path would
+	// otherwise send the chunks somewhere else entirely.
 	if err := runOne(conn, psCommand(
-		fmt.Sprintf("Remove-Item -Force -ErrorAction SilentlyContinue '%s','%s'", tmp, path),
-		// Success is the absence of both files, which is also the state a fresh
-		// target is already in.
-		fmt.Sprintf("-not (Test-Path '%s') -and -not (Test-Path '%s')", tmp, path))); err != nil {
+		fmt.Sprintf("Remove-Item -Force -ErrorAction SilentlyContinue '%s','%s'; New-Item -ItemType File -Path '%s' -ErrorAction Stop | Out-Null", tmp, path, tmp),
+		// Success is an empty file this command created, and no final file yet.
+		fmt.Sprintf("(Test-Path '%s') -and -not (Test-Path '%s') -and (((Get-Item '%s' -Force -ErrorAction Stop).Attributes -band 1024) -eq 0)", tmp, path, tmp))); err != nil {
 		return err
 	}
 
@@ -242,8 +258,8 @@ func writeViaCommand(conn shared.Connection, path, script string) error {
 	// Decode on the target rather than shipping the plain text: this is the one
 	// step whose size does not depend on the script.
 	if err := runOne(conn, psCommand(
-		fmt.Sprintf("[IO.File]::WriteAllBytes('%s',[Convert]::FromBase64String((Get-Content -Raw '%s' -ErrorAction Stop))); Remove-Item -Force -ErrorAction SilentlyContinue '%s'",
-			path, tmp, tmp),
+		fmt.Sprintf("New-Item -ItemType File -Path '%s' -ErrorAction Stop | Out-Null; [IO.File]::WriteAllBytes('%s',[Convert]::FromBase64String((Get-Content -Raw '%s' -ErrorAction Stop))); Remove-Item -Force -ErrorAction SilentlyContinue '%s'",
+			path, path, tmp, tmp),
 		fmt.Sprintf("(Get-Item '%s' -ErrorAction Stop).Length -eq %d", path, len(script)))); err != nil {
 		return err
 	}

--- a/providers/os/resources/powershell/stage_test.go
+++ b/providers/os/resources/powershell/stage_test.go
@@ -132,13 +132,14 @@ func TestStageWritesThroughAWritableFilesystem(t *testing.T) {
 	assert.Equal(t, script, string(body))
 	assert.Empty(t, conn.commands, "the filesystem path must not shell out")
 
+	// The script went on through the filesystem, so the cleanup goes back through
+	// it. Launching powershell.exe to delete a file the connection can unlink
+	// itself costs a whole process start on the target for nothing.
 	staged.Remove()
-	require.Len(t, conn.commands, 1)
-	assert.Contains(t, conn.commands[0], "Remove-Item")
-	assert.Contains(t, conn.commands[0], staged.Path)
-	// The removal is the command most likely to break unnoticed: it runs after
-	// the answer has already been produced, and its failure only logs at debug.
-	assertStagingCommandShape(t, conn.commands)
+	assert.Empty(t, conn.commands, "the filesystem path must not shell out to clean up")
+	left, err := afero.Exists(fs, staged.Path)
+	require.NoError(t, err)
+	assert.False(t, left, "the staged script was left on the target")
 }
 
 // winrm and `ssh --sudo`: the filesystem is there and refuses to write, so the
@@ -254,7 +255,7 @@ func TestStageWillNotWriteThroughAnExistingFile(t *testing.T) {
 	// no RunCommand fallback available, so a refused write is the whole result
 	conn := &fakeConn{
 		connType: shared.Type_SSH, platform: windowsPlatform(),
-		fs: existingFileFs{fs}, caps: shared.Capability_File,
+		fs: undeletableFs{fs}, caps: shared.Capability_File,
 	}
 
 	_, err := powershell.Stage(conn, "iis", script)
@@ -265,11 +266,24 @@ func TestStageWillNotWriteThroughAnExistingFile(t *testing.T) {
 	assert.Equal(t, "planted", string(body), "staging overwrote a file it did not create")
 }
 
-// existingFileFs keeps Remove from clearing the path, standing in for a file
-// the scanner is not permitted to delete.
-type existingFileFs struct{ afero.Fs }
+// undeletableFs stands in for a file the scanner is not permitted to delete:
+// a write may succeed, the removal never does.
+type undeletableFs struct{ afero.Fs }
 
-func (existingFileFs) Remove(string) error { return errors.New("permission denied") }
+func (undeletableFs) Remove(string) error { return errors.New("permission denied") }
+
+// countingFs records the calls staging makes on the filesystem. It is the only
+// way to observe a round trip that is *not* there: over sftp every Remove is a
+// request to the target, and on the common path there is nothing to delete.
+type countingFs struct {
+	afero.Fs
+	removes int
+}
+
+func (c *countingFs) Remove(name string) error {
+	c.removes++
+	return c.Fs.Remove(name)
+}
 
 // The chunked write is the path every read-only connection takes, so it needs
 // the same guarantee: create the file, do not adopt one.
@@ -307,5 +321,91 @@ func TestChunkedStagingCreatesItsOwnFiles(t *testing.T) {
 	// payload somewhere else
 	assert.Contains(t, first, "-band 1024")
 
+	assertStagingCommandShape(t, conn.commands)
+}
+
+// The staging path is free on every scan that cleaned up after itself, which is
+// every scan that was not interrupted. Deleting it first spends a round trip -
+// two, over sftp, where Remove tries the file and then the directory - to
+// delete nothing. Create first, and clear only when the create says something
+// is in the way.
+func TestStageDoesNotDeleteAPathThatIsFree(t *testing.T) {
+	fs := &countingFs{Fs: afero.NewMemMapFs()}
+	conn := &fakeConn{
+		connType: shared.Type_SSH, platform: windowsPlatform(),
+		fs: fs, caps: shared.Capability_RunCommand | shared.Capability_File,
+	}
+
+	script := "ConvertTo-Json @{ a = 1 }\n"
+	staged, err := powershell.Stage(conn, "iis", script)
+	require.NoError(t, err)
+	assert.Zero(t, fs.removes, "staging deleted a file that was not there")
+
+	body, err := afero.ReadFile(fs, staged.Path)
+	require.NoError(t, err)
+	assert.Equal(t, script, string(body))
+}
+
+// A scan that died between the write and the run leaves its file behind. The
+// next one has to clear it rather than degrade to the chunked write, and what
+// it runs has to be its own script and not the leftover.
+func TestStageClearsALeftoverFromAnInterruptedScan(t *testing.T) {
+	fs := &countingFs{Fs: afero.NewMemMapFs()}
+	script := "ConvertTo-Json @{ a = 1 }\n"
+	path := powershell.StagedWindowsPath("iis", script)
+	require.NoError(t, afero.WriteFile(fs, path, []byte("leftover"), 0o600))
+
+	conn := &fakeConn{
+		connType: shared.Type_SSH, platform: windowsPlatform(),
+		fs: fs, caps: shared.Capability_RunCommand | shared.Capability_File,
+	}
+	staged, err := powershell.Stage(conn, "iis", script)
+	require.NoError(t, err)
+	assert.Equal(t, 1, fs.removes, "the leftover has to be cleared exactly once")
+	assert.Empty(t, conn.commands,
+		"clearing a leftover must not cost the chunked write's round trips")
+
+	body, err := afero.ReadFile(fs, staged.Path)
+	require.NoError(t, err)
+	assert.Equal(t, script, string(body))
+}
+
+// The chunked path has no filesystem to remove through, so its cleanup is still
+// a command - and it is the command most likely to break unnoticed, since it
+// runs after the answer has been produced and only logs at debug.
+func TestChunkedStagingRemovesOverTheCommandPath(t *testing.T) {
+	conn := &fakeConn{
+		connType: shared.Type_Winrm, platform: windowsPlatform(),
+		fs:   readOnlyFs{afero.NewMemMapFs()},
+		caps: shared.Capability_RunCommand | shared.Capability_File,
+	}
+	staged, err := powershell.Stage(conn, "iis",
+		"ConvertTo-Json @{ a = 1 }\n"+strings.Repeat("#x\n", 50))
+	require.NoError(t, err)
+	written := len(conn.commands)
+
+	staged.Remove()
+	require.Len(t, conn.commands, written+1, "the chunked path still has to remove by command")
+	assert.Contains(t, conn.commands[written], "Remove-Item")
+	assert.Contains(t, conn.commands[written], staged.Path)
+	assertStagingCommandShape(t, conn.commands)
+}
+
+// A filesystem that took the write and then refuses the delete must not leave
+// the script on the target: the command path is still there to fall back on.
+func TestFilesystemRemovalFallsBackToTheCommand(t *testing.T) {
+	conn := &fakeConn{
+		connType: shared.Type_SSH, platform: windowsPlatform(),
+		fs:   undeletableFs{afero.NewMemMapFs()},
+		caps: shared.Capability_RunCommand | shared.Capability_File,
+	}
+	staged, err := powershell.Stage(conn, "iis", "ConvertTo-Json @{ a = 1 }\n")
+	require.NoError(t, err)
+	require.Empty(t, conn.commands, "the write itself goes over the filesystem")
+
+	staged.Remove()
+	require.Len(t, conn.commands, 1, "a refused unlink has to fall back to the command")
+	assert.Contains(t, conn.commands[0], "Remove-Item")
+	assert.Contains(t, conn.commands[0], staged.Path)
 	assertStagingCommandShape(t, conn.commands)
 }

--- a/providers/os/resources/powershell/stage_test.go
+++ b/providers/os/resources/powershell/stage_test.go
@@ -287,10 +287,21 @@ func TestChunkedStagingCreatesItsOwnFiles(t *testing.T) {
 	last := conn.commands[len(conn.commands)-1]
 
 	// New-Item without -Force fails on an existing item, which is the
-	// exclusive create; -Force would silently reuse whatever is there
-	assert.Contains(t, first, "New-Item -ItemType File")
-	assert.NotContains(t, first, "New-Item -ItemType File -Path -Force")
-	assert.Contains(t, last, "New-Item -ItemType File")
+	// exclusive create; -Force would silently reuse whatever is there. The
+	// path sits between -Path and any -Force, so the two have to be checked
+	// per statement rather than as one substring.
+	for _, cmd := range []string{first, last} {
+		creates := 0
+		for _, stmt := range strings.Split(cmd, ";") {
+			if !strings.Contains(stmt, "New-Item") {
+				continue
+			}
+			creates++
+			assert.NotContains(t, stmt, "-Force",
+				"New-Item has to fail on an existing item, so it cannot take -Force: %s", stmt)
+		}
+		assert.Equal(t, 1, creates, "expected one exclusive create in %q", cmd)
+	}
 
 	// 0x400 is FILE_ATTRIBUTE_REPARSE_POINT: a link at the path would send the
 	// payload somewhere else

--- a/providers/os/resources/powershell/stage_test.go
+++ b/providers/os/resources/powershell/stage_test.go
@@ -6,6 +6,7 @@ package powershell_test
 import (
 	"bytes"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
@@ -24,6 +25,10 @@ import (
 type readOnlyFs struct{ afero.Fs }
 
 func (readOnlyFs) Create(string) (afero.File, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (readOnlyFs) OpenFile(string, int, os.FileMode) (afero.File, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -234,4 +239,62 @@ func TestStagedWindowsPathMatchesStage(t *testing.T) {
 	assert.Equal(t, staged.Path, powershell.StagedWindowsPath("iis", script))
 	assert.Equal(t, staged.Command,
 		powershell.StagedCommand(powershell.StagedWindowsPath("iis", script)))
+}
+
+// The staging directory is writable by every local user and the file name is
+// derived from the script, so the path can be occupied before a scan starts.
+// Staging must create its own file rather than write through one that is
+// already there.
+func TestStageWillNotWriteThroughAnExistingFile(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	script := "ConvertTo-Json @{ a = 1 }\n"
+	path := powershell.StagedWindowsPath("iis", script)
+	require.NoError(t, afero.WriteFile(fs, path, []byte("planted"), 0o644))
+
+	// no RunCommand fallback available, so a refused write is the whole result
+	conn := &fakeConn{
+		connType: shared.Type_SSH, platform: windowsPlatform(),
+		fs: existingFileFs{fs}, caps: shared.Capability_File,
+	}
+
+	_, err := powershell.Stage(conn, "iis", script)
+	require.Error(t, err)
+
+	body, readErr := afero.ReadFile(fs, path)
+	require.NoError(t, readErr)
+	assert.Equal(t, "planted", string(body), "staging overwrote a file it did not create")
+}
+
+// existingFileFs keeps Remove from clearing the path, standing in for a file
+// the scanner is not permitted to delete.
+type existingFileFs struct{ afero.Fs }
+
+func (existingFileFs) Remove(string) error { return errors.New("permission denied") }
+
+// The chunked write is the path every read-only connection takes, so it needs
+// the same guarantee: create the file, do not adopt one.
+func TestChunkedStagingCreatesItsOwnFiles(t *testing.T) {
+	conn := &fakeConn{
+		connType: shared.Type_Winrm, platform: windowsPlatform(),
+		fs:   readOnlyFs{afero.NewMemMapFs()},
+		caps: shared.Capability_RunCommand | shared.Capability_File,
+	}
+	_, err := powershell.Stage(conn, "iis", "ConvertTo-Json @{ a = 1 }\n"+strings.Repeat("#x\n", 50))
+	require.NoError(t, err)
+	require.Greater(t, len(conn.commands), 2)
+
+	first := conn.commands[0]
+	last := conn.commands[len(conn.commands)-1]
+
+	// New-Item without -Force fails on an existing item, which is the
+	// exclusive create; -Force would silently reuse whatever is there
+	assert.Contains(t, first, "New-Item -ItemType File")
+	assert.NotContains(t, first, "New-Item -ItemType File -Path -Force")
+	assert.Contains(t, last, "New-Item -ItemType File")
+
+	// 0x400 is FILE_ATTRIBUTE_REPARSE_POINT: a link at the path would send the
+	// payload somewhere else
+	assert.Contains(t, first, "-band 1024")
+
+	assertStagingCommandShape(t, conn.commands)
 }


### PR DESCRIPTION
Staging writes a script to the target and runs it with `-File`. The directory it writes to is writable by every local user, and the file name is derived from the script's content, so the full path is knowable before a scan runs. Both write paths then opened whatever was already at that path — the filesystem one through `Create`, the chunked one by appending after a best-effort `Remove-Item`.

Both now create the file exclusively: `O_CREATE|O_EXCL` on the filesystem path, `New-Item` without `-Force` on the chunked one, each failing rather than adopting an existing file. The chunked path also checks the file it created is not a reparse point (`-band 1024`) before sending the payload at it. Failing is cheap here — the filesystem path already falls back to the chunked write, which creates the file the same way.

The staged path itself is deliberately unchanged: it is the identity of the `command` resource that runs it, and therefore the key a recording is filed under, so making it unpredictable would make recordings unreplayable.

## Cost of the fix, and two things it paid for

Measured on the only script staged today, `iis.ps1`: 18,545 bytes, 24,728 base64 characters, 5 chunks.

The chunked path is round-trip neutral. Both new operations fold into commands that were already being sent — the prep command grows 337 → 551 characters and the decode command 437 → 536, and the added work on the target is one `CreateFile` and one `GetFileAttributes` against a `powershell.exe` start that dominates by three orders of magnitude. It stays at 1 prep + 5 chunks + 1 decode + 1 run + 1 cleanup.

The filesystem path was not neutral, so this PR now also removes the cost rather than adding it:

- **Create first, clear only on failure.** Clearing the path before creating it charged every scan for a delete, and the path is free on every scan that was not interrupted. Over sftp that is *two* requests, not one: `pkg/sftp`'s `Remove` tries the file and then the directory before it can report that neither is there. The exclusive create is unchanged, and re-planting the path between the delete and the retry is still no way in — that is what the second `O_EXCL` is for.

  The retry is deliberately not gated on the error meaning "already exists". SFTP v3 has no status code for it, so a server answers EEXIST with `SSH_FX_FAILURE` and `pkg/sftp` passes it through untranslated; `os.IsExist` is false on the one transport where the gate would have mattered, and a real leftover would have dropped straight into the chunked write.

- **Unlink over the filesystem it was written through.** Cleanup launched `powershell.exe` on the target to delete a file the same connection could unlink in one request. It now removes through the filesystem where the write went that way, and falls back to the command when the unlink is refused, so nothing is left behind either way.

Net on an SSH/sftp scan: one round trip to write and one to remove, against three and a `powershell.exe` start before. Net on WinRM: unchanged, since its filesystem refuses both calls in-process.

## Two notes on the tests

`readOnlyFs` in `stage_test.go` only stubbed `Create`, while all three real read-only shims (`ssh/cat`, `winrm/cat`, `scp`) stub `OpenFile` too — it now stubs both, so the fallback tests exercise the path they claim to.

Every test added here was run against the implementation it constrains and confirmed to fail on it: the two exclusive-create tests against the previous code, and the four new ones (`TestStageDoesNotDeleteAPathThatIsFree`, `TestStageClearsALeftoverFromAnInterruptedScan`, `TestChunkedStagingRemovesOverTheCommandPath`, `TestFilesystemRemovalFallsBackToTheCommand`) against a build with the retry branch and the command fallback removed.

## Also in here

The comments in `iis.go` and `scriptlength_test.go` still quoted 13,849 characters and 37,078 encoded; the script is 18,545 and 49,554 today, which is one more chunk on the wire than the old figure implies. The prelude figure is replaced with one anybody can reproduce — everything above `Get-ScopeConfiguration`, 11,553 characters.

## Not in here

`iis.ps1` contains em dashes. They are all inside comments, so nothing is mis-decoded today, but PowerShell 5.1 reads a BOM-less file with the ANSI codepage, which means a non-ASCII byte in an *emitted value* would arrive mangled on the staged path where `-EncodedCommand` would have carried it intact. The comment in `writeViaFileSystem` now states that as the constraint it is. Fixing it properly means writing a BOM from both write paths and adjusting the chunked length check, and it wants a Windows host to verify, so it is left for its own change.
