### PR TITLE
🎉 os-13.40.11

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.40.10",
+	Version: "13.40.11",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
Patch release of the `os` provider on the `v13` line: **13.40.10 → 13.40.11**.

### Changelog

Everything on `providers/os/` since the 13.40.10 bump (#10670):

- #10671 — 🐛 os: backport the Solaris and FreeBSD fixes to `v13`, carrying seven PRs over from `main`:
  - **Solaris** — core counting, silently empty lists and release detection (#10516); the `os.uptime` parse that broke on Solaris' singular/plural wording (#10519); the SVR4 `ps`, so `processes` is no longer empty (#10517); and the scp filesystem's `Lstat` stub, which made every file resource fail with `lstat not implemented` and took `services.list` to zero on Solaris 11.4, whose sshd ships without an `sftp` subsystem (#10518).
  - **FreeBSD** — ports listed with `sockstat` instead of `lsof` (#10413), plus the two halves of the BSD build fix: the `networkinterface` route stub (#10412) and the `go-scp` fork that unblocks it (#10414).

### Notes

Version bumped by hand rather than with `providers-sdk/v1/util/version/version.go`, for the same reason as #10670: that tool uses go-git, which cannot resolve a linked worktree, so its `blame` on `config.go` fails and it emits a stub changelog with a hardcoded change count while still exiting zero. The changelog above comes from the real log on `v13`.

Single-line change to `providers/os/config/config.go`; no schema or `.lr.versions` movement, since the backport added no fields.
