### PR TITLE
🎉 os-13.40.10

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.40.9",
+	Version: "13.40.10",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
Patch release of the `os` provider on the `v13` line: **13.40.9 → 13.40.10**.

### Changelog

Everything on `providers/os/` since the 13.40.9 bump (#10025):

- #10669 — 🐛 os: backport the macOS reporting fixes to `v13`, carrying #10283, #10521 and #10666 over from `main`:
  - `os.packages` no longer lists services, plugins and frameworks as installed software; only real application bundles are reported.
  - The ALF/firewall read, the `macos.systemSetup` sharing parse, software-update settings, `ports` and `launchd` services no longer report the wrong security state.
  - Hypervisor detection no longer flags every Apple Silicon Mac as a virtual machine.

### Notes

Version bumped by hand rather than with `providers-sdk/v1/util/version/version.go`. That tool uses go-git, which cannot resolve a linked worktree, so its `blame` on `config.go` fails and it emits a stub changelog with a hardcoded change count while still exiting zero. The changelog above comes from the real log on `v13`.

Single-line change to `providers/os/config/config.go`; no schema or `.lr.versions` movement, since the backport added no fields.
