### PR TITLE
🐛 os: only report real macOS application bundles as installed software

### DIFF
--- a/providers/os/resources/packages/macos_bundle_path_test.go
+++ b/providers/os/resources/packages/macos_bundle_path_test.go
@@ -1,0 +1,47 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package packages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsApplicationBundlePath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"application bundle", "/Applications/Docker.app", true},
+		{"OS-shipped application", "/System/Applications/Utilities/Terminal.app", true},
+		{"per-user application", "/Users/user/Applications/Chrome Apps.localized/Teams (PWA).app", true},
+		{"trailing separator", "/Applications/Docker.app/", true},
+		// APFS is case-insensitive by default, so this bundle launches.
+		{"uppercase extension", "/Applications/Docker.APP", true},
+		// Only a whole Contents segment means "inside a bundle".
+		{"Contents as a name fragment", "/Applications/TableOfContents/Docker.app", true},
+
+		// The reported bug: a renamed bundle keeps its old version forever, and
+		// system_profiler names it "Docker.app" because it strips only .back.
+		{"renamed bundle", "/Applications/Docker.app.back", false},
+		{"disabled bundle", "/Applications/Docker.app.disabled", false},
+		{"service bundle", "/System/Library/Services/Spotlight.service", false},
+		{"non-bundle directory", "/Users/user/Library/HTTPStorages/com.apple.ctcategories.service", false},
+		{"no path reported", "", false},
+
+		// Helper bundles ship with, and are patched by, their container.
+		{"helper in a renamed bundle", "/Applications/Docker.app.back/Contents/MacOS/Docker Desktop.app", false},
+		{"login item helper", "/Applications/Docker.app.back/Contents/Library/LoginItems/DockerHelper.app", false},
+		{"Finder pseudo-application", "/System/Library/CoreServices/Finder.app/Contents/Applications/AirDrop.app", false},
+		{"framework XPC service", "/System/Library/Frameworks/PaperKit.framework/Contents/LinkedNotesUIService.app", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, isApplicationBundlePath(test.path))
+		})
+	}
+}

--- a/providers/os/resources/packages/macos_packages.go
+++ b/providers/os/resources/packages/macos_packages.go
@@ -73,22 +73,28 @@ func ParseMacOSPackages(conn shared.Connection, platform *inventory.Platform, in
 
 	pkgs := make([]Package, 0, len(data[0].Items))
 	for _, entry := range data[0].Items {
+		if !isApplicationBundlePath(entry.Path) {
+			log.Debug().
+				Str("name", entry.Name).
+				Str("path", entry.Path).
+				Msg("skipping entry that is not an installed application bundle")
+			continue
+		}
+
 		// system_profiler only surfaces CFBundleShortVersionString as the
 		// version. Some bundles (e.g. PWAs) ship a version only in
 		// CFBundleVersion, so fall back to the bundle's Info.plist when
 		// system_profiler reports no version.
 		version := entry.Version
 		if version == "" {
-			// system_profiler lists every path carrying a bundle-like
-			// extension, not only application bundles: Firefox origin storage
-			// (https+++example.app), app-group script containers
-			// (group.is.workflow.my.app) and daemon directories all show up. It
-			// names them after the basename minus its final dot component, so a
-			// reverse-DNS directory collapses into a fragment like "com" or
-			// "org.eclipse". An application bundle always carries a
-			// Contents/Info.plist, so its absence means this is not an installed
-			// application: drop the entry instead of reporting it with a
-			// versionless purl that can never match advisory data.
+			// Plenty of directories genuinely end in .app without being
+			// applications: Firefox origin storage (https+++example.app),
+			// app-group script containers (group.is.workflow.my.app) and bare
+			// daemon directories all pass the path check above. An application
+			// bundle always carries a Contents/Info.plist, so its absence means
+			// this is not an installed application: drop the entry instead of
+			// reporting it with a versionless purl that can never match
+			// advisory data.
 			//
 			// Entries that do report a version are never checked, because some
 			// real applications have no Contents/Info.plist. Wrapped iOS apps
@@ -172,6 +178,47 @@ func (mpm *MacOSPkgManager) Available() (map[string]PackageUpdate, error) {
 func (mpm *MacOSPkgManager) Files(name string, version string, arch string) ([]FileRecord, error) {
 	// nothing extra to be done here since the list is already included in the package list
 	return nil, nil
+}
+
+// isApplicationBundlePath reports whether a path system_profiler listed is an
+// application someone installed, as opposed to a directory that merely looks
+// like a bundle or a helper that ships inside another application.
+//
+// system_profiler does not answer that question itself. It walks the
+// filesystem, reports anything bundle-shaped it meets, and names each entry
+// after the basename minus its final dot component. Two shapes come out of
+// that, and both produce inventory rows that no upgrade can ever clear.
+//
+// A renamed bundle such as /Applications/Docker.app.back is still enumerated,
+// under the name "Docker.app" and at whatever version was current when it was
+// set aside. Reported as installed software it pins findings to a version that
+// is not on the machine, and reinstalling the application does not touch the
+// backup directory. An application bundle always ends in .app, so the
+// extension of the final path segment settles it.
+//
+// Renaming also stops macOS treating the directory as one opaque bundle, so
+// every helper bundle nested inside it gets walked and reported separately.
+// Nested bundles are not separately installed in any case: an XPC service
+// under a framework's Contents/, Finder's Contents/Applications/AirDrop.app,
+// and an application's own login-item helper all ship with, and are patched
+// by, whatever contains them. A Contents directory anywhere above the bundle
+// marks that containment.
+func isApplicationBundlePath(path string) bool {
+	if path == "" {
+		return false
+	}
+
+	path = filepath.Clean(path)
+
+	// macOS filesystems are case-insensitive by default, so a bundle stored as
+	// .APP is a working application and must not be dropped.
+	if !strings.EqualFold(filepath.Ext(path), ".app") {
+		return false
+	}
+
+	// The surrounding separators make this a whole-segment match: a directory
+	// named "Contents" matches, one named "TableOfContents" does not.
+	return !strings.Contains(path, "/Contents/")
 }
 
 // bundleVersionFromInfoPlist recovers an app's version from its

--- a/providers/os/resources/packages/macos_packages_test.go
+++ b/providers/os/resources/packages/macos_packages_test.go
@@ -31,7 +31,7 @@ func TestMacOsXPackageParser(t *testing.T) {
 	}
 	m, err := packages.ParseMacOSPackages(mock, pf, c.Stdout)
 	assert.Nil(t, err)
-	assert.Equal(t, 7, len(m), "detected the right amount of packages")
+	assert.Equal(t, 8, len(m), "detected the right amount of packages")
 
 	assert.Equal(t, "Preview", m[0].Name, "pkg name detected")
 	assert.Equal(t, "10.0", m[0].Version, "pkg version detected")
@@ -90,6 +90,16 @@ func TestMacOsXPackageParser(t *testing.T) {
 	assert.Equal(t, "apple", m[0].Origin, "OS-shipped app")
 	assert.Equal(t, "identified_developer", m[2].Origin, "Developer ID-signed app")
 
+	// A backup copy of an application is enumerated by system_profiler at the
+	// version it held when it was set aside, and it is the only Docker entry
+	// that survives if the newer real install is filtered by mistake. Assert
+	// the installed version, not just the name: reporting 4.88.1 here is the
+	// customer-visible bug (findings pinned to a version that is not on the
+	// machine and that no upgrade can clear).
+	assert.Equal(t, "Docker", m[7].Name, "real application kept")
+	assert.Equal(t, "4.89.0", m[7].Version, "version of the installed bundle, not of the backup")
+	assert.Equal(t, []packages.FileRecord{{Path: "/Applications/Docker.app"}}, m[7].Files)
+
 	// system_profiler enumerates every path carrying a bundle-like extension,
 	// not just application bundles. Entries with no version and no
 	// Contents/Info.plist are not installed applications and are dropped
@@ -98,6 +108,18 @@ func TestMacOsXPackageParser(t *testing.T) {
 		"liquiddetectiond",     // bare .app directory holding a daemon
 		"https+++bsky",         // Firefox origin storage directory
 		"group.is.workflow.my", // app-group script container
+	} {
+		assert.NotContains(t, names(m), dropped, "non-application entry dropped")
+	}
+
+	// Paths that are not an installed application bundle are dropped whatever
+	// version they report, so a stale copy on disk cannot keep a fixed CVE open.
+	for _, dropped := range []string{
+		"Docker.app",     // /Applications/Docker.app.back, named by stripping .back
+		"Docker Desktop", // helper bundle inside the backup's Contents/
+		"DockerHelper",   // login item inside the backup's Contents/
+		"AirDrop",        // ships inside Finder.app, patched with Finder
+		"Spotlight",      // a .service bundle, not an application
 	} {
 		assert.NotContains(t, names(m), dropped, "non-application entry dropped")
 	}

--- a/providers/os/resources/packages/testdata/packages_macos.toml
+++ b/providers/os/resources/packages/testdata/packages_macos.toml
@@ -185,6 +185,78 @@ stdout = """<?xml version="1.0" encoding="UTF-8"?>
 				<key>version</key>
 				<string>1.0.16</string>
 			</dict>
+			<dict>
+				<key>_name</key>
+				<string>Docker</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>obtained_from</key>
+				<string>identified_developer</string>
+				<key>path</key>
+				<string>/Applications/Docker.app</string>
+				<key>version</key>
+				<string>4.89.0</string>
+			</dict>
+			<dict>
+				<key>_name</key>
+				<string>Docker.app</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>obtained_from</key>
+				<string>identified_developer</string>
+				<key>path</key>
+				<string>/Applications/Docker.app.back</string>
+				<key>version</key>
+				<string>4.88.1</string>
+			</dict>
+			<dict>
+				<key>_name</key>
+				<string>Docker Desktop</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>obtained_from</key>
+				<string>identified_developer</string>
+				<key>path</key>
+				<string>/Applications/Docker.app.back/Contents/MacOS/Docker Desktop.app</string>
+				<key>version</key>
+				<string>4.88.1</string>
+			</dict>
+			<dict>
+				<key>_name</key>
+				<string>DockerHelper</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>obtained_from</key>
+				<string>identified_developer</string>
+				<key>path</key>
+				<string>/Applications/Docker.app.back/Contents/Library/LoginItems/DockerHelper.app</string>
+				<key>version</key>
+				<string>1.0.1</string>
+			</dict>
+			<dict>
+				<key>_name</key>
+				<string>AirDrop</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>obtained_from</key>
+				<string>apple</string>
+				<key>path</key>
+				<string>/System/Library/CoreServices/Finder.app/Contents/Applications/AirDrop.app</string>
+				<key>version</key>
+				<string>26.4</string>
+			</dict>
+			<dict>
+				<key>_name</key>
+				<string>Spotlight</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>obtained_from</key>
+				<string>apple</string>
+				<key>path</key>
+				<string>/System/Library/Services/Spotlight.service</string>
+				<key>version</key>
+				<string>3.0</string>
+			</dict>
 		</array>
 		<key>_parentDataType</key>
 		<string>SPSoftwareDataType</string>


### PR DESCRIPTION
## The problem

`system_profiler SPApplicationsDataType` — the only source behind `packages` on macOS — walks the filesystem and reports anything bundle-shaped it meets. It names each entry after the basename minus its **final** dot component, so a leftover `/Applications/Docker.app.back` is enumerated as an application named `Docker.app`, at 4.88.1, the version current when it was set aside.

Renaming the directory also stops macOS treating it as one opaque bundle, so the walker descends into it and reports every nested helper separately. One stale copy became four phantom applications on the host where this was found:

| Reported name | Version | Path |
|---|---|---|
| `Docker.app` | 4.88.1 | `/Applications/Docker.app.back` |
| `Docker Desktop` | 4.88.1 | `/Applications/Docker.app.back/Contents/MacOS/Docker Desktop.app` |
| `docker-pass` | 1 | `.../Docker.app.back/Contents/Library/SecretsEngine/docker-pass.app` |
| `DockerHelper` | 1.0.1 | `.../Docker.app.back/Contents/Library/LoginItems/DockerHelper.app` |
| `Docker` | 4.89.0 | `/Applications/Docker.app` — the real install |

Reported as installed software, those rows pin the asset to a version that is not on the machine. Reinstalling or upgrading Docker does not touch a backup directory, so nothing a user does can ever clear them.

## The fix

Gate every entry on its path before reporting it:

1. **The final path segment must carry the `.app` extension.** An application bundle always does; `Docker.app.back` does not.
2. **No `Contents` directory may sit above it.** A bundle below `Contents/` ships with, and is patched by, whatever contains it — a framework's XPC service, `Finder.app/Contents/Applications/AirDrop.app`, an application's own login item. It is never separately installed.

This is pure path logic, so it costs nothing and behaves identically on live hosts, image scans and mock connections. It complements the existing `Contents/Info.plist` check, which stays scoped to versionless entries: that one catches directories that are genuinely `.app`-shaped but aren't applications (Firefox origin storage, app-group script containers), and it cannot be made universal because wrapped iOS apps keep their plist under `Wrapper/` and would all be lost.

## Verified on a real host

macOS 26.4, Apple silicon, against the provider built from this branch:

| | packages reported | Docker rows |
|---|---|---|
| released provider | 392 | 5 |
| this branch | **375** | **1** (`Docker` 4.89.0) |

The 17 dropped rows are exactly the 6 non-`.app` extensions plus the 12 nested-in-`Contents/` bundles, less one the plist gate already caught.

## Behavior change worth calling out

`/System/Library/Services/*.service` bundles (`Spotlight`, `AppleSpell`, `SpeechService`, `OpenSpell`) are no longer reported. They are real bundles, but they are not applications and cannot be remediated independently of the OS. Same for Finder's five `Contents/Applications` pseudo-apps (`AirDrop`, `Computer`, `Network`, `Recents`, `iCloud Drive`), which were previously reported at the macOS version.

One thing for downstream consumers that map several macOS bundles to a single product: on a clean install `system_profiler` reports only `/Applications/Docker.app`, so sibling rows such as `Docker Desktop` and `DockerHelper` appear to have come from hosts carrying a stale copy on disk. Those will stop matching once this ships.

## Tests

- `TestIsApplicationBundlePath` — table test over the real path shapes observed on the host, including the absent, uppercase-extension and `TableOfContents` cases.
- `TestMacOsXPackageParser` — the fixture now carries the full `Docker.app.back` family, a Finder pseudo-app and a `.service` bundle alongside the real `/Applications/Docker.app`. It asserts the **version** that survives, not just the name, because reporting 4.88.1 is the user-visible bug.

## Not addressed here

`available` is empty on every macOS application, so `outdated` evaluates `false` fleet-wide — `MacOSPkgManager.Available()` returns an error by design. That needs an update source (Homebrew, App Store, Sparkle feeds) and is a separate piece of work.
