### PR TITLE
🐛 os: ollama integration models are empty when the config omits the tag

### DIFF
--- a/providers/os/resources/ollama.go
+++ b/providers/os/resources/ollama.go
@@ -564,11 +564,36 @@ func (i *mqlOllamaConfigIntegration) models() ([]any, error) {
 		if !ok {
 			continue
 		}
-		if m, ok := byName[name]; ok {
+		if m, ok := matchOllamaModel(byName, name); ok {
 			out = append(out, m)
 		}
 	}
 	return out, nil
+}
+
+// matchOllamaModel resolves a configured model name against the model store.
+//
+// Ollama treats an untagged name as implicitly :latest - `ollama run qwen3.5`
+// and `ollama run qwen3.5:latest` are the same model - but the store reports
+// the fully qualified name. An integration that records the bare name found
+// nothing, so `models` came back empty on a host that had the model pulled.
+func matchOllamaModel(byName map[string]any, name string) (any, bool) {
+	if m, ok := byName[name]; ok {
+		return m, true
+	}
+	if !strings.Contains(name, ":") {
+		if m, ok := byName[name+":latest"]; ok {
+			return m, true
+		}
+	}
+	// The reverse also happens: a config pinned to :latest against a store
+	// entry that reports the bare name.
+	if base, tag, found := strings.Cut(name, ":"); found && tag == "latest" {
+		if m, ok := byName[base]; ok {
+			return m, true
+		}
+	}
+	return nil, false
 }
 
 // id carries the user as well as the tool name: the integrations are per-user,

--- a/providers/os/resources/ollama_models_test.go
+++ b/providers/os/resources/ollama_models_test.go
@@ -1,0 +1,43 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Ollama treats an untagged model name as implicitly :latest, but the model
+// store reports the fully qualified name. An integration recording the bare
+// name matched nothing, so ollama.config.integration.models came back empty on
+// a host that had the model pulled.
+func TestMatchOllamaModel(t *testing.T) {
+	store := map[string]any{
+		"qwen3.5:latest": "tagged",
+		"llama3.2:1b":    "pinned",
+		"mistral":        "bare",
+	}
+
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  any
+		found bool
+	}{
+		{"bare name matches the :latest entry", "qwen3.5", "tagged", true},
+		{"exact tagged name still matches", "qwen3.5:latest", "tagged", true},
+		{"a non-latest tag matches exactly", "llama3.2:1b", "pinned", true},
+		{"a bare name does not match a differently tagged entry", "llama3.2", nil, false},
+		{":latest matches a store entry reported bare", "mistral:latest", "bare", true},
+		{"an unknown model resolves to nothing", "gemma3", nil, false},
+		{"an empty name resolves to nothing", "", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := matchOllamaModel(store, tc.query)
+			assert.Equal(t, tc.found, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## What

`ollama.config.integration.models` returned `[]` on a host that had the model pulled.

Ollama treats an untagged model name as implicitly `:latest` — `ollama run qwen3.5` and `ollama run qwen3.5:latest` are the same model — but the model store reports the fully qualified name. The join in `ollama.go` was an exact string match, so a config recording the bare name matched nothing.

Observed with a config naming `qwen3.5` against a store holding `qwen3.5:latest`.

## Fix

`matchOllamaModel` resolves in three steps:

1. exact name
2. the implicit `:latest` form, when the configured name carries no tag
3. the reverse — a config pinned to `:latest` against a store entry reported bare

A bare name still does **not** match a differently tagged entry: `qwen3.5` must not silently resolve to `qwen3.5:1b`. That case is pinned by a test.

## Test

`TestMatchOllamaModel` is a table test over a pure helper, covering the bare↔tagged cases in both directions plus the negatives (differently-tagged entry, unknown model, empty name).

Confirmed it can fail — removing the `:latest` fallback gives:

```
--- FAIL: TestMatchOllamaModel/bare_name_matches_the_:latest_entry
    expected: true
    expected: string("tagged")
```

Found while verifying the os provider against Linux containers for the v13→v14 diff. This field is part of that diff.
