### PR TITLE
🐛 os: backport the macOS reporting fixes to v13

### DIFF
--- a/providers/os/id/hypervisor/darwin_h.go
+++ b/providers/os/id/hypervisor/darwin_h.go
@@ -40,10 +40,42 @@ func (h *hyper) detectDarwinIOReg() (string, bool) {
 }
 
 // detectDarwinModelIdentifier uses system_profiler to detect virtualization.
+//
+// Only the model fields are matched, never the whole hardware profile. The
+// profile of a physical Mac carries the vendor name in several unrelated
+// places ("Chip: Apple M4 Pro"), and matching against all of it made every
+// Apple Silicon Mac report the "apple" key and come back as Apple
+// Virtualization. A guest names its hypervisor in the model itself --
+// "Apple Virtual Machine 1", "VMware Virtual Platform", "VirtualBox" -- so
+// those two lines carry the whole signal.
 func (h *hyper) detectDarwinModelIdentifier() (string, bool) {
 	stdout, err := h.RunCommand("system_profiler SPHardwareDataType")
 	if err != nil {
 		return "", false
 	}
-	return mapHypervisor(stdout)
+	return mapHypervisor(darwinHardwareModel(stdout))
+}
+
+// darwinHardwareModelKeys are the SPHardwareDataType labels whose values name
+// the machine. A hypervisor announces itself in one of them or not at all.
+var darwinHardwareModelKeys = []string{"Model Name", "Model Identifier"}
+
+// darwinHardwareModel returns the model values from SPHardwareDataType output,
+// joined by a newline so a key cannot match across two of them.
+func darwinHardwareModel(stdout string) string {
+	var models []string
+	for _, line := range strings.Split(stdout, "\n") {
+		label, value, found := strings.Cut(line, ":")
+		if !found {
+			continue
+		}
+		label = strings.TrimSpace(label)
+		for _, key := range darwinHardwareModelKeys {
+			if label == key {
+				models = append(models, strings.TrimSpace(value))
+				break
+			}
+		}
+	}
+	return strings.Join(models, "\n")
 }

--- a/providers/os/id/hypervisor/darwin_h_test.go
+++ b/providers/os/id/hypervisor/darwin_h_test.go
@@ -1,0 +1,78 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package hypervisor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A physical Apple Silicon Mac names the vendor in fields that have nothing to
+// do with virtualization ("Chip: Apple M4 Pro"). Matching the whole hardware
+// profile picked up the "apple" key and reported every such Mac as running
+// under Apple Virtualization, which also made the asset kind "virtualmachine".
+const physicalAppleSiliconProfile = `Hardware:
+
+    Hardware Overview:
+
+      Model Name: MacBook Pro
+      Model Identifier: Mac16,8
+      Model Number: MX2J3LL/A
+      Chip: Apple M4 Pro
+      Total Number of Cores: 14 (10 Performance and 4 Efficiency)
+      Memory: 24 GB
+      System Firmware Version: 18000.121.3
+      OS Loader Version: 18000.121.3
+      Serial Number (system): DWKDWYVG4W
+      Hardware UUID: 33822EE1-9366-5120-A0B1-6CCC4D8031FA
+      Provisioning UDID: 00006040-000C31D03EF8801C
+      Activation Lock Status: Disabled
+`
+
+const appleVirtualMachineProfile = `Hardware:
+
+    Hardware Overview:
+
+      Model Name: Apple Virtual Machine 1
+      Model Identifier: VirtualMac2,1
+      Chip: Apple M4 Pro
+      Memory: 8 GB
+`
+
+const vmwareGuestProfile = `Hardware:
+
+    Hardware Overview:
+
+      Model Name: VMware Virtual Platform
+      Model Identifier: VMware7,1
+      Processor Name: Intel Core i7
+`
+
+func TestDarwinHardwareModelIgnoresNonModelFields(t *testing.T) {
+	assert.Equal(t, "MacBook Pro\nMac16,8", darwinHardwareModel(physicalAppleSiliconProfile))
+	assert.Equal(t, "Apple Virtual Machine 1\nVirtualMac2,1", darwinHardwareModel(appleVirtualMachineProfile))
+}
+
+func TestMapHypervisorPhysicalMacIsNotVirtual(t *testing.T) {
+	v, ok := mapHypervisor(darwinHardwareModel(physicalAppleSiliconProfile))
+	assert.False(t, ok, "a physical Mac must not be reported as virtualized, got %q", v)
+	assert.Empty(t, v)
+}
+
+func TestMapHypervisorDarwinGuests(t *testing.T) {
+	for name, tt := range map[string]struct {
+		profile string
+		want    string
+	}{
+		"apple virtualization": {appleVirtualMachineProfile, "Apple Virtualization"},
+		"vmware fusion":        {vmwareGuestProfile, "VMware"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			v, ok := mapHypervisor(darwinHardwareModel(tt.profile))
+			assert.True(t, ok, "guest must still be detected")
+			assert.Equal(t, tt.want, v)
+		})
+	}
+}

--- a/providers/os/resources/macos_alf.go
+++ b/providers/os/resources/macos_alf.go
@@ -14,9 +14,19 @@ import (
 	"go.mondoo.com/mql/v13/types"
 )
 
+// alfPlistLocations holds the ALF preferences file, which is where the
+// firewall settings were stored through macOS 14.
+//
+// /usr/libexec/ApplicationFirewall/com.apple.alf.plist is deliberately NOT
+// listed. That file is the factory-default template the OS ships with, not
+// live state: it is owned by root inside a SIP-protected directory and always
+// reads globalstate 0 / stealthenabled 0. Recent macOS releases no longer
+// write /Library/Preferences/com.apple.alf.plist at all, so treating the
+// template as a fallback reported the firewall as disabled with stealth mode
+// off on every such machine, whatever the firewall was actually doing.
+// macos.firewall reads the live state from socketfilterfw instead.
 var alfPlistLocations = []string{
 	"/Library/Preferences/com.apple.alf.plist",
-	"/usr/libexec/ApplicationFirewall/com.apple.alf.plist",
 }
 
 func initMacosAlf(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/os/resources/macos_firewall.go
+++ b/providers/os/resources/macos_firewall.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
@@ -69,7 +68,12 @@ func (m *mqlMacosFirewall) fetchConfig() (plist.Data, error) {
 	}
 
 	if plistLocation == "" {
-		return nil, errors.New("ALF configuration not found")
+		// No preferences file. Modern macOS stops writing one; the live state
+		// is read from socketfilterfw instead. Cache the empty result so the
+		// lookup is not repeated per field.
+		m.fetched = true
+		m.config = nil
+		return nil, nil
 	}
 
 	f, err := fs.Open(plistLocation)
@@ -93,11 +97,18 @@ func (m *mqlMacosFirewall) globalState() (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	v, err := alfConfigFloat(config, "globalstate")
+	if v, err := alfConfigFloat(config, "globalstate"); err == nil {
+		return int64(v), nil
+	}
+
+	stdout, err := m.runSocketfilterfw("--getglobalstate")
 	if err != nil {
 		return 0, err
 	}
-	return int64(v), nil
+	if v, ok := parseGlobalState(stdout); ok {
+		return v, nil
+	}
+	return 0, errFirewallStateUnavailable
 }
 
 func (m *mqlMacosFirewall) enabled() (bool, error) {
@@ -121,11 +132,18 @@ func (m *mqlMacosFirewall) stealthEnabled() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	v, err := alfConfigFloat(config, "stealthenabled")
+	if v, err := alfConfigFloat(config, "stealthenabled"); err == nil {
+		return int64(v) != 0, nil
+	}
+
+	stdout, err := m.runSocketfilterfw("--getstealthmode")
 	if err != nil {
 		return false, err
 	}
-	return int64(v) != 0, nil
+	if v, ok := parseOnOff(stdout); ok {
+		return v, nil
+	}
+	return false, errFirewallStateUnavailable
 }
 
 func (m *mqlMacosFirewall) loggingEnabled() (bool, error) {
@@ -133,11 +151,18 @@ func (m *mqlMacosFirewall) loggingEnabled() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	v, err := alfConfigFloat(config, "loggingenabled")
+	if v, err := alfConfigFloat(config, "loggingenabled"); err == nil {
+		return int64(v) != 0, nil
+	}
+
+	stdout, err := m.runSocketfilterfw("--getloggingmode")
 	if err != nil {
 		return false, err
 	}
-	return int64(v) != 0, nil
+	if v, ok := parseOnOff(stdout); ok {
+		return v, nil
+	}
+	return false, errFirewallStateUnavailable
 }
 
 func (m *mqlMacosFirewall) loggingDetail() (string, error) {
@@ -164,27 +189,37 @@ func (m *mqlMacosFirewall) loggingDetail() (string, error) {
 }
 
 func (m *mqlMacosFirewall) allowSignedApps() (bool, error) {
-	config, err := m.fetchConfig()
-	if err != nil {
-		return false, err
-	}
-	v, err := alfConfigFloat(config, "allowsignedenabled")
-	if err != nil {
-		return false, err
-	}
-	return int64(v) != 0, nil
+	return m.signedAppsFlag("allowsignedenabled", false)
 }
 
 func (m *mqlMacosFirewall) allowDownloadSignedApps() (bool, error) {
+	return m.signedAppsFlag("allowdownloadsignedenabled", true)
+}
+
+// signedAppsFlag reads one of the two auto-allow toggles. socketfilterfw
+// reports both in a single --getallowsigned reply, so `downloaded` picks the
+// line rather than the command.
+func (m *mqlMacosFirewall) signedAppsFlag(plistKey string, downloaded bool) (bool, error) {
 	config, err := m.fetchConfig()
 	if err != nil {
 		return false, err
 	}
-	v, err := alfConfigFloat(config, "allowdownloadsignedenabled")
+	if v, err := alfConfigFloat(config, plistKey); err == nil {
+		return int64(v) != 0, nil
+	}
+
+	stdout, err := m.runSocketfilterfw("--getallowsigned")
 	if err != nil {
 		return false, err
 	}
-	return int64(v) != 0, nil
+	builtin, download, ok := parseAllowSigned(stdout)
+	if !ok {
+		return false, errFirewallStateUnavailable
+	}
+	if downloaded {
+		return download, nil
+	}
+	return builtin, nil
 }
 
 func (m *mqlMacosFirewall) version() (string, error) {

--- a/providers/os/resources/macos_firewall_live.go
+++ b/providers/os/resources/macos_firewall_live.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/v13/llx"
 )
 
 // socketfilterfw is Apple's command line front end for the application

--- a/providers/os/resources/macos_firewall_live.go
+++ b/providers/os/resources/macos_firewall_live.go
@@ -1,0 +1,123 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"go.mondoo.com/mql/llx"
+)
+
+// socketfilterfw is Apple's command line front end for the application
+// firewall. Its read-only getters work without root, and unlike the
+// preference plist it reports the state the firewall is actually running
+// with rather than what was last written to disk.
+const socketfilterfwPath = "/usr/libexec/ApplicationFirewall/socketfilterfw"
+
+// globalStateRegex pulls the numeric state out of `socketfilterfw
+// --getglobalstate`, which prints e.g. "Firewall is enabled. (State = 1)".
+// The number is the same value the plist stores under "globalstate": 0 off,
+// 1 on, 2 blocking all incoming connections.
+var globalStateRegex = regexp.MustCompile(`\(State\s*=\s*(\d+)\)`)
+
+// errFirewallStateUnavailable reports that neither source could answer. It is
+// deliberately an error rather than a false: "the firewall is off" and "we
+// could not read the firewall" are different findings, and reporting the
+// second as the first is how a disabled firewall passes an audit.
+var errFirewallStateUnavailable = errors.New(
+	"cannot determine application firewall state: no ALF preferences file and socketfilterfw did not return a readable answer")
+
+// runSocketfilterfw runs one socketfilterfw getter and returns its stdout.
+func (m *mqlMacosFirewall) runSocketfilterfw(flag string) (string, error) {
+	res, err := NewResource(m.MqlRuntime, "command", map[string]*llx.RawData{
+		"command": llx.StringData(socketfilterfwPath + " " + flag),
+	})
+	if err != nil {
+		return "", err
+	}
+	cmd := res.(*mqlCommand)
+	if exit := cmd.GetExitcode(); exit.Data != 0 {
+		return "", fmt.Errorf("socketfilterfw %s failed: %s", flag, cmd.GetStderr().Data)
+	}
+	return cmd.GetStdout().Data, nil
+}
+
+// parseGlobalState reads the numeric state out of --getglobalstate output.
+func parseGlobalState(stdout string) (int64, bool) {
+	if m := globalStateRegex.FindStringSubmatch(stdout); m != nil {
+		v, err := strconv.ParseInt(m[1], 10, 64)
+		if err == nil {
+			return v, true
+		}
+	}
+	// Older releases print the sentence without the "(State = N)" suffix.
+	switch {
+	case strings.Contains(stdout, "Firewall is enabled"):
+		return 1, true
+	case strings.Contains(stdout, "Firewall is disabled"):
+		return 0, true
+	}
+	return 0, false
+}
+
+// toggleOnRegex and toggleOffRegex anchor on the two sentence shapes
+// socketfilterfw uses for a toggle:
+//
+//	"Firewall stealth mode is on"                     (--getstealthmode)
+//	"Log mode is off"                                 (--getloggingmode)
+//	"Firewall has block all state set to disabled."   (--getblockall)
+//
+// They deliberately do not match a bare "enabled."/"disabled." anywhere in the
+// line. That suffix appears in replies that are not toggles at all -- the
+// --getallowsigned lines end in "signed software ENABLED." -- so accepting it
+// would let one getter's answer be read as another's.
+var (
+	toggleOnRegex  = regexp.MustCompile(`\bis on\b|\bset to enabled\b`)
+	toggleOffRegex = regexp.MustCompile(`\bis off\b|\bset to disabled\b`)
+)
+
+// parseOnOff reads a socketfilterfw toggle sentence. It returns ok=false for
+// anything it does not recognise -- notably the "settings cannot be modified
+// from command line on managed Mac computers" reply -- so an unreadable
+// setting surfaces as an error and never as a confident false.
+func parseOnOff(stdout string) (bool, bool) {
+	s := strings.ToLower(stdout)
+	if strings.Contains(s, "cannot be modified") {
+		return false, false
+	}
+	switch {
+	case toggleOnRegex.MatchString(s):
+		return true, true
+	case toggleOffRegex.MatchString(s):
+		return false, true
+	}
+	return false, false
+}
+
+// parseAllowSigned reads the two-line --getallowsigned reply:
+//
+//	Automatically allow built-in signed software ENABLED.
+//	Automatically allow downloaded signed software ENABLED.
+//
+// It returns the built-in and downloaded flags separately.
+func parseAllowSigned(stdout string) (builtin bool, downloaded bool, ok bool) {
+	var haveBuiltin, haveDownloaded bool
+	for _, line := range strings.Split(stdout, "\n") {
+		l := strings.ToLower(line)
+		if !strings.Contains(l, "signed software") {
+			continue
+		}
+		enabled := strings.Contains(l, "enabled")
+		if strings.Contains(l, "downloaded") {
+			downloaded, haveDownloaded = enabled, true
+		} else if strings.Contains(l, "built-in") {
+			builtin, haveBuiltin = enabled, true
+		}
+	}
+	return builtin, downloaded, haveBuiltin && haveDownloaded
+}

--- a/providers/os/resources/macos_firewall_live_test.go
+++ b/providers/os/resources/macos_firewall_live_test.go
@@ -1,0 +1,89 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseGlobalState(t *testing.T) {
+	for name, tt := range map[string]struct {
+		stdout string
+		want   int64
+		ok     bool
+	}{
+		"enabled":     {"Firewall is enabled. (State = 1)\n", 1, true},
+		"block all":   {"Firewall is enabled. (State = 2)\n", 2, true},
+		"disabled":    {"Firewall is disabled. (State = 0)\n", 0, true},
+		"no state no": {"Firewall is enabled.\n", 1, true},
+		"managed":     {"Firewall settings cannot be modified from command line on managed Mac computers.\n", 0, false},
+		"empty":       {"", 0, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			v, ok := parseGlobalState(tt.stdout)
+			assert.Equal(t, tt.ok, ok)
+			if tt.ok {
+				assert.Equal(t, tt.want, v)
+			}
+		})
+	}
+}
+
+// An unreadable setting must not collapse to false. "the firewall is off" and
+// "we could not read the firewall" are different findings.
+func TestParseOnOff(t *testing.T) {
+	for name, tt := range map[string]struct {
+		stdout string
+		want   bool
+		ok     bool
+	}{
+		"stealth on":     {"Firewall stealth mode is on\n", true, true},
+		"stealth off":    {"Firewall stealth mode is off\n", false, true},
+		"blockall on":    {"Firewall has block all state set to enabled.\n", true, true},
+		"blockall off":   {"Firewall has block all state set to disabled.\n", false, true},
+		"managed mac":    {"Firewall settings cannot be modified from command line on managed Mac computers.\n", false, false},
+		"unrecognised":   {"something else entirely\n", false, false},
+		"empty is not a": {"", false, false},
+		// A bare "enabled."/"disabled." is not a toggle answer. The
+		// --getallowsigned reply ends that way, and a logging line can too, so
+		// matching the suffix would let one getter be read as another.
+		"logging detail line": {"Logging enabled. Detail level: brief\n", false, false},
+		"allowsigned line":    {"Automatically allow built-in signed software ENABLED.\n", false, false},
+		// "is on" must be a whole word, not a prefix of something else.
+		"is one": {"Firewall stealth mode is one of several settings\n", false, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			v, ok := parseOnOff(tt.stdout)
+			assert.Equal(t, tt.ok, ok, "recognised")
+			if tt.ok {
+				assert.Equal(t, tt.want, v)
+			}
+		})
+	}
+}
+
+func TestParseAllowSigned(t *testing.T) {
+	builtin, downloaded, ok := parseAllowSigned(
+		"Automatically allow built-in signed software ENABLED. \n" +
+			"Automatically allow downloaded signed software ENABLED. \n")
+	assert.True(t, ok)
+	assert.True(t, builtin)
+	assert.True(t, downloaded)
+
+	builtin, downloaded, ok = parseAllowSigned(
+		"Automatically allow built-in signed software ENABLED. \n" +
+			"Automatically allow downloaded signed software DISABLED. \n")
+	assert.True(t, ok)
+	assert.True(t, builtin)
+	assert.False(t, downloaded)
+
+	// A partial reply must not be reported as two falses.
+	_, _, ok = parseAllowSigned("Automatically allow built-in signed software ENABLED. \n")
+	assert.False(t, ok)
+
+	_, _, ok = parseAllowSigned("Firewall settings cannot be modified from command line on managed Mac computers.\n")
+	assert.False(t, ok)
+}

--- a/providers/os/resources/macos_sharing.go
+++ b/providers/os/resources/macos_sharing.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"errors"
 	"strings"
 	"sync"
 
@@ -27,11 +28,14 @@ func (s *mqlMacosSharing) id() (string, error) {
 	return "macos.sharing", nil
 }
 
-// fetchState runs `system_profiler SPSharingDataType` once and
-// returns the parsed map of service name → enabled. Non-Darwin hosts
-// (or hosts where system_profiler is unreachable) get an empty map,
-// which surfaces as `false` on every accessor — fail-soft for
-// systems that simply don't have a Sharing panel.
+// fetchState runs `system_profiler SPSharingDataType` once and returns the
+// parsed map of service name → enabled.
+//
+// An empty map means the Sharing panel could not be read, not that every
+// service is off. macOS 26 dropped SPSharingDataType altogether -- the
+// command exits 0 and prints nothing -- so treating an empty result as
+// fail-soft reported every sharing service as disabled on those releases,
+// whatever was actually running. Callers turn the empty map into an error.
 func (s *mqlMacosSharing) fetchState() (map[string]bool, error) {
 	if s.fetched {
 		return s.state, nil
@@ -98,15 +102,26 @@ func parseSharingOutput(stdout string) map[string]bool {
 	return out
 }
 
-// sharingFlag returns the bool for one Sharing panel entry. Missing
-// entries (some macOS versions omit services that aren't installed,
-// e.g. DVD or CD Sharing on Apple Silicon) read as `false` — the
-// "service is not present" outcome is operationally equivalent to
-// "service is off" for audit purposes.
+// errSharingPanelUnavailable reports that the Sharing panel could not be read
+// at all. macOS 26 removed the SPSharingDataType reporter, and there is no
+// replacement in system_profiler, so this is the expected outcome there.
+var errSharingPanelUnavailable = errors.New(
+	"cannot read the Sharing panel: system_profiler has no SPSharingDataType reporter on this macOS release")
+
+// sharingFlag returns the bool for one Sharing panel entry.
+//
+// A panel that returned entries but not this one reads as `false`: some macOS
+// versions omit services that aren't installed (DVD or CD Sharing on Apple
+// Silicon), and "not present" is operationally the same as "off". A panel that
+// returned nothing at all is a different thing -- nothing was measured -- and
+// is reported as an error so it cannot be mistaken for "everything is off".
 func (s *mqlMacosSharing) sharingFlag(name string) (bool, error) {
 	state, err := s.fetchState()
 	if err != nil {
 		return false, err
+	}
+	if len(state) == 0 {
+		return false, errSharingPanelUnavailable
 	}
 	return state[name], nil
 }

--- a/providers/os/resources/macos_sharing_test.go
+++ b/providers/os/resources/macos_sharing_test.go
@@ -122,3 +122,13 @@ func TestParseSharingOutput_ExtraWhitespace(t *testing.T) {
 	_, ok := got["File Sharing"]
 	assert.False(t, ok, "missing colon-space separator means the line is not a key/value")
 }
+
+// macOS 26 removed the SPSharingDataType reporter: the command exits 0 and
+// prints nothing. That must not read as "every sharing service is off".
+func TestParseSharingOutputEmpty(t *testing.T) {
+	assert.Empty(t, parseSharingOutput(""))
+	assert.Empty(t, parseSharingOutput("\n\n"))
+	// A panel that did report keeps working, including entries it omits.
+	state := parseSharingOutput("Sharing:\n\n    Computer Name: My Mac\n    File Sharing: On\n    Screen Sharing: Off\n")
+	assert.Equal(t, map[string]bool{"File Sharing": true, "Screen Sharing": false}, state)
+}

--- a/providers/os/resources/macos_softwareupdate.go
+++ b/providers/os/resources/macos_softwareupdate.go
@@ -34,6 +34,7 @@ type mqlMacosSoftwareupdateInternal struct {
 
 type softwareupdateSettings struct {
 	autoCheckEnabled         bool
+	autoCheckKeyPresent      bool
 	autoDownloadEnabled      bool
 	autoInstallMacOSUpdates  bool
 	installSystemDataFiles   bool
@@ -108,6 +109,7 @@ func (s *mqlMacosSoftwareupdate) readSoftwareUpdatePlist() (softwareupdateSettin
 func parseSoftwareUpdateSettings(d map[string]any) softwareupdateSettings {
 	return softwareupdateSettings{
 		autoCheckEnabled:         boolFromPlist(d, "AutomaticCheckEnabled"),
+		autoCheckKeyPresent:      keyPresentInPlist(d, "AutomaticCheckEnabled"),
 		autoDownloadEnabled:      boolFromPlist(d, "AutomaticDownload"),
 		autoInstallMacOSUpdates:  boolFromPlist(d, "AutomaticallyInstallMacOSUpdates"),
 		installSystemDataFiles:   boolFromPlist(d, "ConfigDataInstall"),
@@ -116,9 +118,63 @@ func parseSoftwareUpdateSettings(d map[string]any) softwareupdateSettings {
 	}
 }
 
+// autoCheckEnabled reports whether macOS checks for updates on its own.
+//
+// The preference key is only written once someone changes the setting, and its
+// absence does not mean "off" -- automatic checking is on by default, so a Mac
+// that has never been touched reads as compliant while the plist says nothing.
+// When the key is missing, ask softwareupdate what the schedule actually is
+// rather than inferring a value from the silence.
 func (s *mqlMacosSoftwareupdate) autoCheckEnabled() (bool, error) {
 	v, err := s.fetchSettings()
-	return v.autoCheckEnabled, err
+	if err != nil {
+		return false, err
+	}
+	if v.autoCheckKeyPresent {
+		return v.autoCheckEnabled, nil
+	}
+	return s.scheduleEnabled()
+}
+
+// errUpdateScheduleUnavailable reports that neither source could answer.
+var errUpdateScheduleUnavailable = errors.New(
+	"cannot determine the software update schedule: AutomaticCheckEnabled is unset and `softwareupdate --schedule` did not return a readable answer")
+
+// scheduleEnabled parses `softwareupdate --schedule`, which prints
+// "Automatic checking for updates is turned on" or "... turned off".
+func (s *mqlMacosSoftwareupdate) scheduleEnabled() (bool, error) {
+	res, err := NewResource(s.MqlRuntime, "command", map[string]*llx.RawData{
+		"command": llx.StringData("softwareupdate --schedule"),
+	})
+	if err != nil {
+		return false, err
+	}
+	cmd := res.(*mqlCommand)
+	if exit := cmd.GetExitcode(); exit.Data != 0 {
+		return false, errUpdateScheduleUnavailable
+	}
+	v, ok := parseSoftwareUpdateSchedule(cmd.GetStdout().Data)
+	if !ok {
+		return false, errUpdateScheduleUnavailable
+	}
+	return v, nil
+}
+
+// parseSoftwareUpdateSchedule reads the `softwareupdate --schedule` sentence.
+// Anything it does not recognise returns ok=false, so an unreadable schedule
+// surfaces as an error and never as a confident "automatic checking is off".
+func parseSoftwareUpdateSchedule(stdout string) (bool, bool) {
+	l := strings.ToLower(stdout)
+	if !strings.Contains(l, "automatic checking") {
+		return false, false
+	}
+	switch {
+	case strings.Contains(l, "turned on"), strings.Contains(l, "is on"):
+		return true, true
+	case strings.Contains(l, "turned off"), strings.Contains(l, "is off"):
+		return false, true
+	}
+	return false, false
 }
 
 func (s *mqlMacosSoftwareupdate) autoDownloadEnabled() (bool, error) {
@@ -370,6 +426,23 @@ func parseSoftwareUpdateSize(raw string) int64 {
 // =============================================================================
 // shared plist helpers
 // =============================================================================
+
+// keyPresentInPlist reports whether the key carries a value the caller can
+// read. A missing key is not the same as a false one: several SoftwareUpdate
+// preferences default to on and are only written once someone changes them, so
+// the caller has to tell "nobody set this" apart from "somebody set it off".
+//
+// A key present with a nil value counts as absent, because it answers the
+// question no better than a missing key does: boolFromPlist has no case for
+// nil and would hand back false, which is the wrong-by-default reading this
+// helper exists to prevent. Reporting it as absent routes the caller to the
+// live `softwareupdate --schedule` lookup instead. Note this is about a nil
+// decoded value, not a written `<false/>`, which is a real answer and is
+// reported as present.
+func keyPresentInPlist(d map[string]any, key string) bool {
+	v, ok := d[key]
+	return ok && v != nil
+}
 
 // boolFromPlist coerces a plist key to bool. Through the plist.Decode
 // helper, real plist booleans arrive as `bool`; integer 0/1 fallbacks

--- a/providers/os/resources/macos_softwareupdate_test.go
+++ b/providers/os/resources/macos_softwareupdate_test.go
@@ -271,3 +271,39 @@ func TestStripPrefix(t *testing.T) {
 	assert.False(t, ok)
 	assert.Equal(t, "", rest)
 }
+
+// AutomaticCheckEnabled is only written once someone changes the setting.
+// Its absence is not "off" -- automatic checking is on by default -- so the
+// key's presence has to be distinguished from its value.
+func TestKeyPresentInPlist(t *testing.T) {
+	d := map[string]any{
+		"AutomaticDownload": float64(1),
+		"ExplicitFalse":     false,
+		"ExplicitNil":       nil,
+	}
+	assert.True(t, keyPresentInPlist(d, "AutomaticDownload"))
+	assert.True(t, keyPresentInPlist(d, "ExplicitFalse"), "an explicit false is still a written key")
+	assert.False(t, keyPresentInPlist(d, "ExplicitNil"))
+	assert.False(t, keyPresentInPlist(d, "AutomaticCheckEnabled"))
+}
+
+func TestParseSoftwareUpdateSchedule(t *testing.T) {
+	for name, tt := range map[string]struct {
+		stdout string
+		want   bool
+		ok     bool
+	}{
+		"on":           {"Automatic checking for updates is turned on\n", true, true},
+		"off":          {"Automatic checking for updates is turned off\n", false, true},
+		"unrecognised": {"softwareupdate: unknown option\n", false, false},
+		"empty":        {"", false, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			v, ok := parseSoftwareUpdateSchedule(tt.stdout)
+			assert.Equal(t, tt.ok, ok)
+			if tt.ok {
+				assert.Equal(t, tt.want, v)
+			}
+		})
+	}
+}

--- a/providers/os/resources/packages/macos_bundle_path_test.go
+++ b/providers/os/resources/packages/macos_bundle_path_test.go
@@ -1,0 +1,47 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package packages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsApplicationBundlePath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"application bundle", "/Applications/Docker.app", true},
+		{"OS-shipped application", "/System/Applications/Utilities/Terminal.app", true},
+		{"per-user application", "/Users/user/Applications/Chrome Apps.localized/Teams (PWA).app", true},
+		{"trailing separator", "/Applications/Docker.app/", true},
+		// APFS is case-insensitive by default, so this bundle launches.
+		{"uppercase extension", "/Applications/Docker.APP", true},
+		// Only a whole Contents segment means "inside a bundle".
+		{"Contents as a name fragment", "/Applications/TableOfContents/Docker.app", true},
+
+		// The reported bug: a renamed bundle keeps its old version forever, and
+		// system_profiler names it "Docker.app" because it strips only .back.
+		{"renamed bundle", "/Applications/Docker.app.back", false},
+		{"disabled bundle", "/Applications/Docker.app.disabled", false},
+		{"service bundle", "/System/Library/Services/Spotlight.service", false},
+		{"non-bundle directory", "/Users/user/Library/HTTPStorages/com.apple.ctcategories.service", false},
+		{"no path reported", "", false},
+
+		// Helper bundles ship with, and are patched by, their container.
+		{"helper in a renamed bundle", "/Applications/Docker.app.back/Contents/MacOS/Docker Desktop.app", false},
+		{"login item helper", "/Applications/Docker.app.back/Contents/Library/LoginItems/DockerHelper.app", false},
+		{"Finder pseudo-application", "/System/Library/CoreServices/Finder.app/Contents/Applications/AirDrop.app", false},
+		{"framework XPC service", "/System/Library/Frameworks/PaperKit.framework/Contents/LinkedNotesUIService.app", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, isApplicationBundlePath(test.path))
+		})
+	}
+}

--- a/providers/os/resources/packages/macos_packages.go
+++ b/providers/os/resources/packages/macos_packages.go
@@ -64,35 +64,60 @@ func ParseMacOSPackages(conn shared.Connection, platform *inventory.Platform, in
 		return nil, errors.New("format not supported")
 	}
 
-	pkgs := make([]Package, len(data[0].Items))
-	for i, entry := range data[0].Items {
-		// We need a special handling for Firefox to determine ESR installations
-		purlQualifiers := getPurlQualifiers(conn, entry)
-
+	pkgs := make([]Package, 0, len(data[0].Items))
+	for _, entry := range data[0].Items {
 		// system_profiler only surfaces CFBundleShortVersionString as the
 		// version. Some bundles (e.g. PWAs) ship a version only in
 		// CFBundleVersion, so fall back to the bundle's Info.plist when
 		// system_profiler reports no version.
 		version := entry.Version
 		if version == "" {
-			version = bundleVersionFromInfoPlist(conn, entry.Path)
+			// system_profiler lists every path carrying a bundle-like
+			// extension, not only application bundles: Firefox origin storage
+			// (https+++example.app), app-group script containers
+			// (group.is.workflow.my.app) and daemon directories all show up. It
+			// names them after the basename minus its final dot component, so a
+			// reverse-DNS directory collapses into a fragment like "com" or
+			// "org.eclipse". An application bundle always carries a
+			// Contents/Info.plist, so its absence means this is not an installed
+			// application: drop the entry instead of reporting it with a
+			// versionless purl that can never match advisory data.
+			//
+			// Entries that do report a version are never checked, because some
+			// real applications have no Contents/Info.plist. Wrapped iOS apps
+			// keep theirs under Wrapper/ and would otherwise be lost.
+			bundleVersion, isBundle := bundleVersionFromInfoPlist(conn, entry.Path)
+			if !isBundle {
+				log.Debug().
+					Str("name", entry.Name).
+					Str("path", entry.Path).
+					Msg("skipping entry that is not an application bundle")
+				continue
+			}
+			version = bundleVersion
 		}
 
-		pkgs[i].Name = entry.Name
-		pkgs[i].Version = version
-		pkgs[i].Format = MacosPkgFormat
-		pkgs[i].FilesAvailable = PkgFilesIncluded
-		pkgs[i].Arch = platform.Arch
-		pkgs[i].PUrl = purl.NewPackageURL(
-			platform, purl.TypeMacos, entry.Name, version, purl.WithQualifiers(purlQualifiers),
-		).String()
+		// We need a special handling for Firefox to determine ESR installations
+		purlQualifiers := getPurlQualifiers(conn, entry)
+
+		pkg := Package{
+			Name:           entry.Name,
+			Version:        version,
+			Format:         MacosPkgFormat,
+			FilesAvailable: PkgFilesIncluded,
+			Arch:           platform.Arch,
+			PUrl: purl.NewPackageURL(
+				platform, purl.TypeMacos, entry.Name, version, purl.WithQualifiers(purlQualifiers),
+			).String(),
+		}
 		if entry.Path != "" {
-			pkgs[i].Files = []FileRecord{
+			pkg.Files = []FileRecord{
 				{
 					Path: entry.Path,
 				},
 			}
 		}
+		pkgs = append(pkgs, pkg)
 	}
 
 	return pkgs, nil
@@ -133,37 +158,44 @@ func (mpm *MacOSPkgManager) Files(name string, version string, arch string) ([]F
 // bundleVersionFromInfoPlist recovers an app's version from its
 // Contents/Info.plist when system_profiler did not report one. It prefers
 // CFBundleShortVersionString (the user-facing version) and falls back to
-// CFBundleVersion (the build version). Returns an empty string when no bundle
-// Info.plist exists (e.g. bare ".app" daemons) or it carries no version.
-func bundleVersionFromInfoPlist(conn shared.Connection, path string) string {
+// CFBundleVersion (the build version).
+//
+// The second return value reports whether the path is an application bundle at
+// all, which is true whenever a Contents/Info.plist could be read. Callers use
+// it to tell a real application that simply carries no version (some Apple
+// CoreServices apps ship neither version key) from a directory that merely has
+// a bundle-like extension.
+func bundleVersionFromInfoPlist(conn shared.Connection, path string) (string, bool) {
 	if path == "" {
-		return ""
+		return "", false
 	}
 
 	infoPath := filepath.Join(path, "Contents", "Info.plist")
 	f, err := conn.FileSystem().Open(infoPath)
 	if err != nil {
 		log.Debug().Err(err).Str("path", infoPath).Msg("could not open Info.plist")
-		return ""
+		return "", false
 	}
 	defer f.Close()
 
 	content, err := io.ReadAll(f)
 	if err != nil {
 		log.Debug().Err(err).Str("path", infoPath).Msg("could not read Info.plist")
-		return ""
+		return "", false
 	}
 
+	// The Info.plist is there, so this is a bundle even if we cannot read a
+	// version out of it.
 	var info infoPlist
 	if _, err := plist.Unmarshal(content, &info); err != nil {
 		log.Debug().Err(err).Str("path", infoPath).Msg("could not parse Info.plist")
-		return ""
+		return "", true
 	}
 
 	if info.ShortVersion != "" {
-		return info.ShortVersion
+		return info.ShortVersion, true
 	}
-	return info.BundleVersion
+	return info.BundleVersion, true
 }
 
 func getPurlQualifiers(conn shared.Connection, entry sysProfilerItem) map[string]string {

--- a/providers/os/resources/packages/macos_packages.go
+++ b/providers/os/resources/packages/macos_packages.go
@@ -66,22 +66,28 @@ func ParseMacOSPackages(conn shared.Connection, platform *inventory.Platform, in
 
 	pkgs := make([]Package, 0, len(data[0].Items))
 	for _, entry := range data[0].Items {
+		if !isApplicationBundlePath(entry.Path) {
+			log.Debug().
+				Str("name", entry.Name).
+				Str("path", entry.Path).
+				Msg("skipping entry that is not an installed application bundle")
+			continue
+		}
+
 		// system_profiler only surfaces CFBundleShortVersionString as the
 		// version. Some bundles (e.g. PWAs) ship a version only in
 		// CFBundleVersion, so fall back to the bundle's Info.plist when
 		// system_profiler reports no version.
 		version := entry.Version
 		if version == "" {
-			// system_profiler lists every path carrying a bundle-like
-			// extension, not only application bundles: Firefox origin storage
-			// (https+++example.app), app-group script containers
-			// (group.is.workflow.my.app) and daemon directories all show up. It
-			// names them after the basename minus its final dot component, so a
-			// reverse-DNS directory collapses into a fragment like "com" or
-			// "org.eclipse". An application bundle always carries a
-			// Contents/Info.plist, so its absence means this is not an installed
-			// application: drop the entry instead of reporting it with a
-			// versionless purl that can never match advisory data.
+			// Plenty of directories genuinely end in .app without being
+			// applications: Firefox origin storage (https+++example.app),
+			// app-group script containers (group.is.workflow.my.app) and bare
+			// daemon directories all pass the path check above. An application
+			// bundle always carries a Contents/Info.plist, so its absence means
+			// this is not an installed application: drop the entry instead of
+			// reporting it with a versionless purl that can never match
+			// advisory data.
 			//
 			// Entries that do report a version are never checked, because some
 			// real applications have no Contents/Info.plist. Wrapped iOS apps
@@ -153,6 +159,47 @@ func (mpm *MacOSPkgManager) Available() (map[string]PackageUpdate, error) {
 func (mpm *MacOSPkgManager) Files(name string, version string, arch string) ([]FileRecord, error) {
 	// nothing extra to be done here since the list is already included in the package list
 	return nil, nil
+}
+
+// isApplicationBundlePath reports whether a path system_profiler listed is an
+// application someone installed, as opposed to a directory that merely looks
+// like a bundle or a helper that ships inside another application.
+//
+// system_profiler does not answer that question itself. It walks the
+// filesystem, reports anything bundle-shaped it meets, and names each entry
+// after the basename minus its final dot component. Two shapes come out of
+// that, and both produce inventory rows that no upgrade can ever clear.
+//
+// A renamed bundle such as /Applications/Docker.app.back is still enumerated,
+// under the name "Docker.app" and at whatever version was current when it was
+// set aside. Reported as installed software it pins findings to a version that
+// is not on the machine, and reinstalling the application does not touch the
+// backup directory. An application bundle always ends in .app, so the
+// extension of the final path segment settles it.
+//
+// Renaming also stops macOS treating the directory as one opaque bundle, so
+// every helper bundle nested inside it gets walked and reported separately.
+// Nested bundles are not separately installed in any case: an XPC service
+// under a framework's Contents/, Finder's Contents/Applications/AirDrop.app,
+// and an application's own login-item helper all ship with, and are patched
+// by, whatever contains them. A Contents directory anywhere above the bundle
+// marks that containment.
+func isApplicationBundlePath(path string) bool {
+	if path == "" {
+		return false
+	}
+
+	path = filepath.Clean(path)
+
+	// macOS filesystems are case-insensitive by default, so a bundle stored as
+	// .APP is a working application and must not be dropped.
+	if !strings.EqualFold(filepath.Ext(path), ".app") {
+		return false
+	}
+
+	// The surrounding separators make this a whole-segment match: a directory
+	// named "Contents" matches, one named "TableOfContents" does not.
+	return !strings.Contains(path, "/Contents/")
 }
 
 // bundleVersionFromInfoPlist recovers an app's version from its

--- a/providers/os/resources/packages/macos_packages_test.go
+++ b/providers/os/resources/packages/macos_packages_test.go
@@ -31,7 +31,7 @@ func TestMacOsXPackageParser(t *testing.T) {
 	}
 	m, err := packages.ParseMacOSPackages(mock, pf, c.Stdout)
 	assert.Nil(t, err)
-	assert.Equal(t, 6, len(m), "detected the right amount of packages")
+	assert.Equal(t, 8, len(m), "detected the right amount of packages")
 
 	assert.Equal(t, "Preview", m[0].Name, "pkg name detected")
 	assert.Equal(t, "10.0", m[0].Version, "pkg version detected")
@@ -75,6 +75,16 @@ func TestMacOsXPackageParser(t *testing.T) {
 	assert.Equal(t, "3.2.1", m[5].Version, "version reported by system_profiler")
 	assert.Equal(t, "pkg:macos/macos/Victory@3.2.1?arch=x86_64", m[5].PUrl)
 
+	// A backup copy of an application is enumerated by system_profiler at the
+	// version it held when it was set aside, and it is the only Docker entry
+	// that survives if the newer real install is filtered by mistake. Assert
+	// the installed version, not just the name: reporting 4.88.1 here is the
+	// customer-visible bug (findings pinned to a version that is not on the
+	// machine and that no upgrade can clear).
+	assert.Equal(t, "Docker", m[7].Name, "real application kept")
+	assert.Equal(t, "4.89.0", m[7].Version, "version of the installed bundle, not of the backup")
+	assert.Equal(t, []packages.FileRecord{{Path: "/Applications/Docker.app"}}, m[7].Files)
+
 	// system_profiler enumerates every path carrying a bundle-like extension,
 	// not just application bundles. Entries with no version and no
 	// Contents/Info.plist are not installed applications and are dropped
@@ -83,6 +93,18 @@ func TestMacOsXPackageParser(t *testing.T) {
 		"liquiddetectiond",     // bare .app directory holding a daemon
 		"https+++bsky",         // Firefox origin storage directory
 		"group.is.workflow.my", // app-group script container
+	} {
+		assert.NotContains(t, names(m), dropped, "non-application entry dropped")
+	}
+
+	// Paths that are not an installed application bundle are dropped whatever
+	// version they report, so a stale copy on disk cannot keep a fixed CVE open.
+	for _, dropped := range []string{
+		"Docker.app",     // /Applications/Docker.app.back, named by stripping .back
+		"Docker Desktop", // helper bundle inside the backup's Contents/
+		"DockerHelper",   // login item inside the backup's Contents/
+		"AirDrop",        // ships inside Finder.app, patched with Finder
+		"Spotlight",      // a .service bundle, not an application
 	} {
 		assert.NotContains(t, names(m), dropped, "non-application entry dropped")
 	}

--- a/providers/os/resources/packages/macos_packages_test.go
+++ b/providers/os/resources/packages/macos_packages_test.go
@@ -31,7 +31,7 @@ func TestMacOsXPackageParser(t *testing.T) {
 	}
 	m, err := packages.ParseMacOSPackages(mock, pf, c.Stdout)
 	assert.Nil(t, err)
-	assert.Equal(t, 5, len(m), "detected the right amount of packages")
+	assert.Equal(t, 6, len(m), "detected the right amount of packages")
 
 	assert.Equal(t, "Preview", m[0].Name, "pkg name detected")
 	assert.Equal(t, "10.0", m[0].Version, "pkg version detected")
@@ -61,8 +61,37 @@ func TestMacOsXPackageParser(t *testing.T) {
 	assert.Equal(t, "7778.181", m[3].Version, "pkg version recovered from Info.plist")
 	assert.Equal(t, "pkg:macos/macos/Microsoft%20Teams%20%28PWA%29@7778.181?arch=x86_64", m[3].PUrl)
 
-	// A bare ".app" directory with no Info.plist (a system daemon) genuinely
-	// has no version anywhere, so the version stays empty.
-	assert.Equal(t, "liquiddetectiond", m[4].Name, "pkg name detected")
-	assert.Equal(t, "", m[4].Version, "no version available for a bare .app daemon")
+	// An application bundle whose Info.plist carries no version keys at all is
+	// still a real installed application, so it is reported with an empty
+	// version rather than dropped.
+	assert.Equal(t, "qFlipper", m[4].Name, "versionless app bundle kept")
+	assert.Equal(t, "", m[4].Version, "no version available in the Info.plist")
+	assert.Equal(t, "pkg:macos/macos/qFlipper?arch=x86_64", m[4].PUrl)
+
+	// Wrapped iOS apps keep their Info.plist inside Wrapper/, so there is no
+	// Contents/Info.plist to find. They report a version, so they must never
+	// be dropped by the bundle check.
+	assert.Equal(t, "Victory", m[5].Name, "wrapped iOS app kept")
+	assert.Equal(t, "3.2.1", m[5].Version, "version reported by system_profiler")
+	assert.Equal(t, "pkg:macos/macos/Victory@3.2.1?arch=x86_64", m[5].PUrl)
+
+	// system_profiler enumerates every path carrying a bundle-like extension,
+	// not just application bundles. Entries with no version and no
+	// Contents/Info.plist are not installed applications and are dropped
+	// instead of being reported with an unusable, versionless purl.
+	for _, dropped := range []string{
+		"liquiddetectiond",     // bare .app directory holding a daemon
+		"https+++bsky",         // Firefox origin storage directory
+		"group.is.workflow.my", // app-group script container
+	} {
+		assert.NotContains(t, names(m), dropped, "non-application entry dropped")
+	}
+}
+
+func names(pkgs []packages.Package) []string {
+	list := make([]string, len(pkgs))
+	for i := range pkgs {
+		list[i] = pkgs[i].Name
+	}
+	return list
 }

--- a/providers/os/resources/packages/testdata/packages_macos.toml
+++ b/providers/os/resources/packages/testdata/packages_macos.toml
@@ -165,6 +165,98 @@ stdout = """<?xml version="1.0" encoding="UTF-8"?>
 				<key>version</key>
 				<string>3.2.1</string>
 			</dict>
+			<dict>
+				<key>_name</key>
+				<string>WireGuard</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>lastModified</key>
+				<date>2026-05-21T08:57:02Z</date>
+				<key>obtained_from</key>
+				<string>mac_app_store</string>
+				<key>path</key>
+				<string>/Applications/WireGuard.app</string>
+				<key>signed_by</key>
+				<array>
+					<string>Apple Mac OS Application Signing</string>
+					<string>Apple Worldwide Developer Relations Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+				<key>version</key>
+				<string>1.0.16</string>
+			</dict>
+			<dict>
+				<key>_name</key>
+				<string>Docker</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>obtained_from</key>
+				<string>identified_developer</string>
+				<key>path</key>
+				<string>/Applications/Docker.app</string>
+				<key>version</key>
+				<string>4.89.0</string>
+			</dict>
+			<dict>
+				<key>_name</key>
+				<string>Docker.app</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>obtained_from</key>
+				<string>identified_developer</string>
+				<key>path</key>
+				<string>/Applications/Docker.app.back</string>
+				<key>version</key>
+				<string>4.88.1</string>
+			</dict>
+			<dict>
+				<key>_name</key>
+				<string>Docker Desktop</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>obtained_from</key>
+				<string>identified_developer</string>
+				<key>path</key>
+				<string>/Applications/Docker.app.back/Contents/MacOS/Docker Desktop.app</string>
+				<key>version</key>
+				<string>4.88.1</string>
+			</dict>
+			<dict>
+				<key>_name</key>
+				<string>DockerHelper</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>obtained_from</key>
+				<string>identified_developer</string>
+				<key>path</key>
+				<string>/Applications/Docker.app.back/Contents/Library/LoginItems/DockerHelper.app</string>
+				<key>version</key>
+				<string>1.0.1</string>
+			</dict>
+			<dict>
+				<key>_name</key>
+				<string>AirDrop</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>obtained_from</key>
+				<string>apple</string>
+				<key>path</key>
+				<string>/System/Library/CoreServices/Finder.app/Contents/Applications/AirDrop.app</string>
+				<key>version</key>
+				<string>26.4</string>
+			</dict>
+			<dict>
+				<key>_name</key>
+				<string>Spotlight</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>obtained_from</key>
+				<string>apple</string>
+				<key>path</key>
+				<string>/System/Library/Services/Spotlight.service</string>
+				<key>version</key>
+				<string>3.0</string>
+			</dict>
 		</array>
 		<key>_parentDataType</key>
 		<string>SPSoftwareDataType</string>

--- a/providers/os/resources/packages/testdata/packages_macos.toml
+++ b/providers/os/resources/packages/testdata/packages_macos.toml
@@ -115,6 +115,56 @@ stdout = """<?xml version="1.0" encoding="UTF-8"?>
 				<key>path</key>
 				<string>/System/Library/CoreServices/liquiddetectiond.app</string>
 			</dict>
+			<dict>
+				<key>_name</key>
+				<string>https+++bsky</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>lastModified</key>
+				<date>2026-05-21T08:57:02Z</date>
+				<key>obtained_from</key>
+				<string>unknown</string>
+				<key>path</key>
+				<string>/Users/user/Library/Application Support/Firefox/Profiles/abcd1234.default-release/storage/default/https+++bsky.app</string>
+			</dict>
+			<dict>
+				<key>_name</key>
+				<string>group.is.workflow.my</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>lastModified</key>
+				<date>2026-05-21T08:57:02Z</date>
+				<key>obtained_from</key>
+				<string>unknown</string>
+				<key>path</key>
+				<string>/Users/user/Library/Application Scripts/group.is.workflow.my.app</string>
+			</dict>
+			<dict>
+				<key>_name</key>
+				<string>qFlipper</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>lastModified</key>
+				<date>2026-05-21T08:57:02Z</date>
+				<key>obtained_from</key>
+				<string>identified_developer</string>
+				<key>path</key>
+				<string>/Applications/qFlipper.app</string>
+			</dict>
+			<dict>
+				<key>_name</key>
+				<string>Victory</string>
+				<key>arch_kind</key>
+				<string>arch_arm_i64</string>
+				<key>lastModified</key>
+				<date>2026-05-21T08:57:02Z</date>
+				<key>obtained_from</key>
+				<string>mac_app_store</string>
+				<key>path</key>
+				<string>/Applications/Victory.app</string>
+				<key>version</key>
+				<string>3.2.1</string>
+			</dict>
 		</array>
 		<key>_parentDataType</key>
 		<string>SPSoftwareDataType</string>
@@ -166,4 +216,19 @@ ServerURL=https://crash-reports.mozilla.com/submit?id={ec8030f7-c20a-464f-9b0e-1
 
 [AppUpdate]
 URL=https://aus5.mozilla.org/update/6/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%SYSTEM_CAPABILITIES%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/update.xml
+"""
+
+[files."/Applications/qFlipper.app/Contents/Info.plist"]
+content = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>qFlipper</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.yourcompany.qFlipper</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+</dict>
+</plist>
 """

--- a/providers/os/resources/port.go
+++ b/providers/os/resources/port.go
@@ -555,6 +555,22 @@ func (p *mqlPorts) parseWindowsPorts(r io.Reader, processes map[int64]*mqlProces
 
 // macOS Implementation
 
+// expandLsofWildcardAddress spells out the wildcard bind lsof writes as "*".
+// A socket bound there listens on every address on every interface, so it maps
+// to the unspecified address -- 0.0.0.0 for IPv4, :: for IPv6 -- which is how
+// the same bind reads on Linux. It is emphatically not loopback: mapping it to
+// 127.0.0.1 reports a listener reachable from the network as a local-only one,
+// and silently passes any check looking for exposed ports.
+func expandLsofWildcardAddress(address string, protocol string) string {
+	if !strings.HasPrefix(address, "*") {
+		return address
+	}
+	if strings.HasSuffix(protocol, "6") {
+		return strings.Replace(address, "*", "::", 1)
+	}
+	return strings.Replace(address, "*", "0.0.0.0", 1)
+}
+
 // listMacos reads the lsof information of all open files that are tcp sockets
 func (p *mqlPorts) listMacos() ([]any, error) {
 	users, err := p.users()
@@ -614,15 +630,7 @@ func (p *mqlPorts) listMacos() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
-			// lsof presents a process listening on any ipv6 address as listening on "*"
-			// change this to a more ipv6-friendly formatting
-			if strings.HasPrefix(localAddress, "*") {
-				if strings.HasSuffix(protocol, "6") {
-					localAddress = strings.Replace(localAddress, "*", "::1", 1)
-				} else {
-					localAddress = strings.Replace(localAddress, "*", "127.0.0.1", 1)
-				}
-			}
+			localAddress = expandLsofWildcardAddress(localAddress, protocol)
 
 			state, ok := TCP_STATES[fd.TcpState()]
 			if !ok {

--- a/providers/os/resources/port_test.go
+++ b/providers/os/resources/port_test.go
@@ -123,3 +123,28 @@ func TestAixPortStatesAreCanonical(t *testing.T) {
 			"AIX state %q maps to %q which is not in TCP_STATES", aix, mapped)
 	}
 }
+
+// A wildcard bind is reachable from the network. It used to be rewritten to
+// loopback, which reported every exposed listener as local-only and quietly
+// passed any check looking for internet-facing ports.
+func TestExpandLsofWildcardAddress(t *testing.T) {
+	for _, tt := range []struct {
+		address  string
+		protocol string
+		want     string
+	}{
+		{"*", "tcp4", "0.0.0.0"},
+		{"*", "udp4", "0.0.0.0"},
+		{"*", "tcp6", "::"},
+		{"*", "udp6", "::"},
+		// concrete binds are passed through untouched
+		{"127.0.0.1", "tcp4", "127.0.0.1"},
+		{"::1", "tcp6", "::1"},
+		{"172.16.1.129", "tcp4", "172.16.1.129"},
+		{"", "tcp4", ""},
+	} {
+		t.Run(tt.protocol+"/"+tt.address, func(t *testing.T) {
+			assert.Equal(t, tt.want, expandLsofWildcardAddress(tt.address, tt.protocol))
+		})
+	}
+}

--- a/providers/os/resources/services/launchd.go
+++ b/providers/os/resources/services/launchd.go
@@ -10,11 +10,14 @@ import (
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 )
 
-var LAUNCHD_REGEX = regexp.MustCompile(`(?m)^\s*([\d-]*)\s+(\d)\s+(.*)$`)
+// launchctl list prints three tab-separated columns: PID, the last exit
+// status, and the label. PID is a number or "-" when the job is not running.
+// The status is a signed integer: 0 for a clean exit, a positive exit code,
+// or a negative signal number (-9 for SIGKILL, -15 for SIGTERM). Matching it
+// as a single digit dropped every job that had ever been killed or exited
+// non-zero -- around 40% of the list on a normal macOS install.
+var LAUNCHD_REGEX = regexp.MustCompile(`(?m)^\s*(-|\d+)\s+(-?\d+)\s+(\S.*)$`)
 
-// PID: pid of process
-// Status: last know exit code
-// ^\s*([\d-]*)\s+(\d)\s+(.*)$
 func ParseServiceLaunchD(input io.Reader) ([]*Service, error) {
 	var services []*Service
 	content, err := io.ReadAll(input)

--- a/providers/os/resources/services/launchd_test.go
+++ b/providers/os/resources/services/launchd_test.go
@@ -4,12 +4,14 @@
 package services_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
-	"go.mondoo.com/mql/v13/providers/os/connection/mock"
-	"go.mondoo.com/mql/v13/providers/os/resources/services"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+	"go.mondoo.com/mql/providers/os/resources/services"
 )
 
 func TestParseServiceLaunchD(t *testing.T) {
@@ -35,4 +37,48 @@ func TestParseServiceLaunchD(t *testing.T) {
 	assert.Equal(t, false, m[0].Running, "service is running")
 	assert.Equal(t, true, m[0].Installed, "service is installed")
 	assert.Equal(t, "launchd", m[0].Type, "service type is added")
+}
+
+// launchctl reports the last exit status as a signed integer. Matching it as a
+// single digit dropped every job that had been killed (-9, -15) or exited with
+// a multi-digit code, which silently hid around 40% of the services on a
+// normal macOS install -- including third-party security agents.
+func TestParseServiceLaunchDNonZeroStatus(t *testing.T) {
+	input := strings.Join([]string{
+		"PID\tStatus\tLabel",
+		"28494\t-9\tcom.apple.accessibility.axassetsd",
+		"-\t-9\tcom.apple.AccessibilityVisualsAgent",
+		"-\t-15\tcom.apple.terminated.by.sigterm",
+		"1354\t0\tcom.crowdstrike.falcon.UserAgent",
+		"-\t0\tcom.apple.screensharing.agent",
+		"500\t78\tcom.example.multidigit",
+		"-\t127\tcom.example.exit127",
+	}, "\n")
+
+	list, err := services.ParseServiceLaunchD(strings.NewReader(input))
+	require.NoError(t, err)
+
+	byName := map[string]*services.Service{}
+	for _, s := range list {
+		byName[s.Name] = s
+	}
+
+	// the header line must not be picked up as a service
+	assert.NotContains(t, byName, "Label")
+	assert.Len(t, list, 7)
+
+	for _, name := range []string{
+		"com.apple.accessibility.axassetsd",
+		"com.apple.AccessibilityVisualsAgent",
+		"com.apple.terminated.by.sigterm",
+		"com.example.multidigit",
+		"com.example.exit127",
+	} {
+		assert.Contains(t, byName, name, "service with a non-zero exit status must still be listed")
+	}
+
+	// a PID means the job is running; "-" means it is not
+	assert.True(t, byName["com.apple.accessibility.axassetsd"].Running)
+	assert.False(t, byName["com.apple.AccessibilityVisualsAgent"].Running)
+	assert.True(t, byName["com.crowdstrike.falcon.UserAgent"].Running)
 }

--- a/providers/os/resources/services/launchd_test.go
+++ b/providers/os/resources/services/launchd_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/mql/providers-sdk/v1/inventory"
-	"go.mondoo.com/mql/providers/os/connection/mock"
-	"go.mondoo.com/mql/providers/os/resources/services"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers/os/connection/mock"
+	"go.mondoo.com/mql/v13/providers/os/resources/services"
 )
 
 func TestParseServiceLaunchD(t *testing.T) {


### PR DESCRIPTION
Backports three merged macOS fixes from `main` onto the `v13` release line.

| PR | Fix |
|---|---|
| #10283 | Drop `system_profiler` entries that are not application bundles, so `os.packages` stops listing services, plugins and frameworks as installed software. |
| #10521 | Correct several macOS resources that reported the wrong security state: the ALF/firewall read, the `macos.systemSetup` sharing parse, software-update settings, `ports`, `launchd` services, and the hypervisor detection that flagged every Apple Silicon Mac as a virtual machine. |
| #10666 | Only report real application bundles as installed software, tightening the bundle-path check added in #10283. |

Each commit is a `cherry-pick -x` of the squash-merge on `main`, so the original SHA is recorded in the trailer.

### v13-specific adaptation

One extra commit retargets imports. The `v13` line is `module go.mondoo.com/mql/v13`, while `main` has dropped the version suffix, so files that arrived whole from `main` (`macos_firewall_live.go`) and the `launchd_test.go` import block still named the unversioned path. There was nothing on the `v13` side to conflict against, so this never surfaces as a merge conflict, only at compile time.

### Conflicts resolved

- `services/launchd_test.go` - import block (kept the incoming imports, on the `v13` module path).
- `packages/testdata/packages_macos.toml` - adjacent fixture additions from #10283 and #10666.
- `packages/macos_packages_test.go` - expected package count, 6 to 8, matching the enlarged fixture.

### Verification

```
go build ./...                      # providers/os - clean
go test -count=1 ./resources/... ./resources/services/... \
        ./resources/packages/... ./id/hypervisor/...      # 0 failures
```

All 40 backported test functions pass.

`connection/device/linux` fails to build on this branch, but it fails the same way on `origin/v13` before these commits - `snapshot.MockVolumeMounter` is a `mockgen` artifact that is not checked in. Nothing here touches `connection/`.
