### PR TITLE
🐛 deterministic schema finalization

### DIFF
--- a/providers-sdk/v1/mqlr/lrcore/schema.go
+++ b/providers-sdk/v1/mqlr/lrcore/schema.go
@@ -90,10 +90,24 @@ func Schema(ast *LR) (*resources.Schema, error) {
 		}
 	}
 
+	// Shallowest first, so a parent is finalized before anything that hangs off
+	// it, then by name so the order is total.
+	//
+	// The name tie-break is not cosmetic. Depth alone leaves every same-depth
+	// group in Go's randomized map order, and the loop below writes into shared
+	// state: an alias and its target are the same *ResourceInfo (see the alias
+	// block above), so two aliases of one target both write the same field on
+	// the same object, and the first one wins. Whichever spelling that was
+	// decided the field's type, so the same .lr produced two different schemas
+	// from run to run -- enough to make the ADR 040 change report warn about
+	// breaking changes that nobody made.
 	sorted := slices.SortedFunc(maps.Keys(res.Resources), func(a, b string) int {
 		aDepth := strings.Count(a, ".")
 		bDepth := strings.Count(b, ".")
-		return aDepth - bDepth
+		if aDepth != bDepth {
+			return aDepth - bDepth
+		}
+		return strings.Compare(a, b)
 	})
 
 	// In this block we finalize the schema. This means:

--- a/providers-sdk/v1/mqlr/lrcore/schema_test.go
+++ b/providers-sdk/v1/mqlr/lrcore/schema_test.go
@@ -495,3 +495,57 @@ extend asset {
 	_, err = Schema(res)
 	require.NoError(t, err)
 }
+
+// TestSchemaAliasOrderIsDeterministic pins the bug where AWS codegen reported
+// three phantom "breaking schema change" warnings on roughly half of its runs.
+//
+// aws.lr declares `aws.accessanalyzer` and `aws.accessAnalyzer` as aliases of
+// the same resource, and likewise for their `.analyzer` children. An alias and
+// its target share one *ResourceInfo, so both children wrote the same `analyzer`
+// field on the same object and the first writer won. The finalization loop
+// ordered names by depth only, which left the two same-depth spellings in map
+// order, so the winner -- and therefore the field's type in the emitted schema
+// -- changed from run to run on identical input.
+func TestSchemaAliasOrderIsDeterministic(t *testing.T) {
+	src := `
+option provider = "🐱"
+
+alias x.thing = x.y.Thing
+alias x.Thing = x.y.Thing
+alias x.thing.leaf = x.y.Thing.leaf
+alias x.Thing.leaf = x.y.Thing.leaf
+
+x.y.Thing {
+  name string
+}
+
+x.y.Thing.leaf {
+  val string
+}
+`
+	read := func(string) ([]byte, error) { return []byte(src), nil }
+
+	schemaOf := func(t *testing.T) *resources.Schema {
+		t.Helper()
+		ast, err := Resolve("providers/x/resources/x.lr", read)
+		require.NoError(t, err)
+		schema, err := Schema(ast)
+		require.NoError(t, err)
+		return schema
+	}
+
+	first := schemaOf(t)
+	target := first.Resources["x.y.Thing"]
+	require.NotNil(t, target)
+	require.NotNil(t, target.Fields["leaf"])
+
+	// Both alias spellings sit at the same depth, so the tie-break is the name:
+	// "x.Thing.leaf" sorts before "x.thing.leaf" (uppercase T is the lower byte).
+	assert.Equal(t, string(types.Resource("x.Thing.leaf")), target.Fields["leaf"].Type,
+		"the lexicographically first spelling must win the shared field")
+
+	for range 50 {
+		next := schemaOf(t)
+		require.Equal(t, first, next, "identical input must produce an identical schema")
+	}
+}


### PR DESCRIPTION
## What

Codegen produced a different schema from run to run on identical input. The finalization pass in `lrcore.Schema` ordered resource names by **depth only**, so every same-depth group came out of Go's randomized map iteration. Sorting is now total: depth first, then name.

## The bug

`providers/aws/resources/aws.lr` declares two spellings of the same alias pair:

```
alias aws.accessanalyzer         = aws.iam.accessAnalyzer
alias aws.accessanalyzer.analyzer = aws.iam.accessAnalyzer.analyzer
alias aws.accessAnalyzer         = aws.iam.accessAnalyzer
alias aws.accessAnalyzer.analyzer = aws.iam.accessAnalyzer.analyzer
```

An alias and its target deliberately share one `*ResourceInfo` (see the comment above the alias block in `schema.go`), so `aws.accessanalyzer`, `aws.accessAnalyzer` and `aws.iam.accessAnalyzer` are all the same object. The implicit-field pass walks each dotted name up to its parent and writes `child.Fields[basename]` **only if it is not already set**, so the two `.analyzer` aliases race to be the one that defines the `analyzer` field, and the winner's spelling becomes the field's type. Both sit at depth 2, the comparator returned `0` for them, and `slices.SortedFunc` is not stable — so which one won was decided by map iteration order.

The AWS schema therefore alternated between two forms, and because `reportSchemaDiff` (ADR 040 part 5) compares the new schema against the one on disk, half of all runs reported three breaking changes that nobody made:

```
WARN breaking schema change: type changed from "aws.accessanalyzer.analyzer" to "aws.accessAnalyzer.analyzer"  path=aws.iam.accessAnalyzer.analyzer
```

Three warnings per flapping run, one for each key that points at the shared object: `aws.accessanalyzer.analyzer`, `aws.accessAnalyzer.analyzer`, `aws.iam.accessAnalyzer.analyzer`.

This is what has been blocking `--fail-on-breaking` from becoming a real gate: turning it on today would fail roughly half of AWS builds at random, on an unchanged tree.

## The fix

A generator fix, not a schema change. The comparator gets a name tie-break, which makes the order total and therefore reproducible:

```go
if aDepth != bDepth {
    return aDepth - bDepth
}
return strings.Compare(a, b)
```

Both alias spellings survive; nothing a user can write stops resolving. `aws.accessAnalyzer.analyzer` now deterministically wins the shared field (uppercase `T`/`A` is the lower byte), which is one of the two forms the generator was already emitting — not a new third one.

Dropping one of the aliases was the other candidate and was rejected: an alias is a user-facing name, removing one is a breaking change for any content that spells it that way, and it would fix exactly one provider while leaving the ordering bug in place for every other. `aws` is the only provider with a case-colliding alias pair today, so the sort is preventive elsewhere and curative here.

## Evidence

Determinism is the whole point of the change, so the evidence is a repetition count rather than one clean run. Each iteration restores a fixed baseline `aws.resources.json` (it is gitignored, so it is the previous run's output that the diff reads) and regenerates:

```bash
make providers/mqlr
for i in $(seq 1 20); do
  cp baseline.json providers/aws/resources/aws.resources.json
  ./mqlr generate providers/aws/resources/aws.lr --dist providers/aws/resources 2>&1 \
    | grep -c "breaking schema change"
  shasum providers/aws/resources/aws.resources.json
done
```

**Before (clean `main`, 20 runs):**

| warnings per run | runs |
|---|---|
| 3 | 13 |
| 0 | 7 |

`aws.resources.json` took **two** distinct checksums across the 20 runs (12 / 8).

**After (this branch, 20 runs):**

| warnings per run | runs |
|---|---|
| 0 | 20 |

One checksum for `aws.resources.json`, one for `aws.lr.go`, one for `aws.lr.versions`, across all 20.

`git status --porcelain` is clean after every run in both the before and after series: `aws.lr.go`, `aws.lr.versions` and `aws.permissions.json` were byte-identical the whole time. That is why this went unnoticed for so long — `aws.resources.json` is gitignored, so the flapping artifact never showed up in a diff.

## Blast radius

The change is in `lrcore`, so it affects every provider's codegen. All 82 `.lr` files were regenerated with the fixed binary (`SKIP_COMPILE=yes make providers/build`, which runs `lr go` + `lr versions` for each): no diff outside the two files in this PR.

## Tests

`TestSchemaAliasOrderIsDeterministic` in `providers-sdk/v1/mqlr/lrcore/schema_test.go` builds the alias shape from the bug, resolves and generates it 51 times, and asserts both that the schema is identical every time and that the specific spelling that wins is the lexicographically first one.

I verified it can actually fail: with the tie-break reverted it goes red on the shared field's type (`x.thing.leaf` vs `x.Thing.leaf`), then green again with the fix restored.
