### PR TITLE
✨ root narrowing (ADR-031, rooted resource)

### DIFF
--- a/docs/adr/031-in-query-cross-asset-traversal.md
+++ b/docs/adr/031-in-query-cross-asset-traversal.md
@@ -248,6 +248,13 @@ uses (`raiseMinimum` narrows a lattice as members are touched). At run time
 refuses one that cannot with `ErrRootMismatch` — a scoping answer the caller can
 recognize, not a failure.
 
+**Refusing is opt-in**, under `RootedNamespace` or by a caller asking
+`SupportsRoot` itself. "Not applicable to this asset" and "this check failed" are
+different answers, and a caller that cannot yet tell them apart would report the
+first as the second; the scanner-side handling that skips the asset instead lands
+with the cnspec work that consumes `compatible_roots`. Until then v14 execution is
+unchanged and a mismatched member degrades as it does today.
+
 Which resources are roots is stated in the schema by `@root`, the same way
 `@global` states reachability without one. Narrowing needs the root *family*, not
 just the declared union, and a diagnostic that names "the root that does carry

--- a/docs/adr/031-in-query-cross-asset-traversal.md
+++ b/docs/adr/031-in-query-cross-asset-traversal.md
@@ -240,13 +240,33 @@ cannot be published:
 ### 4. Root narrowing
 
 `_` compiles against `os.any`, and the compiler **narrows** as members are
-accessed: touch only universals and the requirement stays `os.base`; touch
-`iptables` and it becomes `os.linux`. The narrowed requirement is recorded on the
-bundle beside `MinProviderVersions`, by the same accumulator pattern
-`mqlc/provenance.go` already uses (`raiseMinimum` narrows a lattice as members are
-touched). At run time an asset whose root does not satisfy the requirement is
-**skipped as unsupported**, the way `mqlc.UnmetRequirements` already withholds
-content.
+accessed: reading only universals leaves every root compatible, reading
+`iptables` leaves `os.linux`. The narrowed set is recorded on the bundle as
+`compatible_roots`, by the same accumulator pattern `mqlc/provenance.go` already
+uses (`raiseMinimum` narrows a lattice as members are touched). At run time
+`mqlc.SupportsRoot` answers whether an asset can execute it, and `ExecuteCode`
+refuses one that cannot with `ErrRootMismatch` — a scoping answer the caller can
+recognize, not a failure.
+
+Which resources are roots is stated in the schema by `@root`, the same way
+`@global` states reachability without one. Narrowing needs the root *family*, not
+just the declared union, and a diagnostic that names "the root that does carry
+this" needs it too.
+
+Three rules keep it honest:
+
+- **Only members read off a root narrow anything.** A member of an ordinary
+  resource says nothing about which asset a query is about, and neither does the
+  global namespace — so v14 content that never touches a root records no
+  requirement and runs everywhere, exactly as before.
+- **The union is never in the set.** It carries every member by construction, so
+  counting it would make every intersection non-empty. A bundle compiled against
+  the union is still compatible with an asset that reports it, which is what a
+  provider does before it refines its root per connection.
+- **An empty intersection records nothing.** Content that deliberately spans
+  platforms — one branch per platform — has no single root carrying all of it.
+  Refusing it, or marking it runnable nowhere, would break that pattern, so it
+  runs and each member degrades where it does not apply.
 
 This is single pass. The chunk stays typed `os.any` and is never patched — which
 matters, because checksums are computed incrementally as chunks are added, so
@@ -544,10 +564,10 @@ itself `asset<…>` resolves through the *target* runtime's own resolver.
 5. **`RootedNamespace` feature flag.** The v15 semantics behind a flag: rooted
    only, `@global` for the exceptions, no fallback, a root required. Runnable
    against real content for the months before it becomes the default. **Landed.**
-6. **Root narrowing.** Compile `_` against the union, record the narrowed
-   requirement on the bundle, skip assets that do not satisfy it. Needed for the
+6. **Root narrowing.** Compile `_` against the union, record the narrowed set on
+   the bundle, refuse assets that do not satisfy it. Needed for the
    **disconnected** compile; a connected one already gets the concrete root from
-   `ConnectRes` and is bounded exactly. **Landed for the connected path.**
+   `ConnectRes` and is bounded exactly. **Landed.**
 7. **Recording-backed cross-asset resolution.** `providers.Runtime` implements
    `AssetResolver`; the target asset is found from the reverse edge and connected
    with a `mock` connection, including the `providers/mock.go:182` asset-selection

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -90,12 +90,22 @@ func ExecuteCode(runtime llx.Runtime, codeBundle *llx.CodeBundle, props map[stri
 	// Content narrowed to a set of asset roots says which assets it is about
 	// (ADR 031). Running it against an asset outside that set produces answers
 	// about a platform the content was never written for - nulls that read as
-	// facts - so it is refused with an error the caller can recognize and treat
-	// as "not applicable" rather than as a failure.
-	if src, ok := runtime.(llx.AssetRootSource); ok {
-		if root := src.AssetRoot(); !mqlc.SupportsRoot(codeBundle, root) {
-			return nil, fmt.Errorf("%w: this asset is rooted at %s, the content targets %s",
-				mqlc.ErrRootMismatch, root, strings.Join(codeBundle.CompatibleRoots, ", "))
+	// facts - so it is refused with an error the caller can recognize.
+	//
+	// Only under RootedNamespace, which is the opt-in to this model. Refusing by
+	// default would turn "not applicable to this asset" into a hard failure for
+	// every caller that does not yet tell the two apart, and no caller does yet:
+	// the scanner-side handling that skips such an asset instead of failing the
+	// check lives in cnspec and lands with the work that consumes
+	// compatible_roots. Until then a caller opts in either by that feature or by
+	// asking mqlc.SupportsRoot itself, and v14 execution is unchanged - a
+	// mismatched member degrades exactly as it does today.
+	if features.IsActive(mql.RootedNamespace) {
+		if src, ok := runtime.(llx.AssetRootSource); ok {
+			if root := src.AssetRoot(); !mqlc.SupportsRoot(codeBundle, root) {
+				return nil, fmt.Errorf("%w: this asset is rooted at %s, the content targets %s",
+					mqlc.ErrRootMismatch, root, strings.Join(codeBundle.CompatibleRoots, ", "))
+			}
 		}
 	}
 

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -5,6 +5,8 @@ package exec
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql"
@@ -85,6 +87,18 @@ func ExecStrict(query string, runtime llx.Runtime, features mql.Features, props 
 }
 
 func ExecuteCode(runtime llx.Runtime, codeBundle *llx.CodeBundle, props map[string]*llx.Primitive, features mql.Features) (map[string]*llx.RawResult, error) {
+	// Content narrowed to a set of asset roots says which assets it is about
+	// (ADR 031). Running it against an asset outside that set produces answers
+	// about a platform the content was never written for - nulls that read as
+	// facts - so it is refused with an error the caller can recognize and treat
+	// as "not applicable" rather than as a failure.
+	if src, ok := runtime.(llx.AssetRootSource); ok {
+		if root := src.AssetRoot(); !mqlc.SupportsRoot(codeBundle, root) {
+			return nil, fmt.Errorf("%w: this asset is rooted at %s, the content targets %s",
+				mqlc.ErrRootMismatch, root, strings.Join(codeBundle.CompatibleRoots, ", "))
+		}
+	}
+
 	// Install any downgrade translations this reader needs (ADR 040 part 6).
 	//
 	// Patch returns the code to execute rather than editing in place, so the

--- a/llx/llx.pb.go
+++ b/llx/llx.pb.go
@@ -894,9 +894,9 @@ type CodeBundle struct {
 	// Resources this bundle reached through the global namespace that do not hang
 	// off an asset root and are not marked `@global` (ADR 031 point 7).
 	//
-	// In v14 a bare name resolves globally first and falls back to the asset root,
-	// so both spellings work. In v15 the root is the namespace, and a name that is
-	// neither rooted nor global stops resolving. This list is what makes that
+	// In v14 a bare name resolves globally first and falls back to the asset
+	// root, so both spellings work. In v15 the root is the namespace, and a name
+	// that is neither rooted nor global stops resolving. This list is what makes
 	// cutover measurable: it is the set of names in this bundle that have no home
 	// in the asset's tree, recorded rather than logged so tooling can show which
 	// parts of a bundle reach outside it.
@@ -908,9 +908,21 @@ type CodeBundle struct {
 	// was compiled without one. Provenance - what the query was bounded by - and
 	// what lets a reader tell the chunks the compiler inserted to reach the root
 	// from the ones the author wrote.
-	AssetRoot     string `protobuf:"bytes,30,opt,name=asset_root,json=assetRoot,proto3" json:"asset_root,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	AssetRoot string `protobuf:"bytes,30,opt,name=asset_root,json=assetRoot,proto3" json:"asset_root,omitempty"`
+	// The asset roots that can execute this bundle (ADR 031), narrowed from what
+	// it touched: a query reading only universal members is satisfied by every
+	// root, one reading `iptables` only by the Linux root and the union above it.
+	//
+	// Empty means no requirement was derived - nothing was reached through a
+	// root, which is every bundle compiled before this existed and every one that
+	// only uses the global namespace. A reader treats empty as "runs anywhere".
+	//
+	// This is applicability derived from the query rather than declared beside
+	// it: the same job a hand-written platform filter does today, computed from
+	// what the code actually reads.
+	CompatibleRoots []string `protobuf:"bytes,31,rep,name=compatible_roots,json=compatibleRoots,proto3" json:"compatible_roots,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *CodeBundle) Reset() {
@@ -1046,6 +1058,13 @@ func (x *CodeBundle) GetAssetRoot() string {
 		return x.AssetRoot
 	}
 	return ""
+}
+
+func (x *CodeBundle) GetCompatibleRoots() []string {
+	if x != nil {
+		return x.CompatibleRoots
+	}
+	return nil
 }
 
 // TranslationRef points one call that an older reader cannot make at a block
@@ -1692,7 +1711,7 @@ const file_llx_proto_rawDesc = "" +
 	"\x05field\x18\x01 \x01(\tR\x05field\x12\x14\n" +
 	"\x05title\x18\x02 \x01(\tR\x05title\x12\x12\n" +
 	"\x04desc\x18\x03 \x01(\tR\x04desc\x12\x1a\n" +
-	"\bprovider\x18\x04 \x01(\tR\bprovider\"\xd3\t\n" +
+	"\bprovider\x18\x04 \x01(\tR\bprovider\"\xfe\t\n" +
 	"\n" +
 	"CodeBundle\x12(\n" +
 	"\acode_v2\x18\x06 \x01(\v2\x0f.mql.llx.CodeV2R\x06codeV2\x128\n" +
@@ -1713,7 +1732,8 @@ const file_llx_proto_rawDesc = "" +
 	"\ftranslations\x18\x1c \x03(\v2\x17.mql.llx.TranslationRefR\ftranslations\x12-\n" +
 	"\x12unrooted_resources\x18\x1d \x03(\tR\x11unrootedResources\x12\x1d\n" +
 	"\n" +
-	"asset_root\x18\x1e \x01(\tR\tassetRoot\x1a8\n" +
+	"asset_root\x18\x1e \x01(\tR\tassetRoot\x12)\n" +
+	"\x10compatible_roots\x18\x1f \x03(\tR\x0fcompatibleRoots\x1a8\n" +
 	"\n" +
 	"PropsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +

--- a/llx/llx.proto
+++ b/llx/llx.proto
@@ -196,6 +196,19 @@ message CodeBundle {
   // what lets a reader tell the chunks the compiler inserted to reach the root
   // from the ones the author wrote.
   string asset_root = 30;
+
+  // The asset roots that can execute this bundle (ADR 031), narrowed from what
+  // it touched: a query reading only universal members is satisfied by every
+  // root, one reading `iptables` only by the Linux root and the union above it.
+  //
+  // Empty means no requirement was derived - nothing was reached through a
+  // root, which is every bundle compiled before this existed and every one that
+  // only uses the global namespace. A reader treats empty as "runs anywhere".
+  //
+  // This is applicability derived from the query rather than declared beside
+  // it: the same job a hand-written platform filter does today, computed from
+  // what the code actually reads.
+  repeated string compatible_roots = 31;
 }
 
 // TranslationRef points one call that an older reader cannot make at a block

--- a/llx/llx_vtproto.pb.go
+++ b/llx/llx_vtproto.pb.go
@@ -848,6 +848,17 @@ func (m *CodeBundle) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.CompatibleRoots) > 0 {
+		for iNdEx := len(m.CompatibleRoots) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.CompatibleRoots[iNdEx])
+			copy(dAtA[i:], m.CompatibleRoots[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.CompatibleRoots[iNdEx])))
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0xfa
+		}
+	}
 	if len(m.AssetRoot) > 0 {
 		i -= len(m.AssetRoot)
 		copy(dAtA[i:], m.AssetRoot)
@@ -2005,6 +2016,12 @@ func (m *CodeBundle) SizeVT() (n int) {
 	l = len(m.AssetRoot)
 	if l > 0 {
 		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.CompatibleRoots) > 0 {
+		for _, s := range m.CompatibleRoots {
+			l = len(s)
+			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -5769,6 +5786,38 @@ func (m *CodeBundle) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.AssetRoot = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 31:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CompatibleRoots", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CompatibleRoots = append(m.CompatibleRoots, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/mqlc/asset_test.go
+++ b/mqlc/asset_test.go
@@ -565,3 +565,79 @@ func TestRootMemberSuggestions(t *testing.T) {
 		assert.NotContains(t, out, "hostname")
 	})
 }
+
+// Narrowing derives applicability from what a query reads (ADR 031 point 4):
+// compiled against the union of roots, the bundle records which of them can
+// actually run it. That is the job a hand-written platform filter does today.
+func TestRootNarrowing(t *testing.T) {
+	union := mqlc.NewConfig(core_schema.Add(os_schema), mql.Features{byte(mql.ResourceContext)})
+	union.AssetRoot = "os.any"
+
+	rootsFor := func(t *testing.T, q string) []string {
+		t.Helper()
+		res, err := mqlc.Compile(q, nil, union)
+		require.NoError(t, err, q)
+		return res.CompatibleRoots
+	}
+
+	t.Run("universal members stay portable", func(t *testing.T) {
+		assert.Equal(t,
+			[]string{"os.base", "os.linux", "os.macos", "os.unix", "os.windows"},
+			rootsFor(t, "_.hostname"),
+			"the union is not listed: no connection reports it, and it carries everything")
+	})
+
+	t.Run("a platform member narrows to its family", func(t *testing.T) {
+		assert.Equal(t, []string{"os.linux"}, rootsFor(t, "_.iptables.output"))
+		assert.Equal(t, []string{"os.windows"}, rootsFor(t, "_.registrykey"))
+		assert.Equal(t, []string{"os.macos"}, rootsFor(t, "_.launchd"))
+		// sshd is a unix-family facility, so macOS qualifies and Windows does not
+		assert.Equal(t, []string{"os.linux", "os.macos", "os.unix"},
+			rootsFor(t, "_.sshd.config.params"))
+	})
+
+	t.Run("the narrowest member wins", func(t *testing.T) {
+		assert.Equal(t, []string{"os.linux"},
+			rootsFor(t, "_ { hostname iptables.output }"), "reads inside a block narrow too")
+	})
+
+	// The global namespace says nothing about which asset a query is about, so
+	// v14 content that never touches a root carries no requirement and keeps
+	// running everywhere.
+	t.Run("global reads derive nothing", func(t *testing.T) {
+		assert.Empty(t, rootsFor(t, "packages.list.length"))
+		assert.Empty(t, rootsFor(t, "asset.platform"))
+	})
+
+	// Deliberately cross-platform content - one branch per platform - has no
+	// single root that carries everything. Refusing it, or marking it runnable
+	// nowhere, would break that pattern, so it records no requirement and each
+	// member degrades on the platform that lacks it.
+	t.Run("content spanning platforms records no requirement", func(t *testing.T) {
+		assert.Empty(t, rootsFor(t, "_ { iptables.output registrykey }"))
+	})
+}
+
+// SupportsRoot is the other half: it turns the recorded set into a decision
+// about one asset, and it does not withhold on weak evidence.
+func TestSupportsRoot(t *testing.T) {
+	narrowed := &llx.CodeBundle{AssetRoot: "os.any", CompatibleRoots: []string{"os.linux"}}
+
+	assert.True(t, mqlc.SupportsRoot(narrowed, "os.linux"))
+	assert.False(t, mqlc.SupportsRoot(narrowed, "os.windows"))
+
+	t.Run("no requirement runs anywhere", func(t *testing.T) {
+		assert.True(t, mqlc.SupportsRoot(&llx.CodeBundle{}, "os.windows"))
+	})
+
+	// A provider that has not refined its root per connection reports the union
+	// it declared, which is what the content was compiled against.
+	t.Run("the compile-time root is always compatible", func(t *testing.T) {
+		assert.True(t, mqlc.SupportsRoot(narrowed, "os.any"))
+	})
+
+	t.Run("an unknown root is not refused", func(t *testing.T) {
+		assert.True(t, mqlc.SupportsRoot(narrowed, ""),
+			"not knowing the root is not evidence of a mismatch")
+	})
+}

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -1737,6 +1737,12 @@ func (c *compiler) narrowRoots(resource *resources.ResourceInfo, field string) {
 		}
 		return
 	}
+	// Intersecting can empty the set, and an empty *non-nil* set is meaningful:
+	// members were read off a root, and no single root carries all of them. It
+	// stays distinct from nil (nothing was read off a root at all) only until
+	// recordCompatibleRoots, which deliberately treats both as "no requirement".
+	// Do not add a `!= nil` test to that decision without reading the reasoning
+	// there first - the two states differ in provenance, not in verdict.
 	for name := range top.compatibleRoots {
 		if _, ok := carriers[name]; !ok {
 			delete(top.compatibleRoots, name)

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -434,6 +434,10 @@ type compiler struct {
 	// first such read, which is what "no requirement" looks like.
 	compatibleRoots map[string]struct{}
 
+	// roots indexes the schema's asset roots for narrowing. Held only on the
+	// top-level compiler, where the intersection lives.
+	roots *rootIndex
+
 	// a standalone code is one that doesn't call any of its bindings
 	// examples:
 	//   file(xyz).content          is standalone
@@ -1710,38 +1714,27 @@ func (c *compiler) narrowRoots(resource *resources.ResourceInfo, field string) {
 		return
 	}
 
-	// The provider's declared root is the union of its roots, a compile-time
-	// receiver no connection ever reports. It carries every member by
-	// construction, so counting it would make every intersection non-empty and
-	// leave deliberately cross-platform content narrowed to a root no asset has.
-	unions := c.Schema.AllProviderRoots()
-
-	carriers := map[string]struct{}{}
-	for name, info := range c.Schema.AllResources() {
-		if info == nil || !info.GetRoot() || name != info.Id {
-			continue
-		}
-		if unions[info.GetProvider()] == name {
-			continue
-		}
-		if _, _, ok := c.Schema.FindField(info, field); ok {
-			carriers[name] = struct{}{}
-		}
-	}
-	if len(carriers) == 0 {
-		return
-	}
-
-	// Blocks compile in their own compiler, so the intersection lives on the
-	// one at the top - a member read inside `_ { ... }` narrows the same bundle
-	// as one read outside it.
+	// Blocks compile in their own compiler, so the intersection - and the index
+	// the carriers come from - live on the one at the top: a member read inside
+	// `_ { ... }` narrows the same bundle as one read outside it.
 	top := c
 	for top.parent != nil {
 		top = top.parent
 	}
 
+	carriers := top.rootIdx().carriersOf(c.Schema, field)
+	if len(carriers) == 0 {
+		return
+	}
+
 	if top.compatibleRoots == nil {
-		top.compatibleRoots = carriers
+		// Copied, not aliased: the intersection below mutates this map, and
+		// carriers comes from the index, where it is answering for every other
+		// read of the same member.
+		top.compatibleRoots = make(map[string]struct{}, len(carriers))
+		for name := range carriers {
+			top.compatibleRoots[name] = struct{}{}
+		}
 		return
 	}
 	for name := range top.compatibleRoots {
@@ -1768,6 +1761,59 @@ func (c *compiler) recordCompatibleRoots() {
 	}
 	sort.Strings(roots)
 	c.Result.CompatibleRoots = roots
+}
+
+// rootIndex answers "which asset roots carry this member" without walking the
+// schema for every read.
+//
+// Finding the roots means scanning every resource the schema knows - hundreds
+// in a two-provider schema, many thousands with a full set installed - so doing
+// it per field access made narrowing cost O(fields x resources). Both halves are
+// stable for the length of a compile: the roots do not change, and neither does
+// which of them carries a given member.
+type rootIndex struct {
+	roots    []*resources.ResourceInfo
+	carriers map[string]map[string]struct{}
+}
+
+func (c *compiler) rootIdx() *rootIndex {
+	if c.roots != nil {
+		return c.roots
+	}
+
+	// The provider's declared root is the union of its roots, a compile-time
+	// receiver no connection ever reports. It carries every member by
+	// construction, so counting it would make every intersection non-empty and
+	// leave deliberately cross-platform content narrowed to a root no asset has.
+	unions := c.Schema.AllProviderRoots()
+
+	idx := &rootIndex{carriers: map[string]map[string]struct{}{}}
+	for name, info := range c.Schema.AllResources() {
+		if info == nil || !info.GetRoot() || name != info.Id {
+			continue
+		}
+		if unions[info.GetProvider()] == name {
+			continue
+		}
+		idx.roots = append(idx.roots, info)
+	}
+	c.roots = idx
+	return idx
+}
+
+func (idx *rootIndex) carriersOf(schema resources.ResourcesSchema, field string) map[string]struct{} {
+	if known, ok := idx.carriers[field]; ok {
+		return known
+	}
+
+	carriers := map[string]struct{}{}
+	for _, root := range idx.roots {
+		if _, _, ok := schema.FindField(root, field); ok {
+			carriers[root.Id] = struct{}{}
+		}
+	}
+	idx.carriers[field] = carriers
+	return carriers
 }
 
 // noteIfUnrooted records a resource that this bundle reaches through the global

--- a/mqlc/mqlc.go
+++ b/mqlc/mqlc.go
@@ -429,6 +429,11 @@ type compiler struct {
 	// compiler.translationBlock.
 	translationBlocks map[string]uint64
 
+	// compatibleRoots is the running intersection of the asset roots that can
+	// execute this code, narrowed by every member read off a root. Nil until the
+	// first such read, which is what "no requirement" looks like.
+	compatibleRoots map[string]struct{}
+
 	// a standalone code is one that doesn't call any of its bindings
 	// examples:
 	//   file(xyz).content          is standalone
@@ -1416,6 +1421,7 @@ func (c *compiler) compileBoundIdentifierWithMqlCtx(id string, binding *variable
 
 		fieldPath, fieldinfos, ok := c.Schema.FindField(resource, id)
 		if ok {
+			c.narrowRoots(resource, id)
 			fieldinfo := fieldinfos[len(fieldinfos)-1]
 			c.Stats.CallField(resource.Name, fieldinfo)
 
@@ -1665,6 +1671,11 @@ func (c *compiler) compileResource(id string, calls []*parser.Call) (bool, []*pa
 		if c.prefersFieldOverResource(resource, nuResource, field) {
 			break
 		}
+		// Extending a root by one segment is a member read off that root, the
+		// same as a field access: `_.iptables` reaches the resource by its
+		// rooted name because the alias made one, and it narrows what can run
+		// this bundle just as `_ { iptables }` does.
+		c.narrowRoots(resource, field)
 		resource, id = nuResource, nuID
 		calls = calls[1:]
 	}
@@ -1679,6 +1690,84 @@ func (c *compiler) compileResource(id string, calls []*parser.Call) (bool, []*pa
 
 	typ, err := c.addResource(id, resource, call)
 	return true, calls, typ, err
+}
+
+// narrowRoots keeps track of which asset roots can execute this bundle, by
+// intersecting - for every member read off a root - the roots that carry it
+// (ADR 031 point 4).
+//
+// A query reading only universal members stays satisfied by every root; one
+// reading `iptables` narrows to the Linux root and the union above it. That is
+// applicability derived from what the code reads, rather than declared next to
+// it by hand.
+//
+// Only members read off a *root* count. A member of an ordinary resource says
+// nothing about which asset can run the query, and the global namespace says
+// nothing either - which is why a v14 bundle that never touches a root records
+// no requirement and runs everywhere, exactly as before.
+func (c *compiler) narrowRoots(resource *resources.ResourceInfo, field string) {
+	if resource == nil || !resource.GetRoot() || c.Schema == nil {
+		return
+	}
+
+	// The provider's declared root is the union of its roots, a compile-time
+	// receiver no connection ever reports. It carries every member by
+	// construction, so counting it would make every intersection non-empty and
+	// leave deliberately cross-platform content narrowed to a root no asset has.
+	unions := c.Schema.AllProviderRoots()
+
+	carriers := map[string]struct{}{}
+	for name, info := range c.Schema.AllResources() {
+		if info == nil || !info.GetRoot() || name != info.Id {
+			continue
+		}
+		if unions[info.GetProvider()] == name {
+			continue
+		}
+		if _, _, ok := c.Schema.FindField(info, field); ok {
+			carriers[name] = struct{}{}
+		}
+	}
+	if len(carriers) == 0 {
+		return
+	}
+
+	// Blocks compile in their own compiler, so the intersection lives on the
+	// one at the top - a member read inside `_ { ... }` narrows the same bundle
+	// as one read outside it.
+	top := c
+	for top.parent != nil {
+		top = top.parent
+	}
+
+	if top.compatibleRoots == nil {
+		top.compatibleRoots = carriers
+		return
+	}
+	for name := range top.compatibleRoots {
+		if _, ok := carriers[name]; !ok {
+			delete(top.compatibleRoots, name)
+		}
+	}
+}
+
+// recordCompatibleRoots writes the narrowed set onto the bundle.
+//
+// An empty intersection is recorded as no requirement rather than as
+// "unsatisfiable". A query that reads a Linux-only and a Windows-only member is
+// usually a deliberately cross-platform one - `if ... else ...` over both - and
+// it should still run, with each member degrading on the platform that lacks
+// it. Refusing it, or marking it runnable nowhere, would break that pattern.
+func (c *compiler) recordCompatibleRoots() {
+	if len(c.compatibleRoots) == 0 {
+		return
+	}
+	roots := make([]string, 0, len(c.compatibleRoots))
+	for name := range c.compatibleRoots {
+		roots = append(roots, name)
+	}
+	sort.Strings(roots)
+	c.Result.CompatibleRoots = roots
 }
 
 // noteIfUnrooted records a resource that this bundle reaches through the global
@@ -2964,7 +3053,9 @@ func CompileAST(ast *parser.AST, props PropsHandler, conf CompilerConfig) (*llx.
 		valueBodyBlocks: map[uint64]struct{}{},
 	}
 
-	return c.Result, c.CompileParsed(ast)
+	err := c.CompileParsed(ast)
+	c.recordCompatibleRoots()
+	return c.Result, err
 }
 
 // Compile a code piece against a schema into chunky code

--- a/mqlc/requirements.go
+++ b/mqlc/requirements.go
@@ -4,6 +4,7 @@
 package mqlc
 
 import (
+	"errors"
 	"sort"
 	"strings"
 
@@ -111,4 +112,41 @@ func FormatRequirements(reqs []Requirement) string {
 		parts[i] = reqs[i].Error()
 	}
 	return strings.Join(parts, "; ")
+}
+
+// ErrRootMismatch identifies a bundle that cannot run on an asset because the
+// asset's root is not one the bundle was narrowed to. Match it with errors.Is to
+// tell "this asset is not what the content targets" apart from a failure: the
+// first is a scoping answer, the second is a problem.
+var ErrRootMismatch = errors.New("asset root not supported by this content")
+
+// SupportsRoot reports whether an asset rooted at `root` can execute this
+// bundle (ADR 031 point 4).
+//
+// The bundle carries the roots it was narrowed to while compiling - a query
+// reading `iptables` is satisfied only by the Linux root, one reading `hostname`
+// by every root. This is the check that turns that into applicability, replacing
+// a hand-written platform filter with what the code actually reads.
+//
+// Two ways to be supported without matching: a bundle that derived no
+// requirement runs anywhere, and an asset whose root we do not know is not
+// refused - not knowing is not evidence of a mismatch, the same rule the version
+// requirements above follow.
+func SupportsRoot(bundle *llx.CodeBundle, root string) bool {
+	if bundle == nil || len(bundle.CompatibleRoots) == 0 || root == "" {
+		return true
+	}
+	// An asset rooted at exactly what the content was compiled against is
+	// trivially compatible. That is the union for a disconnected compile, which
+	// is also what a provider reports before it refines its root per connection
+	// - refusing those would withhold every narrowed bundle during a rollout.
+	if root == bundle.AssetRoot {
+		return true
+	}
+	for _, candidate := range bundle.CompatibleRoots {
+		if candidate == root {
+			return true
+		}
+	}
+	return false
 }

--- a/mqlc/rootindex_test.go
+++ b/mqlc/rootindex_test.go
@@ -1,0 +1,50 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql"
+	"go.mondoo.com/mql/providers-sdk/v1/resources"
+	"go.mondoo.com/mql/types"
+)
+
+// rootIndex caches which roots carry a member so narrowing does not walk the
+// whole schema per read (ADR 031). The cache answers for every read of that
+// member, so narrowing must not mutate what it hands back.
+func TestRootIndexIsNotMutatedByNarrowing(t *testing.T) {
+	field := func(n string) map[string]*resources.Field {
+		return map[string]*resources.Field{n: {Name: n, Type: string(types.String)}}
+	}
+	schema := &resources.Schema{
+		ProviderRoots: map[string]string{"p": "p.any"},
+		Resources: map[string]*resources.ResourceInfo{
+			"p.base":    {Id: "p.base", Provider: "p", Root: true, Fields: field("hostname")},
+			"p.linux":   {Id: "p.linux", Provider: "p", Root: true, Fields: field("hostname")},
+			"p.windows": {Id: "p.windows", Provider: "p", Root: true, Fields: field("hostname")},
+			"p.any":     {Id: "p.any", Provider: "p", Root: true, Fields: field("hostname")},
+		},
+	}
+	// only linux carries this one
+	schema.Resources["p.linux"].Fields["iptables"] = &resources.Field{Name: "iptables", Type: string(types.String)}
+
+	c := &compiler{CompilerConfig: NewConfig(schema, mql.Features{})}
+	idx := c.rootIdx()
+
+	require.Len(t, idx.roots, 3, "the provider's declared union is not a candidate")
+
+	universal := idx.carriersOf(schema, "hostname")
+	require.Len(t, universal, 3)
+
+	// narrow: every root carries hostname, only one carries iptables
+	c.narrowRoots(schema.Resources["p.any"], "hostname")
+	c.narrowRoots(schema.Resources["p.any"], "iptables")
+	assert.Equal(t, map[string]struct{}{"p.linux": {}}, c.compatibleRoots)
+
+	assert.Len(t, idx.carriersOf(schema, "hostname"), 3,
+		"narrowing must not shrink the cached answer for a member every root carries")
+}

--- a/providers-sdk/v1/mqlr/lrcore/lr.go
+++ b/providers-sdk/v1/mqlr/lrcore/lr.go
@@ -139,6 +139,7 @@ type Resource struct {
 	Context     string         ` ( '@' "context" '(' @String ')' )? `
 	Maturity    string         ` ( '@' "maturity" '(' @String ')' )? `
 	IsGlobal    bool           ` ( '@' @"global" )? `
+	IsRoot      bool           ` ( '@' @"root" )? `
 	ListType    *SimplListType `[ '{' [ @@ ]`
 	Body        *ResourceDef   `@@ '}' ]`
 	title       string

--- a/providers-sdk/v1/mqlr/lrcore/schema.go
+++ b/providers-sdk/v1/mqlr/lrcore/schema.go
@@ -279,6 +279,7 @@ func resourceSchema(r *Resource, ast *LR) (*resources.ResourceInfo, error) {
 		Context:     r.Context,
 		Maturity:    r.Maturity,
 		Global:      r.IsGlobal,
+		Root:        r.IsRoot,
 	}
 
 	if r.ListType != nil {

--- a/providers-sdk/v1/resources/resources.pb.go
+++ b/providers-sdk/v1/resources/resources.pb.go
@@ -56,9 +56,9 @@ type Schema struct {
 	// The root resource each provider declares for the assets it connects (ADR
 	// 031), keyed the same way provider_versions is. A compile with a live
 	// connection learns the *concrete* root from the connection; this is what a
-	// compile with no connection has - a policy bundle, a lint, an editor - and it
-	// is what tells such a compile whether a name is reachable from the asset's
-	// tree at all.
+	// compile with no connection has - a policy bundle, a lint, an editor - and
+	// it is what tells such a compile whether a name is reachable from the
+	// asset's tree at all.
 	ProviderRoots map[string]string `protobuf:"bytes,6,rep,name=provider_roots,json=providerRoots,proto3" json:"provider_roots,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -357,11 +357,18 @@ type ResourceInfo struct {
 	Others   []*ResourceInfo `protobuf:"bytes,29,rep,name=others,proto3" json:"others,omitempty"`
 	Maturity string          `protobuf:"bytes,32,opt,name=maturity,proto3" json:"maturity,omitempty"`
 	// Whether this resource is reachable without an asset root (ADR 031).
-	// Everything else is expected to hang off the root of the asset it describes;
-	// a handful of resources genuinely do not - `time`, `regex`, `asset` - and say
-	// so with `@global` in their schema. Unmarked and non-rooted is what the
-	// compiler notes on a bundle as reaching outside the asset's tree.
-	Global        bool `protobuf:"varint,33,opt,name=global,proto3" json:"global,omitempty"`
+	// Everything else is expected to hang off the root of the asset it
+	// describes; a handful of resources genuinely do not - `time`, `regex`,
+	// `asset` - and say so with `@global` in their schema. Unmarked and
+	// non-rooted is what the compiler notes on a bundle as reaching outside the
+	// asset's tree.
+	Global bool `protobuf:"varint,33,opt,name=global,proto3" json:"global,omitempty"`
+	// Whether this resource is an asset root (ADR 031): a type a connection can
+	// expose as the thing a query is bounded by. Roots form a family - a
+	// universal base, the platform variants that embed it, and the union a
+	// disconnected compile targets - and knowing which resources are roots is
+	// what lets the compiler narrow a query to the ones that can run it.
+	Root          bool `protobuf:"varint,34,opt,name=root,proto3" json:"root,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -504,6 +511,13 @@ func (x *ResourceInfo) GetMaturity() string {
 func (x *ResourceInfo) GetGlobal() bool {
 	if x != nil {
 		return x.Global
+	}
+	return false
+}
+
+func (x *ResourceInfo) GetRoot() bool {
+	if x != nil {
+		return x.Root
 	}
 	return false
 }
@@ -687,7 +701,7 @@ const file_resources_proto_rawDesc = "" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x1a\n" +
 	"\boptional\x18\x03 \x01(\bR\boptional\"6\n" +
 	"\x04Init\x12.\n" +
-	"\x04args\x18\x01 \x03(\v2\x1a.mondoo.resources.TypedArgR\x04args\"\x84\x05\n" +
+	"\x04args\x18\x01 \x03(\v2\x1a.mondoo.resources.TypedArgR\x04args\"\x98\x05\n" +
 	"\fResourceInfo\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12B\n" +
@@ -704,7 +718,8 @@ const file_resources_proto_rawDesc = "" +
 	"\bprovider\x18\x1b \x01(\tR\bprovider\x126\n" +
 	"\x06others\x18\x1d \x03(\v2\x1e.mondoo.resources.ResourceInfoR\x06others\x12\x1a\n" +
 	"\bmaturity\x18  \x01(\tR\bmaturity\x12\x16\n" +
-	"\x06global\x18! \x01(\bR\x06global\x1aR\n" +
+	"\x06global\x18! \x01(\bR\x06global\x12\x12\n" +
+	"\x04root\x18\" \x01(\bR\x04root\x1aR\n" +
 	"\vFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12-\n" +
 	"\x05value\x18\x02 \x01(\v2\x17.mondoo.resources.FieldR\x05value:\x028\x01J\x04\b\x19\x10\x1aR\x12min_mondoo_version\"\xb7\x03\n" +

--- a/providers-sdk/v1/resources/resources.proto
+++ b/providers-sdk/v1/resources/resources.proto
@@ -106,6 +106,13 @@ message ResourceInfo {
   // non-rooted is what the compiler notes on a bundle as reaching outside the
   // asset's tree.
   bool global = 33;
+
+  // Whether this resource is an asset root (ADR 031): a type a connection can
+  // expose as the thing a query is bounded by. Roots form a family - a
+  // universal base, the platform variants that embed it, and the union a
+  // disconnected compile targets - and knowing which resources are roots is
+  // what lets the compiler narrow a query to the ones that can run it.
+  bool root = 34;
 }
 
 message Field {

--- a/providers-sdk/v1/resources/resources_vtproto.pb.go
+++ b/providers-sdk/v1/resources/resources_vtproto.pb.go
@@ -359,6 +359,18 @@ func (m *ResourceInfo) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Root {
+		i--
+		if m.Root {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0x90
+	}
 	if m.Global {
 		i--
 		if m.Global {
@@ -894,6 +906,9 @@ func (m *ResourceInfo) SizeVT() (n int) {
 		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	if m.Global {
+		n += 3
+	}
+	if m.Root {
 		n += 3
 	}
 	n += len(m.unknownFields)
@@ -2583,6 +2598,26 @@ func (m *ResourceInfo) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Global = bool(v != 0)
+		case 34:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Root", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Root = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/providers-sdk/v1/resources/schema.go
+++ b/providers-sdk/v1/resources/schema.go
@@ -122,6 +122,9 @@ func (s *Schema) Add(other ResourcesSchema) ResourcesSchema {
 			if v.Global {
 				existing.Global = true
 			}
+			if v.Root {
+				existing.Root = true
+			}
 
 			if existing.Fields == nil {
 				existing.Fields = map[string]*Field{}
@@ -158,6 +161,7 @@ func (s *Schema) Add(other ResourcesSchema) ResourcesSchema {
 				// So does reachability without a root, for the same reason: a
 				// rooted compile reads it off the merged schema (ADR 031).
 				Global: v.Global,
+				Root:   v.Root,
 			}
 			for k, v := range v.Fields {
 				ri.Fields[k] = cloneField(v)

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -593,7 +593,7 @@ os.update @defaults("name")  {
 // `alias os.<root>.<resource>` block at the top of this schema is the platform
 // classification: to add a resource you have to place it. Those aliases have to
 // stay contiguous, a comment between two of them fails the parse.
-os.base {
+os.base @root {
   embed machine
 
   // Hypervisor for this OS
@@ -686,7 +686,7 @@ os.base {
 // and similar), carrying the facilities that family provides and Windows does
 // not: `sshd`, `crontab`, `sudo`/`sudoers`, the mount table, the kernel, NFS,
 // ZFS, the classic daemons (`inetd`, `snmpd`, `postfix`, `exim`) and `aide`.
-os.unix {
+os.unix @root {
   embed os.base as base
 }
 
@@ -697,7 +697,7 @@ os.unix {
 // `ufw`, `firewalld`), the `/etc/fstab` mount table, and the AppArmor
 // mandatory-access-control namespace. Use it to write Linux-specific audits
 // without reaching out to global resource handles.
-os.linux {
+os.linux @root {
   embed os.unix as unix
 
   // iptables firewall for IPv4
@@ -721,7 +721,7 @@ os.linux {
 // Extends `os.base` with the facilities only Windows provides: the `windows`
 // surface itself (hotfixes, features, firewall profiles, and the rest), the
 // registry, local security and audit policy, and IIS.
-os.windows {
+os.windows @root {
   embed os.base as base
 }
 
@@ -730,7 +730,7 @@ os.windows {
 // Extends `os.unix` (and through it, `os.base`) with the facilities only macOS
 // provides: the `macos` surface itself, Safari, `launchd` and the OpenBSM audit
 // subsystem.
-os.macos {
+os.macos @root {
   embed os.unix as unix
 }
 
@@ -745,7 +745,7 @@ os.macos {
 // compiler narrows the root as members are accessed, so touching only universal
 // members keeps the query portable while touching `iptables` requires a Linux
 // root. See ADR 031.
-os.any {
+os.any @root {
   embed os.base as base
 }
 


### PR DESCRIPTION
Applicability is declared next to content ("only run this on Linux") up until now. The compiler now watches which members you read off the asset root and records the set of roots that can actually run the bundle, as compatible_roots on the CodeBundle.

```
SupportsRoot(_.iptables.output, os.linux)   = true
SupportsRoot(_.iptables.output, os.windows) = false
SupportsRoot(_.iptables.output, os.macos)   = false
SupportsRoot(_.iptables.output, os.any)     = true 
```

