### PR TITLE
🐛 pomxml: parse a POM that is not UTF-8

### DIFF
--- a/providers/os/resources/languages/java/pomxml/extractor.go
+++ b/providers/os/resources/languages/java/pomxml/extractor.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"strings"
 
+	"golang.org/x/net/html/charset"
+
 	"go.mondoo.com/mql/providers/os/resources/languages"
 	"go.mondoo.com/mql/providers/os/resources/languages/java"
 )
@@ -54,9 +56,18 @@ func (e *Extractor) Parse(r io.Reader, filename string) (languages.Bom, error) {
 }
 
 // parsePomXml reads and parses a Maven pom.xml file.
+//
+// The decoder is given a CharsetReader because a POM is not always UTF-8 and
+// Go's encoding/xml refuses a declared non-UTF-8 encoding outright rather than
+// falling back. Without one, `<?xml version="1.0" encoding="ISO-8859-1"?>` — the
+// header on hamcrest-core and a generation of artifacts published with it —
+// fails the whole parse, and a project whose pom.xml carries it reports NO
+// dependencies at all. That is the silent-empty-inventory failure, arriving
+// through the character encoding rather than through a missing manifest.
 func parsePomXml(r io.Reader) (*pomProject, error) {
 	var project pomProject
 	decoder := xml.NewDecoder(r)
+	decoder.CharsetReader = charset.NewReaderLabel
 	if err := decoder.Decode(&project); err != nil {
 		return nil, err
 	}

--- a/providers/os/resources/languages/java/pomxml/extractor_test.go
+++ b/providers/os/resources/languages/java/pomxml/extractor_test.go
@@ -4,6 +4,7 @@
 package pomxml
 
 import (
+	"bytes"
 	"encoding/xml"
 	"io"
 	"os"
@@ -594,4 +595,57 @@ func TestOptionalIsIndependentOfScope(t *testing.T) {
 	p := bom.Direct().Find("com.example:compile-optional")
 	require.NotNil(t, p, "an optional compile dependency is still declared by this project")
 	assert.True(t, p.Optional)
+}
+
+// TestNonUTF8PomParses — a POM is not always UTF-8, and Go's encoding/xml
+// refuses a declared non-UTF-8 encoding outright rather than falling back. The
+// cost is not a mangled character: the whole parse fails, so a project whose
+// pom.xml carries an ISO-8859-1 header reports NO dependencies at all.
+//
+// hamcrest-core-1.3 ships exactly this header, and a generation of artifacts
+// published alongside it do too.
+func TestNonUTF8PomParses(t *testing.T) {
+	// "Café" in ISO-8859-1: the é is a single 0xE9 byte, which is not valid
+	// UTF-8, so a decoder that ignored the declared encoding would also fail.
+	iso := append([]byte(`<?xml version="1.0" encoding="ISO-8859-1"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.hamcrest</groupId>
+  <artifactId>hamcrest-core</artifactId>
+  <version>1.3</version>
+  <name>Caf`), 0xE9)
+	iso = append(iso, []byte(`</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-parent</artifactId>
+      <version>1.3</version>
+    </dependency>
+  </dependencies>
+</project>`)...)
+
+	bom, err := (&Extractor{}).Parse(bytes.NewReader(iso), "pom.xml")
+	require.NoError(t, err, "a non-UTF-8 POM must parse; failing it reports zero dependencies for the whole project")
+
+	root := bom.Root()
+	require.NotNil(t, root)
+	assert.Equal(t, "org.hamcrest:hamcrest-core", root.Name)
+
+	dep := bom.Transitive().Find("org.hamcrest:hamcrest-parent")
+	require.NotNil(t, dep, "the dependency list must survive the encoding")
+	assert.Equal(t, "1.3", dep.Version)
+}
+
+// TestUTF8PomStillParses is the control: adding a CharsetReader must not change
+// the ordinary case.
+func TestUTF8PomStillParses(t *testing.T) {
+	bom, err := (&Extractor{}).Parse(strings.NewReader(`<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.example</groupId><artifactId>demo</artifactId><version>1.0.0</version>
+  <dependencies>
+    <dependency><groupId>com.google.guava</groupId><artifactId>guava</artifactId><version>31.1-jre</version></dependency>
+  </dependencies>
+</project>`), "pom.xml")
+	require.NoError(t, err)
+	assert.Equal(t, "31.1-jre", bom.Transitive().Find("com.google.guava:guava").Version)
 }


### PR DESCRIPTION
## The bug

Go's `encoding/xml` refuses a declared non-UTF-8 encoding outright rather than falling back, and the cost is not a mangled character — **the whole parse fails**.

A project whose `pom.xml` opens with

```xml
<?xml version="1.0" encoding="ISO-8859-1"?>
```

therefore reported **no dependencies at all**. That is the silent-empty-inventory failure, arriving through the character encoding rather than through a missing manifest:

```
ISO-8859-1 pom.xml -> err=xml: encoding "ISO-8859-1" declared but Decoder.CharsetReader is nil
UTF-8 pom.xml       -> err=<nil>
```

## Not a corner case

`hamcrest-core-1.3` ships that header, as does a generation of artifacts published alongside it.

It was found the way these things usually are — by accident. A transitive-closure walk (xgrep's ADR-0712) could locate hamcrest's POM in the local Gradle cache, confirmed the file was readable and the path resolution correct, and then still could not parse it. The walk marked the closure incomplete, which is what sent me looking.

## The fix

Give the decoder a `CharsetReader`. `golang.org/x/net/html/charset` is already a dependency.

## Tests

The test pins a POM carrying a **real ISO-8859-1 byte** (`0xE9`, which is not valid UTF-8 — so a decoder that merely ignored the declared encoding would fail on it too) and asserts that both the root package and the dependency list survive the encoding. A control pins that the ordinary UTF-8 case is unchanged.

Verified to fail with the fix reverted: `a non-UTF-8 POM must parse; failing it reports zero dependencies for the whole project`.

`go test ./providers/os/resources/languages/...` — 62 packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
