### PR TITLE
⚡ aws: check the resource cache before an asset init spends an API call

### DIFF
--- a/providers/aws/resources/aws_appstream.go
+++ b/providers/aws/resources/aws_appstream.go
@@ -214,6 +214,10 @@ func initAwsAppstreamFleet(runtime *plugin.Runtime, args map[string]*llx.RawData
 			args["arn"] = llx.StringData(assetArn)
 		}
 	}
+	if cached := cachedArgByArn(runtime, ResourceAwsAppstreamFleet, args); cached != nil {
+		return args, cached, nil
+	}
+
 	region, name, err := parseAppstreamRef(args, "fleet/")
 	if err != nil {
 		return nil, nil, err

--- a/providers/aws/resources/aws_cloudtrail.go
+++ b/providers/aws/resources/aws_cloudtrail.go
@@ -77,6 +77,10 @@ func initAwsCloudtrailTrail(runtime *plugin.Runtime, args map[string]*llx.RawDat
 
 	log.Debug().Str("arn", arnVal).Str("name", nameVal).Msg("init cloudtrail trail")
 
+	if cached := cachedByArn(runtime, ResourceAwsCloudtrailTrail, arnVal); cached != nil {
+		return args, cached, nil
+	}
+
 	// Targeted lookup: when we have a real ARN, derive the home region from it
 	// (or use an explicit region arg) and fetch just this one trail instead of
 	// describing every trail in every region.

--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -769,8 +769,13 @@ func initAwsCloudwatchLoggroup(runtime *plugin.Runtime, args map[string]*llx.Raw
 		return nil, nil, errors.New("arn required to fetch cloudwatch log group")
 	}
 
-	conn := runtime.Connection.(*connection.AwsConnection)
 	arnVal := args["arn"].Value.(string)
+
+	if cached := cachedByArn(runtime, ResourceAwsCloudwatchLoggroup, arnVal); cached != nil {
+		return args, cached, nil
+	}
+
+	conn := runtime.Connection.(*connection.AwsConnection)
 
 	// Targeted lookup: derive the region + group name from the ARN and fetch
 	// just this one log group (by name prefix) instead of describing every log

--- a/providers/aws/resources/aws_codebuild.go
+++ b/providers/aws/resources/aws_codebuild.go
@@ -127,6 +127,11 @@ func initAwsCodebuildProject(runtime *plugin.Runtime, args map[string]*llx.RawDa
 		return nil, nil, errors.New("name and region required to fetch codebuild project")
 	}
 
+	// This resource keys its __id on the name alone, so that is the probe key.
+	if cached := cachedArg(runtime, ResourceAwsCodebuildProject, args, "name"); cached != nil {
+		return args, cached, nil
+	}
+
 	name := args["name"].Value.(string)
 	region := args["region"].Value.(string)
 	conn := runtime.Connection.(*connection.AwsConnection)

--- a/providers/aws/resources/aws_cognito.go
+++ b/providers/aws/resources/aws_cognito.go
@@ -135,6 +135,14 @@ func initAwsCognitoUserPool(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	}
 
 	arnVal := args["arn"].Value.(string)
+
+	// The already-built pool carries the same fields this init would set; the
+	// DescribeUserPool the init primes below is then paid once, by whichever
+	// computed field asks for it, instead of once per query.
+	if cached := cachedByArn(runtime, ResourceAwsCognitoUserPool, arnVal); cached != nil {
+		return args, cached, nil
+	}
+
 	parsed, err := arn.Parse(arnVal)
 	if err != nil {
 		return nil, nil, err

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -2789,6 +2789,10 @@ func initAwsEc2Instance(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	}
 	arnVal := args["arn"].Value.(string)
 
+	if cached := cachedByArn(runtime, ResourceAwsEc2Instance, arnVal); cached != nil {
+		return args, cached, nil
+	}
+
 	// Parse the ARN to extract region + instance id and target a single
 	// DescribeInstances call. Fall back to the cross-region list path only
 	// when the ARN is malformed.

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -1132,6 +1132,10 @@ func initAwsEcrRepository(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return nil, nil, errors.New("arn or name required to fetch ecr repository")
 	}
 
+	if cached := cachedArgByArn(runtime, ResourceAwsEcrRepository, args); cached != nil {
+		return args, cached, nil
+	}
+
 	// When an ARN is supplied, the registry kind (private vs public), region,
 	// and repository name are all encoded in it, so we can issue a single
 	// targeted DescribeRepositories call instead of listing every repository in

--- a/providers/aws/resources/aws_efs.go
+++ b/providers/aws/resources/aws_efs.go
@@ -183,6 +183,10 @@ func initAwsEfsFilesystem(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		fsId = strings.TrimPrefix(parsed.Resource, "file-system/")
 	}
 
+	if cached := cachedByArn(runtime, ResourceAwsEfsFilesystem, arnVal); cached != nil {
+		return args, cached, nil
+	}
+
 	if region != "" && fsId != "" {
 		conn := runtime.Connection.(*connection.AwsConnection)
 		svc := conn.Efs(region)

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -469,6 +469,10 @@ func initAwsElbLoadbalancer(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		return nil, nil, errors.New("elb load balancer does not exist")
 	}
 
+	if cached := cachedByArn(runtime, ResourceAwsElbLoadbalancer, arnVal); cached != nil {
+		return args, cached, nil
+	}
+
 	// Issue a single targeted Describe against the ARN's region instead of
 	// listing every load balancer in every region. ELBv2 (app/net/gateway) and
 	// classic ELB live in different APIs; discriminate by the ARN form.

--- a/providers/aws/resources/aws_es.go
+++ b/providers/aws/resources/aws_es.go
@@ -440,6 +440,10 @@ func initAwsEsDomain(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		return nil, nil, errors.New("arn or name required to fetch es domain")
 	}
 
+	if cached := cachedArgByArn(runtime, ResourceAwsEsDomain, args); cached != nil {
+		return args, cached, nil
+	}
+
 	// If we have an ARN but missing region or name, extract from ARN
 	// ARN format: arn:aws:es:REGION:ACCOUNT:domain/DOMAIN_NAME
 	if args["arn"] != nil && (args["region"] == nil || args["name"] == nil) {

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -351,6 +351,10 @@ func initAwsLambdaFunction(runtime *plugin.Runtime, args map[string]*llx.RawData
 		arnVal = args["arn"].Value.(string)
 	}
 
+	if cached := cachedByArn(runtime, ResourceAwsLambdaFunction, arnVal); cached != nil {
+		return args, cached, nil
+	}
+
 	// Targeted lookup: derive the region + function name from the ARN and fetch
 	// just this one function instead of listing every function in every region.
 	region := ""

--- a/providers/aws/resources/aws_memorydb.go
+++ b/providers/aws/resources/aws_memorydb.go
@@ -107,6 +107,11 @@ func initAwsMemorydbCluster(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	}
 
 	arnVal := args["arn"].Value.(string)
+
+	if cached := cachedByArn(runtime, ResourceAwsMemorydbCluster, arnVal); cached != nil {
+		return args, cached, nil
+	}
+
 	parsed, err := arn.Parse(arnVal)
 	if err != nil {
 		return nil, nil, err

--- a/providers/aws/resources/aws_opensearch.go
+++ b/providers/aws/resources/aws_opensearch.go
@@ -124,6 +124,10 @@ func initAwsOpensearchDomain(runtime *plugin.Runtime, args map[string]*llx.RawDa
 		return nil, nil, errors.New("arn or name required to fetch opensearch domain")
 	}
 
+	if cached := cachedArgByArn(runtime, ResourceAwsOpensearchDomain, args); cached != nil {
+		return args, cached, nil
+	}
+
 	// If we have an ARN but missing region or name, extract from ARN
 	// ARN format: arn:aws:es:REGION:ACCOUNT:domain/DOMAIN_NAME
 	if args["arn"] != nil && (args["region"] == nil || args["name"] == nil) {

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -1052,6 +1052,10 @@ func initAwsRdsSnapshot(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	}
 	arnVal := args["arn"].Value.(string)
 
+	if cached := cachedByArn(runtime, ResourceAwsRdsSnapshot, arnVal); cached != nil {
+		return args, cached, nil
+	}
+
 	parsed, err := arn.Parse(arnVal)
 	if err != nil {
 		return nil, nil, errors.New("invalid arn for rds snapshot: " + arnVal)

--- a/providers/aws/resources/aws_secretsmanager.go
+++ b/providers/aws/resources/aws_secretsmanager.go
@@ -65,6 +65,11 @@ func initAwsSecretsmanagerSecret(runtime *plugin.Runtime, args map[string]*llx.R
 	}
 
 	arnVal := args["arn"].Value.(string)
+
+	if cached := cachedByArn(runtime, ResourceAwsSecretsmanagerSecret, arnVal); cached != nil {
+		return args, cached, nil
+	}
+
 	region, err := GetRegionFromArn(arnVal)
 	if err != nil {
 		// Returning (args, nil, nil) here would let the runtime create a

--- a/providers/aws/resources/aws_sqs.go
+++ b/providers/aws/resources/aws_sqs.go
@@ -50,6 +50,24 @@ func sqsQueueName(queueURL string) string {
 // "sqs-fips.<region>.amazonaws.com" variant, and the legacy
 // "<region>.queue.amazonaws.com" host. It returns "" when the host carries no
 // region, such as the region-less legacy "queue.amazonaws.com".
+func regionFromSqsQueueURL(queueURL string) string {
+	u, err := url.Parse(queueURL)
+	if err != nil {
+		return ""
+	}
+	parts := strings.Split(u.Hostname(), ".")
+	if len(parts) < 3 {
+		return ""
+	}
+	switch {
+	case parts[0] == "sqs" || parts[0] == "sqs-fips":
+		return parts[1]
+	case parts[1] == "queue":
+		return parts[0]
+	}
+	return ""
+}
+
 // resolvedSqsQueueByArn returns the queue this ARN names out of the account's
 // queue list, or nil.
 //
@@ -89,24 +107,6 @@ func resolvedSqsQueueByArn(runtime *plugin.Runtime, queueArn arn.ARN) *mqlAwsSqs
 		return q
 	}
 	return nil
-}
-
-func regionFromSqsQueueURL(queueURL string) string {
-	u, err := url.Parse(queueURL)
-	if err != nil {
-		return ""
-	}
-	parts := strings.Split(u.Hostname(), ".")
-	if len(parts) < 3 {
-		return ""
-	}
-	switch {
-	case parts[0] == "sqs" || parts[0] == "sqs-fips":
-		return parts[1]
-	case parts[1] == "queue":
-		return parts[0]
-	}
-	return ""
 }
 
 // initAwsSqsQueue resolves a single SQS queue. Queues are keyed by their URL,

--- a/providers/aws/resources/aws_sqs.go
+++ b/providers/aws/resources/aws_sqs.go
@@ -50,6 +50,47 @@ func sqsQueueName(queueURL string) string {
 // "sqs-fips.<region>.amazonaws.com" variant, and the legacy
 // "<region>.queue.amazonaws.com" host. It returns "" when the host carries no
 // region, such as the region-less legacy "queue.amazonaws.com".
+// resolvedSqsQueueByArn returns the queue this ARN names out of the account's
+// queue list, or nil.
+//
+// It deliberately reads the list only when it is *already* resolved rather than
+// calling GetQueues: for a one-off query against a single queue, listing every
+// queue in every region costs more than the GetQueueUrl it would save. During a
+// scan the list is always resolved, because discovery walks it to build the
+// queue assets in the first place.
+//
+// The queue name and owning account are the URL's path, whatever form the
+// hostname takes (sqs.<region>., sqs-fips.<region>., <region>.queue.), so
+// matching on the path plus the region the hostname implies does not assume a
+// commercial endpoint.
+func resolvedSqsQueueByArn(runtime *plugin.Runtime, queueArn arn.ARN) *mqlAwsSqsQueue {
+	obj, err := CreateResource(runtime, ResourceAwsSqs, map[string]*llx.RawData{})
+	if err != nil {
+		return nil
+	}
+	sqsRes, ok := obj.(*mqlAwsSqs)
+	if !ok || !sqsRes.Queues.IsSet() || sqsRes.Queues.Error != nil {
+		return nil
+	}
+
+	wantPath := "/" + queueArn.AccountID + "/" + queueArn.Resource
+	for _, raw := range sqsRes.Queues.Data {
+		q, ok := raw.(*mqlAwsSqsQueue)
+		if !ok || !q.Url.IsSet() {
+			continue
+		}
+		u, err := url.Parse(q.Url.Data)
+		if err != nil || u.Path != wantPath {
+			continue
+		}
+		if regionFromSqsQueueURL(q.Url.Data) != queueArn.Region {
+			continue
+		}
+		return q
+	}
+	return nil
+}
+
 func regionFromSqsQueueURL(queueURL string) string {
 	u, err := url.Parse(queueURL)
 	if err != nil {
@@ -111,6 +152,14 @@ func initAwsSqsQueue(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 	parsedArn, err := arn.Parse(arnVal)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// This resource keys its __id on the queue URL, which is the very thing
+	// GetQueueUrl is called to resolve, so the ARN cannot be a cache key the
+	// way it is for the ARN-keyed resources. Match the already-resolved list
+	// instead, which during a scan has been walked by discovery already.
+	if q := resolvedSqsQueueByArn(runtime, parsedArn); q != nil {
+		return args, q, nil
 	}
 
 	conn := runtime.Connection.(*connection.AwsConnection)

--- a/providers/aws/resources/aws_transfer.go
+++ b/providers/aws/resources/aws_transfer.go
@@ -117,6 +117,11 @@ func initAwsTransferServer(runtime *plugin.Runtime, args map[string]*llx.RawData
 	}
 
 	arnVal := args["arn"].Value.(string)
+
+	if cached := cachedByArn(runtime, ResourceAwsTransferServer, arnVal); cached != nil {
+		return args, cached, nil
+	}
+
 	parsed, err := arn.Parse(arnVal)
 	if err != nil {
 		return nil, nil, err

--- a/providers/aws/resources/init_cache.go
+++ b/providers/aws/resources/init_cache.go
@@ -8,7 +8,7 @@ import (
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 )
 
-// cachedByArn returns a resource already materialized under this ARN, or nil.
+// cachedResource returns a resource already materialized under this id, or nil.
 //
 // NewResource runs a resource's init *before* it consults the runtime cache --
 // it has to, because the cache key is the resolved resource's MqlID, which for
@@ -18,33 +18,63 @@ import (
 // four EC2 instances in one VPC cost four DescribeVpcs calls for the one VPC,
 // and the fan-in on aws.iam.role reaches 94 referring call sites.
 //
-// The opening exists for callers that already supply the id. These resources
-// key their __id on the ARN, and typed references pass the ARN, so the cache
-// key is known up front and can be checked before spending a call.
+// The cost is worst on a resource that is also a discovery target. cnspec
+// evaluates every policy's filter against every asset, and both filters and
+// data queries compile to a bare resource, so a scanned asset resolves its own
+// resource once per query rather than once per asset. On an EFS file system
+// that was a dozen concurrent DescribeFileSystems calls for the one file
+// system, enough to exhaust the service's quota and report the asset's own id,
+// tags and creation time as null.
+//
+// The opening exists for callers that already supply the id: a typed reference
+// passes it, and an asset init derives it from the scanned asset, so the cache
+// key is known up front and can be checked before spending a call. During a
+// scan the hit rate is near total, because discovery builds each asset by
+// walking the service's list and AWS shares one resource cache across an
+// account and the assets discovered beneath it (see WithParentConnectionId in
+// discovery_conversion.go).
+//
+// A key that does not match how the resource computes its own MqlID simply
+// misses and leaves the caller on its existing path, so the probe can never
+// return the wrong resource.
+func cachedResource(runtime *plugin.Runtime, resourceName, id string) plugin.Resource {
+	if id == "" || runtime == nil || runtime.Resources == nil {
+		return nil
+	}
+	if res, ok := runtime.Resources.Get(resourceName + "\x00" + id); ok {
+		return res
+	}
+	return nil
+}
+
+// cachedByArn is cachedResource for the resources that key their __id on the
+// ARN, which is most of them.
 //
 // Same shape as the checks already in aws_kms.go, aws_vpc.go and aws_ec2.go;
 // this only gives them one name.
 func cachedByArn(runtime *plugin.Runtime, resourceName, arn string) plugin.Resource {
-	if arn == "" || runtime == nil || runtime.Resources == nil {
-		return nil
-	}
-	if res, ok := runtime.Resources.Get(resourceName + "\x00" + arn); ok {
-		return res
-	}
-	return nil
+	return cachedResource(runtime, resourceName, arn)
 }
 
 // cachedArgByArn is cachedByArn for the common init shape, reading the ARN out
 // of args itself. Returns nil when there is no usable "arn" argument, which
 // leaves the caller on its existing path.
 func cachedArgByArn(runtime *plugin.Runtime, resourceName string, args map[string]*llx.RawData) plugin.Resource {
-	raw, ok := args["arn"]
+	return cachedArg(runtime, resourceName, args, "arn")
+}
+
+// cachedArg is cachedResource reading the cache key out of the named argument,
+// for the resources that key their __id on something other than the ARN.
+// Returns nil when that argument is absent or is not a string, which leaves the
+// caller on its existing path.
+func cachedArg(runtime *plugin.Runtime, resourceName string, args map[string]*llx.RawData, key string) plugin.Resource {
+	raw, ok := args[key]
 	if !ok || raw == nil {
 		return nil
 	}
-	arn, ok := raw.Value.(string)
+	id, ok := raw.Value.(string)
 	if !ok {
 		return nil
 	}
-	return cachedByArn(runtime, resourceName, arn)
+	return cachedResource(runtime, resourceName, id)
 }

--- a/providers/aws/resources/init_cache_asset_test.go
+++ b/providers/aws/resources/init_cache_asset_test.go
@@ -1,0 +1,269 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/utils/syncx"
+)
+
+// assetInitCacheCase is one resource that is both a discovery target and an
+// init that fetches. Each one paid an API call per data query and per policy
+// filter, because cnspec compiles both to a bare resource and NewResource runs
+// the init before it consults the cache.
+type assetInitCacheCase struct {
+	resource string
+	// cacheKey is how the resource computes its own MqlID, which is the ARN for
+	// most of them but not all.
+	cacheKey string
+	// seed builds the resource the way its service list does, so the probe has
+	// something to find.
+	seed map[string]*llx.RawData
+	args map[string]*llx.RawData
+	init func(*plugin.Runtime, map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+}
+
+func assetInitCacheCases() []assetInitCacheCase {
+	arnOf := func(service, resource string) string {
+		return "arn:aws:" + service + ":us-east-1:123456789012:" + resource
+	}
+	byArn := func(resource, service, path string, init func(*plugin.Runtime, map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)) assetInitCacheCase {
+		a := arnOf(service, path)
+		return assetInitCacheCase{
+			resource: resource,
+			cacheKey: a,
+			seed:     map[string]*llx.RawData{"arn": llx.StringData(a)},
+			args:     map[string]*llx.RawData{"arn": llx.StringData(a)},
+			init:     init,
+		}
+	}
+
+	cases := []assetInitCacheCase{
+		byArn(ResourceAwsEfsFilesystem, "elasticfilesystem", "file-system/fs-05a7586f1438d5e10", initAwsEfsFilesystem),
+		byArn(ResourceAwsEc2Instance, "ec2", "instance/i-1234567890abcdef0", initAwsEc2Instance),
+		byArn(ResourceAwsLambdaFunction, "lambda", "function:my-func", initAwsLambdaFunction),
+		byArn(ResourceAwsSecretsmanagerSecret, "secretsmanager", "secret:my-secret-AbCdEf", initAwsSecretsmanagerSecret),
+		byArn(ResourceAwsCloudwatchLoggroup, "logs", "log-group:/aws/lambda/my-func:*", initAwsCloudwatchLoggroup),
+		byArn(ResourceAwsCloudtrailTrail, "cloudtrail", "trail/my-trail", initAwsCloudtrailTrail),
+		byArn(ResourceAwsEcrRepository, "ecr", "repository/my-repo", initAwsEcrRepository),
+		byArn(ResourceAwsElbLoadbalancer, "elasticloadbalancing", "loadbalancer/app/my-lb/50dc6c495c0c9188", initAwsElbLoadbalancer),
+		byArn(ResourceAwsEsDomain, "es", "domain/my-domain", initAwsEsDomain),
+		byArn(ResourceAwsOpensearchDomain, "es", "domain/my-os-domain", initAwsOpensearchDomain),
+		byArn(ResourceAwsRdsSnapshot, "rds", "snapshot:my-snapshot", initAwsRdsSnapshot),
+		byArn(ResourceAwsMemorydbCluster, "memorydb", "cluster/my-cluster", initAwsMemorydbCluster),
+		byArn(ResourceAwsTransferServer, "transfer", "server/s-1234567890abcdef0", initAwsTransferServer),
+		byArn(ResourceAwsAppstreamFleet, "appstream", "fleet/my-fleet", initAwsAppstreamFleet),
+	}
+
+	// aws.cognito.userPool has no id() method; its MqlID is the __id it is
+	// created with, which both the list and the init set to the ARN.
+	poolArn := arnOf("cognito-idp", "userpool/us-east-1_AbCdEfGhI")
+	cases = append(cases, assetInitCacheCase{
+		resource: ResourceAwsCognitoUserPool,
+		cacheKey: poolArn,
+		seed: map[string]*llx.RawData{
+			"__id": llx.StringData(poolArn),
+			"arn":  llx.StringData(poolArn),
+		},
+		args: map[string]*llx.RawData{"arn": llx.StringData(poolArn)},
+		init: initAwsCognitoUserPool,
+	})
+
+	// aws.codebuild.project keys its __id on the name alone, so the name is the
+	// probe key and the ARN is not usable as one.
+	cases = append(cases, assetInitCacheCase{
+		resource: ResourceAwsCodebuildProject,
+		cacheKey: "my-project",
+		seed:     map[string]*llx.RawData{"name": llx.StringData("my-project")},
+		args: map[string]*llx.RawData{
+			"name":   llx.StringData("my-project"),
+			"region": llx.StringData("us-east-1"),
+		},
+		init: initAwsCodebuildProject,
+	})
+
+	return cases
+}
+
+// Each of these inits must answer from the resource cache without touching the
+// connection.
+//
+// The runtime here deliberately has a nil Connection, which is what makes the
+// test able to fail: every one of these inits reaches for
+// runtime.Connection.(*connection.AwsConnection) on its fetch path, and a type
+// assertion on a nil interface panics. So deleting a probe, or moving it below
+// the point where the init resolves its client, turns this test red rather than
+// leaving it quietly green on a slower scan.
+//
+// The bug this pins: an EFS file system asset reported its own id, tags and
+// creation time as null under ThrottlingException, because a dozen queries each
+// spent their own DescribeFileSystems on a file system that was already in the
+// cache.
+func TestAssetInits_AnswerFromCacheWithoutAnApiCall(t *testing.T) {
+	for _, tc := range assetInitCacheCases() {
+		t.Run(tc.resource, func(t *testing.T) {
+			runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+
+			seeded, err := CreateResource(runtime, tc.resource, tc.seed)
+			require.NoError(t, err)
+			require.Equal(t, tc.cacheKey, seeded.MqlID(),
+				"the seed must land under the key the probe looks up; if this fails the probe is keyed on the wrong field")
+
+			_, res, err := tc.init(runtime, tc.args)
+			require.NoError(t, err)
+			require.NotNil(t, res, "the init must return the cached resource, not fall through to a fetch")
+			assert.Same(t, seeded, res)
+		})
+	}
+}
+
+// A cache miss must leave the init on its existing path rather than reporting
+// the resource as absent. With a nil connection that path panics, which is
+// exactly the fetch the probe is meant to skip -- so recovering a panic here is
+// the assertion.
+func TestAssetInits_MissFallsThroughToTheFetch(t *testing.T) {
+	for _, tc := range assetInitCacheCases() {
+		t.Run(tc.resource, func(t *testing.T) {
+			runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+
+			reached := func() (reached bool) {
+				defer func() {
+					if r := recover(); r != nil {
+						reached = true
+					}
+				}()
+				_, res, err := tc.init(runtime, tc.args)
+				// Some inits validate the ARN before building a client and
+				// report a lookup failure instead; that is also not a false
+				// "found".
+				return err != nil || res == nil
+			}()
+
+			assert.True(t, reached,
+				"an empty cache must not resolve the resource; the init has to go on and fetch")
+		})
+	}
+}
+
+// The fast path stays: a caller that already supplied every field must not be
+// diverted into a cache lookup that could answer with a different instance.
+func TestAssetInits_KeepTheCompleteArgsFastPath(t *testing.T) {
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	fsArn := "arn:aws:elasticfilesystem:us-east-1:123456789012:file-system/fs-abc"
+
+	args, res, err := initAwsEfsFilesystem(runtime, map[string]*llx.RawData{
+		"arn":       llx.StringData(fsArn),
+		"id":        llx.StringData("fs-abc"),
+		"region":    llx.StringData("us-east-1"),
+		"encrypted": llx.BoolData(true),
+	})
+	require.NoError(t, err)
+	assert.Nil(t, res, "complete args are built by the runtime, not resolved by the init")
+	assert.NotNil(t, args)
+}
+
+func TestCachedArg(t *testing.T) {
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	project, err := CreateResource(runtime, ResourceAwsCodebuildProject, map[string]*llx.RawData{
+		"name": llx.StringData("my-project"),
+	})
+	require.NoError(t, err)
+
+	t.Run("reads the key out of the named argument", func(t *testing.T) {
+		got := cachedArg(runtime, ResourceAwsCodebuildProject,
+			map[string]*llx.RawData{"name": llx.StringData("my-project")}, "name")
+		assert.Same(t, project, got)
+	})
+
+	t.Run("the wrong argument is a miss", func(t *testing.T) {
+		assert.Nil(t, cachedArg(runtime, ResourceAwsCodebuildProject,
+			map[string]*llx.RawData{"arn": llx.StringData("my-project")}, "name"))
+	})
+
+	t.Run("a non-string value is a miss, not a panic", func(t *testing.T) {
+		assert.Nil(t, cachedArg(runtime, ResourceAwsCodebuildProject,
+			map[string]*llx.RawData{"name": llx.IntData(42)}, "name"))
+	})
+}
+
+// aws.sqs.queue keys its __id on the queue URL, which is what its init calls
+// GetQueueUrl to discover, so it resolves out of the already-walked queue list
+// instead of probing by ARN.
+func TestResolvedSqsQueueByArn(t *testing.T) {
+	// Build the aws.sqs singleton through CreateResource so the list lands
+	// under whatever key the resource computes for itself.
+	newSqs := func(t *testing.T) (*plugin.Runtime, *mqlAwsSqs) {
+		runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+		obj, err := CreateResource(runtime, ResourceAwsSqs, map[string]*llx.RawData{})
+		require.NoError(t, err)
+		return runtime, obj.(*mqlAwsSqs)
+	}
+	newRuntime := func(t *testing.T, urls ...string) (*plugin.Runtime, []*mqlAwsSqsQueue) {
+		runtime, sqsRes := newSqs(t)
+		queues := make([]*mqlAwsSqsQueue, 0, len(urls))
+		list := make([]any, 0, len(urls))
+		for _, u := range urls {
+			q := &mqlAwsSqsQueue{Url: plugin.TValue[string]{Data: u, State: plugin.StateIsSet}}
+			queues = append(queues, q)
+			list = append(list, q)
+		}
+		sqsRes.Queues = plugin.TValue[[]any]{Data: list, State: plugin.StateIsSet}
+		return runtime, queues
+	}
+	parse := func(t *testing.T, s string) arn.ARN {
+		a, err := arn.Parse(s)
+		require.NoError(t, err)
+		return a
+	}
+
+	t.Run("matches on the url path", func(t *testing.T) {
+		runtime, queues := newRuntime(t,
+			"https://sqs.us-east-1.amazonaws.com/123456789012/other",
+			"https://sqs.us-east-1.amazonaws.com/123456789012/wanted",
+		)
+		got := resolvedSqsQueueByArn(runtime, parse(t, "arn:aws:sqs:us-east-1:123456789012:wanted"))
+		assert.Same(t, queues[1], got)
+	})
+
+	// The queue name and account live in the path whatever form the hostname
+	// takes, so a fips or legacy endpoint must still match.
+	t.Run("matches a non-standard endpoint form", func(t *testing.T) {
+		runtime, queues := newRuntime(t, "https://sqs-fips.us-east-1.amazonaws.com/123456789012/wanted")
+		got := resolvedSqsQueueByArn(runtime, parse(t, "arn:aws:sqs:us-east-1:123456789012:wanted"))
+		assert.Same(t, queues[0], got)
+	})
+
+	// Same account, same queue name, different region is a different queue.
+	t.Run("region must agree", func(t *testing.T) {
+		runtime, _ := newRuntime(t, "https://sqs.us-west-2.amazonaws.com/123456789012/wanted")
+		assert.Nil(t, resolvedSqsQueueByArn(runtime, parse(t, "arn:aws:sqs:us-east-1:123456789012:wanted")))
+	})
+
+	t.Run("another account's queue of the same name is not a match", func(t *testing.T) {
+		runtime, _ := newRuntime(t, "https://sqs.us-east-1.amazonaws.com/999999999999/wanted")
+		assert.Nil(t, resolvedSqsQueueByArn(runtime, parse(t, "arn:aws:sqs:us-east-1:123456789012:wanted")))
+	})
+
+	t.Run("no match in the list", func(t *testing.T) {
+		runtime, _ := newRuntime(t, "https://sqs.us-east-1.amazonaws.com/123456789012/other")
+		assert.Nil(t, resolvedSqsQueueByArn(runtime, parse(t, "arn:aws:sqs:us-east-1:123456789012:wanted")))
+	})
+
+	// The list must never be forced: for a one-off query against a single
+	// queue, listing every queue in every region costs more than the
+	// GetQueueUrl it would save.
+	t.Run("an unresolved list is a miss, not a fetch", func(t *testing.T) {
+		runtime, sqsRes := newSqs(t)
+
+		assert.False(t, sqsRes.Queues.IsSet())
+		assert.Nil(t, resolvedSqsQueueByArn(runtime, parse(t, "arn:aws:sqs:us-east-1:123456789012:wanted")))
+		assert.False(t, sqsRes.Queues.IsSet(), "the probe must not trigger a ListQueues fan-out")
+	})
+}


### PR DESCRIPTION
## The report

An EFS file system asset came back from a scan with its own `id`, `tags` and
`createdAt` reading `null`, each carrying a `ThrottlingException` on
`DescribeFileSystems`, while `arn`, `region`, `encrypted` and `sizeInBytes` on
the *same* asset resolved fine. The three failures were distinct calls with
distinct RequestIDs against one file system.

## The cause is the init/cache ordering, not EFS

`NewResource` (generated, `aws.lr.go`) runs `f.Init(runtime, args)` **first**,
and only then computes `MqlID()` and checks `runtime.Resources.Get(id)`. It has
to work that way in general: the cache key is the *resolved* resource's id,
which an init may compute.

cnspec compiles both data queries and policy filters to a bare resource, and
evaluates every policy's filter against every asset. Each of those reaches the
provider as `ResourceId == "" && Field == ""` and takes the `NewResource` branch
in `plugin/service.go`. So an init that fetches unconditionally is entered **once
per query**, not once per asset — and every call it makes is then thrown away in
favour of the instance already in the cache. Enough concurrent queries on one
file system exhausts EFS's `DescribeFileSystems` quota, and the SDK's 3 retry
attempts multiply it.

The data was in memory the whole time. Discovery builds each of these assets by
walking its service's list (`discovery.go`), and AWS parents child assets onto
the account runtime (`discovery_conversion.go`), so an account and its assets
share **one** `runtime.Resources` map. The correct number of `DescribeFileSystems`
calls from this init during a scan is zero.

## The change

A cache probe before the fetch, in every asset init that fetched
unconditionally. `cachedByArn` already existed in `init_cache.go` and was used
by `ec2.networkinterface`, `ec2.securitygroup` and `vpc`; these sixteen never
adopted it.

| resource | probe key |
|---|---|
| `efs.filesystem`, `ec2.instance`, `lambda.function`, `secretsmanager.secret`, `cloudwatch.loggroup`, `cloudtrail.trail`, `ecr.repository`, `elb.loadbalancer`, `es.domain`, `opensearch.domain`, `rds.snapshot`, `memorydb.cluster`, `transfer.server`, `appstream.fleet`, `cognito.userPool` | ARN |
| `codebuild.project` | name — this resource keys its `__id` on the name alone |
| `sqs.queue` | the already-walked queue list, see below |

`aws.sqs.queue` keys its `__id` on the queue URL, which is the very thing its
init calls `GetQueueUrl` to resolve, so an ARN cannot be its cache key. It
resolves out of the account's queue list instead, matching on the URL *path*
(`/<account>/<name>`) plus the region the hostname implies, so a fips or legacy
endpoint form still matches. It deliberately reads that list only when it is
**already** resolved and never forces it: during a scan it always is, because
discovery walked it to build the queue assets, and for a one-off query against a
single queue, listing every queue in every region would cost more than the
`GetQueueUrl` it saves.

`aws.iam.group` and `aws.iam.user` already resolve from a list first and are
untouched.

**A probe keyed differently from how the resource computes its `MqlID` simply
misses and leaves the init on its existing path**, so this can never return the
wrong resource — the failure mode is "no improvement", not "wrong data".

Two placement notes: `initAwsCloudwatchLoggroup` asserted the connection before
reading its ARN, so the probe had to move above that; `initAwsCognitoUserPool`
primes a `DescribeUserPool` cache after fetching, so on a probe hit that call is
paid once by whichever computed field asks for it, instead of once per query —
the same behaviour the list path already has.

## Measured, live

Against 5 real EFS file systems (`--discover efs-filesystems`, one query per
asset), with a temporary log line at the init's `DescribeFileSystems` call:

| build | `DescribeFileSystems` from the init |
|---|---|
| probe neutered | **5** |
| probe present | **0** |

Output was byte-identical between the two runs (the only diff was a one-time
provider-install banner in the first), all 5 assets discovered in both, and
`id`, `tags`, `createdAt` and `encrypted` populated in both. The neutered build
is the provenance check the numbers need: it fires the log line from the same
build pipeline and binary path, so the 0 is the probe working rather than the
wrong binary running.

This measures one call per asset per query. A cnspec scan multiplies that by the
number of EFS queries and filters, which is what produced the concurrent
throttled calls in the original report.

## Tests

`init_cache_asset_test.go` drives all 17 inits through a runtime that has a
populated `Resources` map and a **nil `Connection`**. Every one of these inits
reaches `runtime.Connection.(*connection.AwsConnection)` on its fetch path, and
a type assertion on a nil interface panics — so the nil connection turns "did
this init make an API call?" into an ordinary assertion.

Three properties are pinned per resource: the probe answers from the cache; a
miss still falls through to the fetch rather than reporting the resource absent;
and the seed lands under the key the probe looks up (which is what would catch a
probe keyed on the wrong field). Plus the `len(args)` fast path, `cachedArg`'s
absent/non-string cases, and a table for the SQS list matcher including the
region-mismatch, foreign-account and unresolved-list cases.

Per CLAUDE.md §3.7, I ran the mutation: deleting the EFS probe makes
`TestAssetInits_AnswerFromCacheWithoutAnApiCall/aws.efs.filesystem` panic with
`interface conversion: plugin.Connection is nil` at `aws_efs.go:187` — the exact
call the probe exists to skip.

## Not covered

- No `.lr` change, so no codegen, no `.lr.versions` entries, and
  `aws.permissions.json` is unchanged (`1040 permissions (unchanged)`) — the
  change removes calls, it adds none.
- Only EFS was verified against live infrastructure. The other 16 are verified
  by the unit tests and by construction (the probe is the same three lines), not
  against real APIs.
- `aws.codebuild.project` keying its `__id` on the name alone means two projects
  of the same name in different regions collide in the cache. That is
  pre-existing — the post-init cache check collides identically today — and this
  PR does not change it, but it is worth a follow-up.

## The rest of the class

The same defect exists in inits that are *not* discovery targets, where the cost
is set by fan-in per reference rather than per query. Those are out of scope
here. Found with:

```
awk '/^func init[A-Z]/ { fn=$2; sub(/\(.*/,"",fn); infn=1; n=0; apiAt=0; cacheAt=0 }
infn { n++
  if (!apiAt && ($0 ~ /svc\.[A-Z][A-Za-z]*\(ctx/ || $0 ~ /paginator *:?= *[a-z0-9]+\.New[A-Z]/)) apiAt=n
  if (!cacheAt && $0 ~ /cachedByArn|cachedArgByArn|cachedArg|cachedResource/) cacheAt=n }
infn && /^}/ { if (apiAt && !cacheAt) printf "%s:%s\n", FILENAME, fn; infn=0 }
' providers/aws/resources/*.go | grep -v _test
```
