### PR TITLE
🐛 os: I include Homebrew revisions in latestVersion

### DIFF
--- a/providers/os/resources/packages/homebrew_packages.go
+++ b/providers/os/resources/packages/homebrew_packages.go
@@ -308,6 +308,7 @@ type brewFormula struct {
 	Tap      string `json:"tap"`
 	Desc     string `json:"desc"`
 	Homepage string `json:"homepage"`
+	Revision int    `json:"revision"`
 	Versions struct {
 		Stable string `json:"stable"`
 	} `json:"versions"`
@@ -356,11 +357,15 @@ func ParseHomebrewInfo(data []byte, prefix string) ([]HomebrewPackage, error) {
 
 	// Parse formulae — iterate all installed versions (Homebrew can have multiple)
 	for _, f := range info.Formulae {
+		latestVersion := f.Versions.Stable
+		if f.Revision > 0 {
+			latestVersion = fmt.Sprintf("%s_%d", latestVersion, f.Revision)
+		}
 		for _, inst := range f.Installed {
 			pkgs = append(pkgs, HomebrewPackage{
 				Name:                  f.Name,
 				Version:               inst.Version,
-				LatestVersion:         f.Versions.Stable,
+				LatestVersion:         latestVersion,
 				Purl:                  newHomebrewPurl(f.Name, inst.Version, f.Tap),
 				Description:           f.Desc,
 				Homepage:              f.Homepage,

--- a/providers/os/resources/packages/homebrew_packages_test.go
+++ b/providers/os/resources/packages/homebrew_packages_test.go
@@ -75,6 +75,31 @@ func TestParseHomebrewInfo(t *testing.T) {
 	assert.Equal(t, "Microsoft Visual Studio Code", vscode.AppName)
 }
 
+func TestParseHomebrewInfoFormulaRevision(t *testing.T) {
+	data := []byte(`{
+		"formulae": [
+			{
+				"name": "revised",
+				"versions": {"stable": "13.55"},
+				"revision": 1,
+				"installed": [{"version": "13.55_1"}]
+			},
+			{
+				"name": "unrevised",
+				"versions": {"stable": "3.3.0"},
+				"revision": 0,
+				"installed": [{"version": "3.3.0"}]
+			}
+		]
+	}`)
+
+	pkgs, err := ParseHomebrewInfo(data, "/opt/homebrew")
+	require.NoError(t, err)
+	require.Len(t, pkgs, 2)
+	assert.Equal(t, "13.55_1", pkgs[0].LatestVersion)
+	assert.Equal(t, "3.3.0", pkgs[1].LatestVersion)
+}
+
 func TestDeriveBrewPrefix(t *testing.T) {
 	assert.Equal(t, "/opt/homebrew", deriveBrewPrefix("/opt/homebrew/bin/brew"))
 	assert.Equal(t, "/usr/local", deriveBrewPrefix("/usr/local/bin/brew"))


### PR DESCRIPTION
## Summary

- I decode Homebrew's formula `revision` field.
- I append the revision suffix to `latestVersion` only when the revision is greater than zero.
- I added regression coverage for revised and unrevised formulae.

## Validation

- I ran `go test ./providers/os/resources/packages -count=1`.
- I ran `go vet ./providers/os/resources/packages`.
- I ran `gofmt` and `git diff --check`.
- I did not run the full repository suite or the manual Docker-backed package matrix locally.

Fixes #10642
