### PR TITLE
🛑 update to SemVer 2.0.0

### DIFF
--- a/cli/printer/printer_test.go
+++ b/cli/printer/printer_test.go
@@ -88,7 +88,7 @@ func TestPrinter(t *testing.T) {
 			"if ( mondoo.version != null ) { mondoo.build }",
 			"", // ignore
 			[]string{
-				"mondoo.version: \"v13.0.0-rolling\"",
+				"mondoo.version: \"v14.0.0+rolling\"",
 				"if: {\n" +
 					"  mondoo.build: \"development\"\n" +
 					"}",
@@ -133,14 +133,14 @@ func TestPrinter(t *testing.T) {
 			"mondoo { version }",
 			"-> block 1\n   entrypoints: [<1,2>]\n   1: mondoo \n   2: {} bind: <1,1> type:block (=> <2,0>)\n-> block 2\n   entrypoints: [<2,2>]\n   1: context\n   2: version bind: <2,1> type:string\n",
 			[]string{
-				"mondoo: {\n  version: \"v13.0.0-rolling\"\n}",
+				"mondoo: {\n  version: \"v14.0.0+rolling\"\n}",
 			},
 		},
 		{
 			"mondoo { _.version }",
 			"-> block 1\n   entrypoints: [<1,2>]\n   1: mondoo \n   2: {} bind: <1,1> type:block (=> <2,0>)\n-> block 2\n   entrypoints: [<2,2>]\n   1: context\n   2: version bind: <2,1> type:string\n",
 			[]string{
-				"mondoo: {\n  version: \"v13.0.0-rolling\"\n}",
+				"mondoo: {\n  version: \"v14.0.0+rolling\"\n}",
 			},
 		},
 		{
@@ -159,7 +159,7 @@ func TestPrinter(t *testing.T) {
 			"mondoo",
 			"", // ignore
 			[]string{
-				"mondoo: version=\"v13.0.0-rolling\"",
+				"mondoo: version=\"v14.0.0+rolling\"",
 			},
 		},
 		{
@@ -234,7 +234,7 @@ func TestPrinter_Assessment(t *testing.T) {
 				"  [failed] mondoo.build == 1",
 				"    expected: == 1",
 				"    actual:   \"development\"",
-				"  [ok] value: \"v13.0.0-rolling\"",
+				"  [ok] value: \"v14.0.0+rolling\"",
 				"",
 			}, "\n"),
 		},
@@ -273,13 +273,13 @@ func TestPrinter_Assessment(t *testing.T) {
 			}, "\n"),
 		},
 		{
-			"mondoo.build == 1;mondoo.version =='v13.0.0-rolling';",
+			"mondoo.build == 1;mondoo.version =='v14.0.0+rolling';",
 			strings.Join([]string{
-				"[failed] mondoo.build == 1;mondoo.version =='v13.0.0-rolling';",
+				"[failed] mondoo.build == 1;mondoo.version =='v14.0.0+rolling';",
 				"  [failed] mondoo.build == 1",
 				"    expected: == 1",
 				"    actual:   \"development\"",
-				"  [ok] value: \"v13.0.0-rolling\"",
+				"  [ok] value: \"v14.0.0+rolling\"",
 				"",
 			}, "\n"),
 		},
@@ -582,7 +582,7 @@ func TestPrinter_Buggy(t *testing.T) {
 			"mondoo",
 			"", // ignore
 			[]string{
-				"mondoo: version=\"v13.0.0-rolling\"",
+				"mondoo: version=\"v14.0.0+rolling\"",
 			},
 		},
 	})

--- a/llx/translate_test.go
+++ b/llx/translate_test.go
@@ -139,6 +139,10 @@ func TestDowngradePatchSkippedWhenReaderIsCurrent(t *testing.T) {
 	}{
 		{"reader is newer", map[string]string{osProviderID: "99.0.1"}},
 		{"reader is exactly at the change", map[string]string{osProviderID: "99.0.0"}},
+		// A source build of the line that introduced the field has the field.
+		// It satisfies a floor of 99.0.0, so it must not also be told it is
+		// below 99.0.0 and handed the downgrade path.
+		{"reader is a source build of that version", map[string]string{osProviderID: "v99.0.0+rolling"}},
 		// Not knowing a version is not evidence a translation applies. Guessing
 		// would rewrite code that was going to run correctly.
 		{"reader version unknown", map[string]string{}},

--- a/mql.go
+++ b/mql.go
@@ -44,11 +44,27 @@ var DisableMaxLimit string
 <patch> ::= <numeric identifier>
 */
 
+// The version an unstamped build reports: the current line, plus `rolling` as
+// build metadata. Keep the line current - it is the version every floor check
+// sees for a build the release flow did not stamp.
+//
+// The marker belongs after `+`, not after `-`. Rolling means the continuously
+// updated latest of a line, so a rolling build is part of its line and never
+// something that precedes it. Build metadata is ignored when versions are
+// ordered, which is that reading; the `-` slot instead sorted every source
+// build behind the release it was built from, so a locally built core failed
+// the `core >= 13.0.0` floor its own tree declares.
+const (
+	// major.minor.patch on its own, which is what GetCoreVersion answers with.
+	devCoreVersion = "14.0.0"
+	devVersion     = "v" + devCoreVersion + "+rolling"
+)
+
 // GetVersion returns the version of the build
 // valid semver version including build version (e.g. 4.10.0+4900), where 4900 is a forward rolling int
 func GetVersion() string {
 	if Version == "" {
-		return "v13.0.0-rolling"
+		return devVersion
 	}
 	return Version
 }
@@ -106,20 +122,18 @@ func GetLatestVersion(client *http.Client) (string, error) {
 	return releaseName, nil
 }
 
-var coreSemverRegex = regexp.MustCompile(`^(\d+.\d+.\d+)`)
+// The `v` is optional because both spellings reach here: the release flow stamps
+// what `git describe` returns (`v13.53.4`), while a plain semver string has no
+// prefix. The core is the capture group, so the prefix is dropped rather than
+// returned as part of the answer.
+var coreSemverRegex = regexp.MustCompile(`^v?(\d+\.\d+\.\d+)`)
 
 // GetCoreVersion returns the semver core (i.e. major.minor.patch)
 func GetCoreVersion() string {
-	v := Version
-
-	if v != "" {
-		v = coreSemverRegex.FindString(v)
+	if m := coreSemverRegex.FindStringSubmatch(Version); m != nil {
+		return m[1]
 	}
-
-	if v == "" {
-		return "v13.0.0-rolling"
-	}
-	return v
+	return devCoreVersion
 }
 
 // GetBuild returns the git sha of the build

--- a/mql_test.go
+++ b/mql_test.go
@@ -18,3 +18,46 @@ func TestGetLatestVersion(t *testing.T) {
 	assert.NotNil(t, version)
 	assert.Equal(t, mqlLatestReleaseUrl, "https://releases.mondoo.com/mql/latest.json?ignoreCache=1")
 }
+
+// GetCoreVersion reads the ldflag-stamped Version, which the release flow sets
+// to whatever `git describe` returns - a `v`-prefixed tag. The core regex used
+// to be anchored without that prefix, so every stamped build failed to match and
+// fell through to the unstamped fallback, reporting the dev line instead of its
+// own version.
+func TestGetCoreVersion(t *testing.T) {
+	original := Version
+	defer func() { Version = original }()
+
+	for _, test := range []struct {
+		version  string
+		expected string
+	}{
+		{"v13.53.4+1234", "13.53.4"},
+		{"13.53.4+1234", "13.53.4"},
+		{"v13.53.4", "13.53.4"},
+		{"13.53.4", "13.53.4"},
+
+		// no version stamped, and anything that is not a version at all
+		{"", devCoreVersion},
+		{"not-a-version", devCoreVersion},
+		{"rolling", devCoreVersion},
+	} {
+		t.Run(test.version, func(t *testing.T) {
+			Version = test.version
+			assert.Equal(t, test.expected, GetCoreVersion())
+		})
+	}
+}
+
+// An unstamped build has to report a version that orders at or above its own
+// line, so the marker rides in the build-metadata slot after `+`. Ordering
+// ignores build metadata; the `-` slot would sort it behind the release.
+func TestDevVersion(t *testing.T) {
+	original := Version
+	defer func() { Version = original }()
+
+	Version = ""
+	assert.Equal(t, devVersion, GetVersion())
+	assert.Contains(t, devVersion, "+rolling")
+	assert.NotContains(t, devVersion, "-rolling")
+}

--- a/mqlc/requirements_test.go
+++ b/mqlc/requirements_test.go
@@ -47,6 +47,25 @@ func TestUnmetRequirements(t *testing.T) {
 		assert.Equal(t, "requires the os provider >= 13.16.9 (13.10.1 is installed)", got[0].Error())
 	})
 
+	// An unstamped build reports its line with `rolling` as build metadata
+	// (mql.GetVersion). Reading that as an older line would withhold content
+	// from every developer running from source.
+	t.Run("a source build satisfies its own floor", func(t *testing.T) {
+		assert.Empty(t, mqlc.UnmetRequirements(bundle, map[string]string{
+			osProvider:   "v13.16.9+rolling",
+			coreProvider: "v9.0.0+rolling",
+		}))
+	})
+
+	t.Run("a source build of an older line is still too old", func(t *testing.T) {
+		got := mqlc.UnmetRequirements(bundle, map[string]string{
+			osProvider:   "v13.10.1+rolling",
+			coreProvider: "9.0.0",
+		})
+		require.Len(t, got, 1)
+		assert.Equal(t, "v13.10.1+rolling", got[0].Installed)
+	})
+
 	t.Run("comparison is semver, not lexical", func(t *testing.T) {
 		// "13.9.0" > "13.16.9" as strings, but is older as a version.
 		got := mqlc.UnmetRequirements(bundle, map[string]string{

--- a/providers/core/resources/mql_test.go
+++ b/providers/core/resources/mql_test.go
@@ -1431,7 +1431,10 @@ func TestResource_Default(t *testing.T) {
 	require.NotEmpty(t, res)
 	vals := res[0].Data.Value.(map[string]any)
 	require.NotNil(t, vals)
-	require.Equal(t, llx.StringData("v13.0.0-rolling"), vals["J4anmJ+mXJX380Qslh563U7Bs5d6fiD2ghVxV9knAU0iy/P+IVNZsDhBbCmbpJch3Tm0NliAMiaY47lmw887Jw=="])
+	// An unstamped test binary reports mql.GetVersion's dev version, where
+	// `rolling` is build metadata rather than a `-` suffix, so that a build of
+	// a line is not ordered behind that line's release.
+	require.Equal(t, llx.StringData("v14.0.0+rolling"), vals["J4anmJ+mXJX380Qslh563U7Bs5d6fiD2ghVxV9knAU0iy/P+IVNZsDhBbCmbpJch3Tm0NliAMiaY47lmw887Jw=="])
 }
 
 func TestBrokenQueryExecution(t *testing.T) {

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -391,6 +391,16 @@ func TestValidateDeclaredPeers(t *testing.T) {
 	assert.NoError(t, validateDeclaredPeers(caller, peer("13.3.0")))
 	assert.NoError(t, validateDeclaredPeers(caller, peer("13.0.0")))
 
+	// An unstamped build reports its line with `rolling` as build metadata
+	// (mql.GetVersion), which orders equal to the bare release. It used to be
+	// spelled `-rolling`, which orders *behind* the release, so every developer
+	// running from source hit "requires core >= 13.0.0, but v13.0.0-rolling is
+	// installed" for a build of the very tree that declares the floor.
+	assert.NoError(t, validateDeclaredPeers(caller, peer("v13.0.0+rolling")))
+	assert.NoError(t, validateDeclaredPeers(caller, peer("v13.4.0+rolling")))
+	// still an older line, marker or not
+	assert.Error(t, validateDeclaredPeers(caller, peer("v12.9.9+rolling")))
+
 	// not installed: not reported here, it fails later when something needs it
 	assert.NoError(t, validateDeclaredPeers(caller, Providers{}))
 	// unknown version is not evidence of a mismatch


### PR DESCRIPTION
which requires us to go from vA.B.C-rolling to vA.B.C+rolling because otherwise the former is flagged as a pre-release.