### PR TITLE
🟢 os: point the rsyslog .d mock at the find command #9426 now emits

### DIFF
--- a/providers/os/resources/testdata/rsyslog_dotd_nested.toml
+++ b/providers/os/resources/testdata/rsyslog_dotd_nested.toml
@@ -36,12 +36,12 @@ content = """not a config fragment
 """
 
 # Legacy `<conf>.d` auto-discovery.
-[commands."find -L \"/etc/rsyslog.d\" -xdev -type f -perm -0"]
+[commands."find \"/etc/rsyslog.d\" -xdev -type f -perm -0"]
 stdout = """/etc/rsyslog.d/50-frag.conf
 """
 
 # Include expansion out of the auto-discovered fragment.
-[commands."find -L \"/etc/rsyslog.nested\" -xdev -type f -perm -0 -maxdepth 1"]
+[commands."find \"/etc/rsyslog.nested\" -xdev -type f -perm -0 -maxdepth 1"]
 stdout = """/etc/rsyslog.nested/90-nested.conf
 /etc/rsyslog.nested/notes.txt
 """


### PR DESCRIPTION
`main` is red. `go-test-providers` fails on `0b33adede`, and every branch cut from it inherits the failure:

```
FAIL: providers/os/resources TestRsyslogConf_DotDFragmentIncludesAreFollowed
  []string{"/etc/rsyslog.conf"} does not contain "/etc/rsyslog.d/50-frag.conf"
  []string{"/etc/rsyslog.conf"} does not contain "/etc/rsyslog.nested/90-nested.conf"
```

## Cause

#9426 stopped emitting `-L` for anything but a link search, and updated the rsyslog fixtures that key their mocked commands on the old spelling — `rsyslog_includes.toml` and `rsyslog_midpath_include.toml`. There is a third. `rsyslog_dotd_nested.toml` still asks for:

```toml
[commands."find -L \"/etc/rsyslog.d\" -xdev -type f -perm -0"]
```

The resource now runs `find "/etc/rsyslog.d" …`, the mock lookup misses, the command returns nothing, and no fragment is discovered. Two command keys, two lines.

## This is the fixture, not the behaviour

Worth stating plainly, because the failure reads like a collection bug and isn't one. Against a real filesystem `find` without `-L` still lists regular files, so `.d` fragment collection is unaffected on a real host. I checked rather than assumed:

```
find <dir> -type f             →  plain.conf                     (symlinked file not matched)
find -L <dir> -type f          →  plain.conf, symlinked.conf
find <symlinked-dir> -type f   →  (nothing — not descended)
find -L <symlinked-dir> -type f →  linked.conf
```

So #9426's production effect is narrow and real: a **symlinked** file is no longer matched by a `type: "file"` search, and a symlinked start directory is no longer descended. For rsyslog that means a symlinked `.d` fragment, or a symlinked `/etc/rsyslog.d`, is now missed. That is a defensible trade against the hang `-L` invites on a stale mount, and it is #9426's call to have made — noting it here only because it is a user-visible change beyond what the title implies, and it is not written down anywhere yet.

## Swept rather than spot-fixed

Every remaining `find -L` in the repo, checked rather than left:

| where | verdict |
|---|---|
| `unix_findcmd.go:57`, `unix_findcmd_test.go:94` | correct — the link-search branch, which is what #9426 kept `-L` for |
| `rsyslog_dotd_nested.toml` | **this PR** |
| `services/testdata/ubuntu1404.toml:8` | **pre-existing, separate bug** — see below |

`ubuntu1404.toml` is keyed on `find -L /etc/rc*.d -name 'S*'` while `sysv.go:96` runs it *without* `-L`, and has for longer than #9426. The mock is dead: the lookup misses, sysv services come back empty, and the test passes anyway because nothing asserts they are non-empty. That wants its own change plus a test that would notice, so it is deliberately not folded in here.

## Verification

`go test ./providers/os/resources/... ` green with this change, including the previously failing test. Confirmed the failure first on a clean `main` checkout locally, and against CI history — `0b33adede` is the first `go-test-providers=failure`, with the three commits before it green.
