### PR TITLE
🐛 os: backport the Solaris and FreeBSD fixes to v13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -343,3 +343,5 @@ tool (
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc
 	google.golang.org/protobuf/cmd/protoc-gen-go
 )
+
+replace github.com/hnakamur/go-scp => github.com/mondoohq/go-scp v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -283,7 +283,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
@@ -581,10 +580,8 @@ github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
-github.com/hnakamur/go-scp v1.0.2 h1:i2I0O0pjAaX4BXJFrp1blsIdjOBekc5QOaB0AbdO1d0=
-github.com/hnakamur/go-scp v1.0.2/go.mod h1:Dh9GtPFBkiDI1KY1nmf+W7eVCWWmRjJitkCYgvWv+Zc=
-github.com/hnakamur/go-sshd v0.0.0-20170228152141-dccc3399d26a h1:p8dbHRhXhPSwVZqk76FguLzyeCZuvCqFlaYSqXOzbyI=
-github.com/hnakamur/go-sshd v0.0.0-20170228152141-dccc3399d26a/go.mod h1:R+6I3EdoV6ofbNqJsArhT9+Pnu57DxtmDJAQfxkCbGo=
+github.com/hnakamur/go-sshd v0.2.1 h1:HOvlvBWPjedji3PUuF8xpRHVnYXX3LMfoi2NW8+OxOk=
+github.com/hnakamur/go-sshd v0.2.1/go.mod h1:I9pHzExs6WUoAJyT6awiGD+CW2r0EEoqZ1OFVKUhrZs=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f h1:7LYC+Yfkj3CTRcShK0KOL/w6iTiKyqqBA9a41Wnggw8=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
@@ -727,6 +724,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mondoohq/go-scp v1.0.4 h1:DtcpMNvBw7erV8Xf66Q1qruNlciyCwxIHe5h1C/I544=
+github.com/mondoohq/go-scp v1.0.4/go.mod h1:BJpx7G2DFyf9Ujof36llkm8aLKkCRUmLHr/NAQvSr58=
 github.com/mtibben/percent v0.2.1 h1:5gssi8Nqo8QU/r2pynCm+hBQHpkB/uNK7BJCFogWdzs=
 github.com/mtibben/percent v0.2.1/go.mod h1:KG9uO+SZkUp+VkRHsCdYQV3XSZrrSpR3O9ibNBTZrns=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D264iyp3TiX5OmNcI5cIARiQI=
@@ -1012,7 +1011,6 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
@@ -1182,7 +1180,6 @@ golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200828081204-131dc92a58d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/providers/aws/go.mod
+++ b/providers/aws/go.mod
@@ -331,3 +331,5 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 	software.sslmate.com/src/go-pkcs12 v0.7.0 // indirect
 )
+
+replace github.com/hnakamur/go-scp => github.com/mondoohq/go-scp v1.0.4

--- a/providers/aws/go.sum
+++ b/providers/aws/go.sum
@@ -443,7 +443,6 @@ github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
@@ -679,10 +678,8 @@ github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKEN
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
-github.com/hnakamur/go-scp v1.0.2 h1:i2I0O0pjAaX4BXJFrp1blsIdjOBekc5QOaB0AbdO1d0=
-github.com/hnakamur/go-scp v1.0.2/go.mod h1:Dh9GtPFBkiDI1KY1nmf+W7eVCWWmRjJitkCYgvWv+Zc=
-github.com/hnakamur/go-sshd v0.0.0-20170228152141-dccc3399d26a h1:p8dbHRhXhPSwVZqk76FguLzyeCZuvCqFlaYSqXOzbyI=
-github.com/hnakamur/go-sshd v0.0.0-20170228152141-dccc3399d26a/go.mod h1:R+6I3EdoV6ofbNqJsArhT9+Pnu57DxtmDJAQfxkCbGo=
+github.com/hnakamur/go-sshd v0.2.1 h1:HOvlvBWPjedji3PUuF8xpRHVnYXX3LMfoi2NW8+OxOk=
+github.com/hnakamur/go-sshd v0.2.1/go.mod h1:I9pHzExs6WUoAJyT6awiGD+CW2r0EEoqZ1OFVKUhrZs=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f h1:7LYC+Yfkj3CTRcShK0KOL/w6iTiKyqqBA9a41Wnggw8=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
@@ -814,6 +811,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mondoohq/go-scp v1.0.4 h1:DtcpMNvBw7erV8Xf66Q1qruNlciyCwxIHe5h1C/I544=
+github.com/mondoohq/go-scp v1.0.4/go.mod h1:BJpx7G2DFyf9Ujof36llkm8aLKkCRUmLHr/NAQvSr58=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
@@ -1050,7 +1049,6 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
@@ -1218,7 +1216,6 @@ golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200828081204-131dc92a58d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -281,3 +281,5 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 	software.sslmate.com/src/go-pkcs12 v0.7.0 // indirect
 )
+
+replace github.com/hnakamur/go-scp => github.com/mondoohq/go-scp v1.0.4

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -353,7 +353,6 @@ github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
@@ -589,10 +588,8 @@ github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKEN
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
-github.com/hnakamur/go-scp v1.0.2 h1:i2I0O0pjAaX4BXJFrp1blsIdjOBekc5QOaB0AbdO1d0=
-github.com/hnakamur/go-scp v1.0.2/go.mod h1:Dh9GtPFBkiDI1KY1nmf+W7eVCWWmRjJitkCYgvWv+Zc=
-github.com/hnakamur/go-sshd v0.0.0-20170228152141-dccc3399d26a h1:p8dbHRhXhPSwVZqk76FguLzyeCZuvCqFlaYSqXOzbyI=
-github.com/hnakamur/go-sshd v0.0.0-20170228152141-dccc3399d26a/go.mod h1:R+6I3EdoV6ofbNqJsArhT9+Pnu57DxtmDJAQfxkCbGo=
+github.com/hnakamur/go-sshd v0.2.1 h1:HOvlvBWPjedji3PUuF8xpRHVnYXX3LMfoi2NW8+OxOk=
+github.com/hnakamur/go-sshd v0.2.1/go.mod h1:I9pHzExs6WUoAJyT6awiGD+CW2r0EEoqZ1OFVKUhrZs=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f h1:7LYC+Yfkj3CTRcShK0KOL/w6iTiKyqqBA9a41Wnggw8=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
@@ -724,6 +721,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mondoohq/go-scp v1.0.4 h1:DtcpMNvBw7erV8Xf66Q1qruNlciyCwxIHe5h1C/I544=
+github.com/mondoohq/go-scp v1.0.4/go.mod h1:BJpx7G2DFyf9Ujof36llkm8aLKkCRUmLHr/NAQvSr58=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
@@ -960,7 +959,6 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
@@ -1128,7 +1126,6 @@ golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200828081204-131dc92a58d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/providers/gcp/go.mod
+++ b/providers/gcp/go.mod
@@ -304,3 +304,5 @@ require (
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/hnakamur/go-scp => github.com/mondoohq/go-scp v1.0.4

--- a/providers/gcp/go.sum
+++ b/providers/gcp/go.sum
@@ -343,7 +343,6 @@ github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
@@ -602,10 +601,8 @@ github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKEN
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
-github.com/hnakamur/go-scp v1.0.2 h1:i2I0O0pjAaX4BXJFrp1blsIdjOBekc5QOaB0AbdO1d0=
-github.com/hnakamur/go-scp v1.0.2/go.mod h1:Dh9GtPFBkiDI1KY1nmf+W7eVCWWmRjJitkCYgvWv+Zc=
-github.com/hnakamur/go-sshd v0.0.0-20170228152141-dccc3399d26a h1:p8dbHRhXhPSwVZqk76FguLzyeCZuvCqFlaYSqXOzbyI=
-github.com/hnakamur/go-sshd v0.0.0-20170228152141-dccc3399d26a/go.mod h1:R+6I3EdoV6ofbNqJsArhT9+Pnu57DxtmDJAQfxkCbGo=
+github.com/hnakamur/go-sshd v0.2.1 h1:HOvlvBWPjedji3PUuF8xpRHVnYXX3LMfoi2NW8+OxOk=
+github.com/hnakamur/go-sshd v0.2.1/go.mod h1:I9pHzExs6WUoAJyT6awiGD+CW2r0EEoqZ1OFVKUhrZs=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f h1:7LYC+Yfkj3CTRcShK0KOL/w6iTiKyqqBA9a41Wnggw8=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
@@ -737,6 +734,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mondoohq/go-scp v1.0.4 h1:DtcpMNvBw7erV8Xf66Q1qruNlciyCwxIHe5h1C/I544=
+github.com/mondoohq/go-scp v1.0.4/go.mod h1:BJpx7G2DFyf9Ujof36llkm8aLKkCRUmLHr/NAQvSr58=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
@@ -990,7 +989,6 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
@@ -1158,7 +1156,6 @@ golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200828081204-131dc92a58d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/providers/github/go.mod
+++ b/providers/github/go.mod
@@ -246,3 +246,5 @@ require (
 	sigs.k8s.io/release-utils v0.12.4 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.3 // indirect
 )
+
+replace github.com/hnakamur/go-scp => github.com/mondoohq/go-scp v1.0.4

--- a/providers/github/go.sum
+++ b/providers/github/go.sum
@@ -215,7 +215,6 @@ github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
@@ -469,10 +468,8 @@ github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
-github.com/hnakamur/go-scp v1.0.2 h1:i2I0O0pjAaX4BXJFrp1blsIdjOBekc5QOaB0AbdO1d0=
-github.com/hnakamur/go-scp v1.0.2/go.mod h1:Dh9GtPFBkiDI1KY1nmf+W7eVCWWmRjJitkCYgvWv+Zc=
-github.com/hnakamur/go-sshd v0.0.0-20170228152141-dccc3399d26a h1:p8dbHRhXhPSwVZqk76FguLzyeCZuvCqFlaYSqXOzbyI=
-github.com/hnakamur/go-sshd v0.0.0-20170228152141-dccc3399d26a/go.mod h1:R+6I3EdoV6ofbNqJsArhT9+Pnu57DxtmDJAQfxkCbGo=
+github.com/hnakamur/go-sshd v0.2.1 h1:HOvlvBWPjedji3PUuF8xpRHVnYXX3LMfoi2NW8+OxOk=
+github.com/hnakamur/go-sshd v0.2.1/go.mod h1:I9pHzExs6WUoAJyT6awiGD+CW2r0EEoqZ1OFVKUhrZs=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f h1:7LYC+Yfkj3CTRcShK0KOL/w6iTiKyqqBA9a41Wnggw8=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
@@ -604,6 +601,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mondoohq/go-scp v1.0.4 h1:DtcpMNvBw7erV8Xf66Q1qruNlciyCwxIHe5h1C/I544=
+github.com/mondoohq/go-scp v1.0.4/go.mod h1:BJpx7G2DFyf9Ujof36llkm8aLKkCRUmLHr/NAQvSr58=
 github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
@@ -842,7 +841,6 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
@@ -1012,7 +1010,6 @@ golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200828081204-131dc92a58d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/providers/google-workspace/go.mod
+++ b/providers/google-workspace/go.mod
@@ -250,3 +250,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.3 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/hnakamur/go-scp => github.com/mondoohq/go-scp v1.0.4

--- a/providers/google-workspace/go.sum
+++ b/providers/google-workspace/go.sum
@@ -221,7 +221,6 @@ github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
@@ -477,10 +476,8 @@ github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
-github.com/hnakamur/go-scp v1.0.2 h1:i2I0O0pjAaX4BXJFrp1blsIdjOBekc5QOaB0AbdO1d0=
-github.com/hnakamur/go-scp v1.0.2/go.mod h1:Dh9GtPFBkiDI1KY1nmf+W7eVCWWmRjJitkCYgvWv+Zc=
-github.com/hnakamur/go-sshd v0.0.0-20170228152141-dccc3399d26a h1:p8dbHRhXhPSwVZqk76FguLzyeCZuvCqFlaYSqXOzbyI=
-github.com/hnakamur/go-sshd v0.0.0-20170228152141-dccc3399d26a/go.mod h1:R+6I3EdoV6ofbNqJsArhT9+Pnu57DxtmDJAQfxkCbGo=
+github.com/hnakamur/go-sshd v0.2.1 h1:HOvlvBWPjedji3PUuF8xpRHVnYXX3LMfoi2NW8+OxOk=
+github.com/hnakamur/go-sshd v0.2.1/go.mod h1:I9pHzExs6WUoAJyT6awiGD+CW2r0EEoqZ1OFVKUhrZs=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f h1:7LYC+Yfkj3CTRcShK0KOL/w6iTiKyqqBA9a41Wnggw8=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
@@ -612,6 +609,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mondoohq/go-scp v1.0.4 h1:DtcpMNvBw7erV8Xf66Q1qruNlciyCwxIHe5h1C/I544=
+github.com/mondoohq/go-scp v1.0.4/go.mod h1:BJpx7G2DFyf9Ujof36llkm8aLKkCRUmLHr/NAQvSr58=
 github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
@@ -852,7 +851,6 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
@@ -1022,7 +1020,6 @@ golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200828081204-131dc92a58d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/providers/k8s/go.mod
+++ b/providers/k8s/go.mod
@@ -271,3 +271,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.2 // indirect
 	software.sslmate.com/src/go-pkcs12 v0.7.0 // indirect
 )
+
+replace github.com/hnakamur/go-scp => github.com/mondoohq/go-scp v1.0.4

--- a/providers/k8s/go.sum
+++ b/providers/k8s/go.sum
@@ -215,7 +215,6 @@ github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
@@ -502,10 +501,8 @@ github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
-github.com/hnakamur/go-scp v1.0.2 h1:i2I0O0pjAaX4BXJFrp1blsIdjOBekc5QOaB0AbdO1d0=
-github.com/hnakamur/go-scp v1.0.2/go.mod h1:Dh9GtPFBkiDI1KY1nmf+W7eVCWWmRjJitkCYgvWv+Zc=
-github.com/hnakamur/go-sshd v0.0.0-20170228152141-dccc3399d26a h1:p8dbHRhXhPSwVZqk76FguLzyeCZuvCqFlaYSqXOzbyI=
-github.com/hnakamur/go-sshd v0.0.0-20170228152141-dccc3399d26a/go.mod h1:R+6I3EdoV6ofbNqJsArhT9+Pnu57DxtmDJAQfxkCbGo=
+github.com/hnakamur/go-sshd v0.2.1 h1:HOvlvBWPjedji3PUuF8xpRHVnYXX3LMfoi2NW8+OxOk=
+github.com/hnakamur/go-sshd v0.2.1/go.mod h1:I9pHzExs6WUoAJyT6awiGD+CW2r0EEoqZ1OFVKUhrZs=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f h1:7LYC+Yfkj3CTRcShK0KOL/w6iTiKyqqBA9a41Wnggw8=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
@@ -637,6 +634,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mondoohq/go-scp v1.0.4 h1:DtcpMNvBw7erV8Xf66Q1qruNlciyCwxIHe5h1C/I544=
+github.com/mondoohq/go-scp v1.0.4/go.mod h1:BJpx7G2DFyf9Ujof36llkm8aLKkCRUmLHr/NAQvSr58=
 github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
@@ -877,7 +876,6 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
@@ -1047,7 +1045,6 @@ golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200828081204-131dc92a58d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/providers/os/connection/ssh/scp/fs.go
+++ b/providers/os/connection/ssh/scp/fs.go
@@ -76,9 +76,10 @@ func (s Fs) Stat(path string) (os.FileInfo, error) {
 	return statutil.New(s.commandRunner).Stat(path)
 }
 
-func (s Fs) Lstat(p string) (os.FileInfo, error) {
-	return nil, errors.New("lstat not implemented")
-}
+// NOTE: deliberately no Lstat. Connection.FileInfo probes for an Lstat method
+// and uses it as the primary call, so declaring one that always errors makes
+// every stat fail instead of falling through to Stat above, which works. Symlink
+// detection on this filesystem is handled by statutil's compound command.
 
 func (s Fs) Chmod(name string, mode os.FileMode) error {
 	return errors.New("chmod not implemented")

--- a/providers/os/connection/ssh/scp/fs_test.go
+++ b/providers/os/connection/ssh/scp/fs_test.go
@@ -1,0 +1,31 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package scp
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Connection.FileInfo probes for an Lstat method and, when it finds one, uses it
+// as the primary call with no fallback. This filesystem cannot lstat, so it must
+// not advertise the method: doing so made every stat fail with "lstat not
+// implemented" on any SSH target without an sftp subsystem - Oracle Solaris
+// 11.4 ships sshd with no Subsystem line at all - instead of falling through to
+// Stat, which works.
+func TestFsDoesNotAdvertiseLstat(t *testing.T) {
+	type lstater interface {
+		Lstat(string) (os.FileInfo, error)
+	}
+
+	var fs any = Fs{}
+	_, ok := fs.(lstater)
+	assert.False(t, ok, "scp Fs must not satisfy the lstat probe in Connection.FileInfo")
+
+	var pfs any = &Fs{}
+	_, ok = pfs.(lstater)
+	assert.False(t, ok, "*scp.Fs must not satisfy the lstat probe either")
+}

--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -1500,16 +1500,18 @@ var solaris = &PlatformResolver{
 
 		// NOTE: we have only one solaris system here, since we only get here is the family is sunos, we pass
 
-		// try to read "/etc/release" for more details
+		// try to read "/etc/release" for more details. uname already confirmed
+		// SunOS, so a missing or unreadable release file only costs us the title
+		// and version - it must not retract the platform detection itself.
 		f, err := conn.FileSystem().Open("/etc/release")
 		if err != nil {
-			return false, nil
+			return true, nil
 		}
 		defer f.Close()
 
 		c, err := io.ReadAll(f)
 		if err != nil {
-			return false, nil
+			return true, nil
 		}
 
 		release, err := ParseSolarisRelease(string(c))

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -930,6 +930,17 @@ func TestSolaris11Detector(t *testing.T) {
 	assert.Equal(t, []string{"unix", "os"}, di.Family)
 }
 
+// uname already proves the host is SunOS, so an unreadable /etc/release must
+// still detect solaris - just without a title and version.
+func TestSolarisDetectorWithoutReleaseFile(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-solaris11-no-release.toml")
+	require.NoError(t, err, "platform is still detected without /etc/release")
+
+	assert.Equal(t, "solaris", di.Name, "os name should be identified")
+	assert.Equal(t, "i86pc", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"unix", "os"}, di.Family)
+}
+
 func TestAix72Detector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-aix72.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers/os/connection/mock"
 )

--- a/providers/os/detector/parser_sol.go
+++ b/providers/os/detector/parser_sol.go
@@ -15,7 +15,9 @@ type SolarisRelease struct {
 	Release string
 }
 
-var solarisVersionRegex = regexp.MustCompile(`^\s+((?:[\w]\s*)*Solaris)\s([\w\d.]+)`)
+// (?m) so the release line is found even when /etc/release carries preceding
+// content, such as a site banner prepended ahead of the vendor line.
+var solarisVersionRegex = regexp.MustCompile(`(?m)^\s+((?:[\w]\s*)*Solaris)\s([\w\d.]+)`)
 
 func ParseSolarisRelease(content string) (*SolarisRelease, error) {
 	m := solarisVersionRegex.FindStringSubmatch(content)

--- a/providers/os/detector/parser_sol_test.go
+++ b/providers/os/detector/parser_sol_test.go
@@ -39,11 +39,11 @@ func TestSolaris11Release(t *testing.T) {
 	assert.Equal(t, "11", r.Release)
 }
 
+// Verbatim /etc/release from an Oracle Solaris 11.4.86 instance.
 func TestSolaris114Release(t *testing.T) {
-	input := `
-                             Oracle Solaris 11.4 X86
-  Copyright (c) 1983, 2018, Oracle and/or its affiliates.  All rights reserved.
-                            Assembled 16 August 2018
+	input := `                             Oracle Solaris 11.4 X86
+             Copyright (c) 1983, 2025, Oracle and/or its affiliates.
+                            Assembled 07 October 2025
 `
 
 	r, err := detector.ParseSolarisRelease(input)

--- a/providers/os/detector/parser_sol_test.go
+++ b/providers/os/detector/parser_sol_test.go
@@ -39,6 +39,37 @@ func TestSolaris11Release(t *testing.T) {
 	assert.Equal(t, "11", r.Release)
 }
 
+func TestSolaris114Release(t *testing.T) {
+	input := `
+                             Oracle Solaris 11.4 X86
+  Copyright (c) 1983, 2018, Oracle and/or its affiliates.  All rights reserved.
+                            Assembled 16 August 2018
+`
+
+	r, err := detector.ParseSolarisRelease(input)
+	require.NoError(t, err)
+
+	assert.Equal(t, "solaris", r.ID)
+	assert.Equal(t, "Oracle Solaris", r.Title)
+	assert.Equal(t, "11.4", r.Release)
+}
+
+// Some sites prepend a banner to /etc/release. The release line still has to be
+// found rather than only being matched when it happens to come first.
+func TestSolarisReleaseAfterPrecedingLine(t *testing.T) {
+	input := `Authorized use only. Activity may be monitored.
+                             Oracle Solaris 11.4 SPARC
+  Copyright (c) 1983, 2024, Oracle and/or its affiliates.
+`
+
+	r, err := detector.ParseSolarisRelease(input)
+	require.NoError(t, err)
+
+	assert.Equal(t, "solaris", r.ID)
+	assert.Equal(t, "Oracle Solaris", r.Title)
+	assert.Equal(t, "11.4", r.Release)
+}
+
 func TestSolaris10Release(t *testing.T) {
 	input := `
                         Solaris 10 5/08 s10x_u5wos_10 X86

--- a/providers/os/detector/testdata/detect-solaris11-no-release.toml
+++ b/providers/os/detector/testdata/detect-solaris11-no-release.toml
@@ -1,0 +1,8 @@
+[commands."uname -s"]
+stdout = "SunOS"
+
+[commands."uname -m"]
+stdout = "i86pc"
+
+[commands."uname -r"]
+stdout = "5.11"

--- a/providers/os/resources/cpu.go
+++ b/providers/os/resources/cpu.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -325,6 +326,30 @@ func getCpuInfoAIX(conn shared.Connection) (*cpuInfo, error) {
 	return info, nil
 }
 
+// psrinfo reports the core count only when the socket has more than one, and
+// uses the singular "core" for exactly one. A socket line without a core count
+// therefore describes a single-core package.
+//
+//	The physical processor has 4 cores and 8 virtual processors (0-7)
+//	The physical processor has 1 core and 2 virtual processors (0 1)
+//	The physical processor has 1 virtual processor (0)
+var solarisCoreCountRegex = regexp.MustCompile(`\bhas (\d+) cores?\b`)
+
+// solarisSocketCores returns the number of physical cores described by a single
+// "The physical processor has ..." line from psrinfo -pv.
+func solarisSocketCores(line string) int64 {
+	m := solarisCoreCountRegex.FindStringSubmatch(line)
+	if m == nil {
+		// no core count printed => the socket has a single core
+		return 1
+	}
+	n, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil {
+		return 1
+	}
+	return n
+}
+
 func getCpuInfoSolaris(conn shared.Connection) (*cpuInfo, error) {
 	// psrinfo -pv gives per-physical-processor details including model.
 	// Example output:
@@ -355,17 +380,7 @@ func getCpuInfoSolaris(conn shared.Connection) (*cpuInfo, error) {
 		// "The physical processor has N cores and M virtual processors (...)"
 		if strings.HasPrefix(trimmed, "The physical processor has") {
 			sockets++
-			// Extract core count
-			if idx := strings.Index(trimmed, " cores"); idx > 0 {
-				// Find the number before " cores"
-				prefix := trimmed[:idx]
-				parts := strings.Fields(prefix)
-				if len(parts) > 0 {
-					if n, err := strconv.ParseInt(parts[len(parts)-1], 10, 64); err == nil {
-						totalCores += n
-					}
-				}
-			}
+			totalCores += solarisSocketCores(trimmed)
 		}
 
 		// The indented model line (deepest indent, no parens) e.g.:

--- a/providers/os/resources/cpu_test.go
+++ b/providers/os/resources/cpu_test.go
@@ -157,9 +157,57 @@ func TestGetCpuInfoSolaris(t *testing.T) {
 	assert.Equal(t, int64(8), info.Cores)
 }
 
-// psrinfo uses the singular "core" for a single-core socket, which is the
-// common shape for a small cloud VM.
-func TestGetCpuInfoSolarisSingleCore(t *testing.T) {
+// Verbatim psrinfo -pv from a 2 OCPU Oracle Solaris 11.4.86 instance. Note the
+// nested "The core has ..." lines, which must not be mistaken for the model.
+func TestGetCpuInfoSolaris114TwoCore(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"psrinfo -pv": {
+				Stdout: "The physical processor has 2 cores and 4 virtual processors (0-3)\n" +
+					"  The core has 2 virtual processors (0-1)\n" +
+					"  The core has 2 virtual processors (2-3)\n" +
+					"    x86 (AuthenticAMD A10F11 family 25 model 17 step 1 clock 2600 MHz)\n" +
+					"      AMD EPYC 9J14 96-Core Processor\n",
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	info, err := getCpuInfoSolaris(conn)
+	require.NoError(t, err)
+
+	assert.Equal(t, "AMD", info.Manufacturer)
+	assert.Equal(t, "AMD EPYC 9J14 96-Core Processor", info.Model)
+	assert.Equal(t, int64(1), info.ProcessorCount)
+	assert.Equal(t, int64(2), info.Cores)
+}
+
+// Verbatim psrinfo -pv from a 1 OCPU Oracle Solaris 11.4.86 instance. psrinfo
+// prints no core count at all for a single-core socket, which used to be read
+// as zero cores.
+func TestGetCpuInfoSolaris114SingleCore(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"psrinfo -pv": {
+				Stdout: "The physical processor has 2 virtual processors (0-1)\n" +
+					"  x86 (AuthenticAMD A10F11 family 25 model 17 step 1 clock 2600 MHz)\n" +
+					"\tAMD EPYC 9J14 96-Core Processor\n",
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	info, err := getCpuInfoSolaris(conn)
+	require.NoError(t, err)
+
+	assert.Equal(t, "AMD", info.Manufacturer)
+	assert.Equal(t, "AMD EPYC 9J14 96-Core Processor", info.Model)
+	assert.Equal(t, int64(1), info.ProcessorCount)
+	assert.Equal(t, int64(1), info.Cores)
+}
+
+// psrinfo uses the singular "core" for a single-core socket that reports one.
+func TestGetCpuInfoSolarisSingularCoreWording(t *testing.T) {
 	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
 		Commands: map[string]*mock.Command{
 			"psrinfo -pv": {
@@ -175,26 +223,6 @@ func TestGetCpuInfoSolarisSingleCore(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "Intel", info.Manufacturer)
-	assert.Equal(t, int64(1), info.ProcessorCount)
-	assert.Equal(t, int64(1), info.Cores)
-}
-
-// A socket with a single core and no threads prints no core count at all.
-func TestGetCpuInfoSolarisSingleVirtualProcessor(t *testing.T) {
-	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
-		Commands: map[string]*mock.Command{
-			"psrinfo -pv": {
-				Stdout: "The physical processor has 1 virtual processor (0)\n" +
-					"  x86 (GenuineIntel 50654 family 6 model 85 step 4 clock 2000 MHz)\n" +
-					"        Intel(r) Xeon(r) Gold 6138 CPU @ 2.00GHz\n",
-			},
-		},
-	}))
-	require.NoError(t, err)
-
-	info, err := getCpuInfoSolaris(conn)
-	require.NoError(t, err)
-
 	assert.Equal(t, int64(1), info.ProcessorCount)
 	assert.Equal(t, int64(1), info.Cores)
 }

--- a/providers/os/resources/cpu_test.go
+++ b/providers/os/resources/cpu_test.go
@@ -157,6 +157,86 @@ func TestGetCpuInfoSolaris(t *testing.T) {
 	assert.Equal(t, int64(8), info.Cores)
 }
 
+// psrinfo uses the singular "core" for a single-core socket, which is the
+// common shape for a small cloud VM.
+func TestGetCpuInfoSolarisSingleCore(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"psrinfo -pv": {
+				Stdout: "The physical processor has 1 core and 2 virtual processors (0 1)\n" +
+					"  x86 (GenuineIntel 50654 family 6 model 85 step 4 clock 2000 MHz)\n" +
+					"        Intel(r) Xeon(r) Gold 6138 CPU @ 2.00GHz\n",
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	info, err := getCpuInfoSolaris(conn)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Intel", info.Manufacturer)
+	assert.Equal(t, int64(1), info.ProcessorCount)
+	assert.Equal(t, int64(1), info.Cores)
+}
+
+// A socket with a single core and no threads prints no core count at all.
+func TestGetCpuInfoSolarisSingleVirtualProcessor(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"psrinfo -pv": {
+				Stdout: "The physical processor has 1 virtual processor (0)\n" +
+					"  x86 (GenuineIntel 50654 family 6 model 85 step 4 clock 2000 MHz)\n" +
+					"        Intel(r) Xeon(r) Gold 6138 CPU @ 2.00GHz\n",
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	info, err := getCpuInfoSolaris(conn)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), info.ProcessorCount)
+	assert.Equal(t, int64(1), info.Cores)
+}
+
+// Mixed singular and plural sockets have to add up.
+func TestGetCpuInfoSolarisMixedSockets(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"psrinfo -pv": {
+				Stdout: "The physical processor has 1 core and 2 virtual processors (0 1)\n" +
+					"  x86 (GenuineIntel 50654 family 6 model 85 step 4 clock 2000 MHz)\n" +
+					"        Intel(r) Xeon(r) Gold 6138 CPU @ 2.00GHz\n" +
+					"The physical processor has 4 cores and 8 virtual processors (2-9)\n" +
+					"  x86 (GenuineIntel 50654 family 6 model 85 step 4 clock 2000 MHz)\n" +
+					"        Intel(r) Xeon(r) Gold 6138 CPU @ 2.00GHz\n",
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	info, err := getCpuInfoSolaris(conn)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2), info.ProcessorCount)
+	assert.Equal(t, int64(5), info.Cores)
+}
+
+func TestGetCpuInfoSolarisCommandFailure(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"psrinfo -pv": {
+				Stderr:     "bash: psrinfo: command not found",
+				ExitStatus: 127,
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	_, err = getCpuInfoSolaris(conn)
+	require.Error(t, err, "a failing psrinfo must not report a zero-core cpu")
+}
+
 func TestGetCpuInfoLinuxArmWithLscpu(t *testing.T) {
 	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
 		Files: map[string]*mock.MockFileData{

--- a/providers/os/resources/networkinterface/other_unix_routes_stub.go
+++ b/providers/os/resources/networkinterface/other_unix_routes_stub.go
@@ -1,0 +1,23 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !darwin && !linux && !windows
+
+// This file stubs out the Darwin route detection for every other unix build
+// (freebsd, netbsd, openbsd, dragonfly, solaris, aix).
+package networkinterface
+
+import (
+	"github.com/cockroachdb/errors"
+)
+
+// The real implementation lives in darwin_routes.go behind a darwin build tag,
+// because golang.org/x/net/route only builds on the targets Go supports it on.
+// linux and windows each carry their own stub; without one here the package
+// does not compile at all on any other platform, since routes.go references
+// *darwinRouteDetector in a switch case that is compiled on every platform.
+// The case never runs off darwin, but the method still has to exist for the
+// type to satisfy operatingSystemRouteDetector.
+func (*darwinRouteDetector) List() ([]Route, error) {
+	return nil, errors.New("Darwin route detection is not available on this platform")
+}

--- a/providers/os/resources/packages/solaris_packages.go
+++ b/providers/os/resources/packages/solaris_packages.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"strings"
 
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 )
@@ -95,6 +96,13 @@ func (s *SolarisPkgManager) List() ([]Package, error) {
 	cmd, err := s.conn.RunCommand("pkg list -Hv")
 	if err != nil {
 		return nil, fmt.Errorf("could not read solaris package list")
+	}
+	// without this an unavailable or failing pkg reports an empty package list
+	// as if the system genuinely had no packages installed
+	if cmd.ExitStatus != 0 {
+		stderr, _ := io.ReadAll(cmd.Stderr)
+		return nil, fmt.Errorf("pkg list failed with exit code %d: %s",
+			cmd.ExitStatus, strings.TrimSpace(string(stderr)))
 	}
 
 	return ParseSolarisPackages(cmd.Stdout), nil

--- a/providers/os/resources/packages/solaris_packages_test.go
+++ b/providers/os/resources/packages/solaris_packages_test.go
@@ -151,3 +151,21 @@ func TestSolaris114Manager(t *testing.T) {
 	}
 	assert.Contains(t, pkgList, p, "pkg detected")
 }
+
+// A failing or unavailable `pkg` must surface an error. Reporting an empty list
+// would read as "this system has no packages installed".
+func TestSolarisPkgManagerCommandFailure(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"pkg list -Hv": {
+				Stderr:     "bash: pkg: command not found",
+				ExitStatus: 127,
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	pkgs, err := (&SolarisPkgManager{conn: conn}).List()
+	require.Error(t, err)
+	assert.Empty(t, pkgs)
+}

--- a/providers/os/resources/port.go
+++ b/providers/os/resources/port.go
@@ -42,9 +42,13 @@ func (p *mqlPorts) list() ([]any, error) {
 	case pf.IsFamily("windows"):
 		return p.listWindows()
 
-	case pf.IsFamily("darwin") || pf.Name == "freebsd":
-		// both macOS and FreeBSD support lsof
-		// FreeBSD may need an installation via `pkg install sysutils/lsof`
+	case pf.Name == "freebsd":
+		// sockstat ships in the FreeBSD base system. lsof does not, and when it
+		// is absent the lsof path returns an empty list rather than an error,
+		// so a host with listening sockets reported none at all.
+		return p.listFreebsd()
+
+	case pf.IsFamily("darwin"):
 		return p.listMacos()
 
 	case pf.Name == "aix":
@@ -658,6 +662,127 @@ func (p *mqlPorts) listMacos() ([]any, error) {
 
 			res = append(res, obj)
 		}
+	}
+
+	return res, nil
+}
+
+// freebsdPortStates maps sockstat's CONN STATE column onto the canonical
+// TCP_STATES vocabulary, so `state == "listen"` behaves the same on FreeBSD as
+// everywhere else. udp rows carry no state and keep an empty value rather than
+// having one invented for them.
+var freebsdPortStates = map[string]string{
+	"LISTEN":      TCP_STATES[10],
+	"ESTABLISHED": TCP_STATES[1],
+	"SYN_SENT":    TCP_STATES[2],
+	"SYN_RCVD":    TCP_STATES[3],
+	"FIN_WAIT_1":  TCP_STATES[4],
+	"FIN_WAIT_2":  TCP_STATES[5],
+	"TIME_WAIT":   TCP_STATES[6],
+	"CLOSED":      TCP_STATES[7],
+	"CLOSE_WAIT":  TCP_STATES[8],
+	"LAST_ACK":    TCP_STATES[9],
+	"CLOSING":     TCP_STATES[11],
+}
+
+// freebsdPortState translates one sockstat CONN STATE token onto the canonical
+// TCP_STATES vocabulary. An unrecognised token passes through unchanged rather
+// than becoming "", so a state FreeBSD adds later is still visible instead of
+// silently reading as no state at all. udp rows carry no state and keep their
+// empty value.
+func freebsdPortState(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	if state, ok := freebsdPortStates[raw]; ok {
+		return state
+	}
+	return raw
+}
+
+// listFreebsd reads sockets from sockstat, which is part of the base system.
+func (p *mqlPorts) listFreebsd() ([]any, error) {
+	users, err := p.users()
+	if err != nil {
+		return nil, err
+	}
+
+	processes, err := p.processesByPid()
+	if err != nil {
+		return nil, err
+	}
+
+	conn := p.MqlRuntime.Connection.(shared.Connection)
+	executedCmd, err := conn.RunCommand("sockstat -46 -s")
+	if err != nil {
+		return nil, err
+	}
+	if executedCmd.ExitStatus != 0 {
+		// -s is not available on every release; the listing without it still
+		// carries every socket, only without the state column.
+		executedCmd, err = conn.RunCommand("sockstat -46")
+		if err != nil {
+			return nil, err
+		}
+		if executedCmd.ExitStatus != 0 {
+			return nil, errors.New("could not list ports: sockstat failed")
+		}
+	}
+
+	entries, err := ports.ParseSockstat(executedCmd.Stdout)
+	if err != nil {
+		return nil, err
+	}
+
+	// sockstat names the owning user, while the users map is keyed by uid.
+	// Index once: scanning per socket is O(sockets x users).
+	usersByName := make(map[string]*mqlUser, len(users))
+	for uid := range users {
+		u := users[uid]
+		if u != nil {
+			usersByName[u.Name.Data] = u
+		}
+	}
+
+	res := []any{}
+	for i := range entries {
+		entry := entries[i]
+
+		state := freebsdPortState(entry.State)
+
+		args := map[string]*llx.RawData{
+			"protocol":      llx.StringData(entry.Protocol),
+			"port":          llx.IntData(entry.LocalPort),
+			"address":       llx.StringData(entry.LocalAddress),
+			"state":         llx.StringData(state),
+			"remoteAddress": llx.StringData(entry.RemoteAddress),
+			"remotePort":    llx.IntData(entry.RemotePort),
+		}
+
+		mqlUser := usersByName[entry.User]
+		if mqlUser != nil {
+			args["user"] = llx.ResourceData(mqlUser, "user")
+		}
+
+		mqlProcess := processes[entry.Pid]
+		if mqlProcess != nil {
+			args["process"] = llx.ResourceData(mqlProcess, "process")
+		}
+
+		obj, err := CreateResource(p.MqlRuntime, "port", args)
+		if err != nil {
+			return nil, err
+		}
+
+		portObj := obj.(*mqlPort)
+		if mqlProcess == nil {
+			portObj.Process.State = plugin.StateIsSet | plugin.StateIsNull
+		}
+		if mqlUser == nil {
+			portObj.User.State = plugin.StateIsSet | plugin.StateIsNull
+		}
+
+		res = append(res, obj)
 	}
 
 	return res, nil

--- a/providers/os/resources/port_freebsd_state_test.go
+++ b/providers/os/resources/port_freebsd_state_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFreebsdPortState(t *testing.T) {
+	// mapped onto the same vocabulary the other platforms use
+	assert.Equal(t, "listen", freebsdPortState("LISTEN"))
+	assert.Equal(t, "established", freebsdPortState("ESTABLISHED"))
+	assert.Equal(t, "time wait", freebsdPortState("TIME_WAIT"))
+	assert.Equal(t, "close wait", freebsdPortState("CLOSE_WAIT"))
+
+	// udp rows carry no state at all
+	assert.Equal(t, "", freebsdPortState(""))
+
+	// a state FreeBSD adds later must stay visible rather than read as "no
+	// state", which is what a bare map lookup would have produced
+	assert.Equal(t, "SOME_FUTURE_STATE", freebsdPortState("SOME_FUTURE_STATE"))
+}

--- a/providers/os/resources/ports/sockstat.go
+++ b/providers/os/resources/ports/sockstat.go
@@ -1,0 +1,134 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package ports holds the per-platform socket listings that back the `ports`
+// resource. This file parses FreeBSD's sockstat, which ships in the base
+// system, unlike lsof.
+package ports
+
+import (
+	"bufio"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// SockstatEntry is one socket row from `sockstat -46 -s`.
+type SockstatEntry struct {
+	User          string
+	Command       string
+	Pid           int64
+	Protocol      string // tcp4, tcp6, udp4, udp6
+	LocalAddress  string
+	LocalPort     int64
+	RemoteAddress string
+	RemotePort    int64
+	State         string // CONN STATE column, empty for udp
+}
+
+// ParseSockstat reads the output of `sockstat -46 -s`.
+//
+//	USER     COMMAND    PID   FD  PROTO  LOCAL ADDRESS   FOREIGN ADDRESS  CONN STATE
+//	root     sshd       1718  7   tcp4   *:22            *:*              LISTEN
+//	ntpd     ntpd       1666  22  udp4   10.45.1.14:123  *:*
+//
+// Columns are whitespace separated and the command may be truncated, but never
+// contains a space, so splitting on fields is safe. The CONN STATE column is
+// absent for udp rows and on releases whose sockstat has no -s flag, so a row
+// is accepted with anything from 7 fields up.
+func ParseSockstat(r io.Reader) ([]SockstatEntry, error) {
+	var res []SockstatEntry
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 7 {
+			continue
+		}
+		if fields[0] == "USER" {
+			// header
+			continue
+		}
+
+		proto := fields[4]
+		if !isInetProtocol(proto) {
+			// unix domain sockets and anything else sockstat may list
+			continue
+		}
+
+		pid, err := strconv.ParseInt(fields[2], 10, 64)
+		if err != nil {
+			// a kernel socket has no pid ("?"); keep the row, report pid 0
+			pid = 0
+		}
+
+		localAddr, localPort := splitHostPort(fields[5])
+		remoteAddr, remotePort := splitHostPort(fields[6])
+
+		state := ""
+		if len(fields) > 7 {
+			state = strings.Join(fields[7:], " ")
+		}
+
+		res = append(res, SockstatEntry{
+			User:          fields[0],
+			Command:       fields[1],
+			Pid:           pid,
+			Protocol:      proto,
+			LocalAddress:  localAddr,
+			LocalPort:     localPort,
+			RemoteAddress: remoteAddr,
+			RemotePort:    remotePort,
+			State:         state,
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func isInetProtocol(p string) bool {
+	switch p {
+	case "tcp4", "tcp6", "udp4", "udp6":
+		return true
+	}
+	return false
+}
+
+// splitHostPort splits sockstat's ADDRESS:PORT, where the host may be "*", a
+// bare IPv4 address, or a bracketed IPv6 address that carries its own colons
+// and may include a zone ("[fe80::1%lo0]:123"). A wildcard or unknown port
+// yields 0.
+func splitHostPort(s string) (string, int64) {
+	if s == "" || s == "*:*" {
+		return "", 0
+	}
+
+	idx := strings.LastIndex(s, ":")
+	if idx < 0 {
+		return s, 0
+	}
+
+	host := s[:idx]
+	portStr := s[idx+1:]
+
+	// strip the brackets IPv6 literals are wrapped in
+	if len(host) > 1 && host[0] == '[' && host[len(host)-1] == ']' {
+		host = host[1 : len(host)-1]
+	}
+
+	port, err := strconv.ParseInt(portStr, 10, 64)
+	if err != nil {
+		// "*" for a wildcard port, or a service name
+		port = 0
+	}
+
+	return host, port
+}

--- a/providers/os/resources/ports/sockstat_test.go
+++ b/providers/os/resources/ports/sockstat_test.go
@@ -1,0 +1,136 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package ports
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Captured verbatim from `sockstat -46 -s` on FreeBSD 14.4-RELEASE.
+const sockstatFreeBSD14 = `USER     COMMAND    PID   FD  PROTO     LOCAL ADDRESS         FOREIGN ADDRESS       CONN STATE
+ec2-user sshd-sessi 10356 7   tcp4      10.45.1.14:22         97.115.90.143:61073   ESTABLISHED
+root     sshd        1718 6   tcp6      *:22                  *:*                   LISTEN
+root     sshd        1718 7   tcp4      *:22                  *:*                   LISTEN
+ntpd     ntpd        1666 21  udp4      *:123                 *:*
+ntpd     ntpd        1666 22  udp4      10.45.1.14:123        *:*
+ntpd     ntpd        1666 23  udp6      [::1]:123             *:*
+ntpd     ntpd        1666 24  udp6      [fe80::1%lo0]:123     *:*
+`
+
+func TestParseSockstatListeners(t *testing.T) {
+	entries, err := ParseSockstat(strings.NewReader(sockstatFreeBSD14))
+	require.NoError(t, err)
+	require.Len(t, entries, 7, "the header must not become a row")
+
+	// tcp6 listener on the wildcard address
+	e := entries[1]
+	assert.Equal(t, "root", e.User)
+	assert.Equal(t, "sshd", e.Command)
+	assert.Equal(t, int64(1718), e.Pid)
+	assert.Equal(t, "tcp6", e.Protocol)
+	assert.Equal(t, "*", e.LocalAddress)
+	assert.Equal(t, int64(22), e.LocalPort)
+	assert.Equal(t, "", e.RemoteAddress, "*:* is not a peer")
+	assert.Equal(t, int64(0), e.RemotePort)
+	assert.Equal(t, "LISTEN", e.State)
+}
+
+func TestParseSockstatEstablished(t *testing.T) {
+	entries, err := ParseSockstat(strings.NewReader(sockstatFreeBSD14))
+	require.NoError(t, err)
+
+	e := entries[0]
+	assert.Equal(t, "tcp4", e.Protocol)
+	assert.Equal(t, "10.45.1.14", e.LocalAddress)
+	assert.Equal(t, int64(22), e.LocalPort)
+	assert.Equal(t, "97.115.90.143", e.RemoteAddress)
+	assert.Equal(t, int64(61073), e.RemotePort)
+	assert.Equal(t, "ESTABLISHED", e.State)
+}
+
+// udp rows carry no CONN STATE column, and IPv6 literals bring their own
+// colons plus an optional zone.
+func TestParseSockstatUDPAndIPv6(t *testing.T) {
+	entries, err := ParseSockstat(strings.NewReader(sockstatFreeBSD14))
+	require.NoError(t, err)
+
+	udp6 := entries[5]
+	assert.Equal(t, "udp6", udp6.Protocol)
+	assert.Equal(t, "::1", udp6.LocalAddress, "brackets are stripped")
+	assert.Equal(t, int64(123), udp6.LocalPort)
+	assert.Equal(t, "", udp6.State, "udp has no connection state")
+
+	zoned := entries[6]
+	assert.Equal(t, "fe80::1%lo0", zoned.LocalAddress, "the zone is part of the address")
+	assert.Equal(t, int64(123), zoned.LocalPort)
+}
+
+// Older releases have no -s flag, so the state column is simply absent.
+func TestParseSockstatWithoutStateColumn(t *testing.T) {
+	raw := `USER     COMMAND    PID   FD  PROTO     LOCAL ADDRESS         FOREIGN ADDRESS
+root     sshd        1718 7   tcp4      *:22                  *:*
+`
+	entries, err := ParseSockstat(strings.NewReader(raw))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, int64(22), entries[0].LocalPort)
+	assert.Equal(t, "", entries[0].State)
+}
+
+// Unix domain sockets and other non-inet rows are not ports.
+func TestParseSockstatSkipsNonInet(t *testing.T) {
+	raw := `USER     COMMAND    PID   FD  PROTO     LOCAL ADDRESS         FOREIGN ADDRESS
+root     dbus        900  3   stream    /var/run/dbus/system_bus_socket  -
+root     sshd        1718 7   tcp4      *:22                  *:*
+`
+	entries, err := ParseSockstat(strings.NewReader(raw))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "tcp4", entries[0].Protocol)
+}
+
+// A kernel socket has "?" where the pid goes; the row is still a real socket.
+func TestParseSockstatKernelSocket(t *testing.T) {
+	raw := `USER     COMMAND    PID   FD  PROTO     LOCAL ADDRESS         FOREIGN ADDRESS       CONN STATE
+?        ?           ?    ?   tcp4      *:2049                *:*                   LISTEN
+`
+	entries, err := ParseSockstat(strings.NewReader(raw))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, int64(0), entries[0].Pid)
+	assert.Equal(t, int64(2049), entries[0].LocalPort)
+}
+
+func TestParseSockstatEmpty(t *testing.T) {
+	entries, err := ParseSockstat(strings.NewReader(""))
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestSplitHostPort(t *testing.T) {
+	tests := []struct {
+		in   string
+		host string
+		port int64
+	}{
+		{"*:22", "*", 22},
+		{"10.0.0.1:443", "10.0.0.1", 443},
+		{"[::1]:123", "::1", 123},
+		{"[fe80::1%lo0]:123", "fe80::1%lo0", 123},
+		{"*:*", "", 0},
+		{"", "", 0},
+		{"*:sunrpc", "*", 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			h, p := splitHostPort(tc.in)
+			assert.Equal(t, tc.host, h)
+			assert.Equal(t, tc.port, p)
+		})
+	}
+}

--- a/providers/os/resources/processes/solarisps_test.go
+++ b/providers/os/resources/processes/solarisps_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/mql/providers-sdk/v1/inventory"
-	"go.mondoo.com/mql/providers/os/connection/mock"
-	"go.mondoo.com/mql/providers/os/resources/processes"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers/os/connection/mock"
+	"go.mondoo.com/mql/v13/providers/os/resources/processes"
 )
 
 // Solaris 11.4 ships an /etc/os-release and so lands in the linux family, but

--- a/providers/os/resources/processes/solarisps_test.go
+++ b/providers/os/resources/processes/solarisps_test.go
@@ -1,0 +1,73 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package processes_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
+	"go.mondoo.com/mql/providers/os/resources/processes"
+)
+
+// Solaris 11.4 ships an /etc/os-release and so lands in the linux family, but
+// its SVR4 ps rejects the BSD-style "axo" cluster the linux branch uses:
+//
+//	ps: illegal option -- o
+//	usage: ps [ -aceglnrSuUvwx ] [ -t term ] ...
+//
+// Both fixtures below are verbatim from an Oracle Solaris 11.4.86 instance.
+func solarisMock(t *testing.T) *mock.Connection {
+	t.Helper()
+	conn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:   "solaris",
+			Family: []string{"linux", "unix", "os"},
+		},
+	}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"ps axo pid,pcpu,pmem,vsz,rss,tty,stat,stime,time,uid,command": {
+				Stderr:     "ps: illegal option -- o\nusage: ps [ -aceglnrSuUvwx ] [ -t term ] [ --scale[=item1,item2,...] ] [ num ]",
+				ExitStatus: 1,
+			},
+			"ps -eo pid,pcpu,pmem,vsz,rss,tty,s,time,uid,args": {
+				Stdout: "  PID %CPU %MEM   VSZ      RSS TT      S        TIME   UID COMMAND\n" +
+					"    0  0.2  0.0     0        0 ?       T       00:02     0 sched\n" +
+					"    1  0.0  0.1  4952     4008 ?       S       00:00     0 /usr/sbin/init\n" +
+					"    6  0.8  0.0     0        0 ?       S       00:03     0 zpool-rpool\n" +
+					"  892  0.0  0.2 12140     6788 ?       S       00:00    54 /usr/lib/ssh/sshd\n",
+			},
+		},
+	}))
+	require.NoError(t, err)
+	return conn
+}
+
+func TestSolarisProcessList(t *testing.T) {
+	pm, err := processes.ResolveManager(solarisMock(t))
+	require.NoError(t, err)
+	require.NotNil(t, pm)
+
+	list, err := pm.List()
+	require.NoError(t, err, "solaris must not fall through to the BSD ps syntax")
+	require.NotNil(t, list)
+	require.Len(t, list, 4, "a running solaris host reports its processes")
+
+	byPid := map[int64]*processes.OSProcess{}
+	for _, p := range list {
+		byPid[p.Pid] = p
+	}
+
+	init := byPid[1]
+	require.NotNil(t, init)
+	assert.Equal(t, "init", init.Executable)
+	assert.Equal(t, "/usr/sbin/init", init.Command)
+
+	sshd := byPid[892]
+	require.NotNil(t, sshd)
+	assert.Equal(t, "sshd", sshd.Executable)
+	assert.Equal(t, "/usr/lib/ssh/sshd", sshd.Command)
+}

--- a/providers/os/resources/processes/unixps.go
+++ b/providers/os/resources/processes/unixps.go
@@ -272,52 +272,84 @@ func (upm *UnixProcessManager) listLocked() ([]*OSProcess, error) {
 	return upm.processes, nil
 }
 
+// runPs runs a ps invocation and fails loudly when it does not succeed. ps
+// writes nothing to stdout when it rejects its arguments, which would otherwise
+// parse into an empty slice and report a running host as having no processes.
+func (upm *UnixProcessManager) runPs(command string) (io.Reader, error) {
+	c, err := upm.conn.RunCommand(command)
+	if err != nil {
+		// wrapped so a caller can tell a dead connection from a ps that ran
+		return nil, fmt.Errorf("processes> could not run %q: %w", command, err)
+	}
+	if c.ExitStatus != 0 {
+		stderr, _ := io.ReadAll(c.Stderr)
+		return nil, fmt.Errorf("processes> %q failed with exit code %d: %s",
+			command, c.ExitStatus, strings.TrimSpace(string(stderr)))
+	}
+	return c.Stdout, nil
+}
+
 // runList runs the platform-appropriate `ps` command and parses its output.
 func (upm *UnixProcessManager) runList() ([]*OSProcess, error) {
 	var entries []*ProcessEntry
 	// NOTE: improve proc parser instead of supporting multiple ps commands
-	if upm.platform.IsFamily("linux") {
-		c, err := upm.conn.RunCommand("ps axo pid,pcpu,pmem,vsz,rss,tty,stat,stime,time,uid,command")
-		if err != nil {
-			return nil, fmt.Errorf("processes> could not run command")
-		}
-
-		entries, err = ParseLinuxPsResult(c.Stdout)
+	switch {
+	case upm.platform.Name == "solaris":
+		// Solaris ships an SVR4 ps that rejects the BSD-style "axo" cluster with
+		// "ps: illegal option -- o", and has no /usr/ucb/ps to fall back on. This
+		// has to be tested before the linux family, because Solaris 11.4 ships an
+		// /etc/os-release and is therefore reported as part of it.
+		stdout, err := upm.runPs("ps -eo pid,pcpu,pmem,vsz,rss,tty,s,time,uid,args")
 		if err != nil {
 			return nil, err
 		}
-	} else if upm.platform.IsFamily("darwin") {
+
+		entries, err = ParseUnixPsResult(stdout)
+		if err != nil {
+			return nil, err
+		}
+	case upm.platform.IsFamily("linux"):
+		stdout, err := upm.runPs("ps axo pid,pcpu,pmem,vsz,rss,tty,stat,stime,time,uid,command")
+		if err != nil {
+			return nil, err
+		}
+
+		entries, err = ParseLinuxPsResult(stdout)
+		if err != nil {
+			return nil, err
+		}
+	case upm.platform.IsFamily("darwin"):
 		// NOTE: special case on darwin is that the ps axo only shows processes for users with terminals
 		// TODO: the same applies to OpenBSD and may result in missing processes
-		c, err := upm.conn.RunCommand("ps Axo pid,pcpu,pmem,vsz,rss,tty,stat,stime,time,uid,command")
-		if err != nil {
-			return nil, fmt.Errorf("processes> could not run command")
-		}
-
-		entries, err = ParseLinuxPsResult(c.Stdout)
+		stdout, err := upm.runPs("ps Axo pid,pcpu,pmem,vsz,rss,tty,stat,stime,time,uid,command")
 		if err != nil {
 			return nil, err
 		}
-	} else if upm.platform.Name == "aix" {
+
+		entries, err = ParseLinuxPsResult(stdout)
+		if err != nil {
+			return nil, err
+		}
+	case upm.platform.Name == "aix":
 		// special case for aix since it does not understand x
-		c, err := upm.conn.RunCommand("ps -A -o pid,pcpu,pmem,vsz,tty,time,uid,args")
-		if err != nil {
-			return nil, fmt.Errorf("processes> could not run command")
-		}
-
-		entries, err = ParseAixPsResult(c.Stdout)
+		stdout, err := upm.runPs("ps -A -o pid,pcpu,pmem,vsz,tty,time,uid,args")
 		if err != nil {
 			return nil, err
 		}
-	} else {
+
+		entries, err = ParseAixPsResult(stdout)
+		if err != nil {
+			return nil, err
+		}
+	default:
 		// TODO: consider using different ps calls for different platforms to determine max information
 		// do not use stime since it is not available on FreeBSD
-		c, err := upm.conn.RunCommand("ps axo pid,pcpu,pmem,vsz,rss,tty,stat,time,uid,command")
+		stdout, err := upm.runPs("ps axo pid,pcpu,pmem,vsz,rss,tty,stat,time,uid,command")
 		if err != nil {
-			return nil, fmt.Errorf("processes> could not run command")
+			return nil, err
 		}
 
-		entries, err = ParseUnixPsResult(c.Stdout)
+		entries, err = ParseUnixPsResult(stdout)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/os/resources/services/solarissmf.go
+++ b/providers/os/resources/services/solarissmf.go
@@ -5,6 +5,7 @@ package services
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"strings"
 
@@ -25,6 +26,13 @@ func (s *SolarisSmfServiceManager) List() ([]*Service, error) {
 	cmd, err := s.conn.RunCommand("svcs -a")
 	if err != nil {
 		return nil, err
+	}
+	// without this an unavailable or failing svcs reports an empty service list
+	// as if the system genuinely ran no services
+	if cmd.ExitStatus != 0 {
+		stderr, _ := io.ReadAll(cmd.Stderr)
+		return nil, fmt.Errorf("svcs -a failed with exit code %d: %s",
+			cmd.ExitStatus, strings.TrimSpace(string(stderr)))
 	}
 
 	return ParseSolarisSmfServices(cmd.Stdout), nil
@@ -51,11 +59,20 @@ func ParseSolarisSmfServices(r io.Reader) []*Service {
 	var services []*Service
 	scanner := bufio.NewScanner(r)
 
-	// Skip header line: "STATE          STIME           FMRI"
-	_ = scanner.Scan()
-
+	first := true
 	for scanner.Scan() {
 		line := scanner.Text()
+
+		// Drop the header line ("STATE STIME FMRI") when it is present, but only
+		// then. Skipping unconditionally loses the first service on headerless
+		// output such as `svcs -aH`.
+		if first {
+			first = false
+			if fields := strings.Fields(line); len(fields) > 0 && fields[0] == "STATE" {
+				continue
+			}
+		}
+
 		entry := parseSmfLine(line)
 		if entry == nil {
 			continue

--- a/providers/os/resources/services/solarissmf_test.go
+++ b/providers/os/resources/services/solarissmf_test.go
@@ -262,10 +262,44 @@ uninitialized  22:01:39        svc:/test/uninit:default
 	assert.Equal(t, ServiceStopped, svc.State)
 }
 
+// Verbatim `svcs -a` lines from an Oracle Solaris 11.4.86 instance. 11.4 prints
+// STIME as an ISO timestamp rather than the wall-clock time older releases used.
+func TestParseSolarisSmfServices114(t *testing.T) {
+	testOutput := `STATE          STIME               FMRI
+legacy_run     2026-08-27T07:02:19 lrc:/etc/rc2_d/S89PRESERVE
+disabled       2026-08-27T07:01:57 svc:/application/management/net-snmp:default
+online         2026-08-27T07:01:40 svc:/network/ssh:default
+offline*       2026-08-27T07:01:57 svc:/application/man-index:default
+incomplete     2026-08-27T07:01:33 svc:/system/early-manifest-import:default`
+
+	services := ParseSolarisSmfServices(strings.NewReader(testOutput))
+	require.Len(t, services, 5)
+
+	legacy := findServiceByName(services, "lrc:/etc/rc2_d/S89PRESERVE")
+	require.NotNil(t, legacy)
+	assert.True(t, legacy.Running, "legacy_run is running")
+
+	ssh := findServiceByName(services, "svc:/network/ssh:default")
+	require.NotNil(t, ssh)
+	assert.True(t, ssh.Running)
+	assert.True(t, ssh.Enabled)
+
+	// a transitioning state carries a trailing asterisk
+	manIndex := findServiceByName(services, "svc:/application/man-index:default")
+	require.NotNil(t, manIndex)
+	assert.False(t, manIndex.Running, "offline* is not yet running")
+	assert.True(t, manIndex.Enabled, "offline* is still enabled")
+
+	snmp := findServiceByName(services, "svc:/application/management/net-snmp:default")
+	require.NotNil(t, snmp)
+	assert.False(t, snmp.Running)
+	assert.False(t, snmp.Enabled)
+}
+
 // Headerless output must not lose its first service.
 func TestParseSolarisSmfServicesHeaderless(t *testing.T) {
-	testOutput := `online         22:01:55        svc:/network/ssh:default
-disabled       22:01:40        svc:/network/telnet:default`
+	testOutput := `online         2026-08-27T07:01:40 svc:/network/ssh:default
+disabled       2026-08-27T07:01:31 svc:/network/telnet:default`
 
 	services := ParseSolarisSmfServices(strings.NewReader(testOutput))
 	require.Len(t, services, 2)

--- a/providers/os/resources/services/solarissmf_test.go
+++ b/providers/os/resources/services/solarissmf_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/os/connection/mock"
 )
 
 func TestParseSolarisSmfServices(t *testing.T) {
@@ -258,6 +260,41 @@ uninitialized  22:01:39        svc:/test/uninit:default
 	assert.False(t, svc.Running, "uninitialized should not be running")
 	assert.False(t, svc.Enabled, "uninitialized should not be enabled")
 	assert.Equal(t, ServiceStopped, svc.State)
+}
+
+// Headerless output must not lose its first service.
+func TestParseSolarisSmfServicesHeaderless(t *testing.T) {
+	testOutput := `online         22:01:55        svc:/network/ssh:default
+disabled       22:01:40        svc:/network/telnet:default`
+
+	services := ParseSolarisSmfServices(strings.NewReader(testOutput))
+	require.Len(t, services, 2)
+
+	ssh := findServiceByName(services, "svc:/network/ssh:default")
+	require.NotNil(t, ssh, "the first service must not be swallowed as a header")
+	assert.True(t, ssh.Running)
+
+	telnet := findServiceByName(services, "svc:/network/telnet:default")
+	require.NotNil(t, telnet)
+	assert.False(t, telnet.Running)
+}
+
+// A failing or unavailable `svcs` must surface an error rather than reporting a
+// system with no services at all.
+func TestSolarisSmfManagerCommandFailure(t *testing.T) {
+	conn, err := mock.New(0, &inventory.Asset{}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			"svcs -a": {
+				Stderr:     "bash: svcs: command not found",
+				ExitStatus: 127,
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	svcs, err := (&SolarisSmfServiceManager{conn: conn}).List()
+	require.Error(t, err)
+	assert.Empty(t, svcs)
 }
 
 func findServiceByName(services []*Service, name string) *Service {

--- a/providers/os/resources/services/solarissmf_test.go
+++ b/providers/os/resources/services/solarissmf_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mondoo.com/mql/providers-sdk/v1/inventory"
-	"go.mondoo.com/mql/providers/os/connection/mock"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers/os/connection/mock"
 )
 
 func TestParseSolarisSmfServices(t *testing.T) {

--- a/providers/os/resources/uptime/unix.go
+++ b/providers/os/resources/uptime/unix.go
@@ -20,7 +20,11 @@ import (
 // component is exactly zero — "up 11 days, 16 hrs" (macOS prints "N hrs"
 // instead of "N:00" for one minute every hour, so missing that form made
 // the uptime resource error once an hour).
-var UnixUptimeRegex = regexp.MustCompile(`^.*up[\s]*(?:\s*(\d+)\s(day[s]*),)*(?:\s*(\d+)\s(hr[s]*),)*(?:\s*(\d+)\s(min[s]*),)*(?:\s+([\d:]+),\s)*\s*(?:(\d+)\suser[s]*,\s)*\s*load\s+average[s]*:\s+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)\s*$`)
+//
+// Solaris pluralizes with a parenthesized suffix instead of a bare "s",
+// printing "up 26 min(s)" and "up 5 day(s), 21:03", so each unit accepts
+// that spelling too.
+var UnixUptimeRegex = regexp.MustCompile(`^.*up[\s]*(?:\s*(\d+)\s(day(?:s|\(s\))?),)*(?:\s*(\d+)\s(hr(?:s|\(s\))?),)*(?:\s*(\d+)\s(min(?:s|\(s\))?),)*(?:\s+([\d:]+),\s)*\s*(?:(\d+)\suser[s]*,\s)*\s*load\s+average[s]*:\s+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)[,\s]+(\d+[\.,]\d+)\s*$`)
 
 type UnixUptimeResult struct {
 	Duration           int64
@@ -37,18 +41,16 @@ func unixDuration(date, measure string) (int64, error) {
 		return 0, err
 	}
 
+	// "days", "day(s)" and "day" all mean the same unit
+	measure = strings.TrimSuffix(measure, "(s)")
+	measure = strings.TrimSuffix(measure, "s")
+
 	switch measure {
 	case "day":
-		fallthrough
-	case "days":
 		duration = duration * 24 * int64(time.Hour)
 	case "hr":
-		fallthrough
-	case "hrs":
 		duration = duration * int64(time.Hour)
 	case "min":
-		fallthrough
-	case "mins":
 		duration = duration * int64(time.Minute)
 	}
 	return duration, nil

--- a/providers/os/resources/uptime/unix_test.go
+++ b/providers/os/resources/uptime/unix_test.go
@@ -204,3 +204,34 @@ func TestFreebsdUptime(t *testing.T) {
 	}, duration)
 	assert.Equal(t, "24m0s", time.Duration(duration.Duration).String())
 }
+
+// Solaris pluralizes with "(s)" rather than a bare "s". Verbatim output from an
+// Oracle Solaris 11.4.86 host.
+func TestSolarisUptimeMinutes(t *testing.T) {
+	data := "  7:28am  up 27 min(s),  0 users,  load average: 0.02, 0.01, 0.03"
+	duration, err := uptime.ParseUnixUptime(data)
+	assert.Nil(t, err)
+	assert.Equal(t, &uptime.UnixUptimeResult{
+		Duration:           int64(27 * time.Minute),
+		Users:              0,
+		LoadOneMinute:      float64(0.02),
+		LoadFiveMinutes:    float64(0.01),
+		LoadFifteenMinutes: float64(0.03),
+	}, duration)
+	assert.Equal(t, "27m0s", time.Duration(duration.Duration).String())
+}
+
+func TestSolarisUptimeDaysAndClock(t *testing.T) {
+	data := " 10:47am  up 5 day(s), 21:03,  1 user,  load average: 0.10, 0.20, 0.30"
+	duration, err := uptime.ParseUnixUptime(data)
+	assert.Nil(t, err)
+	assert.Equal(t, "141h3m0s", time.Duration(duration.Duration).String())
+	assert.Equal(t, 1, duration.Users)
+}
+
+func TestSolarisUptimeHours(t *testing.T) {
+	data := " 10:47am  up 2 hr(s), 15 min(s),  3 users,  load average: 0.10, 0.20, 0.30"
+	duration, err := uptime.ParseUnixUptime(data)
+	assert.Nil(t, err)
+	assert.Equal(t, "2h15m0s", time.Duration(duration.Duration).String())
+}


### PR DESCRIPTION
Backports every Solaris and FreeBSD fix that is on `main` but not on `v13`.

### Solaris

| PR | Fix |
|---|---|
| #10516 | Core counting, silently empty lists, and release detection. Covers `cpu`, the SMF service manager, the IPS package parser, and a Solaris 11 host with no `/etc/release`. |
| #10519 | `os.uptime` parse, which broke on Solaris' singular/plural wording. |
| #10517 | Run the SVR4 `ps` on Solaris, so `processes` is no longer empty. |
| #10518 | Drop the scp filesystem's `Lstat` stub. Oracle Solaris 11.4 ships sshd with no `sftp` subsystem, so every Solaris scan falls back to scp, where the stub made every file resource fail with `lstat not implemented` and took `services.list` down to zero on a host running 202 services. |

### FreeBSD

| PR | Fix |
|---|---|
| #10413 | List FreeBSD ports with `sockstat` instead of `lsof`. |
| #10412 | A route stub so `networkinterface` compiles on BSD and other unix targets. |
| #10414 | Point `go-scp` at the `mondoohq` fork v1.0.4. |

#10414 is included deliberately. Upstream `go-scp` v1.0.2 calls `newFileInfoFromOS` unconditionally while only defining it for darwin, linux and windows, which made the os provider unbuildable for the BSDs. Its own commit message names the pairing: *"A full freebsd os provider build also needs the networkinterface stub in #10412."* Backporting #10412 alone would have left FreeBSD just as broken, so both halves ship together.

Each fix is a `cherry-pick -x` of the squash-merge on `main`, so the original SHA is recorded in the trailer. All seven applied without conflicts.

### v13-specific adaptation

One extra commit repairs two things a cherry-pick cannot carry, neither of which surfaces as a conflict:

- **Module path.** `v13` is `module go.mondoo.com/mql/v13`; `main` has dropped the suffix. `solarisps_test.go` and `solarissmf_test.go` arrived naming the unversioned path.
- **A missing import.** `detector_platform_test.go` gained a `require.` call site from #10516, but its `require` import was added on `main` by an unrelated commit that is not part of this backport. Only the call came across, so the package stopped compiling under test. This one is invisible to `go build`, which never compiles `_test.go` files.

### Verification

The BSD fixes are only meaningful under cross-compilation, so that is how they were checked. Before this branch the os provider did not build for any BSD; it does now:

```
GOOS=freebsd  go build ./...   # providers/os - OK
GOOS=netbsd   go build ./...   # OK
GOOS=openbsd  go build ./...   # OK
GOOS=darwin   go build ./...   # OK
```

Tests, `go test -count=1`, all green:

```
detector  ports  uptime  processes  services  packages
connection/ssh (+ cat, keypair, scp, sftp)  networkinterface  resources
```

### Out of scope, noted

- **`GOOS=solaris` still does not build**, and does not on `main` either: `glebarez/go-sqlite` has no solaris support, and that dependency predates both lines. This is not a regression and does not affect the fixes above, because Solaris is scanned remotely over SSH from a linux or darwin binary rather than by running a solaris-native provider. A second solaris-only gap sits behind it, `fsutil.handleFsError`, whose `find_files_unix.go` build tag omits solaris identically on both branches.
- **`connection/device/linux` fails to build**, the same way it does on `origin/v13` before these commits: `snapshot.MockVolumeMounter` is a `mockgen` artifact that is not checked in. Nothing here touches `connection/device/`.
- **#10431** (route flags decoded with linux rather than BSD constants) matched a keyword sweep but is a Linux-only fix that leaves the BSD table alone, so it is not included.
