### PR TITLE
🐛 os: Arch Linux ARM is not detected and loses its package manager

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -140,10 +140,13 @@ var arch = &PlatformResolver{
 	Name:     "arch",
 	IsFamily: false,
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
-		if pf.Name == "arch" {
+		// Arch Linux ARM ships ID=archarm. It is the same distribution built for
+		// ARM, so it reports as arch rather than as a platform of its own.
+		if pf.Name == "archarm" {
+			pf.Name = "arch"
 			return true, nil
 		}
-		return false, nil
+		return pf.Name == "arch", nil
 	},
 }
 

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -912,6 +912,32 @@ func TestAltLinuxIsClaimedByItsOwnResolver(t *testing.T) {
 		"a container image claimed only by the generic resolver is reported as scratch")
 }
 
+// Arch Linux ARM sets ID=archarm and reports as arch.
+func TestArchArmDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-archarm.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "arch", di.Name, "Arch Linux ARM is arch, not a platform of its own")
+	assert.Equal(t, []string{"arch", "linux", "unix", "os"}, di.Family,
+		"Arch Linux ARM belongs to the arch family")
+}
+
+// A container image whose platform is only claimed by the generic resolver is
+// reported as "scratch", which is how Arch Linux ARM images were coming back -
+// and an undetected platform takes the package manager with it, so `packages`
+// errored on an image pacman happily lists.
+func TestArchArmIsClaimedByItsOwnResolver(t *testing.T) {
+	mockConn, err := mock.New(0, &inventory.Asset{}, mock.WithPath("./testdata/detect-archarm.toml"))
+	require.NoError(t, err)
+
+	pf, leaf, resolved := OperatingSystems.resolvePlatform(&inventory.Platform{}, mockConn)
+	require.True(t, resolved, "platform should resolve")
+	require.NotNil(t, leaf)
+
+	assert.NotEqual(t, defaultLinux, leaf, "Arch Linux ARM must not be left to the generic linux resolver")
+	assert.False(t, isUnidentifiedPlatform(pf, leaf))
+}
+
 // Manjaro ARM sets ID=manjaro-arm and reports as manjaro.
 func TestManjaroArmDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-manjaro-arm.toml")

--- a/providers/os/detector/testdata/detect-archarm.toml
+++ b/providers/os/detector/testdata/detect-archarm.toml
@@ -1,0 +1,22 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "aarch64"
+
+[files."/etc/arch-release"]
+content = ""
+
+[files."/etc/os-release"]
+content = """
+NAME="Arch Linux ARM"
+PRETTY_NAME="Arch Linux ARM"
+ID=archarm
+ID_LIKE=arch
+BUILD_ID=rolling
+ANSI_COLOR="38;2;23;147;209"
+HOME_URL="https://archlinuxarm.org/"
+SUPPORT_URL="https://archlinuxarm.org/forum"
+BUG_REPORT_URL="https://github.com/archlinuxarm/PKGBUILDs/issues"
+LOGO=archlinux-logo
+"""


### PR DESCRIPTION
## What

Arch Linux ARM ships `ID=archarm` in `/etc/os-release`. The `arch` resolver matched only `pf.Name == "arch"`, so the platform fell through to the generic linux resolver and the image reported as **scratch**.

An undetected platform takes the package manager with it — `packages` **errored** on an image where `pacman -Q` lists **137 packages**.

## Fix

Mirrors the fix already sitting directly below it in the same file for Manjaro ARM (`ID=manjaro-arm` → `manjaro`). Arch Linux ARM is the same distribution built for ARM, so it reports as `arch` rather than as a platform of its own.

```go
// Arch Linux ARM ships ID=archarm. It is the same distribution built for
// ARM, so it reports as arch rather than as a platform of its own.
if pf.Name == "archarm" {
    pf.Name = "arch"
    return true, nil
}
return pf.Name == "arch", nil
```

## Test

`testdata/detect-archarm.toml` captured from a real `ghcr.io/archlinuxarm` image, plus two tests mirroring the existing Manjaro ARM pair:

- `TestArchArmDetector` — resolves to `arch` with family `[arch linux unix os]`
- `TestArchArmIsClaimedByItsOwnResolver` — pins that it is *not* left to the generic resolver, which is the specific failure that produced `scratch`

Both fail without the change (the first on the platform name, the second on `defaultLinux`).

Note: official `archlinux:latest` has no arm64 manifest, which is why this only surfaces on the ARM build — the mainline x86 Arch path was and remains fine (`TestArchLinuxVmDetector` / `TestArchLinuxContainerDetector` still pass).

Found while verifying the os provider against 20 Linux container images for the v13→v14 diff.
