### PR TITLE
⭐ Deprecation notices + replacement info

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -695,6 +695,14 @@ for {
   private cloudflare.zone.plan @defaults("name") @maturity("deprecated") { ... }
   ```
   Keep the existing `.lr.versions` entry at its original version — deprecation does not bump the version.
+- **Name the replacement with `@replaced_by` when there is one.** The description says it in prose for a human reading the schema; `@replaced_by` says it as data so the CLI can tell a user at the moment they run the old name. Give it the **full schema path** of the replacement — the compiler renders the spelling the user's root actually accepts (`os.base.hostname` is shown as `hostname` in a rooted shell). Annotation order is fixed by the grammar: `@defaults` → `@context` → `@maturity` → `@replaced_by` → `@global` → `@root`.
+  ```
+  // Hostname for this OS
+  //
+  // Deprecated in favor of os.base.hostname, reachable as `_.hostname`.
+  hostname() @maturity("deprecated") @replaced_by("os.base.hostname") string
+  ```
+  Generation fails if the target does not name a resource or field in the schema, or if it cannot be reached from any asset root (so it would stop resolving in v15). Both checks run once, when the provider is built, so a target that would send a user somewhere useless cannot ship. The annotation is a **pointer, not a transform**: it changes nothing about how the deprecated name resolves (it keeps working until the field is deleted), and any migration that has to restructure a value, resolve an id, or call an API is a Go lens instead — see [ADR 040](docs/adr/040-cross-version-type-migration.md). Omit it when there is no single destination; a deprecation with no target prints nothing rather than something unhelpful.
 
 ### Provider Modules & Dependencies
 - Each provider in `providers/` has its own `go.mod` for isolation, keeping binaries smaller and dependency trees separate (core mql has deps providers don't need, and vice versa)

--- a/cli/shell/model.go
+++ b/cli/shell/model.go
@@ -256,6 +256,9 @@ func (m *shellModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Println(output)
 		}
 		output := m.formatResults(msg.code, msg.results)
+		if notices := m.deprecationNotices(msg.code); notices != "" {
+			output = notices + "\n" + output
+		}
 		return m, tea.Println(output)
 
 	case spinner.TickMsg:
@@ -1218,4 +1221,25 @@ func (m *shellModel) compilerConfig() mqlc.CompilerConfig {
 	conf := mqlc.NewConfigFrom(m.runtime, m.features)
 	conf.Strict = m.strict
 	return conf
+}
+
+// deprecationNotices renders what the bundle recorded about deprecated names it
+// reads (ADR 040). The compiler only records - it runs on every keystroke
+// behind autocomplete, so a message printed from there lands in the middle of
+// the line being typed - and this is the moment a user is actually reading
+// output.
+//
+// Spellings are relative to the root this session connected to, so the notice
+// tells them what to type here rather than where the field lives in the schema.
+func (m *shellModel) deprecationNotices(code *llx.CodeBundle) string {
+	notices := mqlc.DeprecationNotices(code, m.runtime.Schema())
+	if len(notices) == 0 {
+		return ""
+	}
+	var out strings.Builder
+	for _, n := range notices {
+		out.WriteString(m.theme.Secondary.Render("deprecated: " + n))
+		out.WriteString("\n")
+	}
+	return strings.TrimRight(out.String(), "\n")
 }

--- a/cli/shell/program.go
+++ b/cli/shell/program.go
@@ -202,6 +202,13 @@ func (s *ShellProgram) PrintResults(code *llx.CodeBundle, results map[string]*ll
 	}
 
 	fmt.Fprint(s.out, "\r")
+	// Deprecated names the bundle recorded, spelled the way this run's root
+	// spells them (ADR 040). The compiler records and never prints; this is the
+	// moment someone is reading. The JSON path does not come through here, so
+	// machine-consumed output stays clean.
+	for _, notice := range mqlc.DeprecationNotices(code, s.runtime.Schema()) {
+		fmt.Fprintln(s.out, s.printTheme.Secondary("deprecated: "+notice))
+	}
 	fmt.Fprintln(s.out, printedResult)
 }
 

--- a/docs/adr/031-in-query-cross-asset-traversal.md
+++ b/docs/adr/031-in-query-cross-asset-traversal.md
@@ -473,6 +473,17 @@ in 14, `os.date` in 12, `os.hostname` in 10, `os.env` in 3, across cnspec conten
 and the policy repos). v15 migrates the policies, removes the fields, and leaves
 `os` as the empty namespace node.
 
+Each of them also carries `@replaced_by("os.base.<field>")`, which is the same
+migration target as data rather than prose
+([ADR 040](040-cross-version-type-migration.md#2-migrations-are-composable-directional-lenses--not-aliases)).
+The compiler records every deprecated name a bundle reads on
+`CodeBundle.deprecated_uses` and the CLI renders it against the root the query
+compiled with, so someone running `os.hostname` on a connected asset is told
+`os.hostname has migrated to hostname` - the spelling that works here - rather
+than the schema path. That is the whole mechanism: no lens, no alias, nothing
+that changes how `os.hostname` resolves. It resolves because the field is still
+there, and in v15 it stops because the field is gone.
+
 **Stays legal in both versions:** providers **extending** each other's resources
 with new fields.
 

--- a/docs/adr/040-cross-version-type-migration.md
+++ b/docs/adr/040-cross-version-type-migration.md
@@ -140,6 +140,40 @@ load-bearing ones are structural:
 - `vpcId string → vpc() aws.vpc` — resolve the id to a typed resource.
 - hoist/flatten (`linuxParameters.maxSwap → linuxMaxSwap`), split, merge.
 
+**The degenerate case gets a declarative shortcut.** A pure move — a field that
+now lives somewhere else, unchanged — is declared in the schema as
+`@replaced_by("os.base.hostname")` rather than written as a no-op Go lens. 444
+deprecations in the tree carry that information as prose today, 431 of them
+naming a target; as data it drives the notice a user sees while the old name
+still works.
+
+Note what moment that is. `@maturity("deprecated")` changes no behavior — it
+decorates suggestions and nothing else — so through the whole deprecation window
+both spellings resolve, in one schema, on one engine. There is no version skew to
+bridge, which is why this case needs no lens: the old field is its own
+compatibility. `@replaced_by` only makes the deprecation directed instead of
+silent. When the field is finally deleted, the annotation is deleted with it;
+nothing revives the old name and nothing narrates it, because a full major of
+warnings was the migration. It also does not pre-authorize that deletion — the
+removal still surfaces in the part-5 schema diff as breaking and still gets an
+explicit decision.
+
+**It does not replace or shadow the Go lens path, and must not grow toward it.**
+The annotation carries no code, so it can express exactly one thing: this name is
+now that name. Every migration that has to *act* — resolve an id to a resource,
+restructure a value, split, merge, call an API, coerce at the data boundary — is
+a lens in Go, and that is the general path. Giving the annotation a mapping
+expression would rebuild the restricted DSL this ADR rejected on purpose; when
+the shortcut doesn't suffice, you write the lens.
+
+**It records the schema path and renders the spelling.** The stored value is
+where the field lives (`os.base.hostname`); what a user is told is what they can
+type (`hostname`), computed against whatever root the compile has — from the
+connection in `shell`/`run`, or supplied by a caller compiling against a stated
+root. The two differ once queries are rooted (ADR 031), and storing the typable
+form would leave the annotation useless to any lens, which works
+schema-to-schema.
+
 Lenses **compose along the chain** (`v3→v4→…→v7`) so an arbitrary A→B is bridged
 by traversing intermediate steps, and where a lens is invertible it also runs
 backward (needed for part 3). A lens adapts the *plan/AST* (rewrite chunks into

--- a/exec/root_test.go
+++ b/exec/root_test.go
@@ -1,0 +1,59 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package exec_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql"
+	"go.mondoo.com/mql/exec"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/mqlc"
+	"go.mondoo.com/mql/providers-sdk/v1/testutils"
+)
+
+// Content narrowed to a set of asset roots (ADR 031) must not hard-fail on an
+// asset outside that set until a caller opts into the model: "not applicable to
+// this asset" and "this check failed" are different answers, and a caller that
+// cannot tell them apart would report the first as the second.
+func TestRootMismatchRefusalIsOptIn(t *testing.T) {
+	rt := testutils.LinuxMock()
+
+	// A bundle that targets a platform this asset is not. Built directly rather
+	// than compiled, because compiling it here would resolve against this
+	// asset's own root and never produce the mismatch.
+	bundle, err := mqlc.Compile("asset.platform", nil, mqlc.NewConfigFrom(rt, testutils.Features))
+	require.NoError(t, err)
+	bundle.AssetRoot = "os.any"
+	bundle.CompatibleRoots = []string{"os.windows"}
+
+	t.Run("v14 runs it", func(t *testing.T) {
+		_, err := exec.ExecuteCode(rt, bundle, nil, testutils.Features)
+		assert.NoError(t, err, "execution is unchanged until the model is opted into")
+	})
+
+	t.Run("rooted mode refuses it", func(t *testing.T) {
+		features := append(mql.Features{}, testutils.Features...)
+		features = append(features, byte(mql.RootedNamespace))
+
+		_, err := exec.ExecuteCode(rt, bundle, nil, features)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, mqlc.ErrRootMismatch),
+			"the caller has to be able to tell this apart from a failure")
+	})
+
+	// A bundle that derived no requirement runs everywhere, which is every
+	// bundle compiled before this existed.
+	t.Run("content with no requirement is never refused", func(t *testing.T) {
+		features := append(mql.Features{}, testutils.Features...)
+		features = append(features, byte(mql.RootedNamespace))
+
+		plain := &llx.CodeBundle{CodeV2: bundle.CodeV2, Labels: bundle.Labels}
+		_, err := exec.ExecuteCode(rt, plain, nil, features)
+		assert.NoError(t, err)
+	})
+}

--- a/llx/llx.pb.go
+++ b/llx/llx.pb.go
@@ -921,8 +921,16 @@ type CodeBundle struct {
 	// it: the same job a hand-written platform filter does today, computed from
 	// what the code actually reads.
 	CompatibleRoots []string `protobuf:"bytes,31,rep,name=compatible_roots,json=compatibleRoots,proto3" json:"compatible_roots,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// Names this bundle uses that are deprecated and say where they moved to
+	// (ADR 040). Recorded, never logged: the compiler is called per keystroke by
+	// autocomplete, so the decision to show a notice belongs to whoever is
+	// driving it.
+	//
+	// Only uses with a `@replaced_by` target land here. A deprecation with no
+	// destination has nothing actionable to tell a user, so it stays silent.
+	DeprecatedUses []*DeprecatedUse `protobuf:"bytes,32,rep,name=deprecated_uses,json=deprecatedUses,proto3" json:"deprecated_uses,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *CodeBundle) Reset() {
@@ -1067,6 +1075,71 @@ func (x *CodeBundle) GetCompatibleRoots() []string {
 	return nil
 }
 
+func (x *CodeBundle) GetDeprecatedUses() []*DeprecatedUse {
+	if x != nil {
+		return x.DeprecatedUses
+	}
+	return nil
+}
+
+// DeprecatedUse is one deprecated name a bundle reads, and its replacement.
+type DeprecatedUse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The deprecated name as it exists in the schema, e.g. `os.hostname`.
+	From string `protobuf:"bytes,1,opt,name=from,proto3" json:"from,omitempty"`
+	// Where it moved to, as a full schema path, e.g. `os.base.hostname`. What a
+	// user is shown is rendered from this against the root the query compiled
+	// with, so the same entry reads as `hostname` in a rooted shell and as
+	// `os.base.hostname` where there is no root to shorten it against.
+	To            string `protobuf:"bytes,2,opt,name=to,proto3" json:"to,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeprecatedUse) Reset() {
+	*x = DeprecatedUse{}
+	mi := &file_llx_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeprecatedUse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeprecatedUse) ProtoMessage() {}
+
+func (x *DeprecatedUse) ProtoReflect() protoreflect.Message {
+	mi := &file_llx_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeprecatedUse.ProtoReflect.Descriptor instead.
+func (*DeprecatedUse) Descriptor() ([]byte, []int) {
+	return file_llx_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *DeprecatedUse) GetFrom() string {
+	if x != nil {
+		return x.From
+	}
+	return ""
+}
+
+func (x *DeprecatedUse) GetTo() string {
+	if x != nil {
+		return x.To
+	}
+	return ""
+}
+
 // TranslationRef points one call that an older reader cannot make at a block
 // that computes the same value out of vocabulary it does have.
 type TranslationRef struct {
@@ -1088,7 +1161,7 @@ type TranslationRef struct {
 
 func (x *TranslationRef) Reset() {
 	*x = TranslationRef{}
-	mi := &file_llx_proto_msgTypes[11]
+	mi := &file_llx_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1100,7 +1173,7 @@ func (x *TranslationRef) String() string {
 func (*TranslationRef) ProtoMessage() {}
 
 func (x *TranslationRef) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[11]
+	mi := &file_llx_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1113,7 +1186,7 @@ func (x *TranslationRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TranslationRef.ProtoReflect.Descriptor instead.
 func (*TranslationRef) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{11}
+	return file_llx_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *TranslationRef) GetRef() uint64 {
@@ -1155,7 +1228,7 @@ type Result struct {
 
 func (x *Result) Reset() {
 	*x = Result{}
-	mi := &file_llx_proto_msgTypes[12]
+	mi := &file_llx_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1167,7 +1240,7 @@ func (x *Result) String() string {
 func (*Result) ProtoMessage() {}
 
 func (x *Result) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[12]
+	mi := &file_llx_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1180,7 +1253,7 @@ func (x *Result) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Result.ProtoReflect.Descriptor instead.
 func (*Result) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{12}
+	return file_llx_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *Result) GetData() *Primitive {
@@ -1217,7 +1290,7 @@ type ResourceRecording struct {
 
 func (x *ResourceRecording) Reset() {
 	*x = ResourceRecording{}
-	mi := &file_llx_proto_msgTypes[13]
+	mi := &file_llx_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1229,7 +1302,7 @@ func (x *ResourceRecording) String() string {
 func (*ResourceRecording) ProtoMessage() {}
 
 func (x *ResourceRecording) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[13]
+	mi := &file_llx_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1242,7 +1315,7 @@ func (x *ResourceRecording) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceRecording.ProtoReflect.Descriptor instead.
 func (*ResourceRecording) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{13}
+	return file_llx_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ResourceRecording) GetResource() string {
@@ -1294,7 +1367,7 @@ type Rating struct {
 
 func (x *Rating) Reset() {
 	*x = Rating{}
-	mi := &file_llx_proto_msgTypes[14]
+	mi := &file_llx_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1306,7 +1379,7 @@ func (x *Rating) String() string {
 func (*Rating) ProtoMessage() {}
 
 func (x *Rating) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[14]
+	mi := &file_llx_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1319,7 +1392,7 @@ func (x *Rating) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Rating.ProtoReflect.Descriptor instead.
 func (*Rating) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{14}
+	return file_llx_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *Rating) GetId() string {
@@ -1383,7 +1456,7 @@ type AssessmentItem struct {
 
 func (x *AssessmentItem) Reset() {
 	*x = AssessmentItem{}
-	mi := &file_llx_proto_msgTypes[15]
+	mi := &file_llx_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1395,7 +1468,7 @@ func (x *AssessmentItem) String() string {
 func (*AssessmentItem) ProtoMessage() {}
 
 func (x *AssessmentItem) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[15]
+	mi := &file_llx_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1408,7 +1481,7 @@ func (x *AssessmentItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssessmentItem.ProtoReflect.Descriptor instead.
 func (*AssessmentItem) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{15}
+	return file_llx_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *AssessmentItem) GetSuccess() bool {
@@ -1500,7 +1573,7 @@ type Assessment struct {
 
 func (x *Assessment) Reset() {
 	*x = Assessment{}
-	mi := &file_llx_proto_msgTypes[16]
+	mi := &file_llx_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1512,7 +1585,7 @@ func (x *Assessment) String() string {
 func (*Assessment) ProtoMessage() {}
 
 func (x *Assessment) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[16]
+	mi := &file_llx_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1525,7 +1598,7 @@ func (x *Assessment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Assessment.ProtoReflect.Descriptor instead.
 func (*Assessment) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{16}
+	return file_llx_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *Assessment) GetChecksum() string {
@@ -1567,7 +1640,7 @@ type IP struct {
 
 func (x *IP) Reset() {
 	*x = IP{}
-	mi := &file_llx_proto_msgTypes[17]
+	mi := &file_llx_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1579,7 +1652,7 @@ func (x *IP) String() string {
 func (*IP) ProtoMessage() {}
 
 func (x *IP) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[17]
+	mi := &file_llx_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1592,7 +1665,7 @@ func (x *IP) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IP.ProtoReflect.Descriptor instead.
 func (*IP) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{17}
+	return file_llx_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *IP) GetAddress() []byte {
@@ -1711,7 +1784,8 @@ const file_llx_proto_rawDesc = "" +
 	"\x05field\x18\x01 \x01(\tR\x05field\x12\x14\n" +
 	"\x05title\x18\x02 \x01(\tR\x05title\x12\x12\n" +
 	"\x04desc\x18\x03 \x01(\tR\x04desc\x12\x1a\n" +
-	"\bprovider\x18\x04 \x01(\tR\bprovider\"\xfe\t\n" +
+	"\bprovider\x18\x04 \x01(\tR\bprovider\"\xbf\n" +
+	"\n" +
 	"\n" +
 	"CodeBundle\x12(\n" +
 	"\acode_v2\x18\x06 \x01(\v2\x0f.mql.llx.CodeV2R\x06codeV2\x128\n" +
@@ -1733,7 +1807,8 @@ const file_llx_proto_rawDesc = "" +
 	"\x12unrooted_resources\x18\x1d \x03(\tR\x11unrootedResources\x12\x1d\n" +
 	"\n" +
 	"asset_root\x18\x1e \x01(\tR\tassetRoot\x12)\n" +
-	"\x10compatible_roots\x18\x1f \x03(\tR\x0fcompatibleRoots\x1a8\n" +
+	"\x10compatible_roots\x18\x1f \x03(\tR\x0fcompatibleRoots\x12?\n" +
+	"\x0fdeprecated_uses\x18  \x03(\v2\x16.mql.llx.DeprecatedUseR\x0edeprecatedUses\x1a8\n" +
 	"\n" +
 	"PropsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
@@ -1752,7 +1827,10 @@ const file_llx_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1aF\n" +
 	"\x18MinProviderVersionsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x01\x10\x02J\x04\b\x15\x10\x16\"\x80\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x01\x10\x02J\x04\b\x15\x10\x16\"3\n" +
+	"\rDeprecatedUse\x12\x12\n" +
+	"\x04from\x18\x01 \x01(\tR\x04from\x12\x0e\n" +
+	"\x02to\x18\x02 \x01(\tR\x02to\"\x80\x01\n" +
 	"\x0eTranslationRef\x12\x10\n" +
 	"\x03ref\x18\x01 \x01(\x04R\x03ref\x12\x1a\n" +
 	"\bprovider\x18\x02 \x01(\tR\bprovider\x12#\n" +
@@ -1817,7 +1895,7 @@ func file_llx_proto_rawDescGZIP() []byte {
 }
 
 var file_llx_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_llx_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_llx_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
 var file_llx_proto_goTypes = []any{
 	(Function_Nullability)(0), // 0: mql.llx.Function.Nullability
 	(Chunk_Call)(0),           // 1: mql.llx.Chunk.Call
@@ -1832,70 +1910,72 @@ var file_llx_proto_goTypes = []any{
 	(*Labels)(nil),            // 10: mql.llx.Labels
 	(*Documentation)(nil),     // 11: mql.llx.Documentation
 	(*CodeBundle)(nil),        // 12: mql.llx.CodeBundle
-	(*TranslationRef)(nil),    // 13: mql.llx.TranslationRef
-	(*Result)(nil),            // 14: mql.llx.Result
-	(*ResourceRecording)(nil), // 15: mql.llx.ResourceRecording
-	(*Rating)(nil),            // 16: mql.llx.Rating
-	(*AssessmentItem)(nil),    // 17: mql.llx.AssessmentItem
-	(*Assessment)(nil),        // 18: mql.llx.Assessment
-	(*IP)(nil),                // 19: mql.llx.IP
-	nil,                       // 20: mql.llx.Primitive.MapEntry
-	nil,                       // 21: mql.llx.CodeV1.ChecksumsEntry
-	nil,                       // 22: mql.llx.CodeV1.AssertionsEntry
-	nil,                       // 23: mql.llx.CodeV2.ChecksumsEntry
-	nil,                       // 24: mql.llx.CodeV2.AssertionsEntry
-	nil,                       // 25: mql.llx.Labels.LabelsEntry
-	nil,                       // 26: mql.llx.CodeBundle.PropsEntry
-	nil,                       // 27: mql.llx.CodeBundle.AssertionsEntry
-	nil,                       // 28: mql.llx.CodeBundle.AutoExpandEntry
-	nil,                       // 29: mql.llx.CodeBundle.VarsEntry
-	nil,                       // 30: mql.llx.CodeBundle.ProviderSchemasEntry
-	nil,                       // 31: mql.llx.CodeBundle.MinProviderVersionsEntry
-	nil,                       // 32: mql.llx.ResourceRecording.FieldsEntry
+	(*DeprecatedUse)(nil),     // 13: mql.llx.DeprecatedUse
+	(*TranslationRef)(nil),    // 14: mql.llx.TranslationRef
+	(*Result)(nil),            // 15: mql.llx.Result
+	(*ResourceRecording)(nil), // 16: mql.llx.ResourceRecording
+	(*Rating)(nil),            // 17: mql.llx.Rating
+	(*AssessmentItem)(nil),    // 18: mql.llx.AssessmentItem
+	(*Assessment)(nil),        // 19: mql.llx.Assessment
+	(*IP)(nil),                // 20: mql.llx.IP
+	nil,                       // 21: mql.llx.Primitive.MapEntry
+	nil,                       // 22: mql.llx.CodeV1.ChecksumsEntry
+	nil,                       // 23: mql.llx.CodeV1.AssertionsEntry
+	nil,                       // 24: mql.llx.CodeV2.ChecksumsEntry
+	nil,                       // 25: mql.llx.CodeV2.AssertionsEntry
+	nil,                       // 26: mql.llx.Labels.LabelsEntry
+	nil,                       // 27: mql.llx.CodeBundle.PropsEntry
+	nil,                       // 28: mql.llx.CodeBundle.AssertionsEntry
+	nil,                       // 29: mql.llx.CodeBundle.AutoExpandEntry
+	nil,                       // 30: mql.llx.CodeBundle.VarsEntry
+	nil,                       // 31: mql.llx.CodeBundle.ProviderSchemasEntry
+	nil,                       // 32: mql.llx.CodeBundle.MinProviderVersionsEntry
+	nil,                       // 33: mql.llx.ResourceRecording.FieldsEntry
 }
 var file_llx_proto_depIdxs = []int32{
 	2,  // 0: mql.llx.Primitive.array:type_name -> mql.llx.Primitive
-	20, // 1: mql.llx.Primitive.map:type_name -> mql.llx.Primitive.MapEntry
+	21, // 1: mql.llx.Primitive.map:type_name -> mql.llx.Primitive.MapEntry
 	2,  // 2: mql.llx.Function.args:type_name -> mql.llx.Primitive
 	0,  // 3: mql.llx.Function.nullability:type_name -> mql.llx.Function.Nullability
 	1,  // 4: mql.llx.Chunk.call:type_name -> mql.llx.Chunk.Call
 	2,  // 5: mql.llx.Chunk.primitive:type_name -> mql.llx.Primitive
 	4,  // 6: mql.llx.Chunk.function:type_name -> mql.llx.Function
 	5,  // 7: mql.llx.CodeV1.code:type_name -> mql.llx.Chunk
-	21, // 8: mql.llx.CodeV1.checksums:type_name -> mql.llx.CodeV1.ChecksumsEntry
+	22, // 8: mql.llx.CodeV1.checksums:type_name -> mql.llx.CodeV1.ChecksumsEntry
 	7,  // 9: mql.llx.CodeV1.functions:type_name -> mql.llx.CodeV1
-	22, // 10: mql.llx.CodeV1.assertions:type_name -> mql.llx.CodeV1.AssertionsEntry
+	23, // 10: mql.llx.CodeV1.assertions:type_name -> mql.llx.CodeV1.AssertionsEntry
 	5,  // 11: mql.llx.Block.chunks:type_name -> mql.llx.Chunk
 	8,  // 12: mql.llx.CodeV2.blocks:type_name -> mql.llx.Block
-	23, // 13: mql.llx.CodeV2.checksums:type_name -> mql.llx.CodeV2.ChecksumsEntry
-	24, // 14: mql.llx.CodeV2.assertions:type_name -> mql.llx.CodeV2.AssertionsEntry
-	25, // 15: mql.llx.Labels.labels:type_name -> mql.llx.Labels.LabelsEntry
+	24, // 13: mql.llx.CodeV2.checksums:type_name -> mql.llx.CodeV2.ChecksumsEntry
+	25, // 14: mql.llx.CodeV2.assertions:type_name -> mql.llx.CodeV2.AssertionsEntry
+	26, // 15: mql.llx.Labels.labels:type_name -> mql.llx.Labels.LabelsEntry
 	9,  // 16: mql.llx.CodeBundle.code_v2:type_name -> mql.llx.CodeV2
 	11, // 17: mql.llx.CodeBundle.suggestions:type_name -> mql.llx.Documentation
 	10, // 18: mql.llx.CodeBundle.labels:type_name -> mql.llx.Labels
-	26, // 19: mql.llx.CodeBundle.props:type_name -> mql.llx.CodeBundle.PropsEntry
-	27, // 20: mql.llx.CodeBundle.assertions:type_name -> mql.llx.CodeBundle.AssertionsEntry
-	28, // 21: mql.llx.CodeBundle.auto_expand:type_name -> mql.llx.CodeBundle.AutoExpandEntry
-	29, // 22: mql.llx.CodeBundle.vars:type_name -> mql.llx.CodeBundle.VarsEntry
-	30, // 23: mql.llx.CodeBundle.provider_schemas:type_name -> mql.llx.CodeBundle.ProviderSchemasEntry
-	31, // 24: mql.llx.CodeBundle.min_provider_versions:type_name -> mql.llx.CodeBundle.MinProviderVersionsEntry
-	13, // 25: mql.llx.CodeBundle.translations:type_name -> mql.llx.TranslationRef
-	2,  // 26: mql.llx.Result.data:type_name -> mql.llx.Primitive
-	32, // 27: mql.llx.ResourceRecording.fields:type_name -> mql.llx.ResourceRecording.FieldsEntry
-	2,  // 28: mql.llx.AssessmentItem.expected:type_name -> mql.llx.Primitive
-	2,  // 29: mql.llx.AssessmentItem.actual:type_name -> mql.llx.Primitive
-	2,  // 30: mql.llx.AssessmentItem.data:type_name -> mql.llx.Primitive
-	17, // 31: mql.llx.Assessment.results:type_name -> mql.llx.AssessmentItem
-	2,  // 32: mql.llx.Primitive.MapEntry.value:type_name -> mql.llx.Primitive
-	6,  // 33: mql.llx.CodeV1.AssertionsEntry.value:type_name -> mql.llx.AssertionMessage
-	6,  // 34: mql.llx.CodeV2.AssertionsEntry.value:type_name -> mql.llx.AssertionMessage
-	6,  // 35: mql.llx.CodeBundle.AssertionsEntry.value:type_name -> mql.llx.AssertionMessage
-	14, // 36: mql.llx.ResourceRecording.FieldsEntry.value:type_name -> mql.llx.Result
-	37, // [37:37] is the sub-list for method output_type
-	37, // [37:37] is the sub-list for method input_type
-	37, // [37:37] is the sub-list for extension type_name
-	37, // [37:37] is the sub-list for extension extendee
-	0,  // [0:37] is the sub-list for field type_name
+	27, // 19: mql.llx.CodeBundle.props:type_name -> mql.llx.CodeBundle.PropsEntry
+	28, // 20: mql.llx.CodeBundle.assertions:type_name -> mql.llx.CodeBundle.AssertionsEntry
+	29, // 21: mql.llx.CodeBundle.auto_expand:type_name -> mql.llx.CodeBundle.AutoExpandEntry
+	30, // 22: mql.llx.CodeBundle.vars:type_name -> mql.llx.CodeBundle.VarsEntry
+	31, // 23: mql.llx.CodeBundle.provider_schemas:type_name -> mql.llx.CodeBundle.ProviderSchemasEntry
+	32, // 24: mql.llx.CodeBundle.min_provider_versions:type_name -> mql.llx.CodeBundle.MinProviderVersionsEntry
+	14, // 25: mql.llx.CodeBundle.translations:type_name -> mql.llx.TranslationRef
+	13, // 26: mql.llx.CodeBundle.deprecated_uses:type_name -> mql.llx.DeprecatedUse
+	2,  // 27: mql.llx.Result.data:type_name -> mql.llx.Primitive
+	33, // 28: mql.llx.ResourceRecording.fields:type_name -> mql.llx.ResourceRecording.FieldsEntry
+	2,  // 29: mql.llx.AssessmentItem.expected:type_name -> mql.llx.Primitive
+	2,  // 30: mql.llx.AssessmentItem.actual:type_name -> mql.llx.Primitive
+	2,  // 31: mql.llx.AssessmentItem.data:type_name -> mql.llx.Primitive
+	18, // 32: mql.llx.Assessment.results:type_name -> mql.llx.AssessmentItem
+	2,  // 33: mql.llx.Primitive.MapEntry.value:type_name -> mql.llx.Primitive
+	6,  // 34: mql.llx.CodeV1.AssertionsEntry.value:type_name -> mql.llx.AssertionMessage
+	6,  // 35: mql.llx.CodeV2.AssertionsEntry.value:type_name -> mql.llx.AssertionMessage
+	6,  // 36: mql.llx.CodeBundle.AssertionsEntry.value:type_name -> mql.llx.AssertionMessage
+	15, // 37: mql.llx.ResourceRecording.FieldsEntry.value:type_name -> mql.llx.Result
+	38, // [38:38] is the sub-list for method output_type
+	38, // [38:38] is the sub-list for method input_type
+	38, // [38:38] is the sub-list for extension type_name
+	38, // [38:38] is the sub-list for extension extendee
+	0,  // [0:38] is the sub-list for field type_name
 }
 
 func init() { file_llx_proto_init() }
@@ -1909,7 +1989,7 @@ func file_llx_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_llx_proto_rawDesc), len(file_llx_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   31,
+			NumMessages:   32,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/llx/llx.proto
+++ b/llx/llx.proto
@@ -209,6 +209,26 @@ message CodeBundle {
   // it: the same job a hand-written platform filter does today, computed from
   // what the code actually reads.
   repeated string compatible_roots = 31;
+
+  // Names this bundle uses that are deprecated and say where they moved to
+  // (ADR 040). Recorded, never logged: the compiler is called per keystroke by
+  // autocomplete, so the decision to show a notice belongs to whoever is
+  // driving it.
+  //
+  // Only uses with a `@replaced_by` target land here. A deprecation with no
+  // destination has nothing actionable to tell a user, so it stays silent.
+  repeated DeprecatedUse deprecated_uses = 32;
+}
+
+// DeprecatedUse is one deprecated name a bundle reads, and its replacement.
+message DeprecatedUse {
+  // The deprecated name as it exists in the schema, e.g. `os.hostname`.
+  string from = 1;
+  // Where it moved to, as a full schema path, e.g. `os.base.hostname`. What a
+  // user is shown is rendered from this against the root the query compiled
+  // with, so the same entry reads as `hostname` in a rooted shell and as
+  // `os.base.hostname` where there is no root to shorten it against.
+  string to = 2;
 }
 
 // TranslationRef points one call that an older reader cannot make at a block

--- a/llx/llx_vtproto.pb.go
+++ b/llx/llx_vtproto.pb.go
@@ -848,6 +848,20 @@ func (m *CodeBundle) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.DeprecatedUses) > 0 {
+		for iNdEx := len(m.DeprecatedUses) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.DeprecatedUses[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0x82
+		}
+	}
 	if len(m.CompatibleRoots) > 0 {
 		for iNdEx := len(m.CompatibleRoots) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.CompatibleRoots[iNdEx])
@@ -1072,6 +1086,53 @@ func (m *CodeBundle) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 			i--
 			dAtA[i] = 0x12
 		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *DeprecatedUse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DeprecatedUse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *DeprecatedUse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.To) > 0 {
+		i -= len(m.To)
+		copy(dAtA[i:], m.To)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.To)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.From) > 0 {
+		i -= len(m.From)
+		copy(dAtA[i:], m.From)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.From)))
+		i--
+		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
@@ -2022,6 +2083,30 @@ func (m *CodeBundle) SizeVT() (n int) {
 			l = len(s)
 			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	if len(m.DeprecatedUses) > 0 {
+		for _, e := range m.DeprecatedUses {
+			l = e.SizeVT()
+			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *DeprecatedUse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.From)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.To)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -5818,6 +5903,155 @@ func (m *CodeBundle) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.CompatibleRoots = append(m.CompatibleRoots, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 32:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DeprecatedUses", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DeprecatedUses = append(m.DeprecatedUses, &DeprecatedUse{})
+			if err := m.DeprecatedUses[len(m.DeprecatedUses)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *DeprecatedUse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DeprecatedUse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DeprecatedUse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field From", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.From = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field To", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.To = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/mqlc/deprecation.go
+++ b/mqlc/deprecation.go
@@ -1,0 +1,103 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlc
+
+import (
+	"strings"
+
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/resources"
+)
+
+// A `@replaced_by` target is stored as the schema path of the replacement
+// (`os.base.hostname`) because that is the only form a schema-to-schema
+// consumer - a lens, a diff, a doc generator - can use. It is not what a user
+// types: once a query is rooted (ADR 031), `os.base.hostname` is reached as
+// `hostname`, and telling someone to write the schema path would be telling
+// them to write something that does not compile in v15.
+//
+// So the annotation records the path and this renders the spelling, against
+// whatever root the compile had. Without a root there is nothing to shorten
+// against and the path is the honest answer.
+
+// DeprecationNotices turns the deprecated names a bundle records into lines a
+// user can act on. Returns nil when there is nothing to say, which is the
+// common case.
+func DeprecationNotices(bundle *llx.CodeBundle, schema resources.ResourcesSchema) []string {
+	if bundle == nil || len(bundle.DeprecatedUses) == 0 {
+		return nil
+	}
+
+	res := make([]string, 0, len(bundle.DeprecatedUses))
+	for _, use := range bundle.DeprecatedUses {
+		if use == nil || use.From == "" || use.To == "" {
+			continue
+		}
+		// Only the most specific notice survives. Reading `os.hostname`
+		// records the deprecated field and the deprecated resource it hangs
+		// off, and saying both is saying the same thing twice: the field
+		// notice already tells the user what to type instead. The resource
+		// notice is for the query that names only the resource.
+		if supersededBy(bundle.DeprecatedUses, use.From) {
+			continue
+		}
+		res = append(res, use.From+" has migrated to "+RelativeToRoot(schema, bundle.AssetRoot, use.To))
+	}
+	if len(res) == 0 {
+		return nil
+	}
+	return res
+}
+
+// RelativeToRoot renders a schema path the way a query rooted at root would
+// spell it: `os.base.hostname` under any OS root is `hostname`, and the root
+// itself is `_`. A path that root cannot reach is returned unchanged - a
+// shortened name that does not resolve would be worse than a long one that
+// does.
+func RelativeToRoot(schema resources.ResourcesSchema, root string, target string) string {
+	if root == "" || target == "" || schema == nil {
+		return target
+	}
+	if resources.RootEmbeds(schema, root, target) {
+		return "_"
+	}
+
+	owner, field := splitPath(target)
+	if field == "" || !resources.RootEmbeds(schema, root, owner) {
+		return target
+	}
+	if info := schema.Lookup(owner); info != nil {
+		if f, ok := info.Fields[field]; ok && !f.IsPrivate {
+			return field
+		}
+	}
+	return target
+}
+
+// splitPath splits a schema path into the resource that owns the last segment
+// and the segment itself. Resource names are dotted, so only the final segment
+// can be a field.
+func splitPath(path string) (string, string) {
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == '.' {
+			return path[:i], path[i+1:]
+		}
+	}
+	return path, ""
+}
+
+// supersededBy reports whether some other recorded use is a more specific name
+// than this one - `os.hostname` against `os`.
+func supersededBy(uses []*llx.DeprecatedUse, name string) bool {
+	prefix := name + "."
+	for _, other := range uses {
+		if other == nil || other.From == name {
+			continue
+		}
+		if strings.HasPrefix(other.From, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/mqlc/deprecation_test.go
+++ b/mqlc/deprecation_test.go
@@ -1,0 +1,139 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mqlc_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/mqlc"
+	"go.mondoo.com/mql/providers-sdk/v1/resources"
+)
+
+func deprecatedUses(res *llx.CodeBundle) map[string]string {
+	out := map[string]string{}
+	for _, d := range res.DeprecatedUses {
+		out[d.From] = d.To
+	}
+	return out
+}
+
+// `os.hostname` is deprecated in favor of `os.base.hostname` (ADR 031/040). The
+// bundle has to say so as data -- the compiler runs per keystroke behind
+// autocomplete, so it cannot be the thing that talks to the user.
+func TestDeprecationRecordsTheReplacement(t *testing.T) {
+	schema := provenanceSchema(t)
+
+	res := compileForProvenance(t, schema, `os.hostname`)
+	uses := deprecatedUses(res)
+	assert.Equal(t, "os.base.hostname", uses["os.hostname"])
+	// The resource is deprecated too, and both are recorded. Collapsing the
+	// two into one notice is the renderer's call, not the compiler's.
+	assert.Equal(t, "os.base", uses["os"])
+}
+
+// The destination is not itself deprecated, so reading it says nothing.
+func TestDeprecationSaysNothingAboutTheReplacement(t *testing.T) {
+	schema := provenanceSchema(t)
+
+	res := compileForProvenance(t, schema, `os.base.hostname`)
+	assert.Empty(t, res.DeprecatedUses)
+}
+
+// A name used more than once is one notice, and the order is the query's.
+func TestDeprecationDedupesAndKeepsUseOrder(t *testing.T) {
+	schema := provenanceSchema(t)
+
+	res := compileForProvenance(t, schema, `os { hostname machineid hostname }`)
+	var from []string
+	for _, d := range res.DeprecatedUses {
+		from = append(from, d.From)
+	}
+	assert.Equal(t, []string{"os", "os.hostname", "os.machineid"}, from)
+}
+
+// Nothing else in the tree carries a replacement target yet, so ordinary
+// queries stay silent. A deprecation with no destination has nothing
+// actionable to say and is deliberately not recorded.
+func TestDeprecationIsSilentWithoutATarget(t *testing.T) {
+	schema := provenanceSchema(t)
+
+	res := compileForProvenance(t, schema, `sshd.config.params`)
+	assert.Empty(t, res.DeprecatedUses)
+}
+
+// The annotation stores `os.base.hostname`; a user under an OS root types
+// `hostname`. The message has to say the second one, or it points at something
+// that will not compile in v15.
+func TestDeprecationRendersRelativeToTheRoot(t *testing.T) {
+	schema := provenanceSchema(t)
+
+	for _, root := range []string{"os.any", "os.linux", "os.unix", "os.windows", "os.macos"} {
+		t.Run(root, func(t *testing.T) {
+			assert.Equal(t, "hostname", mqlc.RelativeToRoot(schema, root, "os.base.hostname"))
+			// The root target itself is what `_` means.
+			assert.Equal(t, "_", mqlc.RelativeToRoot(schema, root, "os.base"))
+		})
+	}
+}
+
+// Without a root there is nothing to shorten against, and a shortened name
+// that does not resolve would be worse than a long one that does.
+func TestDeprecationKeepsThePathWhenItCannotShorten(t *testing.T) {
+	schema := provenanceSchema(t)
+
+	assert.Equal(t, "os.base.hostname", mqlc.RelativeToRoot(schema, "", "os.base.hostname"))
+	// A root that cannot reach the target leaves it alone. `sshd.config` is not
+	// in any root's embed chain.
+	assert.Equal(t, "sshd.config.params", mqlc.RelativeToRoot(schema, "os.any", "sshd.config.params"))
+	assert.Equal(t, "os.base.nosuchfield", mqlc.RelativeToRoot(schema, "os.any", "os.base.nosuchfield"))
+}
+
+func TestDeprecationNotices(t *testing.T) {
+	schema := provenanceSchema(t)
+
+	res := compileForProvenance(t, schema, `os.hostname`)
+	assert.Equal(t, []string{
+		"os.hostname has migrated to os.base.hostname",
+	}, mqlc.DeprecationNotices(res, schema), "no root: the schema path is the honest answer")
+
+	res.AssetRoot = "os.linux"
+	assert.Equal(t, []string{
+		"os.hostname has migrated to hostname",
+	}, mqlc.DeprecationNotices(res, schema))
+
+	assert.Nil(t, mqlc.DeprecationNotices(compileForProvenance(t, schema, `os.base.hostname`), schema))
+}
+
+// The resource is deprecated too, but saying so alongside the field notice is
+// saying the same thing twice. Only the most specific one is shown; the
+// resource notice is what a query naming only the resource gets.
+func TestDeprecationShowsOnlyTheMostSpecificNotice(t *testing.T) {
+	schema := provenanceSchema(t)
+
+	res := compileForProvenance(t, schema, `os { hostname machineid }`)
+	res.AssetRoot = "os.linux"
+	assert.Equal(t, []string{
+		"os.hostname has migrated to hostname",
+		"os.machineid has migrated to machineid",
+	}, mqlc.DeprecationNotices(res, schema))
+
+	bare := compileForProvenance(t, schema, `os`)
+	bare.AssetRoot = "os.linux"
+	assert.Equal(t, []string{"os has migrated to _"}, mqlc.DeprecationNotices(bare, schema))
+}
+
+// Against the real os schema, not a fixture: `sshd.config` is reachable because
+// `_.sshd` is a member of a root, while `os` is the bridging namespace node
+// nothing points at - which is precisely why `os.hostname` stops resolving in
+// v15 and why these annotations exist.
+func TestRootReachabilityOnTheRealSchema(t *testing.T) {
+	schema := provenanceSchema(t)
+
+	assert.True(t, resources.RootReachable(schema, "os.base"), "the universal root")
+	assert.True(t, resources.RootReachable(schema, "sshd.config"), "reached as _.sshd.config")
+	assert.True(t, resources.RootReachable(schema, "os.update"), "reached as the element of _.updates")
+	assert.False(t, resources.RootReachable(schema, "os"), "the namespace node nothing hangs off")
+}

--- a/mqlc/provenance.go
+++ b/mqlc/provenance.go
@@ -19,6 +19,9 @@ import (
 //   - min_provider_versions: the highest min_provider_version over every
 //     resource and field the bundle actually touches. A requirement - the
 //     oldest provider that can still resolve every name in it.
+//   - deprecated_uses: the deprecated names it reads that say where they moved
+//     to. Also what the writer saw, and it rides along on the same walk for the
+//     same reason.
 //
 // Both are derived from the finished bytecode rather than recorded during
 // compilation on purpose. Name resolution happens at eighteen call sites spread
@@ -36,6 +39,7 @@ func stampProvenance(res *llx.CodeBundle, schema resources.ResourcesSchema) {
 		versions:       semver.Parser{},
 		schemas:        map[string]string{},
 		minimums:       map[string]string{},
+		deprecatedSeen: map[string]struct{}{},
 	}
 	p.walk()
 
@@ -44,6 +48,9 @@ func stampProvenance(res *llx.CodeBundle, schema resources.ResourcesSchema) {
 	}
 	if len(p.minimums) > 0 {
 		res.MinProviderVersions = p.minimums
+	}
+	if len(p.deprecated) > 0 {
+		res.DeprecatedUses = p.deprecated
 	}
 	if v := minMqlVersion(res); v != "" {
 		res.MinMondooVersion = v
@@ -60,6 +67,10 @@ type provenance struct {
 	versions       semver.Parser
 	schemas        map[string]string
 	minimums       map[string]string
+	// deprecated keeps first-use order rather than being sorted at the end, so
+	// a notice reads in the order the query does.
+	deprecated     []*llx.DeprecatedUse
+	deprecatedSeen map[string]struct{}
 }
 
 func (p *provenance) walk() {
@@ -115,7 +126,11 @@ func (p *provenance) chunkAt(ref uint64) *llx.Chunk {
 
 func (p *provenance) recordResource(name string) {
 	info := p.schema.Lookup(name)
-	if info == nil || info.Provider == "" {
+	if info == nil {
+		return
+	}
+	p.noteReplacement(name, info.ReplacedBy)
+	if info.Provider == "" {
 		return
 	}
 	p.noteProvider(info.Provider)
@@ -133,6 +148,7 @@ func (p *provenance) recordField(resource string, field string) {
 	if f == nil {
 		return
 	}
+	p.noteReplacement(resource+"."+field, f.ReplacedBy)
 	// A field's provider differs from its resource's when one provider extends
 	// another's resource, and then the version belongs to the extending one.
 	owner := f.Provider
@@ -141,6 +157,25 @@ func (p *provenance) recordField(resource string, field string) {
 	}
 	p.noteProvider(owner)
 	p.raiseMinimum(owner, f.MinProviderVersion)
+}
+
+// noteReplacement records that the bundle reads a deprecated name which says
+// where it went. A deprecation with no target is skipped: there is nothing to
+// tell a user beyond "this is old", and 431 of the 444 deprecations in the tree
+// carry a target, so the ones that do not are the ones with nothing to say.
+//
+// This records; it never logs. The compiler runs per keystroke behind
+// autocomplete, and a message printed from here lands in the middle of the line
+// the user is typing.
+func (p *provenance) noteReplacement(from string, to string) {
+	if to == "" || from == "" {
+		return
+	}
+	if _, ok := p.deprecatedSeen[from]; ok {
+		return
+	}
+	p.deprecatedSeen[from] = struct{}{}
+	p.deprecated = append(p.deprecated, &llx.DeprecatedUse{From: from, To: to})
 }
 
 // noteProvider records the writer-schema version for a provider. Both the map

--- a/providers-sdk/v1/mqlr/lrcore/diff.go
+++ b/providers-sdk/v1/mqlr/lrcore/diff.go
@@ -130,6 +130,9 @@ func diffResource(before *resources.ResourceInfo, after *resources.ResourceInfo,
 	if before.Maturity != after.Maturity {
 		add(ChangeAdditive, name, "maturity changed from %q to %q", before.Maturity, after.Maturity)
 	}
+	if before.ReplacedBy != after.ReplacedBy {
+		add(ChangeAdditive, name, "replacement changed from %q to %q", before.ReplacedBy, after.ReplacedBy)
+	}
 
 	diffInit(before.Init, after.Init, name, add)
 
@@ -165,6 +168,9 @@ func diffResource(before *resources.ResourceInfo, after *resources.ResourceInfo,
 		}
 		if bf.Maturity != af.Maturity {
 			add(ChangeAdditive, path, "maturity changed from %q to %q", bf.Maturity, af.Maturity)
+		}
+		if bf.ReplacedBy != af.ReplacedBy {
+			add(ChangeAdditive, path, "replacement changed from %q to %q", bf.ReplacedBy, af.ReplacedBy)
 		}
 	}
 

--- a/providers-sdk/v1/mqlr/lrcore/lr.go
+++ b/providers-sdk/v1/mqlr/lrcore/lr.go
@@ -138,6 +138,7 @@ type Resource struct {
 	Defaults    string         ` ( '@' "defaults" '(' @String ')' )? `
 	Context     string         ` ( '@' "context" '(' @String ')' )? `
 	Maturity    string         ` ( '@' "maturity" '(' @String ')' )? `
+	ReplacedBy  string         ` ( '@' "replaced_by" '(' @String ')' )? `
 	IsGlobal    bool           ` ( '@' @"global" )? `
 	IsRoot      bool           ` ( '@' @"root" )? `
 	ListType    *SimplListType `[ '{' [ @@ ]`
@@ -234,6 +235,7 @@ type BasicField struct {
 	ID         string     `@Ident?`
 	Args       *FieldArgs `[ '(' @@ ')' ]`
 	Maturity   string     ` ( '@' "maturity" '(' @String ')' )? `
+	ReplacedBy string     ` ( '@' "replaced_by" '(' @String ')' )? `
 	Type       Type       `[ @@ ]`
 	isEmbedded bool
 }

--- a/providers-sdk/v1/mqlr/lrcore/schema.go
+++ b/providers-sdk/v1/mqlr/lrcore/schema.go
@@ -167,6 +167,10 @@ func Schema(ast *LR) (*resources.Schema, error) {
 		}
 	}
 
+	if err := validateReplacedBy(res); err != nil {
+		return nil, err
+	}
+
 	if len(schemaErrs) > 0 {
 		return res, errors.Join(schemaErrs...)
 	}
@@ -243,6 +247,7 @@ func resourceFields(r *Resource, ast *LR) (map[string]*resources.Field, error) {
 			Refs:        refs,
 			IsEmbedded:  f.BasicField.isEmbedded,
 			Maturity:    f.BasicField.Maturity,
+			ReplacedBy:  f.BasicField.ReplacedBy,
 		}
 	}
 
@@ -280,6 +285,7 @@ func resourceSchema(r *Resource, ast *LR) (*resources.ResourceInfo, error) {
 		Maturity:    r.Maturity,
 		Global:      r.IsGlobal,
 		Root:        r.IsRoot,
+		ReplacedBy:  r.ReplacedBy,
 	}
 
 	if r.ListType != nil {
@@ -287,4 +293,69 @@ func resourceSchema(r *Resource, ast *LR) (*resources.ResourceInfo, error) {
 	}
 
 	return res, fieldsErr
+}
+
+// validateReplacedBy checks that every `@replaced_by` names something that
+// exists in this schema. The annotation carries the *schema* path of the
+// replacement (`os.base.hostname`), not the spelling a user types - the
+// relative form is rendered later against whatever root the query compiles
+// with - so a typo here would otherwise survive all the way to a message that
+// points a user at nothing. See ADR 040.
+func validateReplacedBy(res *resources.Schema) error {
+	var errs []error
+
+	// The owner of the target - the target itself when it names a resource -
+	// has to survive the v15 cutover, or the notice points a user at something
+	// that will not compile by the time they read it. Checking it here means
+	// checking it once, when the provider is built, instead of discovering it
+	// from a confused user.
+	reachable := func(what string, name string) {
+		if resources.RootReachable(res, name) {
+			return
+		}
+		errs = append(errs, fmt.Errorf("%s: @replaced_by target %q cannot be reached from any asset root, so it stops resolving in v15", what, name))
+	}
+
+	check := func(what string, target string) {
+		if target == "" {
+			return
+		}
+		if _, ok := res.Resources[target]; ok {
+			reachable(what, target)
+			return
+		}
+		// Not a resource, so it has to be a field on one. Only the last segment
+		// can be the field name; everything before it is the owning resource,
+		// which is itself dotted.
+		if idx := strings.LastIndex(target, "."); idx > 0 {
+			owner, field := target[:idx], target[idx+1:]
+			if ri, ok := res.Resources[owner]; ok {
+				if _, ok := ri.Fields[field]; ok {
+					reachable(what, owner)
+					return
+				}
+				errs = append(errs, fmt.Errorf("%s: @replaced_by(%q) - resource %q has no field %q", what, target, owner, field))
+				return
+			}
+		}
+		errs = append(errs, fmt.Errorf("%s: @replaced_by(%q) does not name a resource or field in this schema", what, target))
+	}
+
+	for name, ri := range res.Resources {
+		if ri.ReplacedBy == name {
+			errs = append(errs, fmt.Errorf("resource %s: @replaced_by points at itself", name))
+		} else {
+			check("resource "+name, ri.ReplacedBy)
+		}
+		for fname, f := range ri.Fields {
+			if f.ReplacedBy == name+"."+fname {
+				errs = append(errs, fmt.Errorf("resource %s field %s: @replaced_by points at itself", name, fname))
+				continue
+			}
+			check("resource "+name+" field "+fname, f.ReplacedBy)
+		}
+	}
+
+	slices.SortFunc(errs, func(a, b error) int { return strings.Compare(a.Error(), b.Error()) })
+	return errors.Join(errs...)
 }

--- a/providers-sdk/v1/mqlr/lrcore/schema_test.go
+++ b/providers-sdk/v1/mqlr/lrcore/schema_test.go
@@ -174,3 +174,144 @@ func TestDetermnisticSchema(t *testing.T) {
 		require.Equal(t, schema, newSchema)
 	}
 }
+
+func TestReplacedBy(t *testing.T) {
+	// The annotation is a pointer with no runtime behavior (ADR 040): what it
+	// buys is a deprecation notice that names a real destination, so the only
+	// thing that can go wrong is the destination not existing.
+	schemaWithErr := func(t *testing.T, s string) error {
+		ast := parse(t, s)
+		ast.Options = map[string]string{"provider": provider}
+		_, err := Schema(ast)
+		return err
+	}
+
+	t.Run("field target", func(t *testing.T) {
+		res := schemaFor(t, `
+			os @maturity("deprecated") @replaced_by("os.base") {
+				hostname() @maturity("deprecated") @replaced_by("os.base.hostname") string
+			}
+			os.base @root {
+				hostname() string
+			}
+		`)
+		assert.Equal(t, "os.base", res.Resources["os"].ReplacedBy)
+		assert.Equal(t, "os.base.hostname", res.Resources["os"].Fields["hostname"].ReplacedBy)
+		// The target itself carries nothing; only the deprecated side points.
+		assert.Empty(t, res.Resources["os.base"].ReplacedBy)
+		assert.Empty(t, res.Resources["os.base"].Fields["hostname"].ReplacedBy)
+	})
+
+	t.Run("unknown resource target", func(t *testing.T) {
+		err := schemaWithErr(t, `
+			os @maturity("deprecated") @replaced_by("osbase") {
+				hostname() string
+			}
+		`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `@replaced_by("osbase") does not name a resource or field`)
+	})
+
+	t.Run("dotted target falls back to the field reading", func(t *testing.T) {
+		// `os.nope` is ambiguous on its face: it could be a resource we do not
+		// have, or a field on one we do. The resource lookup misses and the
+		// field lookup hits an owner that exists, so the specific message wins.
+		err := schemaWithErr(t, `
+			os @maturity("deprecated") @replaced_by("os.nope") {
+				hostname() string
+			}
+		`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `resource "os" has no field "nope"`)
+	})
+
+	t.Run("unknown field on a known resource", func(t *testing.T) {
+		err := schemaWithErr(t, `
+			os @maturity("deprecated") {
+				hostname() @replaced_by("os.base.hostnaem") string
+			}
+			os.base @root {
+				hostname() string
+			}
+		`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `resource "os.base" has no field "hostnaem"`)
+	})
+
+	t.Run("self reference", func(t *testing.T) {
+		err := schemaWithErr(t, `
+			os {
+				hostname() @replaced_by("os.hostname") string
+			}
+		`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "points at itself")
+	})
+}
+
+// Existence is not enough: the replacement has to still be addressable once the
+// root is the namespace (ADR 031 v15). Catching it when the provider is built
+// is the whole point - the alternative is a user reading a notice that points
+// at something they cannot type.
+func TestReplacedByReachability(t *testing.T) {
+	schemaWithErr := func(t *testing.T, s string) error {
+		ast := parse(t, s)
+		ast.Options = map[string]string{"provider": provider}
+		_, err := Schema(ast)
+		return err
+	}
+
+	t.Run("reached through a member, not an embed", func(t *testing.T) {
+		// `sshd.config` hangs off no embed chain, but `_.sshd.config` resolves,
+		// so it survives the cutover and is a legal target.
+		ast := parse(t, `
+			os @maturity("deprecated") @replaced_by("sshd.config.params") {
+				sshd() @maturity("deprecated") string
+			}
+			os.base @root {
+				sshd() sshd
+			}
+			sshd {
+				config() sshd.config
+			}
+			sshd.config {
+				params() string
+			}
+		`)
+		ast.Options = map[string]string{"provider": provider}
+		_, err := Schema(ast)
+		require.NoError(t, err)
+	})
+
+	t.Run("target hanging off nothing", func(t *testing.T) {
+		err := schemaWithErr(t, `
+			os @maturity("deprecated") @replaced_by("orphan.thing") {
+				hostname() string
+			}
+			os.base @root {
+				hostname() string
+			}
+			orphan.thing {
+				name() string
+			}
+		`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `@replaced_by target "orphan.thing" cannot be reached from any asset root`)
+	})
+
+	t.Run("a provider with no roots is not asked the question", func(t *testing.T) {
+		// Nothing to be outside of yet. Rejecting here would block every
+		// provider that has not been rooted from recording a replacement.
+		ast := parse(t, `
+			thing @maturity("deprecated") @replaced_by("other.name") {
+				name() string
+			}
+			other {
+				name string
+			}
+		`)
+		ast.Options = map[string]string{"provider": provider}
+		_, err := Schema(ast)
+		require.NoError(t, err)
+	})
+}

--- a/providers-sdk/v1/resources/resources.pb.go
+++ b/providers-sdk/v1/resources/resources.pb.go
@@ -368,7 +368,14 @@ type ResourceInfo struct {
 	// universal base, the platform variants that embed it, and the union a
 	// disconnected compile targets - and knowing which resources are roots is
 	// what lets the compiler narrow a query to the ones that can run it.
-	Root          bool `protobuf:"varint,34,opt,name=root,proto3" json:"root,omitempty"`
+	Root bool `protobuf:"varint,34,opt,name=root,proto3" json:"root,omitempty"`
+	// Where this resource moved to, when it is deprecated in favor of another
+	// one (ADR 040). Holds the full schema path of the replacement, e.g.
+	// `os.base`; what a user is shown is rendered from that against the root
+	// their query is compiled with. A pointer only: it changes nothing about
+	// how this resource resolves, and every migration that has to transform
+	// rather than redirect is a lens in Go, not this field.
+	ReplacedBy    string `protobuf:"bytes,35,opt,name=replaced_by,json=replacedBy,proto3" json:"replaced_by,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -522,6 +529,13 @@ func (x *ResourceInfo) GetRoot() bool {
 	return false
 }
 
+func (x *ResourceInfo) GetReplacedBy() string {
+	if x != nil {
+		return x.ReplacedBy
+	}
+	return ""
+}
+
 type Field struct {
 	state              protoimpl.MessageState `protogen:"open.v1"`
 	Name               string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -541,7 +555,11 @@ type Field struct {
 	// Note: Please do not use this field, it is only temporary and will be
 	// removed in the future once binding resources are mandatory for all
 	// executions.
-	Others        []*Field `protobuf:"bytes,29,rep,name=others,proto3" json:"others,omitempty"`
+	Others []*Field `protobuf:"bytes,29,rep,name=others,proto3" json:"others,omitempty"`
+	// Where this field moved to, when it is deprecated in favor of another one
+	// (ADR 040). Holds the full schema path of the replacement, e.g.
+	// `os.base.hostname`. See ResourceInfo.replaced_by.
+	ReplacedBy    string `protobuf:"bytes,31,opt,name=replaced_by,json=replacedBy,proto3" json:"replaced_by,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -667,6 +685,13 @@ func (x *Field) GetOthers() []*Field {
 	return nil
 }
 
+func (x *Field) GetReplacedBy() string {
+	if x != nil {
+		return x.ReplacedBy
+	}
+	return ""
+}
+
 var File_resources_proto protoreflect.FileDescriptor
 
 const file_resources_proto_rawDesc = "" +
@@ -701,7 +726,7 @@ const file_resources_proto_rawDesc = "" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x1a\n" +
 	"\boptional\x18\x03 \x01(\bR\boptional\"6\n" +
 	"\x04Init\x12.\n" +
-	"\x04args\x18\x01 \x03(\v2\x1a.mondoo.resources.TypedArgR\x04args\"\x98\x05\n" +
+	"\x04args\x18\x01 \x03(\v2\x1a.mondoo.resources.TypedArgR\x04args\"\xb9\x05\n" +
 	"\fResourceInfo\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12B\n" +
@@ -719,10 +744,12 @@ const file_resources_proto_rawDesc = "" +
 	"\x06others\x18\x1d \x03(\v2\x1e.mondoo.resources.ResourceInfoR\x06others\x12\x1a\n" +
 	"\bmaturity\x18  \x01(\tR\bmaturity\x12\x16\n" +
 	"\x06global\x18! \x01(\bR\x06global\x12\x12\n" +
-	"\x04root\x18\" \x01(\bR\x04root\x1aR\n" +
+	"\x04root\x18\" \x01(\bR\x04root\x12\x1f\n" +
+	"\vreplaced_by\x18# \x01(\tR\n" +
+	"replacedBy\x1aR\n" +
 	"\vFieldsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12-\n" +
-	"\x05value\x18\x02 \x01(\v2\x17.mondoo.resources.FieldR\x05value:\x028\x01J\x04\b\x19\x10\x1aR\x12min_mondoo_version\"\xb7\x03\n" +
+	"\x05value\x18\x02 \x01(\v2\x17.mondoo.resources.FieldR\x05value:\x028\x01J\x04\b\x19\x10\x1aR\x12min_mondoo_version\"\xd8\x03\n" +
 	"\x05Field\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12!\n" +
@@ -738,7 +765,9 @@ const file_resources_proto_rawDesc = "" +
 	"\vis_embedded\x18\x19 \x01(\bR\n" +
 	"isEmbedded\x12\x1a\n" +
 	"\bmaturity\x18\x1a \x01(\tR\bmaturity\x12/\n" +
-	"\x06others\x18\x1d \x03(\v2\x17.mondoo.resources.FieldR\x06othersJ\x04\b\x17\x10\x18R\x12min_mondoo_versionB.Z,go.mondoo.com/mql/providers-sdk/v1/resourcesb\x06proto3"
+	"\x06others\x18\x1d \x03(\v2\x17.mondoo.resources.FieldR\x06others\x12\x1f\n" +
+	"\vreplaced_by\x18\x1f \x01(\tR\n" +
+	"replacedByJ\x04\b\x17\x10\x18R\x12min_mondoo_versionB.Z,go.mondoo.com/mql/providers-sdk/v1/resourcesb\x06proto3"
 
 var (
 	file_resources_proto_rawDescOnce sync.Once

--- a/providers-sdk/v1/resources/resources.proto
+++ b/providers-sdk/v1/resources/resources.proto
@@ -113,6 +113,14 @@ message ResourceInfo {
   // disconnected compile targets - and knowing which resources are roots is
   // what lets the compiler narrow a query to the ones that can run it.
   bool root = 34;
+
+  // Where this resource moved to, when it is deprecated in favor of another
+  // one (ADR 040). Holds the full schema path of the replacement, e.g.
+  // `os.base`; what a user is shown is rendered from that against the root
+  // their query is compiled with. A pointer only: it changes nothing about
+  // how this resource resolves, and every migration that has to transform
+  // rather than redirect is a lens in Go, not this field.
+  string replaced_by = 35;
 }
 
 message Field {
@@ -138,4 +146,9 @@ message Field {
   // removed in the future once binding resources are mandatory for all
   // executions.
   repeated Field others = 29;
+
+  // Where this field moved to, when it is deprecated in favor of another one
+  // (ADR 040). Holds the full schema path of the replacement, e.g.
+  // `os.base.hostname`. See ResourceInfo.replaced_by.
+  string replaced_by = 31;
 }

--- a/providers-sdk/v1/resources/resources_vtproto.pb.go
+++ b/providers-sdk/v1/resources/resources_vtproto.pb.go
@@ -359,6 +359,15 @@ func (m *ResourceInfo) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.ReplacedBy) > 0 {
+		i -= len(m.ReplacedBy)
+		copy(dAtA[i:], m.ReplacedBy)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ReplacedBy)))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0x9a
+	}
 	if m.Root {
 		i--
 		if m.Root {
@@ -573,6 +582,15 @@ func (m *Field) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.ReplacedBy) > 0 {
+		i -= len(m.ReplacedBy)
+		copy(dAtA[i:], m.ReplacedBy)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ReplacedBy)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xfa
 	}
 	if len(m.MinProviderVersion) > 0 {
 		i -= len(m.MinProviderVersion)
@@ -911,6 +929,10 @@ func (m *ResourceInfo) SizeVT() (n int) {
 	if m.Root {
 		n += 3
 	}
+	l = len(m.ReplacedBy)
+	if l > 0 {
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -970,6 +992,10 @@ func (m *Field) SizeVT() (n int) {
 		}
 	}
 	l = len(m.MinProviderVersion)
+	if l > 0 {
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.ReplacedBy)
 	if l > 0 {
 		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -2618,6 +2644,38 @@ func (m *ResourceInfo) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Root = bool(v != 0)
+		case 35:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReplacedBy", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ReplacedBy = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -3038,6 +3096,38 @@ func (m *Field) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.MinProviderVersion = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 31:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReplacedBy", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ReplacedBy = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/providers-sdk/v1/resources/roots.go
+++ b/providers-sdk/v1/resources/roots.go
@@ -1,0 +1,148 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go.mondoo.com/mql/types"
+)
+
+// Reachability from an asset root (ADR 031) gets asked in two different shapes,
+// and they are not the same question:
+//
+//   - RootEmbeds asks whether a resource is the root or part of its embed chain
+//     (`os.linux` -> `os.unix` -> `os.base`). Members of those resources are the
+//     ones a rooted query names directly, which is what makes `os.base.hostname`
+//     spellable as `hostname`.
+//   - RootReachable asks whether a resource can be addressed from any root at
+//     all, by any path. `sshd.config` is not in an embed chain, but `_.sshd` is
+//     a member of a root, so `_.sshd.config` resolves.
+//
+// The first answers "can this be shortened", the second "does this exist for a
+// rooted user". Both live here so the compiler and the schema generator agree.
+
+// RootEmbeds reports whether name is root itself or sits in its embed chain.
+func RootEmbeds(schema ResourcesSchema, root string, name string) bool {
+	if schema == nil || root == "" || name == "" {
+		return false
+	}
+
+	seen := map[string]struct{}{}
+	var walk func(string) bool
+	walk = func(current string) bool {
+		if current == name {
+			return true
+		}
+		if _, ok := seen[current]; ok {
+			return false
+		}
+		seen[current] = struct{}{}
+
+		info := schema.Lookup(current)
+		if info == nil {
+			return false
+		}
+		for _, f := range info.Fields {
+			if !f.IsEmbedded {
+				continue
+			}
+			if child := types.ResourceOf(types.Type(f.Type)); child != "" && walk(child) {
+				return true
+			}
+		}
+		return false
+	}
+	return walk(root)
+}
+
+// RootReachable reports whether name can still be addressed once the asset root
+// is the namespace (ADR 031 v15): it is a root, or something reachable from one
+// by following fields. `sshd.config` is not in any embed chain, but `_.sshd`
+// is a member of a root and `sshd` has a `config` field, so `_.sshd.config`
+// resolves and the name survives the cutover. The bridging namespace node `os`
+// does not: nothing has a field of that type, which is exactly why `os.hostname`
+// stops resolving in v15 and this whole migration exists.
+//
+// A resource marked `@global` is reachable by definition - it is declared as not
+// needing a root.
+//
+// Returns true when the schema declares no roots at all: there is nothing to be
+// outside of, so the question is not answerable and a caller must not read a
+// false as "unreachable".
+//
+// This is the build-time counterpart to what the compiler records per bundle as
+// `unrooted_resources`. That one asks a narrower version - only against the
+// provider's own declared root, for one resource a query actually reached -
+// because it measures migration progress rather than validating a schema.
+func RootReachable(schema ResourcesSchema, name string) bool {
+	if schema == nil || name == "" {
+		return false
+	}
+
+	roots := rootsOf(schema)
+	if len(roots) == 0 {
+		return true
+	}
+
+	info := schema.Lookup(name)
+	if info == nil {
+		return false
+	}
+	if info.GetGlobal() {
+		return true
+	}
+	if _, ok := roots[name]; ok {
+		return true
+	}
+
+	seen := map[string]struct{}{}
+	queue := make([]string, 0, len(roots))
+	for rootName := range roots {
+		queue = append(queue, rootName)
+		seen[rootName] = struct{}{}
+	}
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		currentInfo := schema.Lookup(current)
+		if currentInfo == nil {
+			continue
+		}
+		for _, f := range currentInfo.Fields {
+			if f.IsPrivate {
+				continue
+			}
+			// Both `foo bar.baz` and `foo []bar.baz` reach bar.baz; the list
+			// wrapper is not a different destination. ResourceOf unwraps it and
+			// answers "" for a plain string, where ResourceName would panic.
+			child := types.ResourceOf(types.Type(f.Type))
+			if child == "" {
+				continue
+			}
+			if child == name {
+				return true
+			}
+			if _, ok := seen[child]; ok {
+				continue
+			}
+			seen[child] = struct{}{}
+			queue = append(queue, child)
+		}
+	}
+	return false
+}
+
+// rootsOf collects the resources declared as asset roots, skipping the aliases
+// under which a resource can also appear in the schema map.
+func rootsOf(schema ResourcesSchema) map[string]*ResourceInfo {
+	res := map[string]*ResourceInfo{}
+	for name, info := range schema.AllResources() {
+		if info == nil || !info.GetRoot() || name != info.Id {
+			continue
+		}
+		res[name] = info
+	}
+	return res
+}

--- a/providers-sdk/v1/resources/schema.go
+++ b/providers-sdk/v1/resources/schema.go
@@ -49,6 +49,7 @@ func cloneField(fv *Field) *Field {
 		IsImplicitResource: fv.IsImplicitResource,
 		IsEmbedded:         fv.IsEmbedded,
 		Maturity:           fv.Maturity,
+		ReplacedBy:         fv.ReplacedBy,
 	}
 	if fv.Refs != nil {
 		f.Refs = make([]string, len(fv.Refs))
@@ -115,6 +116,9 @@ func (s *Schema) Add(other ResourcesSchema) ResourcesSchema {
 			if v.Maturity != "" {
 				existing.Maturity = v.Maturity
 			}
+			if v.ReplacedBy != "" {
+				existing.ReplacedBy = v.ReplacedBy
+			}
 			// Reachability without a root is a property of the resource, not of
 			// which schema happened to be merged last, so one contributor
 			// claiming it is enough. Dropping it here made `asset` - which os
@@ -162,6 +166,9 @@ func (s *Schema) Add(other ResourcesSchema) ResourcesSchema {
 				// rooted compile reads it off the merged schema (ADR 031).
 				Global: v.Global,
 				Root:   v.Root,
+				// And so does the replacement pointer, which is what a
+				// deprecation notice is rendered from (ADR 040).
+				ReplacedBy: v.ReplacedBy,
 			}
 			for k, v := range v.Fields {
 				ri.Fields[k] = cloneField(v)

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -485,63 +485,63 @@ machine.secureboot @defaults("enabled") {
 // `os.base.hostname` reads what `os.hostname` used to. The fields here keep
 // working for the whole v14 line and are removed in v15; nothing else is
 // attached to `os`, which is only the namespace the roots hang under.
-os @maturity("deprecated") {
+os @maturity("deprecated") @replaced_by("os.base") {
   // Pretty hostname on macOS/Linux or device name on Windows
   //
   // Deprecated in favor of os.base.name, reachable as `_.name`.
-  name() @maturity("deprecated") string
+  name() @maturity("deprecated") @replaced_by("os.base.name") string
   // ENV variable contents
   //
   // Deprecated in favor of os.base.env, reachable as `_.env`.
-  env() @maturity("deprecated") map[string]string
+  env() @maturity("deprecated") @replaced_by("os.base.env") map[string]string
   // PATH variable contents
   //
   // Deprecated in favor of os.base.path, reachable as `_.path`.
-  path(env) @maturity("deprecated") []string
+  path(env) @maturity("deprecated") @replaced_by("os.base.path") []string
   // Current uptime
   //
   // Deprecated in favor of os.base.uptime, reachable as `_.uptime`.
-  uptime() @maturity("deprecated") time
+  uptime() @maturity("deprecated") @replaced_by("os.base.uptime") time
   // List of available OS updates
   //
   // Deprecated in favor of os.base.updates, reachable as `_.updates`.
-  updates() @maturity("deprecated") []os.update
+  updates() @maturity("deprecated") @replaced_by("os.base.updates") []os.update
   // Time the most recent operating system update was installed
   //
   // Deprecated in favor of os.base.lastUpdate, reachable as `_.lastUpdate`,
   // which documents what the timestamp does and does not cover.
-  lastUpdate() @maturity("deprecated") time
+  lastUpdate() @maturity("deprecated") @replaced_by("os.base.lastUpdate") time
   // Time since the most recent operating system update was installed
   //
   // Deprecated in favor of os.base.lastUpdateAge, reachable as
   // `_.lastUpdateAge`.
-  lastUpdateAge() @maturity("deprecated") time
+  lastUpdateAge() @maturity("deprecated") @replaced_by("os.base.lastUpdateAge") time
   // Record the last-update timestamp was read from
   //
   // Deprecated in favor of os.base.lastUpdateSource, reachable as
   // `_.lastUpdateSource`.
-  lastUpdateSource() @maturity("deprecated") string
+  lastUpdateSource() @maturity("deprecated") @replaced_by("os.base.lastUpdateSource") string
   // Whether a reboot is pending
   //
   // Deprecated in favor of os.base.rebootpending, reachable as
   // `_.rebootpending`.
-  rebootpending() @maturity("deprecated") bool
+  rebootpending() @maturity("deprecated") @replaced_by("os.base.rebootpending") bool
   // Hostname for this OS
   //
   // Deprecated in favor of os.base.hostname, reachable as `_.hostname`.
-  hostname() @maturity("deprecated") string
+  hostname() @maturity("deprecated") @replaced_by("os.base.hostname") string
   // Hypervisor for this OS
   //
   // Deprecated in favor of os.base.hypervisor, reachable as `_.hypervisor`.
-  hypervisor() @maturity("deprecated") string
+  hypervisor() @maturity("deprecated") @replaced_by("os.base.hypervisor") string
   // Machine ID for this OS
   //
   // Deprecated in favor of os.base.machineid, reachable as `_.machineid`.
-  machineid() @maturity("deprecated") string
+  machineid() @maturity("deprecated") @replaced_by("os.base.machineid") string
   // Current date and timezone of the system
   //
   // Deprecated in favor of os.base.date, reachable as `_.date`.
-  date() @maturity("deprecated") os.date
+  date() @maturity("deprecated") @replaced_by("os.base.date") os.date
 }
 
 // Operating system date and timezone information


### PR DESCRIPTION
```
$ mql run local -c "os.hostname"
deprecated: os.hostname has migrated to hostname
```

```
$ mql run local -c "os { hostname machineid }"
deprecated: os.hostname has migrated to hostname
deprecated: os.machineid has migrated to machineid
```

```
$ mql run local -c "os"
deprecated: os has migrated to _
```