### PR TITLE
✨ languages: carry whether a dependency is optional

### DIFF
--- a/providers/os/resources/languages/extractor.go
+++ b/providers/os/resources/languages/extractor.go
@@ -75,6 +75,22 @@ type Package struct {
 	// Lets a consumer rank a CVE in a dev-only tool differently from a runtime
 	// one. Populated by parsers whose lockfile carries the flag (npm today).
 	Scope string `json:"scope,omitempty"`
+	// Optional reports that a dependent may be built and run WITHOUT this
+	// package: Maven's <optional>true</optional>, and the same idea in npm's
+	// optionalDependencies and Cargo's optional features.
+	//
+	// It is a second axis, independent of Scope. A package can be production
+	// scope and still optional — the declaring project ships it only if you ask
+	// for the feature it enables.
+	//
+	// The distinction that makes it worth a field: an optional dependency is NOT
+	// inherited by whoever depends on the declaring package. Maven and Gradle
+	// both stop there, so anything walking a dependency graph has to know, and
+	// a walk that does not is not slightly over-broad but wrong by a factor —
+	// log4j-core alone declares 16 optional dependencies (jackson, kafka-clients,
+	// jeromq, javax.mail…), none of which a project using log4j-core depends on.
+	// Populated by parsers whose manifest carries the flag (Maven today).
+	Optional bool `json:"optional,omitempty"`
 	// Hashes are the package's integrity digests — the declared checksums a
 	// lockfile records for tamper-evidence (npm's Subresource-Integrity
 	// `integrity`, `dist.shasum`; …). Populated by parsers whose lockfile carries

--- a/providers/os/resources/languages/java/pomxml/extractor.go
+++ b/providers/os/resources/languages/java/pomxml/extractor.go
@@ -6,6 +6,7 @@ package pomxml
 import (
 	"encoding/xml"
 	"io"
+	"strings"
 
 	"go.mondoo.com/mql/providers/os/resources/languages"
 	"go.mondoo.com/mql/providers/os/resources/languages/java"
@@ -135,9 +136,15 @@ func (p *pomProject) depToPackage(dep pomDependency) *languages.Package {
 		name = groupId + ":" + artifactId
 	}
 
+	// <optional>true</optional> is read through the same property resolution as
+	// every other field: a POM may state it as ${some.flag}, and an unresolved
+	// one is not optional.
+	optional := strings.EqualFold(strings.TrimSpace(p.resolve(dep.Optional)), "true")
+
 	return &languages.Package{
 		Name:         name,
 		Version:      version,
+		Optional:     optional,
 		Purl:         java.NewPackageUrl(groupId, artifactId, version),
 		Cpes:         java.NewCpes(groupId, artifactId, version),
 		EvidenceList: java.NewEvidenceList(p.evidence),

--- a/providers/os/resources/languages/java/pomxml/extractor_test.go
+++ b/providers/os/resources/languages/java/pomxml/extractor_test.go
@@ -500,3 +500,98 @@ func TestPomXmlManagedScopeUsesTheFullKey(t *testing.T) {
 		"a managed test scope on the test-jar must keep it out of the production set")
 	assert.Equal(t, "2.0", packagesByName(p.Transitive())["g:a"].Version)
 }
+
+// TestOptionalDependenciesAreMarked — an optional dependency is not inherited
+// by whoever depends on the declaring package, so anything walking a dependency
+// graph has to know. A walk that does not is not slightly over-broad but wrong
+// by a factor: log4j-core alone declares 16 optional dependencies, and a
+// prototype closure walk that ignored the flag reached 28 packages on a project
+// whose real closure is 16.
+func TestOptionalDependenciesAreMarked(t *testing.T) {
+	bom, err := (&Extractor{}).Parse(strings.NewReader(`<project>
+  <groupId>com.example</groupId>
+  <artifactId>demo</artifactId>
+  <version>1.0.0</version>
+  <properties>
+    <opt.flag>true</opt.flag>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.14.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.12.2</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.lmax</groupId>
+      <artifactId>disruptor</artifactId>
+      <version>3.4.2</version>
+      <optional>${opt.flag}</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.zeromq</groupId>
+      <artifactId>jeromq</artifactId>
+      <version>0.4.3</version>
+      <optional>false</optional>
+    </dependency>
+  </dependencies>
+</project>`), "pom.xml")
+	require.NoError(t, err)
+	deps := bom.Transitive()
+
+	require.NotNil(t, deps.Find("com.fasterxml.jackson.core:jackson-databind"))
+	assert.True(t, deps.Find("com.fasterxml.jackson.core:jackson-databind").Optional)
+	// Read through the same property resolution as every other field.
+	assert.True(t, deps.Find("com.lmax:disruptor").Optional, "${opt.flag} resolving to true is optional")
+
+	assert.False(t, deps.Find("org.apache.logging.log4j:log4j-api").Optional, "no <optional> element")
+	assert.False(t, deps.Find("org.zeromq:jeromq").Optional, "<optional>false</optional>")
+}
+
+// TestUnresolvedOptionalIsNotOptional — a flag that stays a literal
+// "${some.flag}" says nothing, and reading it as true would drop a real
+// dependency out of a dependent's closure. The safe reading of "unknown" here
+// is "inherited", which is what Maven does for a dependency with no <optional>.
+func TestUnresolvedOptionalIsNotOptional(t *testing.T) {
+	bom, err := (&Extractor{}).Parse(strings.NewReader(`<project>
+  <groupId>com.example</groupId><artifactId>demo</artifactId><version>1.0.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId><artifactId>thing</artifactId><version>1.0</version>
+      <optional>${nowhere.defined}</optional>
+    </dependency>
+  </dependencies>
+</project>`), "pom.xml")
+	require.NoError(t, err)
+
+	p := bom.Transitive().Find("com.example:thing")
+	require.NotNil(t, p)
+	assert.False(t, p.Optional, "an unresolved flag is not an assertion that the dependency is optional")
+}
+
+// TestOptionalIsIndependentOfScope pins the two axes apart. A production-scope
+// dependency can be optional — the declaring project ships it only if you ask
+// for the feature it enables — so neither field can be derived from the other.
+func TestOptionalIsIndependentOfScope(t *testing.T) {
+	bom, err := (&Extractor{}).Parse(strings.NewReader(`<project>
+  <groupId>com.example</groupId><artifactId>demo</artifactId><version>1.0.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId><artifactId>compile-optional</artifactId><version>1.0</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+</project>`), "pom.xml")
+	require.NoError(t, err)
+
+	// It is compile scope, so it stays in Direct() — the existing production
+	// filter is unchanged by this field.
+	p := bom.Direct().Find("com.example:compile-optional")
+	require.NotNil(t, p, "an optional compile dependency is still declared by this project")
+	assert.True(t, p.Optional)
+}


### PR DESCRIPTION
## Why

An optional dependency is **not inherited** by whoever depends on the declaring package. Maven and Gradle both stop there, so anything walking a dependency graph has to know — and a walk that does not is not slightly over-broad, it is wrong by a factor.

`org.apache.logging.log4j:log4j-core` alone declares **16 optional dependencies** — jackson, kafka-clients, jeromq, javax.mail — and none of them is a dependency of a project that uses log4j-core.

Measured on a project whose real closure is 16 packages, known from a `gradle.lockfile` Gradle itself wrote: a closure walk that ignored the flag reached **28**. Among the twelve it invented was a *second version* of an artifact already in the closure (`jackson-databind@2.12.2` alongside the project's own `2.9.10.1`). A version the project does not have gets matched against advisories and answered with confidence, which costs a user more than a gap does.

## What changed

The POM parser already read `<optional>` and already resolved it through the same property lookup as every other field. Nothing surfaced it. This adds `Optional bool` to `languages.Package` and populates it from `pomxml`.

**It is a second axis, independent of `Scope`.** A package can be production scope and still optional — the declaring project ships it only if you ask for the feature it enables. Neither field is derivable from the other, which is why this is not folded into `Scope`.

## Deliberately additive only

`Direct()` and `Transitive()` return exactly the sets they returned before. An optional compile dependency is still declared by the project that declares it; it is a *consumer walking a graph*, not this parser, that must stop at it. A test pins that.

**An unresolved flag is not optional.** A literal `${some.flag}` says nothing, and reading it as true would drop a real dependency out of a dependent's closure — so the safe reading of "unknown" is the one Maven applies to a dependency with no `<optional>` at all.

## Tests

Four cases: the flag read plainly, read through property resolution (`${opt.flag}`), `<optional>false</optional>` and an absent element both reading false, an unresolved placeholder reading false, and the two axes pinned apart. Each was verified to fail with the population reverted.

`go test ./providers/os/resources/languages/...` — 59 packages green; `gofmt` clean; `go build ./providers/os/...` clean.

## Context

This unblocks the transitive-closure walk specified in xgrep's ADR-0712, which is explicitly *not implementable* until this field exists — shipping that walk without it would ship the 28. Only `pomxml` populates the field today; the concept is general (npm `optionalDependencies`, Cargo optional features) and other extractors can adopt it as needed, the same way `Scope` started with npm alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
