### PR TITLE
🐛 azure: six resource lists return an error instead of their data

### DIFF
--- a/providers/azure/resources/createresource_args_test.go
+++ b/providers/azure/resources/createresource_args_test.go
@@ -1,0 +1,150 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"strconv"
+	"strings"
+	"testing"
+
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/utils/syncx"
+)
+
+// TestCreateResourceArgsExistInSchema pins the invariant that every key a
+// lister passes to CreateResource is a field the resource actually declares.
+//
+// CreateResource funnels its args through SetAllData, which fails the whole
+// call on the first unknown key with
+//
+//	[azure] cannot set 'tenantId' in resource '...', field not found
+//
+// That error replaces the entire list with an error string - the caller does
+// not get a partial resource, it gets nothing. Nothing catches it at build
+// time, and a lister for a service nobody has provisioned can carry the bug
+// for a long time before anyone notices.
+//
+// Six resources shipped exactly that way after principalId/tenantId moved onto
+// the resourceIdentity sub-resource and the old args were left behind on the
+// parent: dataFactory factory, elasticSan volumeGroup, netApp account,
+// recoveryServices vault, storageCache amlFilesystem and synapse workspace.
+func TestCreateResourceArgsExistInSchema(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("parse package: %v", err)
+	}
+
+	// Resource name constants generated into azure.lr.go: ResourceX string = "azure...."
+	names := map[string]string{}
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				gd, ok := decl.(*ast.GenDecl)
+				if !ok || gd.Tok != token.CONST {
+					continue
+				}
+				for _, spec := range gd.Specs {
+					vs, ok := spec.(*ast.ValueSpec)
+					if !ok || len(vs.Names) != 1 || len(vs.Values) != 1 {
+						continue
+					}
+					lit, ok := vs.Values[0].(*ast.BasicLit)
+					if !ok || lit.Kind != token.STRING {
+						continue
+					}
+					if v, err := strconv.Unquote(lit.Value); err == nil {
+						names[vs.Names[0].Name] = v
+					}
+				}
+			}
+		}
+	}
+
+	type use struct {
+		resource string
+		field    string
+		pos      token.Position
+	}
+	var uses []use
+
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			ast.Inspect(file, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok || len(call.Args) < 3 {
+					return true
+				}
+				fn, ok := call.Fun.(*ast.Ident)
+				if !ok || fn.Name != "CreateResource" {
+					return true
+				}
+
+				var resource string
+				switch a := call.Args[1].(type) {
+				case *ast.Ident:
+					resource = names[a.Name]
+				case *ast.BasicLit:
+					if a.Kind == token.STRING {
+						resource, _ = strconv.Unquote(a.Value)
+					}
+				}
+				if resource == "" {
+					return true
+				}
+
+				lit, ok := call.Args[2].(*ast.CompositeLit)
+				if !ok {
+					return true
+				}
+				for _, elt := range lit.Elts {
+					kv, ok := elt.(*ast.KeyValueExpr)
+					if !ok {
+						continue
+					}
+					k, ok := kv.Key.(*ast.BasicLit)
+					if !ok || k.Kind != token.STRING {
+						continue
+					}
+					field, err := strconv.Unquote(k.Value)
+					if err != nil || field == "__id" {
+						continue
+					}
+					uses = append(uses, use{resource, field, fset.Position(k.Pos())})
+				}
+				return true
+			})
+		}
+	}
+
+	if len(uses) == 0 {
+		t.Fatal("found no CreateResource arg maps - the AST walk is not doing its job")
+	}
+
+	runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+	for _, u := range uses {
+		factory, ok := resourceFactories[u.resource]
+		if !ok || factory.Create == nil {
+			continue
+		}
+		res, err := factory.Create(runtime, map[string]*llx.RawData{"__id": llx.StringData("probe")})
+		if err != nil || res == nil {
+			continue
+		}
+		// Only the "field not found" outcome matters here; a type mismatch
+		// from the probe value is not what this test is about.
+		if err := SetData(res, u.field, llx.StringData("probe")); err != nil &&
+			strings.Contains(err.Error(), "field not found") {
+			t.Errorf("%s: CreateResource(%s) passes %q, which the resource does not declare\n\t%v",
+				u.pos, u.resource, u.field, err)
+		}
+	}
+}

--- a/providers/azure/resources/datafactory.go
+++ b/providers/azure/resources/datafactory.go
@@ -153,8 +153,6 @@ func (a *mqlAzureSubscriptionDataFactoryService) factories() ([]any, error) {
 					"publicNetworkAccess": llx.StringData(publicNetworkAccess),
 					"identity":            llx.DictData(identity),
 					"resourceIdentity":    resourceIdentity,
-					"principalId":         llx.StringDataPtr(factoryIdentity.PrincipalID),
-					"tenantId":            llx.StringDataPtr(factoryIdentity.TenantID),
 					"provisioningState":   llx.StringData(provisioningState),
 					"version":             llx.StringData(version),
 					"repoConfiguration":   llx.DictData(repoConfig),

--- a/providers/azure/resources/elasticsan.go
+++ b/providers/azure/resources/elasticsan.go
@@ -278,8 +278,6 @@ func createElasticSanVolumeGroupResource(runtime *plugin.Runtime, group *armelas
 			"enforceDataIntegrityCheckForIscsi":      llx.BoolDataPtr(props.EnforceDataIntegrityCheckForIscsi),
 			"identity":                               llx.DictData(identity),
 			"resourceIdentity":                       resourceIdentity,
-			"principalId":                            llx.StringDataPtr(groupIdentity.PrincipalID),
-			"tenantId":                               llx.StringDataPtr(groupIdentity.TenantID),
 			"keyName":                                llx.StringData(keyName),
 			"keyVaultUri":                            llx.StringData(keyVaultUri),
 			"keyVersion":                             llx.StringData(keyVersion),

--- a/providers/azure/resources/netapp.go
+++ b/providers/azure/resources/netapp.go
@@ -150,8 +150,6 @@ func createNetAppAccountResource(runtime *plugin.Runtime, account *armnetapp.Acc
 			"provisioningState": llx.StringDataPtr(props.ProvisioningState),
 			"identity":          llx.DictData(identity),
 			"resourceIdentity":  resourceIdentity,
-			"principalId":       llx.StringDataPtr(accountIdentity.PrincipalID),
-			"tenantId":          llx.StringDataPtr(accountIdentity.TenantID),
 			"nfsV4IdDomain":     llx.StringDataPtr(props.NfsV4IDDomain),
 			// The API documents null as false here, so the absence is not a
 			// missing reading: showmount is on unless it was turned off.

--- a/providers/azure/resources/recoveryservices.go
+++ b/providers/azure/resources/recoveryservices.go
@@ -384,8 +384,6 @@ func createVaultResource(runtime *plugin.Runtime, vault *armrecoveryservices.Vau
 			"tags":                                llx.MapData(convert.PtrMapStrToInterface(vault.Tags), types.String),
 			"identity":                            llx.DictData(identity),
 			"resourceIdentity":                    resourceIdentity,
-			"principalId":                         llx.StringDataPtr(vaultIdentity.PrincipalID),
-			"tenantId":                            llx.StringDataPtr(vaultIdentity.TenantID),
 			"skuName":                             llx.StringData(skuName),
 			"provisioningState":                   llx.StringData(provisioningState),
 			"publicNetworkAccess":                 llx.StringData(publicNetworkAccess),

--- a/providers/azure/resources/storagecache.go
+++ b/providers/azure/resources/storagecache.go
@@ -195,8 +195,6 @@ func createAmlFilesystemResource(runtime *plugin.Runtime, fs *armstoragecache.Am
 			"provisioningState":             llx.StringData(enumString(props.ProvisioningState)),
 			"identity":                      llx.DictData(identity),
 			"resourceIdentity":              resourceIdentity,
-			"principalId":                   llx.StringDataPtr(fsIdentity.PrincipalID),
-			"tenantId":                      llx.StringDataPtr(fsIdentity.TenantID),
 			"storageCapacityTiB":            llx.FloatDataPtr(props.StorageCapacityTiB),
 			"currentStorageCapacityTiB":     llx.FloatDataPtr(props.CurrentStorageCapacityTiB),
 			"throughputProvisionedMbps":     llx.IntDataPtr(props.ThroughputProvisionedMBps),

--- a/providers/azure/resources/synapse.go
+++ b/providers/azure/resources/synapse.go
@@ -187,8 +187,6 @@ func (a *mqlAzureSubscriptionSynapseService) workspaces() ([]any, error) {
 					"properties":                  llx.DictData(properties),
 					"identity":                    llx.DictData(identity),
 					"resourceIdentity":            resourceIdentity,
-					"principalId":                 llx.StringDataPtr(wsIdentity.PrincipalID),
-					"tenantId":                    llx.StringDataPtr(wsIdentity.TenantID),
 					"managedVirtualNetwork":       llx.StringData(managedVirtualNetwork),
 					"publicNetworkAccess":         llx.StringData(publicNetworkAccess),
 					"encryption":                  llx.DictData(encryption),


### PR DESCRIPTION
## What

Six Azure resource lists returned an error string where their data should be:

```
Error: [azure] cannot set 'tenantId' in resource
'azure.subscription.netAppService.account', field not found
```

| resource | stale arg |
|---|---|
| `azure.subscription.netAppService.account` | `principalId`, `tenantId` |
| `azure.subscription.elasticSanService.elasticSan.volumeGroup` | `principalId`, `tenantId` |
| `azure.subscription.dataFactoryService.factory` | `principalId`, `tenantId` |
| `azure.subscription.recoveryServicesService.vault` | `principalId`, `tenantId` |
| `azure.subscription.storageCacheService.amlFilesystem` | `principalId`, `tenantId` |
| `azure.subscription.synapseService.workspace` | `principalId`, `tenantId` |

## Why

`principalId`/`tenantId` moved onto the `resourceIdentity` sub-resource and the parent `.lr` blocks no longer declare them, but these six listers still passed both to `CreateResource`. `CreateResource` funnels args through `SetAllData`, which fails the **whole call** on the first unknown key — so the caller gets an error string, not a partial resource.

No data was actually lost: `resourceIdentity` already carries `type`, `principalId` and `tenantId`. Only the lists were unreachable.

## Verification

Against a live subscription, A/B with two `PROVIDERS_PATH` builds:

| query | main | this branch |
|---|---|---|
| `netAppService.accounts { name }` | `"Error: ... cannot set 'tenantId' ..."` | `{"name":"mqlv14-anf"}` |
| `elasticSans { volumeGroups { id } }` | `"Error: ... cannot set 'principalId' ..."` | the volume group |

`resourceIdentity { type }` resolves after the fix, confirming the identity data is intact on the sub-resource.

The other four have the identical call shape and error path; I had no provisioned DataFactory, Recovery Services vault, Managed Lustre or Synapse workspace to exercise them against, so they are fixed by inspection rather than observation. Flagging that explicitly.

## Test

Adds `createresource_args_test.go`: an AST walk over every `CreateResource` call in the package, probing each arg key with `SetData` and failing on `field not found`.

This class is invisible at compile time, and a lister for a service nobody has provisioned can carry it a long time before anyone notices — which is what happened here. Confirmed the test can fail: reintroducing one stale arg gives

```
netapp.go:153:4: CreateResource(azure.subscription.netAppService.account)
passes "tenantId", which the resource does not declare
```

I ran the same scan across aws, gcp and oci. AWS and GCP flag only `NewResource` call sites, where extra args are legitimately consumed by `init`; OCI is clean. Azure was the only provider with real instances.

Found while verifying the v13→v14 provider diff against live infrastructure.
