### PR TITLE
🟢 os: make the sysv runlevel fixture assert Service.Enabled instead of nothing

### DIFF
--- a/providers/os/resources/services/testdata/ubuntu1404.toml
+++ b/providers/os/resources/services/testdata/ubuntu1404.toml
@@ -5,8 +5,14 @@ rc
 ssh
 """
 
-[commands."find -L /etc/rc*.d -name 'S*'"]
-stdout = """
+# The runlevel links behind Service.Enabled. `ssh` is linked into the multi-user
+# runlevels; `cron` is installed but linked into none, which is what an enabled
+# and a disabled sysv service look like side by side.
+[commands."find /etc/rc*.d -name 'S*'"]
+stdout = """/etc/rc2.d/S20ssh
+/etc/rc3.d/S20ssh
+/etc/rc4.d/S20ssh
+/etc/rc5.d/S20ssh
 """
 
 [commands."/sbin/initctl list"]

--- a/providers/os/resources/services/upstart_test.go
+++ b/providers/os/resources/services/upstart_test.go
@@ -27,4 +27,23 @@ func TestParseUpstartServicesRunning(t *testing.T) {
 	services, err := upstart.List()
 	require.NoError(t, err)
 	assert.Equal(t, 9, len(services), "detected the right amount of services")
+
+	// Enabled comes from the runlevel links, which arrive through their own
+	// find command. Nothing here asserted it, so when the fixture's key stopped
+	// matching what sysv.go runs, the lookup returned nothing and every sysv
+	// service reported Enabled=false with the count above still passing. A
+	// disabled service is a real state, so "all false" has to be told from
+	// "nothing was read" by asserting both.
+	byName := map[string]*Service{}
+	for _, s := range services {
+		byName[s.Name] = s
+	}
+
+	ssh := byName["ssh"]
+	require.NotNil(t, ssh, "ssh is a sysv service in this fixture")
+	assert.True(t, ssh.Enabled, "ssh is linked into the multi-user runlevels")
+
+	cron := byName["cron"]
+	require.NotNil(t, cron, "cron is a sysv service in this fixture")
+	assert.False(t, cron.Enabled, "cron is installed but linked into no runlevel")
 }


### PR DESCRIPTION
Found while sweeping stale `find -L` fixtures for #10673. **This one is not #9426's doing** — it predates it — and it is a *dead* fixture rather than a mismatched one.

## The fixture is dead twice over

`ubuntu1404.toml` keys its runlevel command on:

```toml
[commands."find -L /etc/rc*.d -name 'S*'"]
stdout = """
"""
```

`sysv.go:96` runs it **without** `-L`, so the lookup misses. And the payload behind that key is empty anyway — so fixing the key alone would change nothing.

## What it costs

Not cosmetic. `Service.Enabled` for every sysv service is read from exactly that command:

```go
Enabled: len(rl[service]) > 0,
```

With nothing coming back, every sysv service reports `Enabled=false`. Measured on `main` before the change:

```
sysv services=2  of which Enabled=0
runlevel entries parsed from the fixture: 0
```

`TestParseUpstartServicesRunning` asserted only that nine services were found — a count the *other* commands supply — so it passed throughout and would have kept passing however wrong `Enabled` was. A test that asserts nothing about the field its fixture exists to provide.

## The change

The key now matches what `sysv.go` runs, and the payload states the runlevel links a real Ubuntu box has: `ssh` linked into the multi-user runlevels, `cron` installed and linked into none.

**Both are asserted.** A disabled service is a real state, so "all false" has to be distinguishable from "nothing was read" — asserting only the enabled one would pass again the moment the fixture goes dead.

## Verification

Both halves of the deadness confirmed caught, mutated separately:

```
put -L back on the key   -> FAIL: ssh is linked into the multi-user runlevels
empty the payload        -> FAIL: ssh is linked into the multi-user runlevels
```

`go test ./providers/os/resources/services/` green.

## Note on scope

Deliberately separate from #10673, which fixes the rsyslog fixture that #9426 missed and is what actually unblocks `main`. That PR's body says this one is not folded in; this is it.
