### PR TITLE
🐛 sbom: read the CycloneDX dependency graph on import

### DIFF
--- a/sbom/cyclonedx.go
+++ b/sbom/cyclonedx.go
@@ -371,7 +371,54 @@ func (ccx *CycloneDX) convertCycloneDxToSbom(bom *cyclonedx.BOM) (*Sbom, error) 
 		}
 	}
 
+	sbom.Dependencies = cycloneDXDependencies(bom)
+
 	return sbom, nil
+}
+
+// cycloneDXDependencies reads the document's package -> package edge graph.
+//
+// The renderer has always WRITTEN `dependencies`/`dependsOn`; the reader
+// discarded it, so Sbom.Dependencies came back empty from Parse and a
+// render/parse round-trip silently lost the whole graph. That graph is the only
+// thing that distinguishes a transitive dependency something reaches from one
+// nothing reaches, so losing it costs a consumer the distinction entirely.
+//
+// Edges are kept as the document states them, with two exceptions. A self-edge
+// is dropped: it is a no-op that some producers emit, and carrying it invites a
+// consumer's traversal to loop. An entry with no targets is dropped rather than
+// stored as an empty list, because CycloneDX uses it to say "this component was
+// considered and depends on nothing", which is the absence of edges rather than
+// an edge.
+//
+// Refs are NOT validated against the component set here. A dangling ref is a
+// producer bug, but which components exist is the caller's question and a
+// reader that silently drops edges would hide it.
+func cycloneDXDependencies(bom *cyclonedx.BOM) []*Dependency {
+	if bom.Dependencies == nil || len(*bom.Dependencies) == 0 {
+		return nil
+	}
+	out := make([]*Dependency, 0, len(*bom.Dependencies))
+	for _, d := range *bom.Dependencies {
+		if d.Ref == "" || d.Dependencies == nil {
+			continue
+		}
+		refs := make([]string, 0, len(*d.Dependencies))
+		for _, r := range *d.Dependencies {
+			if r == "" || r == d.Ref {
+				continue
+			}
+			refs = append(refs, r)
+		}
+		if len(refs) == 0 {
+			continue
+		}
+		out = append(out, &Dependency{Ref: d.Ref, DependencyRefs: refs})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 var familyMap = map[string][]string{

--- a/sbom/cyclonedx_test.go
+++ b/sbom/cyclonedx_test.go
@@ -175,3 +175,59 @@ func TestCycloneDxJsonDecoding_Alpine_syft(t *testing.T) {
 	assert.Equal(t, "3.19.9", bom.Asset.Platform.Version)
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/docker/images/cd03a8ea6f29f815", bom.Asset.PlatformIds[0])
 }
+
+// TestCycloneDXRoundTripPreservesDependencyGraph pins the edge graph across a
+// render/parse cycle.
+//
+// The renderer always wrote `dependencies`/`dependsOn`; the reader discarded
+// it, so Parse returned an Sbom with no edges at all and the round-trip was
+// silently lossy in the one field that distinguishes a transitive dependency
+// something reaches from one nothing reaches.
+func TestCycloneDXRoundTripPreservesDependencyGraph(t *testing.T) {
+	in := &sbom.Sbom{
+		Asset: &sbom.Asset{Name: "app", Platform: &sbom.Platform{Name: "alpine", Version: "3.19"}},
+		Packages: []*sbom.Package{
+			{Name: "a", Version: "1", Purl: "pkg:maven/g/a@1", Type: "maven"},
+			{Name: "b", Version: "2", Purl: "pkg:maven/g/b@2", Type: "maven"},
+		},
+		Dependencies: []*sbom.Dependency{
+			{Ref: "pkg:maven/g/a@1", DependencyRefs: []string{"pkg:maven/g/b@2"}},
+		},
+	}
+
+	var buf bytes.Buffer
+	cdx := sbom.NewCycloneDX("json")
+	require.NoError(t, cdx.Render(&buf, in))
+
+	out, err := cdx.Parse(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+
+	require.Len(t, out.Dependencies, 1, "the edge graph must survive the round-trip")
+	assert.Equal(t, "pkg:maven/g/a@1", out.Dependencies[0].Ref)
+	assert.Equal(t, []string{"pkg:maven/g/b@2"}, out.Dependencies[0].DependencyRefs)
+}
+
+// TestCycloneDXImportDropsSelfAndEmptyEdges — a self-edge is a no-op that
+// invites a consumer's traversal to loop, and an entry with no targets states
+// the ABSENCE of edges rather than an edge.
+func TestCycloneDXImportDropsSelfAndEmptyEdges(t *testing.T) {
+	doc := `{
+      "bomFormat": "CycloneDX", "specVersion": "1.5", "version": 1,
+      "metadata": {"component": {"bom-ref": "root:app", "type": "application", "name": "app"}},
+      "components": [
+        {"bom-ref": "pkg:maven/g/a@1", "type": "library", "name": "a", "version": "1", "purl": "pkg:maven/g/a@1"},
+        {"bom-ref": "pkg:maven/g/b@2", "type": "library", "name": "b", "version": "2", "purl": "pkg:maven/g/b@2"}
+      ],
+      "dependencies": [
+        {"ref": "pkg:maven/g/a@1", "dependsOn": ["pkg:maven/g/a@1", "pkg:maven/g/b@2"]},
+        {"ref": "pkg:maven/g/b@2", "dependsOn": []}
+      ]
+    }`
+
+	out, err := sbom.NewCycloneDX("json").Parse(bytes.NewReader([]byte(doc)))
+	require.NoError(t, err)
+
+	require.Len(t, out.Dependencies, 1, "the targetless entry must not become an edge")
+	assert.Equal(t, []string{"pkg:maven/g/b@2"}, out.Dependencies[0].DependencyRefs,
+		"the self-edge must be dropped")
+}


### PR DESCRIPTION
## The bug

The CycloneDX renderer has always **written** the package→package edge graph (`dependencies` / `dependsOn`). `convertCycloneDxToSbom` never read it back, so `Sbom.Dependencies` came out empty from every `Parse`, and a render/parse round-trip silently lost the whole graph.

Measured, before the fix:

```
doc has dependsOn: true
ROUND TRIP: deps in=1 out=0
```

The document is correct; the reader discards it.

## Why it matters

That graph is the only thing that distinguishes a transitive dependency something reaches from one nothing reaches. A consumer ingesting an SBOM gets a flat bag of packages and cannot rank them — which is the gap reported in mondoohq/xgrep#2233, where every vulnerable package classifies as `transitive` with no edges and no filtering is possible.

## What it does

Reads `bom.Dependencies` into `Sbom.Dependencies`, dropping two shapes rather than storing them:

- **Self-edges** — a no-op some producers emit, which invites a consumer's traversal to loop.
- **Entries with no targets** — CycloneDX uses these to say *"this component was considered and depends on nothing"*. That is the absence of edges, not an edge, so storing an empty list would misreport it.

Refs are deliberately **not** validated against the component set. A dangling ref is a producer bug, but which components exist is the caller's question, and a reader that silently dropped such edges would hide it.

Two tests, both verified to fail without the change.

## Found while measuring, deliberately not fixed

The `operating-system` component is imported as a package *as well as* the platform. That looked like a defect — until the test pinning it turned out to say so on purpose:

```go
// 1 library components + 1 os component
assert.Len(t, bom.Packages, 2)
```

and the real syft OS component in `testdata/ubuntu-22.04-cyclonedx.json` carries neither purl nor CPE either. So it is a deliberate modelling choice, not an accident, and I reverted the change I had made to it.

There is a genuine residue, reported rather than patched: an OS-typed *package* renders as a `library` component while the platform separately renders as an `os` component, so a second round-trip re-imports both and the package count grows by one (saturating at two):

```
round-trip 1: packages=2 [alpine a]
round-trip 2: packages=3 [alpine alpine a]
round-trip 3: packages=3 [alpine alpine a]
```

Fixing that needs a decision about which of the two representations is canonical, which belongs with whoever owns the OS modelling rather than in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
