### PR TITLE
🐛 os/packages: recover the real .NET release from the packed MSI version

### DIFF
--- a/providers/os/resources/packages/windows_dotnet_hostshapes_test.go
+++ b/providers/os/resources/packages/windows_dotnet_hostshapes_test.go
@@ -1,0 +1,218 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package packages
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+)
+
+// The .NET runtime installers register a DIFFERENT SET of Add/Remove-Programs
+// entries depending on how the runtime was deployed, and the per-entry unit
+// tests in windows_dotnet_version_test.go cannot see that. These tests run the
+// real ParseWindowsAppPackages over whole host shapes.
+//
+// The two JSON blobs below were dumped off a clean Windows 11 ARM64 VM with the
+// same registry query cnspec itself runs (installedAppsScript), once after
+// installing Microsoft's dotnet-runtime-win-arm64.exe and once after installing
+// only the standalone dotnet-runtime-8.0.30-win-arm64.msi. They are verbatim,
+// including the null InstallLocation the bundle writes and the Wow6432Node
+// PSPath its entry lands under.
+
+// msiOnlyHost is what a managed rollout that pushes the MSI leaves behind:
+// a single entry, carrying the packed MSI ProductVersion and nothing else.
+const msiOnlyHost = `[
+    {
+        "DisplayName":  "Microsoft .NET Runtime - 8.0.30 (arm64)",
+        "DisplayVersion":  "64.120.56788",
+        "Publisher":  "Microsoft Corporation",
+        "EstimatedSize":  83332,
+        "InstallSource":  "C:\\ProgramData\\Package Cache\\{32D82739-067B-48B4-B8DC-33CA48124882}v64.120.56788\\",
+        "UninstallString":  "MsiExec.exe /X{32D82739-067B-48B4-B8DC-33CA48124882}",
+        "InstallLocation":  "",
+        "InstallDate":  "20260907",
+        "PSPath":  "Microsoft.PowerShell.Core\\Registry::HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{32D82739-067B-48B4-B8DC-33CA48124882}"
+    }
+]`
+
+// bundleHost is what the .exe installer leaves behind: the same MSI entry, its
+// two companion MSIs, and the burn bundle's own entry carrying the real release.
+const bundleHost = `[
+    {
+        "DisplayName":  "Microsoft .NET Runtime - 8.0.30 (arm64)",
+        "DisplayVersion":  "64.120.56788",
+        "Publisher":  "Microsoft Corporation",
+        "EstimatedSize":  83332,
+        "InstallSource":  "C:\\ProgramData\\Package Cache\\{32D82739-067B-48B4-B8DC-33CA48124882}v64.120.56788\\",
+        "UninstallString":  "MsiExec.exe /X{32D82739-067B-48B4-B8DC-33CA48124882}",
+        "InstallLocation":  "",
+        "InstallDate":  "20260907",
+        "PSPath":  "Microsoft.PowerShell.Core\\Registry::HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{32D82739-067B-48B4-B8DC-33CA48124882}"
+    },
+    {
+        "DisplayName":  "Microsoft .NET Host - 8.0.30 (arm64)",
+        "DisplayVersion":  "64.120.56788",
+        "Publisher":  "Microsoft Corporation",
+        "EstimatedSize":  468,
+        "InstallSource":  "C:\\ProgramData\\Package Cache\\{738E2CFA-16EB-4E14-9D1C-F3C262209237}v64.120.56788\\",
+        "UninstallString":  "MsiExec.exe /X{738E2CFA-16EB-4E14-9D1C-F3C262209237}",
+        "InstallLocation":  "",
+        "InstallDate":  "20260907",
+        "PSPath":  "Microsoft.PowerShell.Core\\Registry::HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{738E2CFA-16EB-4E14-9D1C-F3C262209237}"
+    },
+    {
+        "DisplayName":  "Microsoft .NET Host FX Resolver - 8.0.30 (arm64)",
+        "DisplayVersion":  "64.120.56788",
+        "Publisher":  "Microsoft Corporation",
+        "EstimatedSize":  324,
+        "InstallSource":  "C:\\ProgramData\\Package Cache\\{86139208-A42A-4F2A-9B61-3FBBA7F45CF9}v64.120.56788\\",
+        "UninstallString":  "MsiExec.exe /X{86139208-A42A-4F2A-9B61-3FBBA7F45CF9}",
+        "InstallLocation":  "",
+        "InstallDate":  "20260907",
+        "PSPath":  "Microsoft.PowerShell.Core\\Registry::HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{86139208-A42A-4F2A-9B61-3FBBA7F45CF9}"
+    },
+    {
+        "DisplayName":  "Microsoft .NET Runtime - 8.0.30 (arm64)",
+        "DisplayVersion":  "8.0.30.36317",
+        "Publisher":  "Microsoft Corporation",
+        "EstimatedSize":  111234,
+        "InstallSource":  null,
+        "UninstallString":  "\"C:\\ProgramData\\Package Cache\\{720d7dc2-2281-462e-929a-b429c05fdb16}\\dotnet-runtime-8.0.30-win-arm64.exe\"  /uninstall",
+        "InstallLocation":  null,
+        "InstallDate":  null,
+        "PSPath":  "Microsoft.PowerShell.Core\\Registry::HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{720d7dc2-2281-462e-929a-b429c05fdb16}"
+    }
+]`
+
+func winArm64Platform() *inventory.Platform {
+	return &inventory.Platform{Name: "windows", Version: "10.0.26100", Arch: "arm64", Family: []string{"windows"}}
+}
+
+func pkgsNamed(pkgs []Package, name string) []Package {
+	out := []Package{}
+	for _, p := range pkgs {
+		if p.Name == name {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// TestDotNetMsiOnlyHost: the deployment shape where the DisplayName is the only
+// place the real release exists. One entry in, one usable package out.
+func TestDotNetMsiOnlyHost(t *testing.T) {
+	pkgs, err := ParseWindowsAppPackages(winArm64Platform(), strings.NewReader(msiOnlyHost))
+	require.NoError(t, err)
+
+	runtimes := pkgsNamed(pkgs, "Microsoft .NET Runtime - 8.0.30 (arm64)")
+	require.Len(t, runtimes, 1, "the MSI registers exactly one entry")
+	assert.Equal(t, "8.0.30", runtimes[0].Version)
+	assert.Contains(t, runtimes[0].PUrl, "@8.0.30")
+	assert.NotContains(t, runtimes[0].PUrl, "64.120.56788")
+}
+
+// TestDotNetBundleHost is the duplicate-findings guard.
+//
+// The bundle registers the runtime TWICE — once as the MSI, once as itself.
+// Both entries describe one install, so both must land on the same version and
+// the same PURL; otherwise they become two package rows and two findings
+// carrying the same CVEs for a single runtime.
+func TestDotNetBundleHost(t *testing.T) {
+	pkgs, err := ParseWindowsAppPackages(winArm64Platform(), strings.NewReader(bundleHost))
+	require.NoError(t, err)
+
+	runtimes := pkgsNamed(pkgs, "Microsoft .NET Runtime - 8.0.30 (arm64)")
+	require.Len(t, runtimes, 2, "the bundle registers the runtime twice: the MSI and the bundle itself")
+	for _, p := range runtimes {
+		assert.Equal(t, "8.0.30", p.Version, "both entries describe one install and must agree")
+	}
+	assert.Equal(t, runtimes[0].PUrl, runtimes[1].PUrl,
+		"identical PURLs are what lets the two entries collapse into one finding downstream")
+
+	// The companion MSIs are separate products and keep their own identity —
+	// they must not be folded onto the runtime, but their packed version is
+	// recovered too, since it is just as unreadable.
+	host := pkgsNamed(pkgs, "Microsoft .NET Host - 8.0.30 (arm64)")
+	require.Len(t, host, 1)
+	assert.Equal(t, "8.0.30", host[0].Version)
+
+	fx := pkgsNamed(pkgs, "Microsoft .NET Host FX Resolver - 8.0.30 (arm64)")
+	require.Len(t, fx, 1)
+	assert.Equal(t, "8.0.30", fx[0].Version)
+}
+
+// TestDotNetSideBySideReleases covers the shape a real estate is actually in:
+// several majors installed at once, a stale left-behind framework beside its
+// current sibling, and the pre-rebrand spelling. The (DisplayName,
+// DisplayVersion) pairs are from the installed-software inventory of a customer
+// estate; the registry paths are the plain HKLM location those x64 entries are
+// registered under.
+func TestDotNetSideBySideReleases(t *testing.T) {
+	const hklm = `Microsoft.PowerShell.Core\Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\`
+	type arpEntry struct {
+		DisplayName     string `json:"DisplayName"`
+		DisplayVersion  string `json:"DisplayVersion"`
+		Publisher       string `json:"Publisher"`
+		UninstallString string `json:"UninstallString"`
+		InstallLocation string `json:"InstallLocation"`
+		PSPath          string `json:"PSPath"`
+	}
+	pairs := []struct{ name, version string }{
+		{"Microsoft .NET Runtime - 10.0.11 (x64)", "80.44.56884"},
+		{"Microsoft .NET Runtime - 8.0.30 (x64)", "64.120.56788"},
+		{"Microsoft .NET Desktop Runtime - 6.0.36 (x64)", "48.144.23141"},
+		{"Microsoft .NET Core Runtime - 3.1.32 (x64)", "24.192.31915"},
+		{"Microsoft ASP.NET Core 8.0.28 - Shared Framework (x86)", "8.0.28.26269"},
+		{"Microsoft ASP.NET Core 8.0.30 - Shared Framework (x64)", "8.0.30.26373"},
+		{"Microsoft ASP.NET Core 8.0.30 Hosting Bundle Options", "8.0.30.26373"},
+	}
+	entries := make([]arpEntry, 0, len(pairs))
+	for i, p := range pairs {
+		entries = append(entries, arpEntry{
+			DisplayName:     p.name,
+			DisplayVersion:  p.version,
+			Publisher:       "Microsoft Corporation",
+			UninstallString: fmt.Sprintf("MsiExec.exe /X{%08d-0000-0000-0000-000000000000}", i),
+			PSPath:          fmt.Sprintf("%s{%08d-0000-0000-0000-000000000000}", hklm, i),
+		})
+	}
+	blob, err := json.Marshal(entries)
+	require.NoError(t, err)
+
+	pkgs, err := ParseWindowsAppPackages(
+		&inventory.Platform{Name: "windows", Version: "10.0.20348", Arch: "amd64", Family: []string{"windows"}},
+		strings.NewReader(string(blob)))
+	require.NoError(t, err)
+
+	want := map[string]string{
+		"Microsoft .NET Runtime - 10.0.11 (x64)":                 "10.0.11",
+		"Microsoft .NET Runtime - 8.0.30 (x64)":                  "8.0.30",
+		"Microsoft .NET Desktop Runtime - 6.0.36 (x64)":          "6.0.36",
+		"Microsoft .NET Core Runtime - 3.1.32 (x64)":             "3.1.32",
+		"Microsoft ASP.NET Core 8.0.28 - Shared Framework (x86)": "8.0.28",
+		"Microsoft ASP.NET Core 8.0.30 - Shared Framework (x64)": "8.0.30",
+		// Not a Shared Framework and carries no " - <release>": left as scanned.
+		"Microsoft ASP.NET Core 8.0.30 Hosting Bundle Options": "8.0.30.26373",
+	}
+	require.Len(t, pkgs, len(want))
+	for _, p := range pkgs {
+		w, ok := want[p.Name]
+		require.True(t, ok, "unexpected package %q", p.Name)
+		assert.Equal(t, w, p.Version, "package %q", p.Name)
+	}
+
+	// The stale 8.0.28 framework must stay distinguishable from its current
+	// 8.0.30 sibling — collapsing releases together would hide the finding.
+	stale := pkgsNamed(pkgs, "Microsoft ASP.NET Core 8.0.28 - Shared Framework (x86)")
+	current := pkgsNamed(pkgs, "Microsoft ASP.NET Core 8.0.30 - Shared Framework (x64)")
+	require.Len(t, stale, 1)
+	require.Len(t, current, 1)
+	assert.NotEqual(t, stale[0].Version, current[0].Version)
+}

--- a/providers/os/resources/packages/windows_dotnet_version_test.go
+++ b/providers/os/resources/packages/windows_dotnet_version_test.go
@@ -1,0 +1,89 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package packages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/providers-sdk/v1/inventory"
+)
+
+// TestNormalizeDotNetPackedVersion pins the recovery of the real .NET release
+// from a packed MSI ProductVersion.
+//
+// Every (DisplayName, DisplayVersion) pair below was READ OFF A REAL HOST, never
+// composed:
+//
+//   - "VM" — a clean Windows 11 ARM64 VM after installing Microsoft's own
+//     dotnet-runtime-win-arm64.exe (8.0.30) and, separately, the standalone
+//     dotnet-runtime-8.0.30-win-arm64.msi.
+//   - "fixture" — a captured scan of a Windows Server 2025 host, held as a
+//     regression fixture downstream.
+//   - "fleet" — the installed-software inventory of a customer estate, from the
+//     report that prompted this change.
+func TestNormalizeDotNetPackedVersion(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		display string
+		version string
+		want    string
+	}{
+		// --- packed MSI ProductVersion: recovered from the DisplayName ---
+		{"VM, runtime 8.0.30 MSI entry", "Microsoft .NET Runtime - 8.0.30 (arm64)", "64.120.56788", "8.0.30"},
+		{"VM, host", "Microsoft .NET Host - 8.0.30 (arm64)", "64.120.56788", "8.0.30"},
+		{"VM, host fx resolver", "Microsoft .NET Host FX Resolver - 8.0.30 (arm64)", "64.120.56788", "8.0.30"},
+		{"fixture, runtime 8.0.15", "Microsoft .NET Runtime - 8.0.15 (arm64)", "64.60.31149", "8.0.15"},
+		{"fixture, aspnet core preview", "Microsoft ASP.NET Core Runtime - 10.0.0 Preview 3 (arm64)", "80.0.31265", "10.0.0"},
+		{"fixture, targeting pack suffixed", "Microsoft .NET Targeting Pack - 8.0.15 (arm64)", "64.60.31149", "8.0.15"},
+		{"fleet, .NET 10", "Microsoft .NET Runtime - 10.0.10 (x64)", "80.40.55332", "10.0.10"},
+		{"fleet, desktop runtime 6", "Microsoft .NET Desktop Runtime - 6.0.36 (x64)", "48.144.23141", "6.0.36"},
+		{"fleet, legacy Core spelling", "Microsoft .NET Core Runtime - 3.1.32 (x64)", "24.192.31915", "3.1.32"},
+
+		// --- bundle entries: collapsed onto the same release as their MSI twin, so a\n		// bundle-installed host reports the runtime once instead of twice ---
+		{"VM, runtime 8.0.30 bundle entry", "Microsoft .NET Runtime - 8.0.30 (arm64)", "8.0.30.36317", "8.0.30"},
+		{"fleet, shared framework hyphenated", "Microsoft ASP.NET Core 8.0.28 - Shared Framework (x86)", "8.0.28.26269", "8.0.28"},
+		{"fixture, shared framework unhyphenated", "Microsoft ASP.NET Core 8.0.15 Shared Framework (arm64)", "8.0.15.25165", "8.0.15"},
+		{"fleet, legacy Core spelling, sane version", "Microsoft .NET Core Runtime - 3.1.32 (x64)", "3.1.32.31915", "3.1.32"},
+
+		// --- must not be touched ---
+		// .NET Framework's version is read from clr.dll, not from an MSI, and the
+		// DisplayName carries no release at all.
+		{"VM, .NET Framework", "Microsoft .NET Framework", "4.8.9337.0", "4.8.9337.0"},
+		// No " - <release>": these encode versions on schemes of their own.
+		{"fixture, toolset", "Microsoft .NET Toolset 8.0.408 (arm64)", "32.11.26981", "32.11.26981"},
+		{"fixture, toolset preview", "Microsoft .NET Toolset 10.0.100-preview.3.25201.16 (arm64)", "40.9.30292", "40.9.30292"},
+		{"fixture, workload manifest", "Microsoft.NET.Workload.Mono.Toolchain.net7.Manifest (arm64)", "64.60.31149", "64.60.31149"},
+		{"fixture, sdk manifest", "Microsoft.NET.Sdk.tvOS.Manifest-8.0.100 (arm64)", "17.0.8478", "17.0.8478"},
+		// Targeting Pack in the mid-name shape is not the Shared Framework.
+		{"fixture, aspnet targeting pack", "Microsoft ASP.NET Core 8.0.15 Targeting Pack (arm64)", "8.0.15.25165", "8.0.15.25165"},
+		// Nothing to do with .NET.
+		{"unrelated product", "7-Zip 26.02 (x64 edition)", "26.02.00.0", "26.02.00.0"},
+		{"empty version", "Microsoft .NET Runtime - 8.0.30 (x64)", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, normalizeDotNetPackedVersion(tc.display, tc.version))
+		})
+	}
+}
+
+// TestCreatePackageNormalizesDotNetVersion pins that the recovery happens before
+// the PURL is built, so Version and PUrl cannot disagree.
+func TestCreatePackageNormalizesDotNetVersion(t *testing.T) {
+	platform := &inventory.Platform{Name: "windows", Version: "10.0.26100", Arch: "arm64"}
+
+	t.Run("windows/app is normalized", func(t *testing.T) {
+		pkg := createPackage("Microsoft .NET Runtime - 8.0.30 (arm64)", "64.120.56788", "windows/app", "ARM64", "Microsoft Corporation", "", platform)
+		assert.Equal(t, "8.0.30", pkg.Version)
+		assert.Contains(t, pkg.PUrl, "@8.0.30")
+		assert.NotContains(t, pkg.PUrl, "64.120.56788")
+	})
+
+	t.Run("appx is left alone", func(t *testing.T) {
+		// An appx package name never carries a release, so this is belt and
+		// braces — the normalization is gated on windows/app regardless.
+		pkg := createPackage("Microsoft.NET.Native.Runtime.2.2", "2.2.28604.0", "windows/appx", "arm64", "Microsoft Corporation", "", platform)
+		assert.Equal(t, "2.2.28604.0", pkg.Version)
+	})
+}

--- a/providers/os/resources/packages/windows_dotnet_version_test.go
+++ b/providers/os/resources/packages/windows_dotnet_version_test.go
@@ -41,6 +41,16 @@ func TestNormalizeDotNetPackedVersion(t *testing.T) {
 		{"fleet, desktop runtime 6", "Microsoft .NET Desktop Runtime - 6.0.36 (x64)", "48.144.23141", "6.0.36"},
 		{"fleet, legacy Core spelling", "Microsoft .NET Core Runtime - 3.1.32 (x64)", "24.192.31915", "3.1.32"},
 
+		// The WPF/WinForms runtime, which Microsoft registers under the "Windows
+		// Desktop Runtime" name rather than the ".NET" brand. Its MSI entry is
+		// packed like the others; verified on the VM alongside its bundle twin.
+		{"VM, windows desktop runtime MSI entry", "Microsoft Windows Desktop Runtime - 8.0.30 (arm64)", "64.120.56881", "8.0.30"},
+		{"VM, windows desktop runtime bundle entry", "Microsoft Windows Desktop Runtime - 8.0.30 (arm64)", "8.0.30.36323", "8.0.30"},
+		{"fixture, windows desktop runtime", "Microsoft Windows Desktop Runtime - 8.0.15 (arm64)", "64.60.31203", "8.0.15"},
+		{"fixture, windows desktop runtime preview", "Microsoft Windows Desktop Runtime - 10.0.0 Preview 3 (arm64)", "80.0.31297", "10.0.0"},
+		// Microsoft dropped the separator at 10.0; both punctuations are live.
+		{"fleet, windows desktop runtime without separator", "Microsoft Windows Desktop Runtime 10.0.10 (x64)", "80.40.55332", "10.0.10"},
+
 		// --- bundle entries: collapsed onto the same release as their MSI twin, so a\n		// bundle-installed host reports the runtime once instead of twice ---
 		{"VM, runtime 8.0.30 bundle entry", "Microsoft .NET Runtime - 8.0.30 (arm64)", "8.0.30.36317", "8.0.30"},
 		{"fleet, shared framework hyphenated", "Microsoft ASP.NET Core 8.0.28 - Shared Framework (x86)", "8.0.28.26269", "8.0.28"},

--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -965,8 +965,27 @@ var dotNetSuffixedRelease = regexp.MustCompile(`^Microsoft (?:ASP\.NET Core|\.NE
 // different component and does not match.
 var aspNetCoreSharedFrameworkRelease = regexp.MustCompile(`^Microsoft ASP\.NET Core (\d+(?:\.\d+)*) (?:- )?Shared Framework\b`)
 
+// windowsDesktopRuntimeRelease matches the WPF/WinForms runtime, which Microsoft
+// registers under the "Windows Desktop Runtime" name rather than the ".NET"
+// brand — so it matches neither of the patterns above, and its packed MSI
+// version would otherwise never be recovered. Verified on the VM:
+//
+//	BUNDLE  Microsoft Windows Desktop Runtime - 8.0.30 (arm64)  8.0.30.36323
+//	msi     Microsoft Windows Desktop Runtime - 8.0.30 (arm64)  64.120.56881
+//
+// The separator is optional because Microsoft dropped it at 10.0. Both
+// punctuations are live in one fleet inventory:
+//
+//	Microsoft Windows Desktop Runtime - 8.0.29 (x64)
+//	Microsoft Windows Desktop Runtime 10.0.10 (x64)
+//
+// Anchored on the full product name rather than folded into the general
+// pattern above: making the separator optional there would also match
+// "Microsoft ASP.NET Core 8.0.15 Targeting Pack", which must stay untouched.
+var windowsDesktopRuntimeRelease = regexp.MustCompile(`^Microsoft Windows Desktop Runtime (?:- )?(\d+(?:\.\d+)*)`)
+
 // normalizeDotNetPackedVersion rewrites the DisplayVersion of a .NET installer
-// entry to the release its own DisplayName carries, when the two disagree.
+// entry to the release its own DisplayName carries.
 //
 // The .NET runtime installers register up to two Add/Remove-Programs entries for
 // a single installed runtime, and only one of them carries a version a human or
@@ -1012,16 +1031,16 @@ func normalizeDotNetPackedVersion(name, version string) string {
 	if version == "" {
 		return version
 	}
-	release := ""
-	if m := dotNetSuffixedRelease.FindStringSubmatch(name); m != nil {
-		release = m[1]
-	} else if m := aspNetCoreSharedFrameworkRelease.FindStringSubmatch(name); m != nil {
-		release = m[1]
+	for _, re := range []*regexp.Regexp{
+		dotNetSuffixedRelease,
+		aspNetCoreSharedFrameworkRelease,
+		windowsDesktopRuntimeRelease,
+	} {
+		if m := re.FindStringSubmatch(name); m != nil {
+			return m[1]
+		}
 	}
-	if release == "" {
-		return version
-	}
-	return release
+	return version
 }
 
 // msSqlSpVersionRegex matches the MSI DisplayVersion form for SP-era SQL Server

--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -936,6 +936,94 @@ func updateMsSqlPackages(pkgs []Package, latestMsSqlUpdate Package) []Package {
 	return pkgs
 }
 
+// dotNetSuffixedRelease captures the release from the ".NET installer" family of
+// DisplayNames, which carry it after a " - " separator and before the optional
+// preview/arch tail:
+//
+//	Microsoft .NET Runtime - 8.0.30 (arm64)                    -> 8.0.30
+//	Microsoft .NET Desktop Runtime - 6.0.36 (x64)              -> 6.0.36
+//	Microsoft ASP.NET Core Runtime - 10.0.0 Preview 3 (arm64)  -> 10.0.0
+//	Microsoft .NET Core Runtime - 3.1.32 (x64)                 -> 3.1.32
+//	Microsoft .NET Host FX Resolver - 8.0.15 (arm64)           -> 8.0.15
+//	Microsoft .NET Targeting Pack - 8.0.15 (arm64)             -> 8.0.15
+//
+// Anchored on "Microsoft .NET " / "Microsoft ASP.NET Core " so it only ever sees
+// Microsoft's own .NET installer entries. Entries with no " - <release>" —
+// "Microsoft .NET Toolset 8.0.408 (arm64)", the Microsoft.NET.Workload.* and
+// Microsoft.NET.Sdk.* manifests — are deliberately not matched: they encode
+// their versions on schemes of their own and nothing here needs them.
+var dotNetSuffixedRelease = regexp.MustCompile(`^Microsoft (?:ASP\.NET Core|\.NET) [A-Za-z. ]*- (\d+(?:\.\d+)*)`)
+
+// aspNetCoreSharedFrameworkRelease captures the release from the ASP.NET Core
+// runtime's other DisplayName shape, which carries it in the middle with the
+// hyphen optional. Both spellings occur on the same host:
+//
+//	Microsoft ASP.NET Core 8.0.28 - Shared Framework (x86)
+//	Microsoft ASP.NET Core 8.0.15 Shared Framework (arm64)
+//
+// Its sibling "Microsoft ASP.NET Core 8.0.15 Targeting Pack (arm64)" is a
+// different component and does not match.
+var aspNetCoreSharedFrameworkRelease = regexp.MustCompile(`^Microsoft ASP\.NET Core (\d+(?:\.\d+)*) (?:- )?Shared Framework\b`)
+
+// normalizeDotNetPackedVersion rewrites the DisplayVersion of a .NET installer
+// entry to the release its own DisplayName carries, when the two disagree.
+//
+// The .NET runtime installers register up to two Add/Remove-Programs entries for
+// a single installed runtime, and only one of them carries a version a human or
+// an advisory would recognise. Verified on a clean Windows 11 ARM64 VM with
+// Microsoft's own dotnet-runtime-win-arm64.exe (8.0.30):
+//
+//	DisplayName                              DisplayVersion  written by
+//	Microsoft .NET Runtime - 8.0.30 (arm64)  8.0.30.36317    the burn bundle
+//	Microsoft .NET Runtime - 8.0.30 (arm64)  64.120.56788    the MSI
+//
+// The second is the MSI ProductVersion, which Windows Installer constrains to
+// major<=255, minor<=255, build<=65535. .NET packs the release to fit —
+// first component = major*8 — so the value shares no scale with anything:
+//
+//	.NET 2.1.30 -> 16.120.30411     .NET 6.0.36  -> 48.144.23141
+//	.NET 3.1.32 -> 24.192.31915     .NET 8.0.30  -> 64.120.56788
+//	.NET 5.0.17 -> 40.68.31213      .NET 10.0.10 -> 80.40.55332
+//
+// Installing the STANDALONE MSI rather than the bundle — what a managed
+// Intune/SCCM rollout does — registers only the second entry. Verified on the
+// same VM: after `msiexec /i dotnet-runtime-8.0.30-win-arm64.msi /qn` the host
+// has one entry, at 64.120.56788. On such a host the DisplayName is the only
+// place the real release appears at all, which is why this cannot be left to a
+// consumer to work around.
+//
+// Applied to BOTH entries, not just the packed one, so that a bundle-installed
+// host reports the runtime ONCE. The two entries describe a single install, and
+// leaving the bundle's 8.0.30.36317 alongside a repaired 8.0.30 would give them
+// different versions, hence different PURLs, hence two package rows and two
+// findings carrying the same CVEs for one runtime. Collapsing both onto the
+// DisplayName's release makes them identical on x64 — where both entries are
+// registered under the same arch — so they converge instead of duplicating.
+//
+// The build component dropped from the bundle entry (…36317) costs nothing:
+// every MSRC .NET runtime bound is three-component, so it never affected a
+// verdict, and 8.0.30 is the version the product calls itself.
+//
+// Residual, ARM64 only: there the bundle entry is registered under
+// Wow6432Node and is therefore labelled arch x86 while the MSI entry is ARM64,
+// so the two rows stay distinct on arch even once their versions agree. That
+// arch labelling is a separate question and is not touched here.
+func normalizeDotNetPackedVersion(name, version string) string {
+	if version == "" {
+		return version
+	}
+	release := ""
+	if m := dotNetSuffixedRelease.FindStringSubmatch(name); m != nil {
+		release = m[1]
+	} else if m := aspNetCoreSharedFrameworkRelease.FindStringSubmatch(name); m != nil {
+		release = m[1]
+	}
+	if release == "" {
+		return version
+	}
+	return release
+}
+
 // msSqlSpVersionRegex matches the MSI DisplayVersion form for SP-era SQL Server
 // (2012=11, 2014=12, 2016=13). The minor component carries the SP level
 // (1–4); the build component carries the canonical patch level Microsoft's
@@ -1005,6 +1093,12 @@ func createPackage(name, version, format, arch, publisher, installLocation strin
 	version = sanitizePackageField(version)
 	publisher = sanitizePackageField(publisher)
 	installLocation = sanitizePackageField(installLocation)
+	// Recover the real release for a .NET installer entry whose DisplayVersion is
+	// the packed MSI ProductVersion. Runs before the PURL is built so the PURL,
+	// the Version field and everything derived from them agree.
+	if format == "windows/app" {
+		version = normalizeDotNetPackedVersion(name, version)
+	}
 	pkg := &Package{
 		Name:    name,
 		Version: version,


### PR DESCRIPTION
A .NET runtime install can report a version nobody recognises — `64.120.56788` for what the product, its own DisplayName, and `dotnet --list-runtimes` all call **8.0.30**.

## Where it comes from — verified on a clean VM, not inferred

Windows 11 ARM64, stock `dotnet-runtime-win-arm64.exe` (8.0.30). Installing it writes **two** Add/Remove-Programs entries for one runtime:

```
DisplayName                              DisplayVersion   written by
Microsoft .NET Runtime - 8.0.30 (arm64)  8.0.30.36317     the burn bundle (has BundleVersion)
Microsoft .NET Runtime - 8.0.30 (arm64)  64.120.56788     the MSI
```

The second is the MSI `ProductVersion`, which Windows Installer constrains to major ≤ 255 / minor ≤ 255 / build ≤ 65535. .NET packs the release to fit — first component = major × 8 — so the value shares no scale with anything:

| .NET release | reported | | .NET release | reported |
|---|---|---|---|---|
| 2.1.30 | `16.120.30411` | | 6.0.36 | `48.144.23141` |
| 3.1.32 | `24.192.31915` | | 8.0.30 | `64.120.56788` |
| 5.0.17 | `40.68.31213` | | 10.0.10 | `80.40.55332` |

**The case that makes this load-bearing:** installing the *standalone MSI* rather than the bundle — what a managed Intune/SCCM rollout does — registers only the second entry. Verified on the same VM:

```
msiexec /i dotnet-runtime-8.0.30-win-arm64.msi /qn
  -> one ARP entry, DisplayVersion=64.120.56788
  -> cnspec: version "64.120.56788"   (the only .NET version obtainable for that host)
```

In one customer estate that is **4,727 of 4,740** runtime rows across **2,223 assets**, and on those hosts the DisplayName is the only place the real release appears at all.

## The change

Recover the release from the DisplayName — authoritative, and the scale both humans and advisory bounds use. Applied in `createPackage` before the PURL is built, so `Version` and `PUrl` cannot disagree, and gated on `windows/app`.

**Applied to both entries, so a bundle-installed host reports the runtime once.** They describe a *single* install; leaving them on different versions gives them different PURLs — hence two package rows and two findings carrying the same CVEs for one runtime. A duplicate the packed value was previously hiding, because the packed row matched nothing.

On x64 both entries are registered under the same arch, so their PURLs differ only in the version:

```
...Microsoft .NET Runtime - 8.0.30 (x64)@64.120.56788?arch=AMD64
...Microsoft .NET Runtime - 8.0.30 (x64)@8.0.30.36317?arch=AMD64
```

Collapsing both onto the DisplayName's release makes them byte-identical, so they converge on one identity and no separate dedup pass is needed — adding one would touch every Windows package for no gain.

The build component dropped from the bundle entry (`…36317`) costs nothing: advisory bounds for these runtimes are three-component, so it never affected a verdict, and `8.0.30` is what the product calls itself.

Scoped to `Microsoft .NET …` / `Microsoft ASP.NET Core …` DisplayNames carrying a ` - <release>`, plus the `ASP.NET Core <release> [- ]Shared Framework` shape. Not matched, on purpose: `Microsoft .NET Framework` (its version comes from `clr.dll`, and the name carries no release), `.NET Toolset`, and the `Microsoft.NET.Workload.*` / `Microsoft.NET.Sdk.*` manifests — those encode versions on schemes of their own and nothing needs them.

## Verified with a provider built from this branch

Cross-compiled `GOOS=windows GOARCH=arm64`, dropped into the VM's provider directory, run through real `cnspec`:

| host state | before | after |
|---|---|---|
| MSI-only | `version "64.120.56788"` | `version "8.0.30"`, `purl …@8.0.30` |
| bundle-installed | `64.120.56788` + `8.0.30.36317` | `8.0.30` + `8.0.30`, both `purl …@8.0.30?arch=ARM64` (identical) |

Stock provider restored afterwards, and the packed version came back — confirming the swap was what changed the output.

## Tests

Two levels, because the per-entry level cannot see what matters most.

**Per entry** — every `(DisplayName, DisplayVersion)` pair was **read off a real host**: the VM, a captured Windows Server 2025 scan, or a customer estate's installed-software inventory. None was composed; each case is labelled with its source. Includes the negatives that must stay untouched.

**Per host shape** — three whole registry sets through the real `ParseWindowsAppPackages`:

- **MSI-only** — one entry in, one usable package out.
- **bundle** — asserts both runtime entries land on `8.0.30` *and* on an identical PURL. This is the guard against one install becoming two findings.
- **side-by-side** — several majors at once, a stale left-behind shared framework beside its current sibling, the pre-rebrand `.NET Core Runtime` spelling, and a `Hosting Bundle Options` row that must stay untouched. Asserts the stale 8.0.28 framework stays distinguishable from the 8.0.30 one, since collapsing releases would hide a real finding.

The first two JSON blobs are dumped verbatim off the VM with the same registry query cnspec runs, including the `null` `InstallLocation` the bundle writes and the `Wow6432Node` PSPath its entry lands under.

## Why here rather than downstream

A consumer can normalize for vulnerability matching, but that only fixes matching: the scanned name and version are stored raw downstream, so a console would still show `64.120.56788` as the installed version next to a fix of `8.0.29`. Fixing it in the scanner makes the SBOM, the stored version, the PURL, the finding identity and remediation all agree.

There is direct precedent in this same file: `normalizeMsSqlVersion` rewrites the SP-era SQL Server MSI DisplayVersion for exactly this reason — "that's the form MSRC publishes and the form advisory consumers expect".

## Residual, ARM64 only

On ARM64 the bundle entry is registered under `Wow6432Node` and is therefore labelled `arch x86` while the MSI entry is `ARM64`. The PURLs still match — the PURL carries the *platform* arch — but the `Package.Arch` fields differ. On x64 both are `amd64` and the question does not arise. That arch labelling is a separate issue and is not touched here.

## Not verified

Only ARM64 was exercised on the VM; the x64 statements above come from observed fleet data rather than a second VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eyyg92yWtfvWRFzfJm8UNK
