### PR TITLE
✨ rooted network provider + vsphere fix

### DIFF
--- a/providers/network/config/config.go
+++ b/providers/network/config/config.go
@@ -11,9 +11,15 @@ import (
 )
 
 var Config = plugin.Provider{
-	Name:            "network",
-	ID:              "go.mondoo.com/mql/providers/network",
-	Version:         "13.3.0",
+	Name: "network",
+	// The host this provider connects to (ADR 031).
+	Root:    "network.host",
+	ID:      "go.mondoo.com/mql/providers/network",
+	Version: "13.3.0",
+	// Every root carries `asset`, which core owns (ADR 042).
+	Requires: []plugin.ProviderDep{
+		{ID: "go.mondoo.com/mql/providers/core", Name: "core", MinVersion: "13.0.0"},
+	},
 	ConnectionTypes: []string{provider.HostConnectionType},
 	Platforms:       provider.Platforms,
 	// Host scans are almost entirely spent waiting on DNS, TLS and HTTP against

--- a/providers/network/resources/host.go
+++ b/providers/network/resources/host.go
@@ -1,0 +1,31 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go.mondoo.com/mql/providers/network/connection"
+)
+
+// network.host is the asset this provider connects to (ADR 031). Before it
+// existed the connected host was only reachable through resources that quietly
+// defaulted their target to it - `dns.records` meaning *this* host's records -
+// which left nothing for a query to be rooted at.
+func (r *mqlNetworkHost) id() (string, error) {
+	return "network.host/" + r.MqlRuntime.Connection.(*connection.HostConnection).FQDN(), nil
+}
+
+func (r *mqlNetworkHost) fqdn() (string, error) {
+	return r.MqlRuntime.Connection.(*connection.HostConnection).FQDN(), nil
+}
+
+// scheme is what the target was given with. The connection stores it as the
+// runtime, and leaves it empty when the target carried none - which it then
+// reads as HTTPS.
+func (r *mqlNetworkHost) scheme() (string, error) {
+	conn := r.MqlRuntime.Connection.(*connection.HostConnection)
+	if conn.Conf == nil {
+		return "", nil
+	}
+	return conn.Conf.Runtime, nil
+}

--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -1,15 +1,22 @@
 // Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
+import core
+
 option provider = "go.mondoo.com/mql/providers/network"
 option go_package = "go.mondoo.com/mql/providers/network/resources"
+option root = "network.host"
+
+alias network.host.domainName = domainName
+alias network.host.dns = dns
+alias network.host.tls = tls
 
 // Network socket
 //
 // Addressable network endpoint identified by its transport `protocol`,
 // `port`, and `address`. Serves as a building block for higher-level
 // resources such as `tls` that need to know what to connect to.
-socket @defaults("protocol port address") {
+socket @defaults("protocol port address") @global {
   // Transport protocol (e.g., tcp, udp)
   protocol string
   // Port number
@@ -24,7 +31,7 @@ socket @defaults("protocol port address") {
 // to perform a GET against a URL and inspect the response status,
 // headers (parsed into sub-resources for HSTS, CSP, cookies, and other
 // security headers), and body.
-http {}
+http @global {}
 
 // HTTP GET request
 //
@@ -167,7 +174,7 @@ private http.header.setCookie @defaults("name value") {
 // inspect any of the parsed components individually: scheme, user /
 // password user-info pair, host, port, path, parsed query map, raw
 // query string, and fragment.
-url @defaults("string") {
+url @defaults("string") @global {
   init(raw string)
   // The full URL as a string
   string() string
@@ -292,7 +299,7 @@ private tls.cipher @defaults("name") {
 // returns the original source. Blocks that cannot be decoded are left
 // out of the list and counted in unparseable, so a bundle holding one
 // malformed certificate still yields the rest.
-certificates {
+certificates @global {
   []certificate
   // PEM content
   pem string
@@ -315,7 +322,7 @@ certificates {
 // the isCA and key-usage constraints, and the revocation, verification,
 // and expiration status. Useful for flagging weak keys, expired or
 // soon-to-expire leaf certificates, and untrusted or revoked chains.
-certificate @defaults("serial subject.commonName subject.dn") {
+certificate @defaults("serial subject.commonName subject.dn") @global {
   // PEM content
   pem string
   // Certificate fingerprints
@@ -1104,4 +1111,21 @@ dns.dkimRecord @defaults("dnsTxt") {
   flags []string
   // Whether the DKIM entry and public key is valid
   valid() bool
+}
+
+// Remote host
+//
+// The host this connection targets, addressed by a domain name or an IP. What
+// the provider can tell you about it hangs off here: `domainName` parses the
+// name into its registrable domain and labels, `dns` reads its records, and
+// `tls` inspects its TLS endpoint. Each of those also stands on its own with an
+// explicit target, which is how they were reached before this resource existed.
+network.host @defaults("fqdn") @root {
+  // Domain name or IP address this connection targets
+  fqdn() string
+  // URL scheme the connection uses, e.g. https
+  //
+  // Empty when the target was given without one, which the connection reads as
+  // HTTPS.
+  scheme() string
 }

--- a/providers/network/resources/network.lr.go
+++ b/providers/network/resources/network.lr.go
@@ -49,6 +49,7 @@ const (
 	ResourceDnsSpfRecord              string = "dns.spfRecord"
 	ResourceDnsDmarcRecord            string = "dns.dmarcRecord"
 	ResourceDnsDkimRecord             string = "dns.dkimRecord"
+	ResourceNetworkHost               string = "network.host"
 )
 
 var resourceFactories map[string]plugin.ResourceFactory
@@ -186,6 +187,10 @@ func init() {
 		"dns.dkimRecord": {
 			// to override args, implement: initDnsDkimRecord(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createDnsDkimRecord,
+		},
+		"network.host": {
+			// to override args, implement: initNetworkHost(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createNetworkHost,
 		},
 	}
 }
@@ -1016,6 +1021,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"dns.dkimRecord.valid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDnsDkimRecord).GetValid()).ToDataRes(types.Bool)
+	},
+	"network.host.fqdn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNetworkHost).GetFqdn()).ToDataRes(types.String)
+	},
+	"network.host.scheme": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNetworkHost).GetScheme()).ToDataRes(types.String)
 	},
 }
 
@@ -2171,6 +2182,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"dns.dkimRecord.valid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDnsDkimRecord).Valid, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"network.host.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNetworkHost).__id, ok = v.Value.(string)
+		return
+	},
+	"network.host.fqdn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNetworkHost).Fqdn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"network.host.scheme": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNetworkHost).Scheme, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 }
@@ -5436,5 +5459,63 @@ func (c *mqlDnsDkimRecord) GetFlags() *plugin.TValue[[]any] {
 func (c *mqlDnsDkimRecord) GetValid() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.Valid, func() (bool, error) {
 		return c.valid()
+	})
+}
+
+// mqlNetworkHost for the network.host resource
+type mqlNetworkHost struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlNetworkHostInternal it will be used here
+	Fqdn   plugin.TValue[string]
+	Scheme plugin.TValue[string]
+}
+
+// createNetworkHost creates a new instance of this resource
+func createNetworkHost(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlNetworkHost{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("network.host", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlNetworkHost) MqlName() string {
+	return "network.host"
+}
+
+func (c *mqlNetworkHost) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlNetworkHost) GetFqdn() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Fqdn, func() (string, error) {
+		return c.fqdn()
+	})
+}
+
+func (c *mqlNetworkHost) GetScheme() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Scheme, func() (string, error) {
+		return c.scheme()
 	})
 }

--- a/providers/network/resources/network.lr.versions
+++ b/providers/network/resources/network.lr.versions
@@ -186,6 +186,9 @@ http.header.xssProtection 9.0.5
 http.header.xssProtection.enabled 9.0.5
 http.header.xssProtection.mode 9.0.5
 http.header.xssProtection.report 9.0.5
+network.host 13.3.1
+network.host.fqdn 13.3.1
+network.host.scheme 13.3.1
 openpgp.entities 9.0.1
 openpgp.entities.content 9.0.1
 openpgp.entities.list 9.0.1

--- a/providers/roots_test.go
+++ b/providers/roots_test.go
@@ -8,11 +8,13 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/providers-sdk/v1/mqlr/lrcore"
+	"go.mondoo.com/mql/providers-sdk/v1/resources"
 )
 
 // Every provider you can connect to has to declare an asset root.
@@ -35,10 +37,8 @@ var rootBacklog = map[string]struct{}{}
 func init() {
 	// What is left needs a decision, not a sweep:
 	//   aws, azure, gcp - "the root of an account" is the flat-os question again
-	//   network         - the asset is a host or URL and nothing models it;
-	//                     socket/tls/dns/http are aspects of one
 	for _, p := range []string{
-		"aws", "azure", "gcp", "network",
+		"aws", "azure", "gcp",
 	} {
 		rootBacklog[p] = struct{}{}
 	}
@@ -157,4 +157,74 @@ func TestDeclaredRootsAgree(t *testing.T) {
 				"`option root` names %q, which is not one of the roots this provider declares", st.declared)
 		})
 	}
+}
+
+// Every resource a rooted provider owns has to be reachable from one of its
+// roots, or it stops resolving in v15 when the root becomes the namespace
+// (ADR 031).
+//
+// This is the check that was missing. `@replaced_by` targets are verified at
+// generate time, so an orphan is caught only if something happens to point at
+// it: ms365's orphaned Exchange/SharePoint/Teams tree failed loudly because a
+// deprecation pointed into it, while vsphere's `vulnmgmt` and its whole ESXi
+// host tree passed in silence. Nothing was checking a provider's own surface.
+//
+// Exempt, and why:
+//   - `@global` says outright that it needs no root (core's `time`, network's
+//     `url` - a parser, not an aspect of any asset)
+//   - private resources are reached through a parent by construction
+//   - a namespaced name (`foo.bar`) is reached through `foo`
+//   - deprecated resources are on their way out; flat `os` and vsphere's `esxi`
+//     are *expected* to be unreachable, that being the point of retiring them
+func TestRootedProvidersHaveNoOrphans(t *testing.T) {
+	dirs, err := filepath.Glob(filepath.Join("..", "providers", "*"))
+	require.NoError(t, err)
+
+	repoFile := func(p string) ([]byte, error) { return os.ReadFile(filepath.Join("..", p)) }
+
+	checked := 0
+	for _, dir := range dirs {
+		name := filepath.Base(dir)
+		lrs, _ := filepath.Glob(filepath.Join(dir, "resources", "*.lr"))
+		if len(lrs) != 1 {
+			continue
+		}
+		raw, err := os.ReadFile(lrs[0])
+		require.NoError(t, err)
+		if !strings.Contains(string(raw), "@root") {
+			continue
+		}
+
+		t.Run(name, func(t *testing.T) {
+			// Resolve, not Parse: aliases are what attach a provider's surface
+			// to its root, and they only exist after imports are resolved.
+			ast, err := lrcore.Resolve(
+				filepath.ToSlash(filepath.Join("providers", name, "resources", filepath.Base(lrs[0]))),
+				repoFile)
+			require.NoError(t, err)
+			schema, err := lrcore.Schema(ast)
+			require.NoError(t, err)
+
+			var orphans []string
+			for res, info := range schema.Resources {
+				switch {
+				case info == nil, info.Id != res, strings.Contains(res, "."),
+					info.Private, info.GetGlobal(), info.IsExtension,
+					info.Maturity == "deprecated",
+					!strings.HasSuffix(info.Provider, "/"+name):
+					continue
+				}
+				if !resources.RootReachable(schema, res) {
+					orphans = append(orphans, res)
+				}
+			}
+			sort.Strings(orphans)
+			assert.Emptyf(t, orphans, "unreachable from any root, so they stop resolving in v15: %v. "+
+				"Attach each to a root (`alias <root>.<name> = <name>`), mark it `@global` if it "+
+				"genuinely needs no asset, or deprecate it", orphans)
+		})
+		checked++
+	}
+
+	require.Greater(t, checked, 50, "the provider scan found almost nothing, so it is measuring the wrong directory")
 }

--- a/providers/vsphere/provider/provider.go
+++ b/providers/vsphere/provider/provider.go
@@ -129,6 +129,9 @@ func (s *Service) Connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		Name:      conn.Name(),
 		Asset:     req.Asset,
 		Inventory: in,
+		// The API or a single ESXi host; the static Root can only name one
+		// (ADR 031).
+		Root: assetRoot(req.Asset.GetPlatform()),
 	}, nil
 }
 

--- a/providers/vsphere/provider/root.go
+++ b/providers/vsphere/provider/root.go
@@ -1,0 +1,22 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/providers/vsphere/connection"
+)
+
+// assetRoot returns the resource that roots this asset's tree (ADR 031). This
+// provider serves two kinds: the vSphere API and an individual ESXi host, which
+// it already distinguishes by platform (connection.EsxiPlatform), so this reads
+// that rather than deciding again.
+//
+// The API is the fallback, matching what the provider declares statically.
+func assetRoot(platform *inventory.Platform) string {
+	if platform != nil && platform.Name == connection.EsxiPlatform {
+		return "vsphere.host"
+	}
+	return "vsphere"
+}

--- a/providers/vsphere/resources/vsphere.lr
+++ b/providers/vsphere/resources/vsphere.lr
@@ -7,6 +7,9 @@ option provider = "go.mondoo.com/mql/providers/vsphere"
 option go_package = "go.mondoo.com/mql/providers/vsphere/resources"
 option root = "vsphere"
 
+alias vsphere.vulnmgmt = vulnmgmt
+alias vsphere.host.vulnmgmt = vulnmgmt
+
 // vSphere asset resource
 extend asset {
   // Common Platform Enumeration (CPE) for the asset
@@ -512,7 +515,7 @@ private vsphere.cluster @defaults("moid name") {
 // and operational settings such as advanced settings, management services,
 // NTP, SNMP, and the host TLS certificate. Audit these to assess a host's
 // hardening and patch state.
-private vsphere.host @defaults("moid name") {
+private vsphere.host @defaults("moid name") @root {
   // vSphere managed object ID
   moid string
   // vSphere resource name

--- a/providers/weaviate/resources/weaviate.go
+++ b/providers/weaviate/resources/weaviate.go
@@ -17,10 +17,6 @@ import (
 	"go.mondoo.com/mql/types"
 )
 
-func (r *mqlWeaviate) id() (string, error) {
-	return "weaviate", nil
-}
-
 func weaviateConnection(runtime *plugin.Runtime) *connection.WeaviateConnection {
 	return runtime.Connection.(*connection.WeaviateConnection)
 }

--- a/providers/weaviate/resources/weaviate.lr
+++ b/providers/weaviate/resources/weaviate.lr
@@ -7,13 +7,6 @@ option provider = "go.mondoo.com/mql/providers/weaviate"
 option go_package = "go.mondoo.com/mql/providers/weaviate/resources"
 option root = "weaviate.instance"
 
-// Weaviate vector database
-//
-// Root of the Weaviate provider. The connected server and everything
-// queryable through it (collections, roles, users, and cluster nodes) is
-// reached from weaviate.instance.
-weaviate {
-}
 
 // Weaviate server
 //

--- a/providers/weaviate/resources/weaviate.lr.go
+++ b/providers/weaviate/resources/weaviate.lr.go
@@ -15,7 +15,6 @@ import (
 
 // The MQL type names exposed as public consts for ease of reference.
 const (
-	ResourceWeaviate               string = "weaviate"
 	ResourceWeaviateInstance       string = "weaviate.instance"
 	ResourceWeaviateCollection     string = "weaviate.collection"
 	ResourceWeaviateRole           string = "weaviate.role"
@@ -28,10 +27,6 @@ var resourceFactories map[string]plugin.ResourceFactory
 
 func init() {
 	resourceFactories = map[string]plugin.ResourceFactory{
-		"weaviate": {
-			// to override args, implement: initWeaviate(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
-			Create: createWeaviate,
-		},
 		"weaviate.instance": {
 			Init:   initWeaviateInstance,
 			Create: createWeaviateInstance,
@@ -253,10 +248,6 @@ func GetData(resource plugin.Resource, field string, args map[string]*llx.RawDat
 }
 
 var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
-	"weaviate.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlWeaviate).__id, ok = v.Value.(string)
-		return
-	},
 	"weaviate.instance.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWeaviateInstance).__id, ok = v.Value.(string)
 		return
@@ -455,50 +446,6 @@ func SetAllData(resource plugin.Resource, args map[string]*llx.RawData) error {
 		}
 	}
 	return nil
-}
-
-// mqlWeaviate for the weaviate resource
-type mqlWeaviate struct {
-	MqlRuntime *plugin.Runtime
-	__id       string
-	// optional: if you define mqlWeaviateInternal it will be used here
-}
-
-// createWeaviate creates a new instance of this resource
-func createWeaviate(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
-	res := &mqlWeaviate{
-		MqlRuntime: runtime,
-	}
-
-	err := SetAllData(res, args)
-	if err != nil {
-		return res, err
-	}
-
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if runtime.HasRecording {
-		args, err = runtime.ResourceFromRecording("weaviate", res.__id)
-		if err != nil || args == nil {
-			return res, err
-		}
-		return res, SetAllData(res, args)
-	}
-
-	return res, nil
-}
-
-func (c *mqlWeaviate) MqlName() string {
-	return "weaviate"
-}
-
-func (c *mqlWeaviate) MqlID() string {
-	return c.__id
 }
 
 // mqlWeaviateInstance for the weaviate.instance resource

--- a/providers/weaviate/resources/weaviate.lr.versions
+++ b/providers/weaviate/resources/weaviate.lr.versions
@@ -1,7 +1,6 @@
 # Copyright Mondoo, Inc. 2024, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
-weaviate 13.0.0
 weaviate.collection 13.0.0
 weaviate.collection.asyncReplicationEnabled 13.0.0
 weaviate.collection.autoTenantActivation 13.0.0


### PR DESCRIPTION
network:
- by default we root into `network.host`
  - from there you have access to: `domainName, dns, tls`
- pure helpers: `url, http, socket, certificate(s)`

vmware: two roots depending on choosing vsphere or esxi