### PR TITLE
🐛 azure: stop publishing container instance secrets through dict fields

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -16969,11 +16969,22 @@ azure.subscription.containerInstanceService.containerGroup @defaults("name locat
   subnetIds []string
   // DNS configuration (nameServers, searchDomains, options)
   dnsConfig dict
-  // Image registry credentials — each entry has {server, username?, identity?, identityUrl?}
+  // Image registry credentials
+  //
+  // One entry per private registry the group pulls from, with keys `server`,
+  // `username`, `identity`, and `identityUrl`. The registry password is
+  // deliberately not published; `registryAuthUsesIdentity` reports whether the
+  // group authenticates with a managed identity instead of a password.
   imageRegistryCredentials []dict
   // Whether any registry credential uses managed identity (vs username/password)
   registryAuthUsesIdentity bool
-  // Volumes mounted into containers — entries are azureFile / emptyDir / secret / gitRepo
+  // Volumes mounted into containers
+  //
+  // One entry per volume, each of type `azureFile`, `emptyDir`, `secret`, or
+  // `gitRepo`. A secret volume lists the file names it mounts as the keys of
+  // its `secret` map, with every value null: the file contents are deliberately
+  // not published. The Azure File storage account key is likewise absent, while
+  // the share name, storage account name, and read-only flag are reported.
   volumes []dict
   // Convenience: any volume of type "secret"
   hasSecretVolume bool
@@ -17003,7 +17014,11 @@ private azure.subscription.containerInstanceService.containerGroup.container @de
   imagePinned bool
   // Container start command
   command []string
-  // Environment variables — each entry has {name, value, secureValue}
+  // Environment variables
+  //
+  // One entry per variable, with keys `name` and `value`. A variable declared
+  // as a secure value reports its name with no value, since the value is a
+  // credential and is deliberately not published.
   env []dict
   // CPU cores requested
   cpuCores float

--- a/providers/azure/resources/containerinstance.go
+++ b/providers/azure/resources/containerinstance.go
@@ -78,6 +78,103 @@ func (a *mqlAzureSubscriptionContainerInstanceService) containerGroups() ([]any,
 	return res, nil
 }
 
+// redactedImageRegistryCredentials copies the registry credentials with the
+// registry passwords removed.
+//
+// The password authenticates to the private registry the group pulls from, and
+// the audit signal it would serve is already carried by registryAuthUsesIdentity,
+// which is computed from the same records. The server, username and identity
+// are kept, so a check on which registry a group pulls from and whether it
+// authenticates with a managed identity reads as before.
+//
+// The copy is by field rather than by JSON key so that a field renamed in a
+// future SDK breaks the build instead of silently leaking again.
+func redactedImageRegistryCredentials(creds []*aci.ImageRegistryCredential) []*aci.ImageRegistryCredential {
+	if creds == nil {
+		return nil
+	}
+	out := make([]*aci.ImageRegistryCredential, 0, len(creds))
+	for _, cred := range creds {
+		if cred == nil {
+			out = append(out, nil)
+			continue
+		}
+		safe := *cred
+		safe.Password = nil
+		out = append(out, &safe)
+	}
+	return out
+}
+
+// redactedVolumes copies the group's volumes with the secret-volume contents
+// and the Azure File storage account key removed.
+//
+// A secret volume's map holds the base64 file contents mounted into the
+// containers, and the Azure File key grants access to the whole file share.
+// The file names are kept as the map's keys, with each value nulled, so a check
+// on which files a secret volume mounts still reads while their contents do
+// not. Everything else about a volume is kept, including the share name,
+// storage account name and read-only flag, and hasSecretVolume is computed from
+// the unredacted records.
+//
+// The copy is by field rather than by JSON key so that a field renamed in a
+// future SDK breaks the build instead of silently leaking again.
+func redactedVolumes(volumes []*aci.Volume) []*aci.Volume {
+	if volumes == nil {
+		return nil
+	}
+	out := make([]*aci.Volume, 0, len(volumes))
+	for _, v := range volumes {
+		if v == nil {
+			out = append(out, nil)
+			continue
+		}
+		safe := *v
+		if v.Secret != nil {
+			names := make(map[string]*string, len(v.Secret))
+			for name := range v.Secret {
+				names[name] = nil
+			}
+			safe.Secret = names
+		}
+		if v.AzureFile != nil {
+			file := *v.AzureFile
+			file.StorageAccountKey = nil
+			safe.AzureFile = &file
+		}
+		out = append(out, &safe)
+	}
+	return out
+}
+
+// redactedEnvironmentVariables copies a container's environment with the secure
+// values removed.
+//
+// SecureValue is the write-only half of an ACI environment variable, the one
+// callers use precisely because the value is a credential. The variable's name
+// is kept, so a check on which secure variables a container declares still
+// reads; only the value is dropped. Plain Value entries are not secure by
+// declaration and are kept as before.
+//
+// The copy is by field rather than by JSON key so that a field renamed in a
+// future SDK breaks the build instead of silently leaking again.
+func redactedEnvironmentVariables(env []*aci.EnvironmentVariable) []*aci.EnvironmentVariable {
+	if env == nil {
+		return nil
+	}
+	out := make([]*aci.EnvironmentVariable, 0, len(env))
+	for _, e := range env {
+		if e == nil {
+			out = append(out, nil)
+			continue
+		}
+		safe := *e
+		safe.SecureValue = nil
+		out = append(out, &safe)
+	}
+	return out
+}
+
 func aciContainerGroupToMQL(runtime *plugin.Runtime, entry *aci.ContainerGroup) (plugin.Resource, error) {
 	var provisioningState, osType, restartPolicy, sku, ccePolicyHash string
 	var ipAddressType, publicIp, fqdn, dnsLabelScope string
@@ -166,7 +263,7 @@ func aciContainerGroupToMQL(runtime *plugin.Runtime, entry *aci.ContainerGroup) 
 			dnsConfig = d
 		}
 		if len(props.ImageRegistryCredentials) > 0 {
-			d, err := convert.JsonToDictSlice(props.ImageRegistryCredentials)
+			d, err := convert.JsonToDictSlice(redactedImageRegistryCredentials(props.ImageRegistryCredentials))
 			if err != nil {
 				return nil, err
 			}
@@ -178,7 +275,7 @@ func aciContainerGroupToMQL(runtime *plugin.Runtime, entry *aci.ContainerGroup) 
 			}
 		}
 		if len(props.Volumes) > 0 {
-			d, err := convert.JsonToDictSlice(props.Volumes)
+			d, err := convert.JsonToDictSlice(redactedVolumes(props.Volumes))
 			if err != nil {
 				return nil, err
 			}
@@ -313,7 +410,7 @@ func aciContainersToMQL(runtime *plugin.Runtime, parentId string, specs []*aci.C
 
 		env := []any{}
 		if len(c.Properties.EnvironmentVariables) > 0 {
-			d, err := convert.JsonToDictSlice(c.Properties.EnvironmentVariables)
+			d, err := convert.JsonToDictSlice(redactedEnvironmentVariables(c.Properties.EnvironmentVariables))
 			if err != nil {
 				return nil, err
 			}

--- a/providers/azure/resources/secret_redaction_test.go
+++ b/providers/azure/resources/secret_redaction_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	web "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v6"
+	aci "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerinstance/armcontainerinstance/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,6 +23,10 @@ import (
 const (
 	fakeStorageConnString = "DefaultEndpointsProtocol=https;AccountName=acct;AccountKey=SUPERSECRETKEY==;"
 	fakeClientSecret      = "SUPERSECRETCLIENTSECRET"
+	fakeRegistryPassword  = "SUPERSECRETREGISTRYPW"
+	fakeSecureEnvValue    = "SUPERSECRETENVVALUE"
+	fakeSecretVolumeData  = "SUPERSECRETVOLUMEDATA"
+	fakeFileShareKey      = "SUPERSECRETSHAREKEY"
 )
 
 func TestRedactedRedisConfigurationDropsStorageCredentials(t *testing.T) {
@@ -160,6 +165,129 @@ func TestCreateRedisInstanceRawDataLeavesTheSourceAlone(t *testing.T) {
 	require.NotNil(t, withSecret.Properties.RedisConfiguration.RdbStorageConnectionString)
 	assert.Equal(t, fakeStorageConnString,
 		*withSecret.Properties.RedisConfiguration.RdbStorageConnectionString)
+}
+
+func TestRedactedImageRegistryCredentialsDropsThePassword(t *testing.T) {
+	creds := []*aci.ImageRegistryCredential{
+		{
+			Server:   to.Ptr("myregistry.azurecr.io"),
+			Username: to.Ptr("pull-user"),
+			Password: to.Ptr(fakeRegistryPassword),
+		},
+		{
+			Server:   to.Ptr("identity.azurecr.io"),
+			Identity: to.Ptr("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/pull"),
+		},
+		nil,
+	}
+
+	dict, err := convert.JsonToDictSlice(redactedImageRegistryCredentials(creds))
+	require.NoError(t, err)
+	serialized := mustJSON(t, dict)
+
+	assert.NotContains(t, serialized, fakeRegistryPassword,
+		"the registry password must not reach MQL")
+
+	// The audit signal has to survive: which registry a group pulls from, and
+	// whether it authenticates with an identity rather than a password.
+	assert.Contains(t, serialized, "myregistry.azurecr.io")
+	assert.Contains(t, serialized, "pull-user", "the username is not a credential")
+	assert.Contains(t, serialized, "userAssignedIdentities/pull",
+		"the managed identity is what registryAuthUsesIdentity reads")
+
+	// The source is not mutated: registryAuthUsesIdentity is computed from the
+	// caller's own records after this runs.
+	require.NotNil(t, creds[0].Password)
+	assert.Equal(t, fakeRegistryPassword, *creds[0].Password)
+
+	assert.Nil(t, redactedImageRegistryCredentials(nil))
+}
+
+// TestRedactedVolumesDropsSecretContentsAndShareKey covers two secrets in one
+// field: a secret volume's file contents, and the storage account key that
+// grants access to an entire Azure File share.
+func TestRedactedVolumesDropsSecretContentsAndShareKey(t *testing.T) {
+	volumes := []*aci.Volume{
+		{
+			Name: to.Ptr("secrets"),
+			Secret: map[string]*string{
+				"app.key": to.Ptr(fakeSecretVolumeData + "-app"),
+				"tls.pem": to.Ptr(fakeSecretVolumeData + "-tls"),
+				"absent":  nil,
+			},
+		},
+		{
+			Name: to.Ptr("share"),
+			AzureFile: &aci.AzureFileVolume{
+				ShareName:          to.Ptr("data"),
+				StorageAccountName: to.Ptr("acct"),
+				ReadOnly:           to.Ptr(true),
+				StorageAccountKey:  to.Ptr(fakeFileShareKey),
+			},
+		},
+		{
+			Name:    to.Ptr("repo"),
+			GitRepo: &aci.GitRepoVolume{Repository: to.Ptr("https://example.invalid/repo.git")},
+		},
+		nil,
+	}
+
+	dict, err := convert.JsonToDictSlice(redactedVolumes(volumes))
+	require.NoError(t, err)
+	serialized := mustJSON(t, dict)
+
+	for _, suffix := range []string{"-app", "-tls"} {
+		assert.NotContains(t, serialized, fakeSecretVolumeData+suffix,
+			"secret volume contents %q must not reach MQL", suffix)
+	}
+	assert.NotContains(t, serialized, fakeSecretVolumeData)
+	assert.NotContains(t, serialized, fakeFileShareKey,
+		"the Azure File storage account key must not reach MQL")
+
+	// The audit signal has to survive: which files a secret volume mounts, and
+	// which share is mounted read-only from where.
+	assert.Contains(t, serialized, "app.key", "the mounted file names are kept")
+	assert.Contains(t, serialized, "tls.pem")
+	assert.Contains(t, serialized, "data", "the share name is kept")
+	assert.Contains(t, serialized, "acct", "the storage account name is kept")
+	assert.Contains(t, serialized, "https://example.invalid/repo.git",
+		"a git repo volume carries no credential and is untouched")
+
+	// The source is not mutated: hasSecretVolume is computed from the caller's
+	// own records after this runs.
+	require.NotNil(t, volumes[0].Secret["app.key"])
+	assert.Equal(t, fakeSecretVolumeData+"-app", *volumes[0].Secret["app.key"])
+	require.NotNil(t, volumes[1].AzureFile.StorageAccountKey)
+	assert.Equal(t, fakeFileShareKey, *volumes[1].AzureFile.StorageAccountKey)
+
+	assert.Nil(t, redactedVolumes(nil))
+}
+
+func TestRedactedEnvironmentVariablesDropsTheSecureValue(t *testing.T) {
+	env := []*aci.EnvironmentVariable{
+		{Name: to.Ptr("LOG_LEVEL"), Value: to.Ptr("debug")},
+		{Name: to.Ptr("DB_PASSWORD"), SecureValue: to.Ptr(fakeSecureEnvValue)},
+		nil,
+	}
+
+	dict, err := convert.JsonToDictSlice(redactedEnvironmentVariables(env))
+	require.NoError(t, err)
+	serialized := mustJSON(t, dict)
+
+	assert.NotContains(t, serialized, fakeSecureEnvValue,
+		"a secure environment value must not reach MQL")
+
+	// The audit signal has to survive: which variables a container declares,
+	// including the secure ones, and the plain values that are not credentials.
+	assert.Contains(t, serialized, "DB_PASSWORD", "the variable name is kept")
+	assert.Contains(t, serialized, "LOG_LEVEL")
+	assert.Contains(t, serialized, "debug",
+		"a plain value is not secure by declaration and is kept")
+
+	require.NotNil(t, env[1].SecureValue)
+	assert.Equal(t, fakeSecureEnvValue, *env[1].SecureValue, "source not mutated")
+
+	assert.Nil(t, redactedEnvironmentVariables(nil))
 }
 
 // mustJSON serializes exactly as the value will reach MQL. It deliberately does


### PR DESCRIPTION
### What

Four pieces of secret material were reaching MQL through shipped `dict` fields on `azure.subscription.containerInstanceService.containerGroup` and its containers.

| field | SDK member published | what it is |
|---|---|---|
| `imageRegistryCredentials` | `ImageRegistryCredential.Password` | password for the private registry the group pulls from |
| `volumes` | `Volume.Secret` | base64 contents of every file a secret volume mounts into the containers |
| `volumes` | `AzureFileVolume.StorageAccountKey` | storage account key granting access to the whole file share |
| `env` | `EnvironmentVariable.SecureValue` | the write-only half of an ACI environment variable, used precisely because the value is a credential |

All four are exported fields of structs handed to `convert.JsonToDict` / `JsonToDictSlice`, which publishes **every** exported field of whatever it is given. That is why none of these was visible in schema review: the `.lr` only said `dict`.

Two of the three doc comments already described a shape the code did not honor:

- `imageRegistryCredentials` documented `{server, username?, identity?, identityUrl?}` and shipped the password alongside them.
- `env` documented `secureValue` as a key users could read.

The `env` site covers init containers too: `aciContainerGroupToMQL` copies each init container's `EnvironmentVariables` into a synthesized `aci.Container`, so both paths funnel through the one call in `aciContainersToMQL`.

### Why this is a fix and not a breaking change

None of the four carries an audit signal that is not already available:

- `registryAuthUsesIdentity` and `hasSecretVolume` are computed from the same records a few lines away, from the **unredacted** structs.
- The mounted file names, share name, storage account name, and read-only flag all survive.
- The names of secure environment variables survive; only the values are dropped.

This follows #10566, which removed the GKE control-plane password and the IAP client secret from GCP dicts in exactly this way, and is marked the same way. The keys removed are credential material, not audit signal, and no check can have depended on reading them. Every other key is unchanged.

### How

Three copy-by-field helpers in `containerinstance.go`, matching `redactedRedisConfiguration` and `redactedAuthSettings` already in this provider. Copy-by-field rather than by JSON key is deliberate: a secret field renamed in a future SDK breaks the build instead of silently leaking again.

The helpers copy before editing. The caller keeps using the original records afterwards to compute `registryAuthUsesIdentity` and `hasSecretVolume`, so mutating in place would have traded a leak for a wrong answer. Each test asserts the source is unchanged.

A secret volume's file names are kept as the map's keys with every value nulled, so `volumes` still answers which files a secret volume mounts without carrying their contents.

### Tests

Added to `secret_redaction_test.go`, the file this provider already keeps these guarantees in, in its idiom: assert on the **serialized** form, because serialization is what actually reaches MQL. A redaction that nils a field the marshaller does not emit would pass a struct-level assertion and still leak.

Each test covers three things: the secret is gone from the serialized output, the audit signal survives (a redaction that empties the field trades one wrong answer for another), and the caller's records are unmutated. Nil slices, nil elements, and a secret map holding a nil value are covered.

```
--- PASS: TestRedactedImageRegistryCredentialsDropsThePassword
--- PASS: TestRedactedVolumesDropsSecretContentsAndShareKey
--- PASS: TestRedactedEnvironmentVariablesDropsTheSecureValue
--- PASS: TestRedactedRedisConfigurationDropsStorageCredentials
--- PASS: TestRedactedRedisResourceDropsStorageCredentials
--- PASS: TestRedactedAuthSettingsDropsEveryProviderSecret
ok  	go.mondoo.com/mql/providers/azure/resources
```

I verified the tests can actually fail rather than assuming it: reverting `safe.SecureValue = nil` alone turns two of them red, one on the struct assertion and one on the serialized output.

```
Error: "[{\"name\":\"DB_PASSWORD\",\"secureValue\":\"SUPERSECRETENVVALUE\"}]" should not contain "SUPERSECRETENVVALUE"
Messages: env published a secret
```

Full `go test ./...` in `providers/azure/` is green.

### Schema

Doc comments only, no field changes. Regenerating with `mqlr generate` produced **zero** diff in `azure.lr.go`, `azure.resources.json`, and `azure.lr.versions`, so there is no new version entry and no `config.go` bump. Confirmed rather than assumed, with `git status --porcelain` after regeneration.

### Not verified live

I have not run this against a live container group with a secret volume, a private registry credential, or a secure environment variable. ARM commonly redacts some of these on GET, so the leak's blast radius in practice depends on what the API returns for a given group, and I could not measure that here.

That does not change whether the fix is correct: the provider currently publishes whatever ARM hands back, with no redaction at any of the four sites, and the fix removes that dependency entirely. But if someone has a container group with a secure env var and a secret volume to hand, reading `env` and `volumes` on it before and after is worth doing.
