### PR TITLE
🐛 providers: move the Windows plugin port range off 10000 and make it configurable

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -212,6 +212,20 @@ func GetUpdatesURL() string {
 	return viper.GetString("updates_url")
 }
 
+// KeyProviderPortRange is the config key for the loopback TCP port range that
+// provider subprocesses may listen on, written as "min-max" (for example
+// "50000-50100"). It comes from mondoo.yml or, through viper's env binding,
+// from MONDOO_PROVIDER_PORT_RANGE. Only Windows uses TCP for the provider
+// transport; other platforms talk to providers over Unix sockets and ignore it.
+const KeyProviderPortRange = "provider_port_range"
+
+// GetProviderPortRange returns the provider_port_range setting, or an empty
+// string when unset. Parsing and the default live with the providers package,
+// which is the one that hands the range to the plugin runtime.
+func GetProviderPortRange() string {
+	return viper.GetString(KeyProviderPortRange)
+}
+
 // GetFeatures returns the features from viper config.
 // This can be called after InitViperConfig() to get features before cobra initialization.
 func GetFeatures() mql.Features {
@@ -316,6 +330,12 @@ type CommonOpts struct {
 	// This can be a custom URL for an internal release registry
 	// Providers are fetched from UpdatesURL + "/providers"
 	UpdatesURL string `json:"updates_url,omitempty" mapstructure:"updates_url"`
+
+	// ProviderPortRange is the loopback TCP port range ("min-max") that provider
+	// subprocesses may listen on. Only Windows uses TCP for the provider
+	// transport, so the setting has no effect elsewhere. Unset means the
+	// providers package default. See KeyProviderPortRange.
+	ProviderPortRange string `json:"provider_port_range,omitempty" mapstructure:"provider_port_range"`
 }
 
 // Workload Identity Federation

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -332,3 +332,45 @@ space_mrn: //captain.api.mondoo.app/spaces/musing-saha-952142
 		assert.Equal(t, "baz", cfg.Annotations["foo.bar"])
 	})
 }
+
+func TestGetProviderPortRange(t *testing.T) {
+	t.Cleanup(func() {
+		viper.Reset()
+		AppFs = afero.NewOsFs()
+	})
+
+	t.Run("unset reads as empty so the providers package applies its default", func(t *testing.T) {
+		viper.Reset()
+		assert.Equal(t, "", GetProviderPortRange())
+	})
+
+	t.Run("reads the config key", func(t *testing.T) {
+		viper.Reset()
+		viper.Set(KeyProviderPortRange, "50000-50100")
+		assert.Equal(t, "50000-50100", GetProviderPortRange())
+	})
+
+	t.Run("round-trips through the Config struct", func(t *testing.T) {
+		viper.Reset()
+		viper.SetConfigType("yaml")
+		viper.SetOptions(viper.KeyDelimiter("\\"))
+		require.NoError(t, ApplyConfig(&Config{CommonOpts: CommonOpts{ProviderPortRange: "50000-50100"}}))
+		assert.Equal(t, "50000-50100", GetProviderPortRange())
+
+		cfg, err := Read()
+		require.NoError(t, err)
+		assert.Equal(t, "50000-50100", cfg.ProviderPortRange)
+	})
+
+	t.Run("MONDOO_PROVIDER_PORT_RANGE is picked up through the env binding InitViperConfig sets up", func(t *testing.T) {
+		viper.Reset()
+		resetAppFsToMemFs(t) // no config file anywhere, so only the environment can supply the value
+		t.Setenv("MONDOO_CONFIG_BASE64", "")
+		t.Setenv("MONDOO_CONFIG_PATH", "")
+		t.Setenv("MONDOO_PROVIDER_PORT_RANGE", "50000-50100")
+		UserProvidedPath = ""
+
+		InitViperConfig()
+		assert.Equal(t, "50000-50100", GetProviderPortRange())
+	})
+}

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -397,6 +397,14 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 	// (SIGKILL with empty stderr ≈ OOM killer) and peak RSS.
 	procTracker := &processTracker{}
 
+	// On Windows the plugin transport is loopback TCP and the client picks the
+	// port range; see plugin_ports.go for why go-plugin's own default is not
+	// acceptable and how the range is resolved. Other platforms ignore it.
+	ports, err := resolvePluginPortRange()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to start provider "+id)
+	}
+
 	connectFunc := func() (pp.ProviderPlugin, *plugin.Client, error) {
 		pluginCmd := exec.Command(provider.binPath(), []string{"run_as_plugin", "--log-level", zerolog.GlobalLevel().String()}...)
 
@@ -411,8 +419,10 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 			AllowedProtocols: []plugin.Protocol{
 				plugin.ProtocolNetRPC, plugin.ProtocolGRPC,
 			},
-			Logger: pluginLogger,
-			Stderr: crashLog,
+			Logger:  pluginLogger,
+			Stderr:  crashLog,
+			MinPort: ports.Min,
+			MaxPort: ports.Max,
 		})
 
 		// Connect via RPC

--- a/providers/plugin_ports.go
+++ b/providers/plugin_ports.go
@@ -1,0 +1,124 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"go.mondoo.com/mql/cli/config"
+)
+
+// Providers are hashicorp/go-plugin subprocesses. On Linux and macOS the host
+// reaches them over a Unix socket, but go-plugin hard-codes loopback TCP on
+// Windows and lets the client pick the port range. Its own default is
+// 10000-25000, tried in ascending order, so the first provider a scan started
+// (usually os) always took port 10000 and collided with anything else that
+// owns it, and 10000 is a popular one (Webmin, plenty of Java stacks). The
+// range reaches the subprocess as PLUGIN_MIN_PORT/PLUGIN_MAX_PORT appended
+// after the host environment, so setting those on the host changed nothing
+// either.
+//
+// The default below sits in the IANA dynamic range (49152-65535), which no
+// service is supposed to claim as a fixed port. go-plugin skips ports that are
+// busy or excluded (Hyper-V and WSL reserve blocks in that range), and each
+// running provider takes one port, so the range needs room for as many
+// providers as a scan runs at once.
+const (
+	// envPluginMinPort and envPluginMaxPort are go-plugin's own environment
+	// variables. Honoring them on the host makes the values a user sees in a
+	// provider process's environment actually mean something.
+	envPluginMinPort = "PLUGIN_MIN_PORT"
+	envPluginMaxPort = "PLUGIN_MAX_PORT"
+
+	defaultPluginMinPort uint = 50000
+	defaultPluginMaxPort uint = 65535
+)
+
+// pluginPortRange is the inclusive loopback TCP port range handed to a
+// provider subprocess. Only Windows uses it; other platforms ignore it.
+type pluginPortRange struct {
+	Min, Max uint
+}
+
+// resolvePluginPortRange decides which ports a provider subprocess may listen on:
+//
+//  1. provider_port_range in mondoo.yml or MONDOO_PROVIDER_PORT_RANGE, as "min-max"
+//  2. PLUGIN_MIN_PORT and PLUGIN_MAX_PORT in the host environment, both required
+//  3. the default range
+//
+// A value that is present but malformed is an error rather than a silent fall
+// back to the default: an operator who set it did so to move away from a
+// collision, and keeping the old range would leave that collision in place
+// unannounced.
+func resolvePluginPortRange() (pluginPortRange, error) {
+	return resolvePluginPortRangeFrom(config.GetProviderPortRange(), os.Getenv(envPluginMinPort), os.Getenv(envPluginMaxPort))
+}
+
+// resolvePluginPortRangeFrom is the pure core of resolvePluginPortRange, with
+// the config value and the two environment variables passed in so it can be
+// tested without touching the process environment.
+func resolvePluginPortRangeFrom(configured, envMin, envMax string) (pluginPortRange, error) {
+	if configured = strings.TrimSpace(configured); configured != "" {
+		r, err := parsePluginPortRange(configured)
+		if err != nil {
+			return pluginPortRange{}, errors.Wrapf(err, "invalid %s %q", config.KeyProviderPortRange, configured)
+		}
+		return r, nil
+	}
+
+	envMin, envMax = strings.TrimSpace(envMin), strings.TrimSpace(envMax)
+	if envMin != "" || envMax != "" {
+		if envMin == "" || envMax == "" {
+			return pluginPortRange{}, errors.Newf("%s and %s must be set together", envPluginMinPort, envPluginMaxPort)
+		}
+		r, err := newPluginPortRange(envMin, envMax)
+		if err != nil {
+			return pluginPortRange{}, errors.Wrapf(err, "invalid %s=%q %s=%q", envPluginMinPort, envMin, envPluginMaxPort, envMax)
+		}
+		return r, nil
+	}
+
+	return pluginPortRange{Min: defaultPluginMinPort, Max: defaultPluginMaxPort}, nil
+}
+
+// parsePluginPortRange parses the "min-max" form, for example "50000-50100".
+func parsePluginPortRange(s string) (pluginPortRange, error) {
+	minS, maxS, ok := strings.Cut(s, "-")
+	if !ok {
+		return pluginPortRange{}, errors.New("expected the form min-max, for example 50000-50100")
+	}
+	return newPluginPortRange(strings.TrimSpace(minS), strings.TrimSpace(maxS))
+}
+
+func newPluginPortRange(minS, maxS string) (pluginPortRange, error) {
+	minPort, err := parsePort(minS)
+	if err != nil {
+		return pluginPortRange{}, err
+	}
+	maxPort, err := parsePort(maxS)
+	if err != nil {
+		return pluginPortRange{}, err
+	}
+	if minPort > maxPort {
+		return pluginPortRange{}, errors.Newf("min port %d is greater than max port %d", minPort, maxPort)
+	}
+	return pluginPortRange{Min: minPort, Max: maxPort}, nil
+}
+
+// parsePort accepts 1-65535. Port 0 is rejected because go-plugin reads a
+// 0-0 range as "unset" and falls back to its own 10000-25000 default, which
+// is exactly the range this setting exists to move away from.
+func parsePort(s string) (uint, error) {
+	p, err := strconv.ParseUint(s, 10, 16)
+	if err != nil {
+		return 0, errors.Newf("%q is not a valid port", s)
+	}
+	if p == 0 {
+		return 0, errors.New("port 0 is not allowed")
+	}
+	return uint(p), nil
+}

--- a/providers/plugin_ports_test.go
+++ b/providers/plugin_ports_test.go
@@ -1,0 +1,109 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePluginPortRangeFrom(t *testing.T) {
+	t.Run("default when nothing is configured", func(t *testing.T) {
+		r, err := resolvePluginPortRangeFrom("", "", "")
+		require.NoError(t, err)
+		// The whole point of the change: the default must stay out of
+		// go-plugin's own 10000-25000, and inside the IANA dynamic range.
+		assert.Equal(t, pluginPortRange{Min: 50000, Max: 65535}, r)
+	})
+
+	t.Run("config value wins", func(t *testing.T) {
+		r, err := resolvePluginPortRangeFrom("50000-50100", "", "")
+		require.NoError(t, err)
+		assert.Equal(t, pluginPortRange{Min: 50000, Max: 50100}, r)
+	})
+
+	t.Run("config value tolerates whitespace", func(t *testing.T) {
+		r, err := resolvePluginPortRangeFrom(" 50000 - 50100 ", "", "")
+		require.NoError(t, err)
+		assert.Equal(t, pluginPortRange{Min: 50000, Max: 50100}, r)
+	})
+
+	t.Run("single port range is allowed", func(t *testing.T) {
+		r, err := resolvePluginPortRangeFrom("50000-50000", "", "")
+		require.NoError(t, err)
+		assert.Equal(t, pluginPortRange{Min: 50000, Max: 50000}, r)
+	})
+
+	t.Run("config value overrides go-plugin environment", func(t *testing.T) {
+		r, err := resolvePluginPortRangeFrom("50000-50100", "20000", "21000")
+		require.NoError(t, err)
+		assert.Equal(t, pluginPortRange{Min: 50000, Max: 50100}, r)
+	})
+
+	t.Run("malformed config value is an error even when the environment is valid", func(t *testing.T) {
+		_, err := resolvePluginPortRangeFrom("fifty-thousand", "20000", "21000")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "provider_port_range")
+	})
+
+	t.Run("go-plugin environment is honored", func(t *testing.T) {
+		r, err := resolvePluginPortRangeFrom("", "20000", "21000")
+		require.NoError(t, err)
+		assert.Equal(t, pluginPortRange{Min: 20000, Max: 21000}, r)
+	})
+
+	t.Run("half-set go-plugin environment is an error", func(t *testing.T) {
+		_, err := resolvePluginPortRangeFrom("", "20000", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be set together")
+
+		_, err = resolvePluginPortRangeFrom("", "", "21000")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be set together")
+	})
+
+	t.Run("malformed go-plugin environment is an error", func(t *testing.T) {
+		_, err := resolvePluginPortRangeFrom("", "21000", "20000")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "PLUGIN_MIN_PORT")
+		assert.Contains(t, err.Error(), "greater than")
+	})
+}
+
+func TestParsePluginPortRange(t *testing.T) {
+	bad := map[string]string{
+		"no dash":         "50000",
+		"empty min":       "-50000",
+		"empty max":       "50000-",
+		"min above max":   "50100-50000",
+		"port zero min":   "0-100",
+		"port zero max":   "0-0",
+		"above 65535":     "50000-70000",
+		"negative":        "-1-50000",
+		"not a number":    "abc-def",
+		"float":           "50000.5-50100",
+		"extra separator": "50000-50100-50200",
+	}
+	for name, in := range bad {
+		t.Run(name, func(t *testing.T) {
+			_, err := parsePluginPortRange(in)
+			assert.Error(t, err, in)
+		})
+	}
+
+	good := map[string]pluginPortRange{
+		"1-65535":     {Min: 1, Max: 65535},
+		"50000-50100": {Min: 50000, Max: 50100},
+		"8080-8080":   {Min: 8080, Max: 8080},
+	}
+	for in, want := range good {
+		t.Run(in, func(t *testing.T) {
+			r, err := parsePluginPortRange(in)
+			require.NoError(t, err)
+			assert.Equal(t, want, r)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Providers are hashicorp/go-plugin subprocesses. On Linux and macOS the host reaches them over a Unix socket, but go-plugin hard-codes loopback TCP on Windows and lets the *client* pick the port range. Our `plugin.ClientConfig` never set one, so go-plugin's default of 10000-25000 applied, tried in ascending order. The first provider a scan starts (usually `os`) therefore always took port 10000, which is a popular application port (Webmin, plenty of Java stacks), and any product that needs it fails its own port check while a scan is running.

There was no workaround either: go-plugin passes the range to the subprocess as `PLUGIN_MIN_PORT`/`PLUGIN_MAX_PORT` *appended after* the host environment, so setting those on the host was silently overridden.

## Fix

- **New default range 50000-65535**, inside the IANA dynamic range where no service is supposed to claim a fixed port. go-plugin skips busy and excluded ports (Hyper-V/WSL reservations), and each running provider takes one port.
- **`PLUGIN_MIN_PORT` / `PLUGIN_MAX_PORT` from the host environment are honored**, so go-plugin's own knobs work the way their names suggest. Both must be set together.
- **New `provider_port_range` config key** (`"min-max"`, e.g. `50000-50100`) in `mondoo.yml`, also readable as `MONDOO_PROVIDER_PORT_RANGE`. It lives in the shared `cli/config` layer, so cnspec picks it up with its next mql bump without a code change.
- **Precedence:** config key > `PLUGIN_*` env pair > default. A present-but-malformed value fails provider start with a clear error rather than silently keeping the range the operator was trying to leave.

Linux and macOS keep using Unix sockets and are unaffected: the fields are set but the Unix listener ignores them.

## Verification

- Unit tests for the resolution order and every malformed shape (`providers/plugin_ports_test.go`), and for the config key including the env binding through the real `InitViperConfig` (`cli/config/config_test.go`).
- End to end on macOS: spawned the `os` provider under each setting and read `PLUGIN_MIN_PORT`/`PLUGIN_MAX_PORT` from the child's environment. Default, config key, env pair, config-beats-env, and both error paths all behaved as designed. The child's environment is exactly what go-plugin's Windows listener reads, but Windows itself was not exercised here.
- `golangci-lint run ./providers/ ./cli/config/`: 0 issues.

## Follow-ups

- The docs site needs an entry for `provider_port_range` / `MONDOO_PROVIDER_PORT_RANGE`; no in-repo doc lists `mondoo.yml` keys.
- Longer term the right fix is Unix sockets on Windows (AF_UNIX exists since Windows 10 1803 / Server 2019), which needs an upstream go-plugin change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
