### PR TITLE
⭐ oci: report the Autonomous Database scheduled maintenance window

### DIFF
--- a/providers/oci/go.mod
+++ b/providers/oci/go.mod
@@ -5,7 +5,7 @@ go 1.26.8
 replace go.mondoo.com/mql => ../..
 
 require (
-	github.com/oracle/oci-go-sdk/v65 v65.124.0
+	github.com/oracle/oci-go-sdk/v65 v65.124.1
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.12.1
 	go.mondoo.com/mql v0.0.0-20260831061709-d8437f66ebc6

--- a/providers/oci/go.sum
+++ b/providers/oci/go.sum
@@ -328,8 +328,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/oracle/oci-go-sdk/v65 v65.124.0 h1:R2UkEZWDgJ1/Fvxz1oRDBnBuDxrGzbcurio3bY6ex/U=
-github.com/oracle/oci-go-sdk/v65 v65.124.0/go.mod h1:Pzy+BpgkDesvGZXEHgslwhIYobHCPHg6wRta1mWnlqQ=
+github.com/oracle/oci-go-sdk/v65 v65.124.1 h1:Wuos4/Ru9PRI83ObOfAmaEu+m+LcmjG7f17c0p6YzwM=
+github.com/oracle/oci-go-sdk/v65 v65.124.1/go.mod h1:Pzy+BpgkDesvGZXEHgslwhIYobHCPHg6wRta1mWnlqQ=
 github.com/package-url/packageurl-go v0.1.7 h1:iFWg6tzAjLA6F/qX3M5nZaiMHJgc+p2zxVyr/fY+sZY=
 github.com/package-url/packageurl-go v0.1.7/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/pandatix/go-cvss v0.6.4 h1:9w2RCO/Q4UTiJyEgpCHRiVc6CfrsFEnkoX+OtATqKio=

--- a/providers/oci/resources/database.go
+++ b/providers/oci/resources/database.go
@@ -297,46 +297,53 @@ func (o *mqlOciDatabase) autonomousDatabases() ([]any, error) {
 				}
 
 				ltb := longTermBackupArgs(a.LongTermBackupSchedule, a.NextLongTermBackupTimeStamp)
+				smw := scheduledMaintenanceWindowArgs(a.ScheduledMaintenanceWindow, a.TimeScheduledMaintenanceWindowUpdate)
 
 				mqlInstance, err := createOciResourceInCompartment(o.MqlRuntime, "oci.database.autonomousDatabase", stringValue(a.CompartmentId), map[string]*llx.RawData{
-					"id":                                  llx.StringDataPtr(a.Id),
-					"name":                                llx.StringDataPtr(a.DisplayName),
-					"dbName":                              llx.StringDataPtr(a.DbName),
-					"isRefreshableClone":                  llx.BoolDataPtr(a.IsRefreshableClone),
-					"dbVersion":                           llx.StringDataPtr(a.DbVersion),
-					"dbWorkload":                          llx.StringData(string(a.DbWorkload)),
-					"isDedicated":                         llx.BoolDataPtr(a.IsDedicated),
-					"isFreeTier":                          llx.BoolDataPtr(a.IsFreeTier),
-					"cpuCoreCount":                        llx.IntData(intValue(a.CpuCoreCount)),
-					"dataStorageSizeInTBs":                llx.IntData(intValue(a.DataStorageSizeInTBs)),
-					"isMtlsConnectionRequired":            llx.BoolDataPtr(a.IsMtlsConnectionRequired),
-					"isAccessControlEnabled":              llx.BoolDataPtr(a.IsAccessControlEnabled),
-					"whitelistedIps":                      llx.ArrayData(convert.SliceAnyToInterface(a.WhitelistedIps), types.String),
-					"standbyWhitelistedIps":               llx.ArrayData(convert.SliceAnyToInterface(a.StandbyWhitelistedIps), types.String),
-					"isAutoScalingEnabled":                llx.BoolDataPtr(a.IsAutoScalingEnabled),
-					"isLocalDataGuardEnabled":             llx.BoolDataPtr(a.IsLocalDataGuardEnabled),
-					"isRemoteDataGuardEnabled":            llx.BoolDataPtr(a.IsRemoteDataGuardEnabled),
-					"isDataGuardEnabled":                  llx.BoolDataPtr(a.IsDataGuardEnabled),
-					"backupRetentionPeriodInDays":         llx.IntData(intValue(a.BackupRetentionPeriodInDays)),
-					"isBackupRetentionLocked":             llx.BoolDataPtr(a.IsBackupRetentionLocked),
-					"longTermBackupRepeatCadence":         ltb["longTermBackupRepeatCadence"],
-					"longTermBackupTimeOfBackup":          ltb["longTermBackupTimeOfBackup"],
-					"longTermBackupRetentionPeriodInDays": ltb["longTermBackupRetentionPeriodInDays"],
-					"longTermBackupScheduleDisabled":      ltb["longTermBackupScheduleDisabled"],
-					"nextLongTermBackupTimestamp":         ltb["nextLongTermBackupTimestamp"],
-					"dataSafeStatus":                      llx.StringData(string(a.DataSafeStatus)),
-					"openMode":                            llx.StringData(string(a.OpenMode)),
-					"permissionLevel":                     llx.StringData(string(a.PermissionLevel)),
-					"licenseModel":                        llx.StringData(string(a.LicenseModel)),
-					"privateEndpointIp":                   llx.StringDataPtr(a.PrivateEndpointIp),
-					"privateEndpointLabel":                llx.StringDataPtr(a.PrivateEndpointLabel),
-					"connectionUrls":                      llx.DictData(connectionUrls),
-					"publicConnectionUrls":                llx.DictData(publicConnectionUrls),
-					"state":                               llx.StringData(string(a.LifecycleState)),
-					"created":                             llx.TimeDataPtr(created),
-					"freeformTags":                        llx.MapData(strMapToAny(a.FreeformTags), types.String),
-					"definedTags":                         llx.MapData(definedTagsToAny(a.DefinedTags), types.Any),
-					"systemTags":                          llx.MapData(definedTagsToAny(a.SystemTags), types.Dict),
+					"id":                                   llx.StringDataPtr(a.Id),
+					"name":                                 llx.StringDataPtr(a.DisplayName),
+					"dbName":                               llx.StringDataPtr(a.DbName),
+					"isRefreshableClone":                   llx.BoolDataPtr(a.IsRefreshableClone),
+					"dbVersion":                            llx.StringDataPtr(a.DbVersion),
+					"dbWorkload":                           llx.StringData(string(a.DbWorkload)),
+					"isDedicated":                          llx.BoolDataPtr(a.IsDedicated),
+					"isFreeTier":                           llx.BoolDataPtr(a.IsFreeTier),
+					"cpuCoreCount":                         llx.IntData(intValue(a.CpuCoreCount)),
+					"dataStorageSizeInTBs":                 llx.IntData(intValue(a.DataStorageSizeInTBs)),
+					"isMtlsConnectionRequired":             llx.BoolDataPtr(a.IsMtlsConnectionRequired),
+					"isAccessControlEnabled":               llx.BoolDataPtr(a.IsAccessControlEnabled),
+					"whitelistedIps":                       llx.ArrayData(convert.SliceAnyToInterface(a.WhitelistedIps), types.String),
+					"standbyWhitelistedIps":                llx.ArrayData(convert.SliceAnyToInterface(a.StandbyWhitelistedIps), types.String),
+					"isAutoScalingEnabled":                 llx.BoolDataPtr(a.IsAutoScalingEnabled),
+					"isLocalDataGuardEnabled":              llx.BoolDataPtr(a.IsLocalDataGuardEnabled),
+					"isRemoteDataGuardEnabled":             llx.BoolDataPtr(a.IsRemoteDataGuardEnabled),
+					"isDataGuardEnabled":                   llx.BoolDataPtr(a.IsDataGuardEnabled),
+					"backupRetentionPeriodInDays":          llx.IntData(intValue(a.BackupRetentionPeriodInDays)),
+					"isBackupRetentionLocked":              llx.BoolDataPtr(a.IsBackupRetentionLocked),
+					"longTermBackupRepeatCadence":          ltb["longTermBackupRepeatCadence"],
+					"longTermBackupTimeOfBackup":           ltb["longTermBackupTimeOfBackup"],
+					"longTermBackupRetentionPeriodInDays":  ltb["longTermBackupRetentionPeriodInDays"],
+					"longTermBackupScheduleDisabled":       ltb["longTermBackupScheduleDisabled"],
+					"nextLongTermBackupTimestamp":          ltb["nextLongTermBackupTimestamp"],
+					"maintenanceDayOfWeek":                 smw["maintenanceDayOfWeek"],
+					"maintenanceStartTime":                 smw["maintenanceStartTime"],
+					"maintenanceEndTime":                   smw["maintenanceEndTime"],
+					"maintenanceAvailabilityDomain":        smw["maintenanceAvailabilityDomain"],
+					"maintenanceWindowChangeScheduled":     smw["maintenanceWindowChangeScheduled"],
+					"timeScheduledMaintenanceWindowUpdate": smw["timeScheduledMaintenanceWindowUpdate"],
+					"dataSafeStatus":                       llx.StringData(string(a.DataSafeStatus)),
+					"openMode":                             llx.StringData(string(a.OpenMode)),
+					"permissionLevel":                      llx.StringData(string(a.PermissionLevel)),
+					"licenseModel":                         llx.StringData(string(a.LicenseModel)),
+					"privateEndpointIp":                    llx.StringDataPtr(a.PrivateEndpointIp),
+					"privateEndpointLabel":                 llx.StringDataPtr(a.PrivateEndpointLabel),
+					"connectionUrls":                       llx.DictData(connectionUrls),
+					"publicConnectionUrls":                 llx.DictData(publicConnectionUrls),
+					"state":                                llx.StringData(string(a.LifecycleState)),
+					"created":                              llx.TimeDataPtr(created),
+					"freeformTags":                         llx.MapData(strMapToAny(a.FreeformTags), types.String),
+					"definedTags":                          llx.MapData(definedTagsToAny(a.DefinedTags), types.Any),
+					"systemTags":                           llx.MapData(definedTagsToAny(a.SystemTags), types.Dict),
 				})
 				if err != nil {
 					return nil, err
@@ -769,5 +776,45 @@ func longTermBackupArgs(sched *database.LongTermBackUpScheduleDetails, next *com
 		"longTermBackupRetentionPeriodInDays": llx.IntDataPtr(retention),
 		"longTermBackupScheduleDisabled":      llx.BoolDataPtr(disabled),
 		"nextLongTermBackupTimestamp":         llx.TimeDataPtr(nextRun),
+	}
+}
+
+// scheduledMaintenanceWindowArgs flattens an Autonomous Database's scheduled
+// maintenance window onto the parent resource. Every value stays null when the
+// window is absent, so a database Oracle patches at a time of its own choosing
+// reads as "not scheduled" rather than as a window with blank values.
+func scheduledMaintenanceWindowArgs(win *database.AutonomousDatabaseMaintenanceWindowSummary, update *common.SDKTime) map[string]*llx.RawData {
+	var (
+		day           *string
+		startTime     *string
+		endTime       *string
+		availability  *string
+		changePending *bool
+	)
+	if win != nil {
+		// The SDK leaves an unset enum as "", which would otherwise reach MQL
+		// as an empty day rather than as null.
+		if win.DayOfWeek != nil && win.DayOfWeek.Name != "" {
+			d := string(win.DayOfWeek.Name)
+			day = &d
+		}
+		startTime = win.MaintenanceStartTime
+		endTime = win.MaintenanceEndTime
+		availability = win.AvailabilityDomain
+		changePending = win.IsMaintenanceWindowChangeScheduled
+	}
+
+	var updateAt *time.Time
+	if update != nil {
+		updateAt = &update.Time
+	}
+
+	return map[string]*llx.RawData{
+		"maintenanceDayOfWeek":                 llx.StringDataPtr(day),
+		"maintenanceStartTime":                 llx.StringDataPtr(startTime),
+		"maintenanceEndTime":                   llx.StringDataPtr(endTime),
+		"maintenanceAvailabilityDomain":        llx.StringDataPtr(availability),
+		"maintenanceWindowChangeScheduled":     llx.BoolDataPtr(changePending),
+		"timeScheduledMaintenanceWindowUpdate": llx.TimeDataPtr(updateAt),
 	}
 }

--- a/providers/oci/resources/database_maintenance_window_test.go
+++ b/providers/oci/resources/database_maintenance_window_test.go
@@ -1,0 +1,169 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScheduledMaintenanceWindowArgs(t *testing.T) {
+	updateAt := time.Date(2026, 9, 14, 3, 30, 0, 0, time.UTC)
+
+	args := scheduledMaintenanceWindowArgs(&database.AutonomousDatabaseMaintenanceWindowSummary{
+		DayOfWeek:                          &database.DayOfWeek{Name: database.DayOfWeekNameTuesday},
+		MaintenanceStartTime:               strPtr("02:00"),
+		MaintenanceEndTime:                 strPtr("06:00"),
+		AvailabilityDomain:                 strPtr("Uocm:PHX-AD-1"),
+		IsMaintenanceWindowChangeScheduled: boolPtr(true),
+	}, &common.SDKTime{Time: updateAt})
+
+	assert.Equal(t, "TUESDAY", args["maintenanceDayOfWeek"].Value)
+	assert.Equal(t, "02:00", args["maintenanceStartTime"].Value)
+	assert.Equal(t, "06:00", args["maintenanceEndTime"].Value)
+	assert.Equal(t, "Uocm:PHX-AD-1", args["maintenanceAvailabilityDomain"].Value)
+	assert.Equal(t, true, args["maintenanceWindowChangeScheduled"].Value)
+	assert.Equal(t, updateAt, *args["timeScheduledMaintenanceWindowUpdate"].Value.(*time.Time))
+}
+
+// A database with no scheduled maintenance window must read null across the
+// board. An empty day or start time would report a window the database does
+// not have, and a zero time would date the pending change to year 1.
+func TestScheduledMaintenanceWindowArgsAreNullWithoutAWindow(t *testing.T) {
+	args := scheduledMaintenanceWindowArgs(nil, nil)
+
+	for _, k := range []string{
+		"maintenanceDayOfWeek",
+		"maintenanceStartTime",
+		"maintenanceEndTime",
+		"maintenanceAvailabilityDomain",
+		"maintenanceWindowChangeScheduled",
+		"timeScheduledMaintenanceWindowUpdate",
+	} {
+		require.NotNil(t, args[k], k)
+		assert.Nil(t, args[k].Value, k)
+	}
+}
+
+// The window and the pending-change timestamp are separate fields on the API
+// record. A database with a fixed window and no change queued must report the
+// window and leave the update time null, rather than dating the change to the
+// zero time.
+func TestScheduledMaintenanceWindowArgsNullUpdateWithAWindow(t *testing.T) {
+	args := scheduledMaintenanceWindowArgs(&database.AutonomousDatabaseMaintenanceWindowSummary{
+		DayOfWeek:                          &database.DayOfWeek{Name: database.DayOfWeekNameSunday},
+		MaintenanceStartTime:               strPtr("22:00"),
+		IsMaintenanceWindowChangeScheduled: boolPtr(false),
+	}, nil)
+
+	assert.Equal(t, "SUNDAY", args["maintenanceDayOfWeek"].Value)
+	assert.Equal(t, "22:00", args["maintenanceStartTime"].Value)
+	assert.Nil(t, args["timeScheduledMaintenanceWindowUpdate"].Value)
+
+	// "No change queued" is a measured false, not an absence.
+	assert.Equal(t, false, args["maintenanceWindowChangeScheduled"].Value)
+}
+
+// DayOfWeek is a pointer to a struct carrying an enum, so two absences are
+// possible: no DayOfWeek at all, and a DayOfWeek whose enum the SDK left as
+// the empty string. Passing either through would give a day of "" that
+// compares unequal to every real day while looking like a configured value.
+func TestScheduledMaintenanceWindowArgsDayOfWeekAbsence(t *testing.T) {
+	nilDay := scheduledMaintenanceWindowArgs(&database.AutonomousDatabaseMaintenanceWindowSummary{
+		MaintenanceStartTime: strPtr("04:00"),
+	}, nil)
+	assert.Nil(t, nilDay["maintenanceDayOfWeek"].Value)
+	assert.Equal(t, "04:00", nilDay["maintenanceStartTime"].Value)
+
+	emptyEnum := scheduledMaintenanceWindowArgs(&database.AutonomousDatabaseMaintenanceWindowSummary{
+		DayOfWeek:            &database.DayOfWeek{},
+		MaintenanceStartTime: strPtr("04:00"),
+	}, nil)
+	assert.Nil(t, emptyEnum["maintenanceDayOfWeek"].Value)
+}
+
+// Every day the API can return has to survive the enum-to-string conversion.
+// A window pinned to a day this misses would read null, reporting a database
+// as unscheduled when Oracle has a fixed patch day for it.
+func TestScheduledMaintenanceWindowArgsCoversEveryDay(t *testing.T) {
+	for _, tc := range []struct {
+		day  database.DayOfWeekNameEnum
+		want string
+	}{
+		{database.DayOfWeekNameMonday, "MONDAY"},
+		{database.DayOfWeekNameTuesday, "TUESDAY"},
+		{database.DayOfWeekNameWednesday, "WEDNESDAY"},
+		{database.DayOfWeekNameThursday, "THURSDAY"},
+		{database.DayOfWeekNameFriday, "FRIDAY"},
+		{database.DayOfWeekNameSaturday, "SATURDAY"},
+		{database.DayOfWeekNameSunday, "SUNDAY"},
+	} {
+		args := scheduledMaintenanceWindowArgs(&database.AutonomousDatabaseMaintenanceWindowSummary{
+			DayOfWeek: &database.DayOfWeek{Name: tc.day},
+		}, nil)
+		assert.Equal(t, tc.want, args["maintenanceDayOfWeek"].Value)
+	}
+
+	// The set above is the whole set the SDK accepts. If Oracle adds an
+	// eighth day this fails, which is the signal to widen the doc comment.
+	assert.Len(t, database.GetDayOfWeekNameEnumStringValues(), 7)
+}
+
+// The maintenance window arrives on the list response, so the whole schedule
+// is readable without a second API call. This pins the struct tags the decode
+// depends on: a mistyped tag yields a zero value, which would report a
+// database as having no patch window while Oracle patches it every Tuesday.
+func TestAutonomousDatabaseSummaryDecodesMaintenanceWindow(t *testing.T) {
+	payload := []byte(`{
+		"id": "ocid1.autonomousdatabase.oc1.phx.exampleuniqueid",
+		"displayName": "adb-1",
+		"scheduledMaintenanceWindow": {
+			"dayOfWeek": {"name": "WEDNESDAY"},
+			"maintenanceStartTime": "01:00",
+			"maintenanceEndTime": "05:00",
+			"availabilityDomain": "Uocm:PHX-AD-2",
+			"isMaintenanceWindowChangeScheduled": true
+		},
+		"timeScheduledMaintenanceWindowUpdate": "2026-10-01T00:00:00.000Z"
+	}`)
+
+	var summary database.AutonomousDatabaseSummary
+	require.NoError(t, summary.UnmarshalJSON(payload))
+
+	require.NotNil(t, summary.ScheduledMaintenanceWindow)
+	args := scheduledMaintenanceWindowArgs(summary.ScheduledMaintenanceWindow, summary.TimeScheduledMaintenanceWindowUpdate)
+
+	assert.Equal(t, "WEDNESDAY", args["maintenanceDayOfWeek"].Value)
+	assert.Equal(t, "01:00", args["maintenanceStartTime"].Value)
+	assert.Equal(t, "05:00", args["maintenanceEndTime"].Value)
+	assert.Equal(t, "Uocm:PHX-AD-2", args["maintenanceAvailabilityDomain"].Value)
+	assert.Equal(t, true, args["maintenanceWindowChangeScheduled"].Value)
+	assert.Equal(t,
+		time.Date(2026, 10, 1, 0, 0, 0, 0, time.UTC),
+		args["timeScheduledMaintenanceWindowUpdate"].Value.(*time.Time).UTC())
+}
+
+// An Autonomous Database whose response carries no maintenance window at all
+// must not fabricate one from the surrounding record.
+func TestAutonomousDatabaseSummaryWithoutMaintenanceWindow(t *testing.T) {
+	payload := []byte(`{
+		"id": "ocid1.autonomousdatabase.oc1.phx.exampleuniqueid",
+		"displayName": "adb-2"
+	}`)
+
+	var summary database.AutonomousDatabaseSummary
+	require.NoError(t, summary.UnmarshalJSON(payload))
+
+	assert.Nil(t, summary.ScheduledMaintenanceWindow)
+	assert.Nil(t, summary.TimeScheduledMaintenanceWindowUpdate)
+
+	args := scheduledMaintenanceWindowArgs(summary.ScheduledMaintenanceWindow, summary.TimeScheduledMaintenanceWindowUpdate)
+	assert.Nil(t, args["maintenanceDayOfWeek"].Value)
+	assert.Nil(t, args["timeScheduledMaintenanceWindowUpdate"].Value)
+}

--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -8520,6 +8520,39 @@ private oci.database.autonomousDatabase @defaults("name") {
   // Null when no long-term backup schedule is configured, or when a
   // ONE_TIME schedule has already run.
   nextLongTermBackupTimestamp time
+  // Day of the week the scheduled maintenance window opens on
+  //
+  // One of MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, or SUNDAY.
+  // Null when the database has no scheduled maintenance window, in which case
+  // Oracle chooses when to patch it.
+  maintenanceDayOfWeek string
+  // Time of day the scheduled maintenance window opens, in ISO-8601 `hh:mm` form
+  //
+  // Null when the database has no scheduled maintenance window, or when the
+  // window fixes only the day and leaves the hour to Oracle.
+  maintenanceStartTime string
+  // Time of day the scheduled maintenance window closes, in ISO-8601 `hh:mm` form
+  //
+  // With maintenanceStartTime this bounds the span in which the database may be
+  // patched and restarted. Null when the database has no scheduled maintenance
+  // window, or when the window sets no end time.
+  maintenanceEndTime string
+  // Availability domain the scheduled maintenance runs in
+  //
+  // Null when the database has no scheduled maintenance window, or when the
+  // window is not pinned to a single availability domain.
+  maintenanceAvailabilityDomain string
+  // Whether a change to the maintenance window is pending
+  //
+  // True when a request to move the window has been accepted but has not taken
+  // effect, so the window reported by the other maintenance fields is the one
+  // about to be replaced. Null when the database has no scheduled maintenance
+  // window.
+  maintenanceWindowChangeScheduled bool
+  // Time the pending maintenance window change takes effect
+  //
+  // Null when no change to the maintenance window is pending.
+  timeScheduledMaintenanceWindowUpdate time
   // Oracle Data Safe status (REGISTERED, NOT_REGISTERED, REGISTERING, DEREGISTERING, FAILED)
   dataSafeStatus string
   // Open mode (READ_ONLY, READ_WRITE)

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -8665,6 +8665,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"oci.database.autonomousDatabase.nextLongTermBackupTimestamp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetNextLongTermBackupTimestamp()).ToDataRes(types.Time)
 	},
+	"oci.database.autonomousDatabase.maintenanceDayOfWeek": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseAutonomousDatabase).GetMaintenanceDayOfWeek()).ToDataRes(types.String)
+	},
+	"oci.database.autonomousDatabase.maintenanceStartTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseAutonomousDatabase).GetMaintenanceStartTime()).ToDataRes(types.String)
+	},
+	"oci.database.autonomousDatabase.maintenanceEndTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseAutonomousDatabase).GetMaintenanceEndTime()).ToDataRes(types.String)
+	},
+	"oci.database.autonomousDatabase.maintenanceAvailabilityDomain": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseAutonomousDatabase).GetMaintenanceAvailabilityDomain()).ToDataRes(types.String)
+	},
+	"oci.database.autonomousDatabase.maintenanceWindowChangeScheduled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseAutonomousDatabase).GetMaintenanceWindowChangeScheduled()).ToDataRes(types.Bool)
+	},
+	"oci.database.autonomousDatabase.timeScheduledMaintenanceWindowUpdate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOciDatabaseAutonomousDatabase).GetTimeScheduledMaintenanceWindowUpdate()).ToDataRes(types.Time)
+	},
 	"oci.database.autonomousDatabase.dataSafeStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOciDatabaseAutonomousDatabase).GetDataSafeStatus()).ToDataRes(types.String)
 	},
@@ -22332,6 +22350,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"oci.database.autonomousDatabase.nextLongTermBackupTimestamp": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOciDatabaseAutonomousDatabase).NextLongTermBackupTimestamp, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"oci.database.autonomousDatabase.maintenanceDayOfWeek": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseAutonomousDatabase).MaintenanceDayOfWeek, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.database.autonomousDatabase.maintenanceStartTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseAutonomousDatabase).MaintenanceStartTime, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.database.autonomousDatabase.maintenanceEndTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseAutonomousDatabase).MaintenanceEndTime, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.database.autonomousDatabase.maintenanceAvailabilityDomain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseAutonomousDatabase).MaintenanceAvailabilityDomain, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"oci.database.autonomousDatabase.maintenanceWindowChangeScheduled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseAutonomousDatabase).MaintenanceWindowChangeScheduled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"oci.database.autonomousDatabase.timeScheduledMaintenanceWindowUpdate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOciDatabaseAutonomousDatabase).TimeScheduledMaintenanceWindowUpdate, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"oci.database.autonomousDatabase.dataSafeStatus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -53530,54 +53572,60 @@ type mqlOciDatabaseAutonomousDatabase struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlOciDatabaseAutonomousDatabaseInternal
-	Id                                  plugin.TValue[string]
-	Name                                plugin.TValue[string]
-	Compartment                         plugin.TValue[*mqlOciCompartment]
-	DbName                              plugin.TValue[string]
-	SourceDatabase                      plugin.TValue[*mqlOciDatabaseAutonomousDatabase]
-	IsRefreshableClone                  plugin.TValue[bool]
-	DbVersion                           plugin.TValue[string]
-	DbWorkload                          plugin.TValue[string]
-	IsDedicated                         plugin.TValue[bool]
-	IsFreeTier                          plugin.TValue[bool]
-	CpuCoreCount                        plugin.TValue[int64]
-	DataStorageSizeInTBs                plugin.TValue[int64]
-	IsMtlsConnectionRequired            plugin.TValue[bool]
-	IsAccessControlEnabled              plugin.TValue[bool]
-	WhitelistedIps                      plugin.TValue[[]any]
-	InternetReachable                   plugin.TValue[bool]
-	StandbyWhitelistedIps               plugin.TValue[[]any]
-	IsAutoScalingEnabled                plugin.TValue[bool]
-	IsLocalDataGuardEnabled             plugin.TValue[bool]
-	IsRemoteDataGuardEnabled            plugin.TValue[bool]
-	IsDataGuardEnabled                  plugin.TValue[bool]
-	BackupRetentionPeriodInDays         plugin.TValue[int64]
-	IsBackupRetentionLocked             plugin.TValue[bool]
-	LongTermBackupRepeatCadence         plugin.TValue[string]
-	LongTermBackupTimeOfBackup          plugin.TValue[*time.Time]
-	LongTermBackupRetentionPeriodInDays plugin.TValue[int64]
-	LongTermBackupScheduleDisabled      plugin.TValue[bool]
-	NextLongTermBackupTimestamp         plugin.TValue[*time.Time]
-	DataSafeStatus                      plugin.TValue[string]
-	OpenMode                            plugin.TValue[string]
-	PermissionLevel                     plugin.TValue[string]
-	LicenseModel                        plugin.TValue[string]
-	KmsKey                              plugin.TValue[*mqlOciKmsKey]
-	KmsVault                            plugin.TValue[*mqlOciKmsVault]
-	Subnet                              plugin.TValue[*mqlOciNetworkSubnet]
-	SecurityGroups                      plugin.TValue[[]any]
-	PrivateEndpointIp                   plugin.TValue[string]
-	PrivateEndpointLabel                plugin.TValue[string]
-	ConnectionUrls                      plugin.TValue[any]
-	PublicConnectionUrls                plugin.TValue[any]
-	ManagementUrls                      plugin.TValue[*mqlOciDatabaseAutonomousDatabaseConsoleUrls]
-	PublicManagementUrls                plugin.TValue[*mqlOciDatabaseAutonomousDatabaseConsoleUrls]
-	State                               plugin.TValue[string]
-	Created                             plugin.TValue[*time.Time]
-	FreeformTags                        plugin.TValue[map[string]any]
-	DefinedTags                         plugin.TValue[map[string]any]
-	SystemTags                          plugin.TValue[map[string]any]
-	Backups                             plugin.TValue[[]any]
+	Id                                   plugin.TValue[string]
+	Name                                 plugin.TValue[string]
+	Compartment                          plugin.TValue[*mqlOciCompartment]
+	DbName                               plugin.TValue[string]
+	SourceDatabase                       plugin.TValue[*mqlOciDatabaseAutonomousDatabase]
+	IsRefreshableClone                   plugin.TValue[bool]
+	DbVersion                            plugin.TValue[string]
+	DbWorkload                           plugin.TValue[string]
+	IsDedicated                          plugin.TValue[bool]
+	IsFreeTier                           plugin.TValue[bool]
+	CpuCoreCount                         plugin.TValue[int64]
+	DataStorageSizeInTBs                 plugin.TValue[int64]
+	IsMtlsConnectionRequired             plugin.TValue[bool]
+	IsAccessControlEnabled               plugin.TValue[bool]
+	WhitelistedIps                       plugin.TValue[[]any]
+	InternetReachable                    plugin.TValue[bool]
+	StandbyWhitelistedIps                plugin.TValue[[]any]
+	IsAutoScalingEnabled                 plugin.TValue[bool]
+	IsLocalDataGuardEnabled              plugin.TValue[bool]
+	IsRemoteDataGuardEnabled             plugin.TValue[bool]
+	IsDataGuardEnabled                   plugin.TValue[bool]
+	BackupRetentionPeriodInDays          plugin.TValue[int64]
+	IsBackupRetentionLocked              plugin.TValue[bool]
+	LongTermBackupRepeatCadence          plugin.TValue[string]
+	LongTermBackupTimeOfBackup           plugin.TValue[*time.Time]
+	LongTermBackupRetentionPeriodInDays  plugin.TValue[int64]
+	LongTermBackupScheduleDisabled       plugin.TValue[bool]
+	NextLongTermBackupTimestamp          plugin.TValue[*time.Time]
+	MaintenanceDayOfWeek                 plugin.TValue[string]
+	MaintenanceStartTime                 plugin.TValue[string]
+	MaintenanceEndTime                   plugin.TValue[string]
+	MaintenanceAvailabilityDomain        plugin.TValue[string]
+	MaintenanceWindowChangeScheduled     plugin.TValue[bool]
+	TimeScheduledMaintenanceWindowUpdate plugin.TValue[*time.Time]
+	DataSafeStatus                       plugin.TValue[string]
+	OpenMode                             plugin.TValue[string]
+	PermissionLevel                      plugin.TValue[string]
+	LicenseModel                         plugin.TValue[string]
+	KmsKey                               plugin.TValue[*mqlOciKmsKey]
+	KmsVault                             plugin.TValue[*mqlOciKmsVault]
+	Subnet                               plugin.TValue[*mqlOciNetworkSubnet]
+	SecurityGroups                       plugin.TValue[[]any]
+	PrivateEndpointIp                    plugin.TValue[string]
+	PrivateEndpointLabel                 plugin.TValue[string]
+	ConnectionUrls                       plugin.TValue[any]
+	PublicConnectionUrls                 plugin.TValue[any]
+	ManagementUrls                       plugin.TValue[*mqlOciDatabaseAutonomousDatabaseConsoleUrls]
+	PublicManagementUrls                 plugin.TValue[*mqlOciDatabaseAutonomousDatabaseConsoleUrls]
+	State                                plugin.TValue[string]
+	Created                              plugin.TValue[*time.Time]
+	FreeformTags                         plugin.TValue[map[string]any]
+	DefinedTags                          plugin.TValue[map[string]any]
+	SystemTags                           plugin.TValue[map[string]any]
+	Backups                              plugin.TValue[[]any]
 }
 
 // createOciDatabaseAutonomousDatabase creates a new instance of this resource
@@ -53753,6 +53801,30 @@ func (c *mqlOciDatabaseAutonomousDatabase) GetLongTermBackupScheduleDisabled() *
 
 func (c *mqlOciDatabaseAutonomousDatabase) GetNextLongTermBackupTimestamp() *plugin.TValue[*time.Time] {
 	return &c.NextLongTermBackupTimestamp
+}
+
+func (c *mqlOciDatabaseAutonomousDatabase) GetMaintenanceDayOfWeek() *plugin.TValue[string] {
+	return &c.MaintenanceDayOfWeek
+}
+
+func (c *mqlOciDatabaseAutonomousDatabase) GetMaintenanceStartTime() *plugin.TValue[string] {
+	return &c.MaintenanceStartTime
+}
+
+func (c *mqlOciDatabaseAutonomousDatabase) GetMaintenanceEndTime() *plugin.TValue[string] {
+	return &c.MaintenanceEndTime
+}
+
+func (c *mqlOciDatabaseAutonomousDatabase) GetMaintenanceAvailabilityDomain() *plugin.TValue[string] {
+	return &c.MaintenanceAvailabilityDomain
+}
+
+func (c *mqlOciDatabaseAutonomousDatabase) GetMaintenanceWindowChangeScheduled() *plugin.TValue[bool] {
+	return &c.MaintenanceWindowChangeScheduled
+}
+
+func (c *mqlOciDatabaseAutonomousDatabase) GetTimeScheduledMaintenanceWindowUpdate() *plugin.TValue[*time.Time] {
+	return &c.TimeScheduledMaintenanceWindowUpdate
 }
 
 func (c *mqlOciDatabaseAutonomousDatabase) GetDataSafeStatus() *plugin.TValue[string] {

--- a/providers/oci/resources/oci.lr.versions
+++ b/providers/oci/resources/oci.lr.versions
@@ -1266,6 +1266,11 @@ oci.database.autonomousDatabase.longTermBackupRepeatCadence 13.21.1
 oci.database.autonomousDatabase.longTermBackupRetentionPeriodInDays 13.21.1
 oci.database.autonomousDatabase.longTermBackupScheduleDisabled 13.21.1
 oci.database.autonomousDatabase.longTermBackupTimeOfBackup 13.21.1
+oci.database.autonomousDatabase.maintenanceAvailabilityDomain 13.21.1
+oci.database.autonomousDatabase.maintenanceDayOfWeek 13.21.1
+oci.database.autonomousDatabase.maintenanceEndTime 13.21.1
+oci.database.autonomousDatabase.maintenanceStartTime 13.21.1
+oci.database.autonomousDatabase.maintenanceWindowChangeScheduled 13.21.1
 oci.database.autonomousDatabase.managementUrls 13.21.1
 oci.database.autonomousDatabase.name 13.1.1
 oci.database.autonomousDatabase.nextLongTermBackupTimestamp 13.21.1
@@ -1281,6 +1286,7 @@ oci.database.autonomousDatabase.standbyWhitelistedIps 13.10.1
 oci.database.autonomousDatabase.state 13.1.1
 oci.database.autonomousDatabase.subnet 13.1.1
 oci.database.autonomousDatabase.systemTags 13.12.2
+oci.database.autonomousDatabase.timeScheduledMaintenanceWindowUpdate 13.21.1
 oci.database.autonomousDatabase.whitelistedIps 13.1.1
 oci.database.autonomousDatabaseBackup 13.4.1
 oci.database.autonomousDatabaseBackup.autonomousDatabase 13.4.1


### PR DESCRIPTION
`oci.database.autonomousDatabase` models backups, Data Guard and encryption, but said nothing about **when Oracle may patch and restart the database**. That is the gap this closes: an Autonomous Database with a maintenance window landing in a business-critical hour was not something a policy could see, let alone assert on.

## What the fields report

| field | reports |
|---|---|
| `maintenanceDayOfWeek` | `MONDAY` .. `SUNDAY`, the day the window opens on |
| `maintenanceStartTime` | ISO-8601 `hh:mm`, when the window opens |
| `maintenanceEndTime` | ISO-8601 `hh:mm`, when it closes |
| `maintenanceAvailabilityDomain` | the AD the maintenance runs in |
| `maintenanceWindowChangeScheduled` | a move of the window has been accepted but not yet applied |
| `timeScheduledMaintenanceWindowUpdate` | when that pending move takes effect |

`maintenanceStartTime` and `maintenanceEndTime` together bound the span in which the database may be restarted, which is the question an availability audit actually asks.

## Why it costs nothing at runtime

`oci-go-sdk/v65` **v65.124.1** adds `ScheduledMaintenanceWindow` and `TimeScheduledMaintenanceWindowUpdate` to **both** `AutonomousDatabase` and `AutonomousDatabaseSummary`. The summary is what `ListAutonomousDatabases` already returns, so the existing list call carries the whole window:

- **no new API call**
- **no new IAM permission** (OCI generates no `permissions.json`, and nothing in the call graph changed)
- the `init` path resolves from the same cached list, so a single-database lookup gets the fields too

The only dependency change is that one bump, `v65.124.0` → `v65.124.1`. Nothing else was pulled in.

## Schema shape

Flattened onto the parent, not a sub-resource. Per CLAUDE.md §6, a sub-resource needs a clear natural ID or nested resource references, and `AutonomousDatabaseMaintenanceWindowSummary` has neither. The existing `oci.database.maintenanceWindow` sub-resource is the **dbSystem** shape (`preference`, `patchingMode`, `weeksOfMonth`, `skipRu`) and does not fit this struct at all, so reusing it would have been wrong. Hence the disambiguating `maintenance*` prefix on scalars.

No typed-reference gate hits: `maintenanceAvailabilityDomain` is an AD *name*, and OCI models no `availabilityDomain` resource. Every one of the ~20 other `availabilityDomain` fields in `oci.lr` is likewise a raw string.

`.lr.versions` entries are **13.21.1**, matching the 401 other unreleased entries already at that version. `config.go` `Version` was not touched.

## Null over zero

`scheduledMaintenanceWindowArgs` keeps every value null when the window is absent. This is the whole reason the mapping is a separate function rather than inline `llx.StringDataPtr` calls:

- a database with **no** scheduled window reads null across all six fields, not a window of blank strings
- an absent `timeScheduledMaintenanceWindowUpdate` stays **null**, not the zero time, which would otherwise report a pending change dated to **1 January year 1**
- an unset `DayOfWeek` enum, which the SDK leaves as `""`, reads null rather than a day that compares unequal to every real day while looking configured
- `DayOfWeek` is a pointer to a struct containing the enum, so **both** absences are guarded

"Oracle picks the time" and "the window is Tuesday 02:00" are different findings, and only null keeps them apart.

## Tests

`providers/oci/resources/database_maintenance_window_test.go`, seven tests covering the happy path, the fully-absent case, an absent update timestamp alongside a present window, both `DayOfWeek` absences, all seven enum days, and JSON decode of the real `AutonomousDatabaseSummary` shape (which pins the struct tags a mistyped `json:"..."` would silently zero).

Each was checked against four deliberate regressions of the implementation, and every one is caught:

| regression introduced | tests that fail |
|---|---|
| absent update timestamp becomes the zero time | 3 |
| `DayOfWeek` empty-enum guard removed | 1 |
| `MaintenanceStartTime` / `MaintenanceEndTime` crossed | 4 |
| absent window yields blank strings instead of null | 1 |

The implementation was restored and the suite is green. No test here passes regardless of what the implementation does.

## Verification

```
$ cd providers/oci && gofmt -l .
provider/provider_test.go        # pre-existing drift on main, not touched by this PR

$ go build ./...
(clean)

$ go test ./...
?       go.mondoo.com/mql/providers/oci          [no test files]
?       go.mondoo.com/mql/providers/oci/config   [no test files]
ok      go.mondoo.com/mql/providers/oci/connection      8.699s
?       go.mondoo.com/mql/providers/oci/gen      [no test files]
ok      go.mondoo.com/mql/providers/oci/provider        2.603s
ok      go.mondoo.com/mql/providers/oci/resources       1.899s
```

`go mod tidy` was run inside `providers/oci/`; the resulting `go.mod`/`go.sum` diff is the single `oci-go-sdk` line and its two checksums, nothing else. Codegen ran via `mqlr generate` and reported no breaking schema changes; `oci.resources.json` is gitignored repo-wide and OCI ships no `permissions.json`, so neither appears in the diff. `typos` is clean and the added `.lr` lines carry no em dashes.

## Not verified against a live tenancy

**Nothing in this PR was run against a live OCI tenancy.** No Autonomous Database was provisioned, and no maintenance window was read from a real API response. The evidence here is the SDK type definitions, the JSON-decode test against the documented response shape, and the mutation results above.

What that leaves unproven is specifically: whether a real `ListAutonomousDatabases` response populates `scheduledMaintenanceWindow` for a database that has one, and whether Oracle returns the window on the *summary* in practice as well as in the model. The nil-handling is proven; the population is not. Worth a live read before anyone builds an availability policy on top of these fields.
