### PR TITLE
🐛 oci: exposure ignores a VNIC's own route table

### DIFF
--- a/providers/oci/resources/compute.go
+++ b/providers/oci/resources/compute.go
@@ -483,8 +483,9 @@ func (o *mqlOciComputeInstance) vnics() ([]any, error) {
 
 type mqlOciComputeVnicInternal struct {
 	ociCompartmentRef
-	cacheNsgIDs   []any
-	cacheSubnetID string
+	cacheNsgIDs       []any
+	cacheSubnetID     string
+	cacheRouteTableID string
 }
 
 func (o *mqlOciComputeVnic) id() (string, error) {
@@ -503,6 +504,28 @@ func (o *mqlOciComputeVnic) subnet() (*mqlOciNetworkSubnet, error) {
 		return nil, err
 	}
 	return mqlSubnet.(*mqlOciNetworkSubnet), nil
+}
+
+// routeTable resolves the route table the VNIC routes through, which OCI calls
+// per-resource routing. Null when the VNIC sets none, in which case its subnet's
+// route table governs the interface.
+//
+// A route table the VNIC names but that cannot be resolved is reported as an
+// error rather than as null, the same way the subnet reference behaves: the
+// exposure verdict reads this field, and an unread route table must not be
+// indistinguishable from a VNIC that overrides nothing.
+func (o *mqlOciComputeVnic) routeTable() (*mqlOciNetworkRouteTable, error) {
+	if o.cacheRouteTableID == "" {
+		o.RouteTable.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	mqlRouteTable, err := NewResource(o.MqlRuntime, "oci.network.routeTable", map[string]*llx.RawData{
+		"id": llx.StringData(o.cacheRouteTableID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return mqlRouteTable.(*mqlOciNetworkRouteTable), nil
 }
 
 func (o *mqlOciCompute) images() ([]any, error) {

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -936,6 +936,9 @@ func ociVnicToMql(runtime *plugin.Runtime, vnic core.Vnic) (*mqlOciComputeVnic, 
 	}
 	mqlVnic := res.(*mqlOciComputeVnic)
 	mqlVnic.cacheSubnetID = stringValue(vnic.SubnetId)
+	// Per-resource routing: set only when the VNIC overrides its subnet's route
+	// table, and what the exposure verdict routes on when it is.
+	mqlVnic.cacheRouteTableID = stringValue(vnic.RouteTableId)
 	mqlVnic.cacheNsgIDs = convert.SliceAnyToInterface(vnic.NsgIds)
 	return mqlVnic, nil
 }

--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -1572,6 +1572,15 @@ private oci.compute.vnic @defaults("name") {
   hostnameLabel string
   // Subnet the VNIC is in
   subnet() oci.network.subnet
+  // Route table the VNIC routes through
+  //
+  // Per-resource routing lets a VNIC carry a route table of its own, which
+  // governs traffic on that interface instead of the one attached to the
+  // subnet. Null when the VNIC sets none, in which case the subnet's route
+  // table applies. A VNIC routed to an internet gateway from a subnet that
+  // has no such route, or routed away from one on a subnet that has, reaches
+  // the internet differently from every other interface on that subnet.
+  routeTable() oci.network.routeTable
   // Network Security Groups attached to the VNIC
   securityGroups() []oci.network.networkSecurityGroup
   // Whether source/destination check is skipped

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -2868,6 +2868,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.compute.vnic.subnet": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeVnic).GetSubnet()).ToDataRes(types.Resource("oci.network.subnet"))
 	},
+	"oci.compute.vnic.routeTable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciComputeVnic).GetRouteTable()).ToDataRes(types.Resource("oci.network.routeTable"))
+	},
 	"oci.compute.vnic.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciComputeVnic).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("oci.network.networkSecurityGroup")))
 	},
@@ -13594,6 +13597,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.compute.vnic.subnet": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciComputeVnic).Subnet, ok = plugin.RawToTValue[*mqlOciNetworkSubnet](v.Value, v.Error)
+		return
+	},
+	"oci.compute.vnic.routeTable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciComputeVnic).RouteTable, ok = plugin.RawToTValue[*mqlOciNetworkRouteTable](v.Value, v.Error)
 		return
 	},
 	"oci.compute.vnic.securityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31023,6 +31030,7 @@ type mqlOciComputeVnic struct {
 	MacAddress                plugin.TValue[string]
 	HostnameLabel             plugin.TValue[string]
 	Subnet                    plugin.TValue[*mqlOciNetworkSubnet]
+	RouteTable                plugin.TValue[*mqlOciNetworkRouteTable]
 	SecurityGroups            plugin.TValue[[]any]
 	SkipSourceDestCheck       plugin.TValue[bool]
 	SecurityAttributes        plugin.TValue[map[string]any]
@@ -31132,6 +31140,22 @@ func (c *mqlOciComputeVnic) GetSubnet() *plugin.TValue[*mqlOciNetworkSubnet] {
 		}
 
 		return c.subnet()
+	})
+}
+
+func (c *mqlOciComputeVnic) GetRouteTable() *plugin.TValue[*mqlOciNetworkRouteTable] {
+	return plugin.GetOrCompute[*mqlOciNetworkRouteTable](&c.RouteTable, func() (*mqlOciNetworkRouteTable, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("oci.compute.vnic", c.__id, "routeTable")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlOciNetworkRouteTable), nil
+			}
+		}
+
+		return c.routeTable()
 	})
 }
 

--- a/providers/oci/resources/oci.lr.versions
+++ b/providers/oci/resources/oci.lr.versions
@@ -942,6 +942,7 @@ oci.compute.vnic.macAddress 13.1.1
 oci.compute.vnic.name 13.1.1
 oci.compute.vnic.privateIp 13.1.1
 oci.compute.vnic.publicIp 13.1.1
+oci.compute.vnic.routeTable 13.21.1
 oci.compute.vnic.securityAttributes 13.18.2
 oci.compute.vnic.securityGroups 13.6.2
 oci.compute.vnic.skipSourceDestCheck 13.1.1

--- a/providers/oci/resources/oci_exposure.go
+++ b/providers/oci/resources/oci_exposure.go
@@ -419,6 +419,35 @@ func ociSubnetReachesInternet(subnet *mqlOciNetworkSubnet) (bool, error) {
 	return ociRouteTableReachesInternet(rt.Data)
 }
 
+// ociVnicReachesInternet reports whether traffic on a VNIC is routed to an
+// enabled internet gateway, reading the route table that actually governs the
+// interface.
+//
+// OCI per-resource routing lets a VNIC carry a route table of its own, and that
+// table, not the subnet's, decides where the interface's traffic goes. Judging
+// the subnet alone is wrong in both directions: a VNIC routed to an internet
+// gateway from a subnet with no such route reads as unreachable, and a VNIC
+// routed away from one on a subnet that has it reads as reachable.
+//
+// A VNIC that names a route table the scan could not read is an unknown, not a
+// closed one, so it counts as internet-reaching. An unreadable route table must
+// not be the reason an instance is reported as protected, which is the same
+// reason an unresolvable internet gateway counts as internet-reaching.
+//
+// Only a VNIC with no route table of its own falls back to the subnet's.
+func ociVnicReachesInternet(vnic *mqlOciComputeVnic, subnet *mqlOciNetworkSubnet) (bool, error) {
+	if vnic != nil {
+		rt := vnic.GetRouteTable()
+		if rt.Error != nil {
+			return true, nil
+		}
+		if rt.Data != nil {
+			return ociRouteTableReachesInternet(rt.Data)
+		}
+	}
+	return ociSubnetReachesInternet(subnet)
+}
+
 // ociIngressOpen reports whether ingress from any address is admitted. OCI
 // evaluates the union of network security group and security-list rules, so the
 // path is open when either an actual NSG rule admits any address or the
@@ -607,10 +636,9 @@ func (i *mqlOciComputeInstance) exposure() (*mqlOciNetworkExposure, error) {
 		}
 
 		// Subnet-level gates: a subnet that prohibits internet ingress blocks
-		// reachability, and the subnet's security lists and route table decide
-		// the security-list layer and whether internet traffic is routed at all.
+		// reachability and its security lists decide the security-list layer.
+		// Routing is read separately, because the VNIC can override it.
 		subnetProhibits := false
-		vnicRoutesToInternet := false
 		var slOpenRules, slInternetRules []any
 		// Default open so an unresolvable subnet fails toward "reachable"
 		// rather than silently clearing the resource. subnetResolved keeps that
@@ -639,12 +667,15 @@ func (i *mqlOciComputeInstance) exposure() (*mqlOciNetworkExposure, error) {
 			if err != nil {
 				return nil, err
 			}
+		}
 
-			reaches, err := ociSubnetReachesInternet(subnet.Data)
-			if err != nil {
-				return nil, err
-			}
-			vnicRoutesToInternet = reaches
+		// Routing is decided by the VNIC's own route table when it has one and
+		// by the subnet's otherwise, so it is read outside the subnet block: a
+		// VNIC that overrides its subnet's routing answers on its own table
+		// whatever the subnet's says.
+		vnicRoutesToInternet, err := ociVnicReachesInternet(vnic, subnet.Data)
+		if err != nil {
+			return nil, err
 		}
 
 		// Network security groups attached to this VNIC.

--- a/providers/oci/resources/oci_exposure_vnic_route_test.go
+++ b/providers/oci/resources/oci_exposure_vnic_route_test.go
@@ -1,0 +1,269 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"go/ast"
+	"go/parser"
+	gotoken "go/token"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+)
+
+// internetGateway builds a gateway resource whose enabled flag was read.
+func internetGateway(enabled bool) *mqlOciNetworkInternetGateway {
+	return &mqlOciNetworkInternetGateway{
+		IsEnabled: plugin.TValue[bool]{Data: enabled, State: plugin.StateIsSet},
+	}
+}
+
+// routeToGateway builds a route rule forwarding dest at a target of the given
+// type. An internet gateway target also carries the gateway resource, which is
+// what the verdict reads to tell an enabled gateway from a disabled one.
+func routeToGateway(dest string, targetType string, igw *mqlOciNetworkInternetGateway) any {
+	route := &mqlOciNetworkRouteTableRoute{
+		Destination: plugin.TValue[string]{Data: dest, State: plugin.StateIsSet},
+		TargetType:  plugin.TValue[string]{Data: targetType, State: plugin.StateIsSet},
+	}
+	route.InternetGateway = plugin.TValue[*mqlOciNetworkInternetGateway]{
+		Data:  igw,
+		State: plugin.StateIsSet,
+	}
+	return route
+}
+
+// routeTableWith builds a route table whose rules were read.
+func routeTableWith(routes ...any) *mqlOciNetworkRouteTable {
+	return &mqlOciNetworkRouteTable{
+		Routes: plugin.TValue[[]any]{Data: routes, State: plugin.StateIsSet},
+	}
+}
+
+// subnetRoutedBy builds a subnet whose route table reference was resolved.
+func subnetRoutedBy(rt *mqlOciNetworkRouteTable) *mqlOciNetworkSubnet {
+	return &mqlOciNetworkSubnet{
+		RouteTable: plugin.TValue[*mqlOciNetworkRouteTable]{Data: rt, State: plugin.StateIsSet},
+	}
+}
+
+// vnicRoutedBy builds a VNIC that overrides its subnet's routing with rt.
+func vnicRoutedBy(rt *mqlOciNetworkRouteTable) *mqlOciComputeVnic {
+	return &mqlOciComputeVnic{
+		RouteTable: plugin.TValue[*mqlOciNetworkRouteTable]{Data: rt, State: plugin.StateIsSet},
+	}
+}
+
+// TestOciVnicReachesInternet pins which route table decides an instance's
+// internet reachability.
+//
+// The bug: the verdict read the subnet's route table and nothing else, while
+// OCI per-resource routing lets a VNIC carry a route table of its own that
+// governs the interface instead. That is wrong in both directions. A VNIC
+// routed to an internet gateway from a subnet with no such route reported
+// internetReachable false, so an exposed instance passed a "nothing may be
+// reachable" policy; a VNIC routed away from an internet gateway on a public
+// subnet reported true, so a hardened instance failed one.
+func TestOciVnicReachesInternet(t *testing.T) {
+	openTable := routeTableWith(routeToGateway("0.0.0.0/0", "INTERNET_GATEWAY", internetGateway(true)))
+	closedTable := routeTableWith(routeToGateway("0.0.0.0/0", "NAT_GATEWAY", nil))
+	ipv6Table := routeTableWith(routeToGateway("::/0", "INTERNET_GATEWAY", internetGateway(true)))
+	disabledGatewayTable := routeTableWith(routeToGateway("0.0.0.0/0", "INTERNET_GATEWAY", internetGateway(false)))
+
+	// A VNIC that states no route table of its own. Reading it yields null,
+	// which is what sends the verdict to the subnet.
+	noOverride := &mqlOciComputeVnic{
+		RouteTable: plugin.TValue[*mqlOciNetworkRouteTable]{State: plugin.StateIsSet | plugin.StateIsNull},
+	}
+	// A VNIC that names a route table the scan could not read: it lives in a
+	// compartment the scanner cannot list, or the call was refused.
+	unreadable := &mqlOciComputeVnic{
+		RouteTable: plugin.TValue[*mqlOciNetworkRouteTable]{
+			State: plugin.StateIsSet | plugin.StateIsNull,
+			Error: errors.New("oci.network.routeTable not found"),
+		},
+	}
+
+	tests := []struct {
+		name   string
+		vnic   *mqlOciComputeVnic
+		subnet *mqlOciNetworkSubnet
+		want   bool
+	}{
+		// The VNIC's own table decides, whichever way it points.
+		{
+			name:   "vnic routes to an internet gateway from a subnet that does not",
+			vnic:   vnicRoutedBy(openTable),
+			subnet: subnetRoutedBy(closedTable),
+			want:   true,
+		},
+		{
+			// The case that proves the fix: the subnet's table is the wide-open
+			// one, and reading it instead of the VNIC's reports an instance as
+			// internet-reachable that per-resource routing has taken off the
+			// internet.
+			name:   "vnic routes away from the internet on a subnet that routes to it",
+			vnic:   vnicRoutedBy(closedTable),
+			subnet: subnetRoutedBy(openTable),
+			want:   false,
+		},
+		{
+			name:   "vnic routes ::/0 to an internet gateway",
+			vnic:   vnicRoutedBy(ipv6Table),
+			subnet: subnetRoutedBy(closedTable),
+			want:   true,
+		},
+		{
+			name:   "vnic routes to a disabled internet gateway",
+			vnic:   vnicRoutedBy(disabledGatewayTable),
+			subnet: subnetRoutedBy(openTable),
+			want:   false,
+		},
+
+		// No override: the subnet's table is the one in force.
+		{
+			name:   "vnic sets no route table on a subnet that routes to the internet",
+			vnic:   noOverride,
+			subnet: subnetRoutedBy(openTable),
+			want:   true,
+		},
+		{
+			name:   "vnic sets no route table on a subnet that does not",
+			vnic:   noOverride,
+			subnet: subnetRoutedBy(closedTable),
+			want:   false,
+		},
+
+		// Unread evidence must not read as "not exposed".
+		{
+			name:   "vnic names a route table that could not be read",
+			vnic:   unreadable,
+			subnet: subnetRoutedBy(closedTable),
+			want:   true,
+		},
+
+		// Degenerate inputs.
+		{
+			name:   "no vnic and no subnet",
+			vnic:   nil,
+			subnet: nil,
+			want:   false,
+		},
+		{
+			name:   "no vnic falls back to the subnet",
+			vnic:   nil,
+			subnet: subnetRoutedBy(openTable),
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ociVnicReachesInternet(tt.vnic, tt.subnet)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestInstanceExposureRoutesOnTheVnic guards the wiring behind
+// hasRouteToInternet on a compute instance.
+//
+// The verdict resource cannot be built from a unit test, so the call is pinned
+// at the source level the way the load balancer address wiring is. Routing the
+// instance verdict back through ociSubnetReachesInternet fails this test.
+func TestInstanceExposureRoutesOnTheVnic(t *testing.T) {
+	fset := gotoken.NewFileSet()
+	file, err := parser.ParseFile(fset, exposureSourceFile, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", exposureSourceFile, err)
+	}
+
+	found := false
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "exposure" || fn.Recv == nil || len(fn.Recv.List) != 1 {
+			continue
+		}
+		star, ok := fn.Recv.List[0].Type.(*ast.StarExpr)
+		if !ok {
+			continue
+		}
+		ident, ok := star.X.(*ast.Ident)
+		if !ok || ident.Name != "mqlOciComputeInstance" {
+			continue
+		}
+		found = true
+
+		called := map[string]bool{}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if name, ok := call.Fun.(*ast.Ident); ok {
+				called[name.Name] = true
+			}
+			return true
+		})
+
+		if !called["ociVnicReachesInternet"] {
+			t.Error("the compute instance exposure() must route on ociVnicReachesInternet; a VNIC can carry a route table that overrides its subnet's")
+		}
+		if called["ociSubnetReachesInternet"] {
+			t.Error("the compute instance exposure() reads the subnet's route table directly, which ignores per-resource routing on the VNIC")
+		}
+	}
+
+	if !found {
+		t.Error("no exposure() found on mqlOciComputeInstance; this guard has gone stale")
+	}
+}
+
+// TestVnicMappingCachesRouteTableId guards the other half of the wiring: the
+// accessor can only answer if the creator cached the OCID the VNIC reported.
+//
+// Dropping the assignment leaves routeTable reading null on every VNIC, which
+// silently sends every instance verdict back to the subnet's route table. The
+// mapping needs a live connection to exercise, so the field read is pinned at
+// the source level.
+func TestVnicMappingCachesRouteTableId(t *testing.T) {
+	const mappingSourceFile = "network.go"
+
+	fset := gotoken.NewFileSet()
+	file, err := parser.ParseFile(fset, mappingSourceFile, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", mappingSourceFile, err)
+	}
+
+	found := false
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "ociVnicToMql" || fn.Recv != nil {
+			continue
+		}
+		found = true
+
+		reads := map[string]bool{}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			if sel, ok := n.(*ast.SelectorExpr); ok {
+				reads[sel.Sel.Name] = true
+			}
+			return true
+		})
+
+		if !reads["RouteTableId"] {
+			t.Error("ociVnicToMql must read vnic.RouteTableId; without it the routeTable reference is null on every VNIC")
+		}
+		if !reads["cacheRouteTableID"] {
+			t.Error("ociVnicToMql must set cacheRouteTableID; the routeTable accessor resolves from it")
+		}
+	}
+
+	if !found {
+		t.Error("no ociVnicToMql found; this guard has gone stale")
+	}
+}


### PR DESCRIPTION
`oci.network.exposure` judged a compute instance's internet reachability from
the **subnet's** route table alone. OCI [per-resource
routing](https://docs.oracle.com/iaas/Content/Network/Tasks/managingroutetables.htm)
lets a VNIC carry a route table of its own, and that table, not the subnet's,
decides where the interface's traffic goes. `core.Vnic.RouteTableId` was dropped
on the way into MQL, so the field the verdict needed did not exist at all.

The verdict was wrong in **both** directions:

- A VNIC routed to an internet gateway from a subnet with no such route reported
  `internetReachable` **false**. An exposed instance passed a "nothing may be
  reachable" policy with nothing to fail on.
- A VNIC routed away from an internet gateway on a public subnet reported
  **true**. A hardened instance failed a policy it satisfies.

## What changed

`oci.compute.vnic` gains a `routeTable` reference to `oci.network.routeTable`,
null when the VNIC sets none. The instance verdict routes on the VNIC's table
when it has one and falls back to the subnet's when it does not, so
`hasRouteToInternet` and `internetReachable` now describe the routing that is
actually in force on the interface.

Everything else in the verdict is untouched: the public-IP check, the
prohibit-internet-ingress gate, and the NSG / security-list union are unchanged,
and the load balancer paths are unaffected because a load balancer sits on
subnets rather than VNICs.

## Unread evidence still fails closed

Following #10624, a read that could not be made must not degrade into a
confident "not exposed":

- A VNIC that names a route table the scan could not read (another compartment,
  a refused call) counts as **internet-reaching**, the same way an unresolvable
  internet gateway already does in `ociRouteTableReachesInternet`.
- That is why the new reference reports a failed resolution as an **error**
  rather than as null. Null has to mean "this VNIC overrides nothing", and if a
  failed lookup also read null it would be indistinguishable from that and would
  silently send the verdict back to the subnet. The sibling `subnet` reference on
  the same resource behaves the same way.

## Schema

One additive field, `oci.compute.vnic.routeTable` at `13.21.1` (next patch after
the provider's current `13.21.0`; `config.go` is untouched). No field types
changed, nothing removed.

`oci.permissions.json` is unchanged: no new API call. Route tables are already
listed, and the reference resolves through that collection rather than issuing a
per-VNIC lookup.

## Tests

`providers/oci/resources/oci_exposure_vnic_route_test.go`:

- **VNIC route table set and internet-reaching**, on a subnet that is not.
- **VNIC route table set and not internet-reaching, while the subnet's is.**
  This is the case that proves the bug is fixed.
- **VNIC route table absent**, falling back to the subnet, in both the reaching
  and non-reaching directions.
- Disabled internet gateway on the VNIC's own table, `::/0` default route, and
  an unreadable route table on a closed subnet (must read as reaching).
- Two source-level guards, in the style of the existing
  `TestLoadBalancerExposureReadsTypedAddresses`, on the halves of the wiring a
  unit test cannot reach: that the instance `exposure()` routes through the new
  helper and no longer calls `ociSubnetReachesInternet`, and that `ociVnicToMql`
  reads `RouteTableId` into the cache the reference resolves from. Dropping
  either one is silent otherwise: the field just reads null on every VNIC.

Mutation-checked by delegating the helper back to the subnet's route table,
which fails five named cases.

`go build ./... && go test ./...` pass in `providers/oci/`, and `golangci-lint
run ./resources/...` reports 0 issues.

The schema half is proven at compile time: with the `.lr.versions` gate lifted
locally (the field sits at `13.21.1`, one patch above the provider's shipped
`13.21.0`, so it is invisible until the release bump, exactly like the already
merged `oci.compute.vnic.systemTags`), `mql run oci --info` resolves
`oci.compute.instances { vnics { routeTable { routes { destination targetType
} } } }` with `routeTable type=oci.network.routeTable`.

## Verification

**I could not verify this against live infrastructure.** The available OCI test
tenancy is Always-Free and near-empty (one compartment, no VCNs), so there is no
VNIC, route table, or internet gateway to query. Specifically unverified against
a real tenancy: that `core.Vnic.RouteTableId` is populated on a VNIC configured
with per-resource routing, and that `oci.compute.vnic.routeTable` resolves to the
right `oci.network.routeTable` end to end. Both are covered by unit tests and by
the SDK field definition (`core/vnic.go`, `oci-go-sdk/v65 v65.124.0`), not by a
live scan.
