### PR TITLE
🐛 digitalocean: teams reads empty when the token cannot see them

### DIFF
--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -101,6 +101,10 @@ digitalocean {
   // Account billing balance and month-to-date usage
   billing() digitalocean.billing
   // Teams belonging to the organization the token is scoped to
+  //
+  // Null when the token carries no organization context, since that
+  // establishes only that the teams cannot be read, not that there are
+  // none. An empty list means the organization was read and has no teams.
   teams() []digitalocean.team
 }
 

--- a/providers/digitalocean/resources/digitalocean_organizations.go
+++ b/providers/digitalocean/resources/digitalocean_organizations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/providers/digitalocean/connection"
 )
 
@@ -45,12 +46,13 @@ type organizationTeamsRoot struct {
 }
 
 // noOrganizationContext reports the answers that mean this token has no
-// organization to enumerate, rather than that the read failed.
+// organization context, so the teams cannot be enumerated.
 //
-// The endpoint "must be called in an organization context", so a token scoped
-// to a plain account is not a failure to report: it is an account with no
-// teams. A 401 is deliberately excluded, since a rejected token is a real
-// problem and must not be laundered into an empty list.
+// The endpoint "must be called in an organization context". A token without
+// that context does not establish that the organization has no teams - only
+// that this token may not read them, which is a different fact and must not be
+// reported as an empty list. A 401 is excluded because a rejected token is a
+// plain failure that should surface as an error.
 func noOrganizationContext(err error) bool {
 	var er *godo.ErrorResponse
 	if !errors.As(err, &er) || er.Response == nil {
@@ -80,8 +82,20 @@ func (r *mqlDigitalocean) teams() ([]interface{}, error) {
 	root := new(organizationTeamsRoot)
 	if _, err := client.Do(ctx, req, root); err != nil {
 		if noOrganizationContext(err) {
-			log.Debug().Err(err).Msg("digitalocean> token is not scoped to an organization; reporting no teams")
-			return []interface{}{}, nil
+			// Null, not an empty list. An empty list is an answer - "this
+			// organization has no teams" - and `.none()` / `.all()` over it
+			// pass vacuously, so a token that may not read the teams would
+			// silently satisfy every assertion about them. Null carries no
+			// answer and fails those assertions closed.
+			//
+			// Setting the state proactively is required: returning nil from a
+			// list accessor still serializes as [], because the runtime cannot
+			// tell a nil slice from an empty one. plugin.GetOrCompute only
+			// keeps this value because IsSet() is checked after the accessor
+			// runs.
+			log.Debug().Err(err).Msg("digitalocean> token is not scoped to an organization; teams are unknown")
+			r.Teams.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/providers/digitalocean/resources/digitalocean_organizations_test.go
+++ b/providers/digitalocean/resources/digitalocean_organizations_test.go
@@ -20,19 +20,20 @@ func doErr(status int) error {
 	}
 }
 
-// The teams endpoint must be called in an organization context, so a token
-// scoped to a plain account has no teams to enumerate rather than a failed
-// read. A rejected token is a different thing entirely and must not be
-// laundered into an empty list.
+// The teams endpoint must be called in an organization context. A token
+// without that context cannot read the teams, which the accessor reports as
+// null rather than as an empty list - an empty list is an answer, and
+// `.none()` over it passes vacuously. A rejected token (401) is a plain
+// failure and stays an error.
 func TestNoOrganizationContext(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		err  error
 		want bool
 	}{
-		{"forbidden means no organization", doErr(http.StatusForbidden), true},
-		{"not found means no organization", doErr(http.StatusNotFound), true},
-		{"precondition failed means no organization", doErr(http.StatusPreconditionFailed), true},
+		{"forbidden means the teams are unreadable", doErr(http.StatusForbidden), true},
+		{"not found means the teams are unreadable", doErr(http.StatusNotFound), true},
+		{"precondition failed means the teams are unreadable", doErr(http.StatusPreconditionFailed), true},
 
 		{"an unauthorized token is a real problem", doErr(http.StatusUnauthorized), false},
 		{"a rate limit is transient", doErr(http.StatusTooManyRequests), false},

--- a/providers/digitalocean/resources/digitalocean_teams_null_test.go
+++ b/providers/digitalocean/resources/digitalocean_teams_null_test.go
@@ -1,0 +1,96 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/digitalocean/connection"
+)
+
+// teamsRuntime points a real connection at a server that answers the
+// organization teams endpoint with the given status and body.
+func teamsRuntime(t *testing.T, status int, body string) *plugin.Runtime {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v2/organizations/teams", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("DIGITALOCEAN_TOKEN", "test-token")
+	conn, err := connection.NewDigitaloceanConnection(0, &inventory.Asset{},
+		&inventory.Config{Options: map[string]string{}})
+	require.NoError(t, err)
+
+	base, err := url.Parse(srv.URL + "/")
+	require.NoError(t, err)
+	conn.Client().BaseURL = base
+
+	return &plugin.Runtime{Connection: conn}
+}
+
+// TestTeamsUnreadableIsNull pins the distinction the accessor exists to make.
+//
+// A token with no organization context cannot read the teams. That is not the
+// same fact as "this organization has no teams", and reporting it as an empty
+// list is worse than useless: `.none()` and `.all()` over an empty list are
+// vacuously true, so every assertion about teams passes on an account nobody
+// was allowed to look at. Null carries no answer and fails those closed.
+//
+// The state has to be set proactively. Returning a nil slice is not enough -
+// the runtime cannot tell a nil slice from an empty one and serializes both as
+// [], which is exactly how this shipped.
+func TestTeamsUnreadableIsNull(t *testing.T) {
+	for _, status := range []int{
+		http.StatusForbidden,
+		http.StatusNotFound,
+		http.StatusPreconditionFailed,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			r := &mqlDigitalocean{MqlRuntime: teamsRuntime(t, status,
+				`{"id":"forbidden","message":"You are not authorized to perform this operation"}`)}
+
+			out, err := r.teams()
+
+			require.NoError(t, err, "an unreadable teams list is not a scan failure")
+			assert.Nil(t, out)
+			assert.Equal(t, plugin.StateIsSet|plugin.StateIsNull, r.Teams.State,
+				"unreadable teams must be null; an empty list would pass .none() vacuously")
+		})
+	}
+}
+
+// A read that succeeded and found nothing is a real answer, and has to stay an
+// empty list - turning it into null would fail assertions that should pass.
+func TestTeamsEmptyStaysEmpty(t *testing.T) {
+	r := &mqlDigitalocean{MqlRuntime: teamsRuntime(t, http.StatusOK, `{"teams":[]}`)}
+
+	out, err := r.teams()
+
+	require.NoError(t, err)
+	assert.NotNil(t, out, "a successful read with no teams is [], not null")
+	assert.Empty(t, out)
+	assert.Equal(t, plugin.State(0), r.Teams.State,
+		"the accessor must not pre-mark the field when it has a real answer")
+}
+
+// A rejected token is a plain failure and must surface as one.
+func TestTeamsUnauthorizedIsError(t *testing.T) {
+	r := &mqlDigitalocean{MqlRuntime: teamsRuntime(t, http.StatusUnauthorized,
+		`{"id":"unauthorized","message":"Unable to authenticate you"}`)}
+
+	_, err := r.teams()
+
+	require.Error(t, err, "401 must not be laundered into null or an empty list")
+}


### PR DESCRIPTION
## What

`digitalocean.teams` returned an **empty list** when the organization teams endpoint refused the token.

An empty list is an *answer* — "this organization has no teams" — and `.none()` / `.all()` over it are vacuously true. So every assertion about teams passed on an account nobody was allowed to look at.

## The evidence

Against a live account whose token carries no organization context:

```
GET /v2/organizations/teams  ->  403 "You are not authorized to perform this operation"
GET /v2/teams                ->  {"teams":[{"name":"My Team", ...}]}
```

The account demonstrably **has** a team, while the resource reported none.

## The fix

Report null. Null carries no answer and fails those assertions closed.

| case | before | after |
|---|---|---|
| 403 / 404 / 412 — cannot read | `[]` | **null** |
| 200 with no teams — a real answer | `[]` | `[]` (unchanged) |
| 401 — rejected token | error | error (unchanged) |

A/B against the same live account, two `PROVIDERS_PATH` builds:

```
main:  digitalocean.teams  ->  []
fix:   digitalocean.teams  ->  null

main:  digitalocean.teams.none(name == 'unexpected')  ->  [ok] value: true
fix:   digitalocean.teams.none(name == 'unexpected')  ->  [failed] [].none()
```

That flip is the whole change: a check that silently passed now fails closed.

## Why the state is set explicitly

`r.Teams.State = plugin.StateIsSet | plugin.StateIsNull` is required, not stylistic. Returning a nil slice still serializes as `[]` — the runtime cannot distinguish a nil slice from an empty one, and `plugin.GetOrCompute` only preserves the null because `IsSet()` is checked *after* the accessor returns. Without the assignment this fix would look correct and change nothing.

## Consistency

This is the same distinction the provider already draws one commit earlier, in `c624de7af` — *"stop reporting an unread Spaces bucket as a clean one"*. The two answered the same question differently; this aligns them.

## Test

`digitalocean_teams_null_test.go` drives the accessor against an `httptest` server through a real connection, pinning all three behaviours: unreadable → null (403/404/412), successful-and-empty → `[]`, 401 → error.

Confirmed it fails against the old behaviour:

```
--- FAIL: TestTeamsUnreadableIsNull/Forbidden
    expected: 0x3
    actual  : 0x0
    Messages: unreadable teams must be null; an empty list would pass .none() vacuously
```

Found while verifying the v13→v14 provider diff against live infrastructure.
