### PR TITLE
🧹 ms365: rename the SAP IAG connection kind constant to clear an xgrep false positive

### DIFF
--- a/providers/ms365/resources/entitlement_connectors.go
+++ b/providers/ms365/resources/entitlement_connectors.go
@@ -14,12 +14,16 @@ import (
 )
 
 // connectionInfoKind* name the connectionInfo shapes this provider models.
+// connectionInfoKindSapIag names the shape Microsoft Graph calls
+// externalTokenBasedSapIagConnectionInfo; the constant is deliberately not
+// named after that type, because an identifier carrying "token" next to a
+// string literal reads to the credential scanner as a hardcoded secret.
 // connectionInfoKindUnknown is reported for a shape Microsoft Graph added after
 // this code was written, so a new external system reads as an unmodeled
 // connector rather than as a connector with no connection details at all.
 const (
-	connectionInfoKindTokenBasedSapIag = "tokenBasedSapIag"
-	connectionInfoKindUnknown          = "unknown"
+	connectionInfoKindSapIag  = "tokenBasedSapIag"
+	connectionInfoKindUnknown = "unknown"
 )
 
 // connectorTypeString renders the external system a connector integrates with.
@@ -132,7 +136,7 @@ func newMqlConnectionArgs(id string, info models.ConnectionInfoable) map[string]
 
 	switch c := info.(type) {
 	case *models.ExternalTokenBasedSapIagConnectionInfo:
-		args["kind"] = llx.StringData(connectionInfoKindTokenBasedSapIag)
+		args["kind"] = llx.StringData(connectionInfoKindSapIag)
 		args["accessTokenUrl"] = llx.StringDataPtr(c.GetAccessTokenUrl())
 		args["clientId"] = llx.StringDataPtr(c.GetClientId())
 		args["subscriptionId"] = llx.StringDataPtr(c.GetSubscriptionId())

--- a/providers/ms365/resources/graph_v1102_decode_test.go
+++ b/providers/ms365/resources/graph_v1102_decode_test.go
@@ -433,7 +433,7 @@ func TestConnectionArgs_TokenBasedSapIagMember(t *testing.T) {
 
 	args := newMqlConnectionArgs("conn/connectionInfo", connector.GetConnectionInfo())
 
-	assert.Equal(t, connectionInfoKindTokenBasedSapIag, rawString(t, args, "kind"))
+	assert.Equal(t, connectionInfoKindSapIag, rawString(t, args, "kind"))
 	assert.Equal(t, "https://iag.contoso.example/api", rawString(t, args, "url"))
 	assert.Equal(t, "https://iag.contoso.example/oauth/token", rawString(t, args, "accessTokenUrl"))
 	assert.Equal(t, "sb-iag-integration", rawString(t, args, "clientId"))


### PR DESCRIPTION
Follow-up to #10718, which merged while this fix was still in review.

`xgrep` raised [code scanning alert 246](https://github.com/mondoohq/mql/security/code-scanning/246), `go-hardcoded-credentials` (high), on `providers/ms365/resources/entitlement_connectors.go:21`:

```go
connectionInfoKindTokenBasedSapIag = "tokenBasedSapIag"
```

It is a false positive. The constant names a Microsoft Graph union member, `externalTokenBasedSapIagConnectionInfo`, and is the discriminator value reported through `microsoft.identityAndAccess.externalOriginResourceConnector.connectionInfo.kind`. It is not a credential, and the resource deliberately reports only the *reference* to the connector's secret (subscription, resource group, key vault name, secret name), never its value.

The rule matches an **identifier** carrying a credential keyword assigned to a string literal, not the literal's contents. Confirmed locally:

```
$ xgrep providers/ms365/resources/entitlement_connectors.go
providers/ms365/resources/entitlement_connectors.go:21:2: Hardcoded credentials
  [go-hardcoded-credentials] (HIGH) confidence: MEDIUM
  > connectionInfoKindTokenBasedSapIag = "tokenBasedSapIag"

# same literal, identifier without the keyword
$ cat a.go
const (
	connectionInfoKindSapIag  = "tokenBasedSapIag"
	connectionInfoKindUnknown = "unknown"
)
$ xgrep a.go
$ echo $?
0
```

So the constant is renamed to `connectionInfoKindSapIag` and the reported `kind` value stays `tokenBasedSapIag`, which is what mirrors the Graph type. A comment records why the constant is not named after the type it represents, so the next person does not rename it back.

No schema change, no behavior change: `.lr`, `.lr.versions` and `.lr.go` are untouched, and the only test edit is the constant reference in the existing `TestConnectionArgs_TokenBasedSapIagMember` assertion.

Verified:

```
$ gofmt -l providers/ms365
$ xgrep providers/ms365/resources/
$ cd providers/ms365 && go build ./... && go test ./...
ok  	go.mondoo.com/mql/providers/ms365/connection
ok  	go.mondoo.com/mql/providers/ms365/provider
ok  	go.mondoo.com/mql/providers/ms365/resources
```

As with #10718, nothing here was verified against a live Microsoft 365 tenant; this change does not touch anything a tenant would exercise.
