### PR TITLE
🧹 ci: move Go to 1.26.8

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,2 +1,2 @@
-golang-version=1.26.6
+golang-version=1.26.8
 protoc-version=33.x

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.mondoo.com/mql
 
-go 1.26.6
+go 1.26.8
 
 require (
 	cloud.google.com/go/logging v1.13.1

--- a/providers/activedirectory/go.mod
+++ b/providers/activedirectory/go.mod
@@ -1,6 +1,6 @@
 module go.mondoo.com/mql/providers/activedirectory
 
-go 1.26.6
+go 1.26.8
 
 replace go.mondoo.com/mql => ../..
 

--- a/providers/alicloud/go.mod
+++ b/providers/alicloud/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/alicloud
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/alibabacloud-go/actiontrail-20200706/v3 v3.5.0

--- a/providers/ansible/go.mod
+++ b/providers/ansible/go.mod
@@ -1,6 +1,6 @@
 module go.mondoo.com/mql/providers/ansible
 
-go 1.26.6
+go 1.26.8
 
 replace go.mondoo.com/mql => ../..
 

--- a/providers/arista/go.mod
+++ b/providers/arista/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/arista
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/aristanetworks/goeapi v1.0.0

--- a/providers/artifactory/go.mod
+++ b/providers/artifactory/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/artifactory
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/rs/zerolog v1.35.1

--- a/providers/atlassian/go.mod
+++ b/providers/atlassian/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/atlassian
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/cockroachdb/errors v1.14.0

--- a/providers/auth0/go.mod
+++ b/providers/auth0/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/auth0
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/auth0/go-auth0 v1.48.0

--- a/providers/aws/go.mod
+++ b/providers/aws/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/aws
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.45.1

--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/azure
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.23.1

--- a/providers/bicep/go.mod
+++ b/providers/bicep/go.mod
@@ -1,6 +1,6 @@
 module go.mondoo.com/mql/providers/bicep
 
-go 1.26.6
+go 1.26.8
 
 replace go.mondoo.com/mql => ../..
 

--- a/providers/bitwarden/go.mod
+++ b/providers/bitwarden/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/bitwarden
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/cockroachdb/errors v1.14.0

--- a/providers/cassandra/go.mod
+++ b/providers/cassandra/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/cassandra
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/gocql/gocql v1.7.0

--- a/providers/claude/go.mod
+++ b/providers/claude/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/claude
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.68.0

--- a/providers/clickhousecloud/go.mod
+++ b/providers/clickhousecloud/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/clickhousecloud
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	go.mondoo.com/mql v0.0.0-20260831061709-d8437f66ebc6

--- a/providers/clickhousedb/go.mod
+++ b/providers/clickhousedb/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/clickhousedb
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.48.0

--- a/providers/cloudflare/go.mod
+++ b/providers/cloudflare/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/cloudflare
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/cloudflare/cloudflare-go/v7 v7.9.0

--- a/providers/cloudformation/go.mod
+++ b/providers/cloudformation/go.mod
@@ -1,6 +1,6 @@
 module go.mondoo.com/mql/providers/cloudformation
 
-go 1.26.6
+go 1.26.8
 
 replace go.mondoo.com/mql => ../..
 

--- a/providers/databricks/go.mod
+++ b/providers/databricks/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/databricks
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/databricks/databricks-sdk-go v0.177.0

--- a/providers/datadog/go.mod
+++ b/providers/datadog/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/datadog
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.64.0

--- a/providers/depsdev/go.mod
+++ b/providers/depsdev/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/depsdev
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/cockroachdb/errors v1.14.0

--- a/providers/digitalocean/go.mod
+++ b/providers/digitalocean/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/digitalocean
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.45.1

--- a/providers/dropbox/go.mod
+++ b/providers/dropbox/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/dropbox
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/cockroachdb/errors v1.14.0

--- a/providers/elasticsearch/go.mod
+++ b/providers/elasticsearch/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/elasticsearch
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/elastic/elastic-transport-go/v8 v8.11.0

--- a/providers/gcp/go.mod
+++ b/providers/gcp/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/gcp
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	cloud.google.com/go/accessapproval v1.13.0

--- a/providers/github/go.mod
+++ b/providers/github/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/github
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.19.0

--- a/providers/gitlab/go.mod
+++ b/providers/gitlab/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/gitlab
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/rs/zerolog v1.35.1

--- a/providers/google-workspace/go.mod
+++ b/providers/google-workspace/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/google-workspace
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/providers/grafana/go.mod
+++ b/providers/grafana/go.mod
@@ -1,6 +1,6 @@
 module go.mondoo.com/mql/providers/grafana
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/hashicorp/go-retryablehttp v0.7.8

--- a/providers/hcp/go.mod
+++ b/providers/hcp/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/hcp
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/go-openapi/runtime v0.33.1

--- a/providers/helm/go.mod
+++ b/providers/helm/go.mod
@@ -1,6 +1,6 @@
 module go.mondoo.com/mql/providers/helm
 
-go 1.26.6
+go 1.26.8
 
 replace go.mondoo.com/mql => ../..
 

--- a/providers/hetzner/go.mod
+++ b/providers/hetzner/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/hetzner
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/hetznercloud/hcloud-go/v2 v2.47.0

--- a/providers/huggingface/go.mod
+++ b/providers/huggingface/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/huggingface
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/providers/ipinfo/go.mod
+++ b/providers/ipinfo/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/ipinfo
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/cockroachdb/errors v1.14.0

--- a/providers/ipmi/go.mod
+++ b/providers/ipmi/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/ipmi
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/providers/iru/go.mod
+++ b/providers/iru/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/iru
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/rs/zerolog v1.35.1

--- a/providers/jamf/go.mod
+++ b/providers/jamf/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/jamf
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/deploymenttheory/go-api-sdk-jamfpro v1.53.0

--- a/providers/jumpcloud/go.mod
+++ b/providers/jumpcloud/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/jumpcloud
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/rs/zerolog v1.35.1

--- a/providers/k8s/go.mod
+++ b/providers/k8s/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/k8s
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/cockroachdb/errors v1.14.0

--- a/providers/keycloak/go.mod
+++ b/providers/keycloak/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/keycloak
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/rs/zerolog v1.35.1

--- a/providers/kustomize/go.mod
+++ b/providers/kustomize/go.mod
@@ -1,6 +1,6 @@
 module go.mondoo.com/mql/providers/kustomize
 
-go 1.26.6
+go 1.26.8
 
 replace go.mondoo.com/mql => ../..
 

--- a/providers/mikrotik/go.mod
+++ b/providers/mikrotik/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/mikrotik
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/go-routeros/routeros/v3 v3.0.1

--- a/providers/mistral/go.mod
+++ b/providers/mistral/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/mistral
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/providers/mondoo/go.mod
+++ b/providers/mondoo/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/mondoo
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/providers/mongo/go.mod
+++ b/providers/mongo/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/mongo
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	go.mondoo.com/mql v0.0.0-20260831061709-d8437f66ebc6

--- a/providers/mongodbatlas/go.mod
+++ b/providers/mongodbatlas/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/mongodbatlas
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/providers/ms365/go.mod
+++ b/providers/ms365/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/ms365
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.23.1

--- a/providers/mssql/go.mod
+++ b/providers/mssql/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/mssql
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/microsoft/go-mssqldb v1.11.0

--- a/providers/mysqldb/go.mod
+++ b/providers/mysqldb/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/mysqldb
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/go-sql-driver/mysql v1.10.0

--- a/providers/neon/go.mod
+++ b/providers/neon/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/neon
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/rs/zerolog v1.35.1

--- a/providers/netlify/go.mod
+++ b/providers/netlify/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/netlify
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/rs/zerolog v1.35.1

--- a/providers/nextdns/go.mod
+++ b/providers/nextdns/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/nextdns
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/providers/nmap/go.mod
+++ b/providers/nmap/go.mod
@@ -1,6 +1,6 @@
 module go.mondoo.com/mql/providers/nmap
 
-go 1.26.6
+go 1.26.8
 
 replace go.mondoo.com/mql => ../..
 

--- a/providers/nutanix/go.mod
+++ b/providers/nutanix/go.mod
@@ -18,7 +18,7 @@ replace (
 	github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4 => github.com/nutanix/ntnx-api-golang-clients/volumes-go-client/v4 v4.0.1
 )
 
-go 1.26.6
+go 1.26.8
 
 require (
 	// pin v4.0.2

--- a/providers/oci/go.mod
+++ b/providers/oci/go.mod
@@ -1,6 +1,6 @@
 module go.mondoo.com/mql/providers/oci
 
-go 1.26.6
+go 1.26.8
 
 replace go.mondoo.com/mql => ../..
 

--- a/providers/okta/go.mod
+++ b/providers/okta/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/okta
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/okta/okta-sdk-golang/v6 v6.1.7

--- a/providers/ollama/go.mod
+++ b/providers/ollama/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/ollama
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/ollama/ollama v0.33.2

--- a/providers/opcua/go.mod
+++ b/providers/opcua/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/opcua
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/gopcua/opcua v0.9.1

--- a/providers/openai/go.mod
+++ b/providers/openai/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/openai
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/openai/openai-go/v3 v3.54.0

--- a/providers/opensearch/go.mod
+++ b/providers/opensearch/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/opensearch
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/opensearch-project/opensearch-go/v4 v4.7.3

--- a/providers/openstack/go.mod
+++ b/providers/openstack/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/openstack
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/gophercloud/gophercloud/v2 v2.14.0

--- a/providers/portainer/go.mod
+++ b/providers/portainer/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/portainer
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/go-openapi/runtime v0.33.1

--- a/providers/postgresdb/go.mod
+++ b/providers/postgresdb/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/postgresdb
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/jackc/pgx/v5 v5.10.0

--- a/providers/proxmox/go.mod
+++ b/providers/proxmox/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/proxmox
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/rs/zerolog v1.35.1

--- a/providers/redfish/go.mod
+++ b/providers/redfish/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/redfish
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/rs/zerolog v1.35.1

--- a/providers/redisdb/go.mod
+++ b/providers/redisdb/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/redisdb
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/redis/go-redis/v9 v9.22.0

--- a/providers/shodan/go.mod
+++ b/providers/shodan/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/shodan
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/rs/zerolog v1.35.1

--- a/providers/slack/go.mod
+++ b/providers/slack/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/slack
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/hashicorp/go-retryablehttp v0.7.8

--- a/providers/snowflake/go.mod
+++ b/providers/snowflake/go.mod
@@ -7,7 +7,7 @@ replace go.mondoo.com/mql => ../..
 // Drop this once the next upstream release ships the fix.
 replace github.com/apache/thrift => github.com/apache/thrift v0.22.0
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/Snowflake-Labs/terraform-provider-snowflake v1.2.3

--- a/providers/stackit/go.mod
+++ b/providers/stackit/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/stackit
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/rs/zerolog v1.35.1

--- a/providers/tailscale/go.mod
+++ b/providers/tailscale/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/tailscale
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/cockroachdb/errors v1.14.0

--- a/providers/terraform/go.mod
+++ b/providers/terraform/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/terraform
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/hashicorp/hcl/v2 v2.24.0

--- a/providers/together/go.mod
+++ b/providers/together/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/together
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/providers/vcd/go.mod
+++ b/providers/vcd/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/vcd
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/rs/zerolog v1.35.1

--- a/providers/vercel/go.mod
+++ b/providers/vercel/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/vercel
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require go.mondoo.com/mql v0.0.0-20260831061709-d8437f66ebc6
 

--- a/providers/vllm/go.mod
+++ b/providers/vllm/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/vllm
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/stretchr/testify v1.12.1

--- a/providers/vsphere/go.mod
+++ b/providers/vsphere/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/vsphere
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/facebookincubator/nvdtools v0.1.5

--- a/providers/weaviate/go.mod
+++ b/providers/weaviate/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/weaviate
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/weaviate/weaviate-go-client/v5 v5.7.3

--- a/providers/zoom/go.mod
+++ b/providers/zoom/go.mod
@@ -2,7 +2,7 @@ module go.mondoo.com/mql/providers/zoom
 
 replace go.mondoo.com/mql => ../..
 
-go 1.26.6
+go 1.26.8
 
 require (
 	github.com/cockroachdb/errors v1.14.0


### PR DESCRIPTION
Moves the Go pin from **1.26.6 to 1.26.8**, the current 1.26 patch release.

The version lives in two places, and they have to move together:

| where | what |
|---|---|
| `.github/env` | `golang-version`, installed verbatim by every `setup-go` step across 11 workflows since #10217 dropped the `>=` |
| `go.mod` × 79 | the `go` directive in every module in the tree |

The three `providers/os/resources/languages/golang/gomod/testdata/*.go.mod` files are parser fixtures for the golang gomod resource, not modules, and are deliberately left at `go 1.20`/`go 1.21`.

### What's in the two upstream patches

Both are bug-fix only. Neither carries a security advisory.

- **go1.26.7** (2026-08-19) fixes to `net/http`
- **go1.26.8** (2026-09-01) fixes to cgo, the compiler, the runtime, and the `debug/elf` and `os` packages

`debug/elf` is the one with a consumer here: `providers/os/detector` parses ELF headers for architecture detection. cgo is not a factor, builds set `CGO_ENABLED=0`.

### Staying inside 1.26 is deliberate

#10217 pinned CI exactly because Go 1.27 drifted in on its own and turned two jobs red. Both of those are *minor*-version boundaries rather than patch ones, so a 1.26.6 → 1.26.8 move should not reach them. Re-checked rather than assumed:

- `llx TestRawDataJson_Umlauts` — **passes**. Go 1.27 changed how `encoding/json` escapes U+FFFD; 1.26.8 does not.
- `golangci-lint run ./utils/syncx/...` — **0 issues**. 2.12.2 reads 1.26.8 export data fine; it could not read 1.27's (`export data version 4 is greater than maximum supported version 2`), and `utils/syncx/map.go` was the file it invented typecheck errors in.

### Verification

All under `GOTOOLCHAIN=go1.26.8`:

- `go build ./...` — clean
- `make test/go/plain` — green (after `make test/generate`; the mockgen output is gitignored)
- `go test ./providers/os/detector/...` — green, the `debug/elf` consumer
- `make providers/build/{aws,azure,k8s}` — all build, permissions manifests reported **unchanged** (aws 1040, azure 343)

The diff is exactly two kinds of line, and nothing else:

```
-go 1.26.6                 +go 1.26.8
-golang-version=1.26.6     +golang-version=1.26.8
```

### Out of scope

`.devcontainer/Dockerfile` pins `ARG VARIANT="1.19-bullseye"` against `mcr.microsoft.com/vscode/devcontainers/go:1-${VARIANT}`. That looks stale and unrelated to the CI pin, so it is left alone here rather than folded into a version bump.
