### PR TITLE
🐛 providers: OS-assigned plugin port by default, Windows-only enforcement, no go-plugin env

### DIFF
--- a/.github/workflows/pr-test-windows.yml
+++ b/.github/workflows/pr-test-windows.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - "providers/os/**"
+      # the plugin transport tests pin how go-plugin picks ports on Windows
+      - "providers-sdk/v1/plugin/**"
       - ".github/workflows/pr-test-windows.yml"
 
 concurrency:
@@ -38,7 +40,7 @@ jobs:
         run: |
           # Find all _windows_test.go files and extract unique package directories
           $repoRoot = (Get-Location).Path -replace '\\','/'
-          $packages = Get-ChildItem -Path providers/os -Recurse -Filter "*_windows_test.go" |
+          $packages = Get-ChildItem -Path providers/os, providers-sdk/v1/plugin -Recurse -Filter "*_windows_test.go" |
             ForEach-Object {
               $rel = ($_.DirectoryName -replace '\\','/').Replace($repoRoot + '/', '')
               "./$rel/..."

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -215,8 +215,9 @@ func GetUpdatesURL() string {
 // KeyProviderPortRange is the config key for the loopback TCP port range that
 // provider subprocesses may listen on, written as "min-max" (for example
 // "50000-50100"). It comes from mondoo.yml or, through viper's env binding,
-// from MONDOO_PROVIDER_PORT_RANGE. Only Windows uses TCP for the provider
-// transport; other platforms talk to providers over Unix sockets and ignore it.
+// from MONDOO_PROVIDER_PORT_RANGE. Unset means an OS-assigned port. Only
+// Windows uses TCP for the provider transport; other platforms talk to
+// providers over Unix sockets and ignore it.
 const KeyProviderPortRange = "provider_port_range"
 
 // GetProviderPortRange returns the provider_port_range setting, or an empty
@@ -333,8 +334,8 @@ type CommonOpts struct {
 
 	// ProviderPortRange is the loopback TCP port range ("min-max") that provider
 	// subprocesses may listen on. Only Windows uses TCP for the provider
-	// transport, so the setting has no effect elsewhere. Unset means the
-	// providers package default. See KeyProviderPortRange.
+	// transport, so the setting has no effect elsewhere. Unset means an
+	// OS-assigned port. See KeyProviderPortRange.
 	ProviderPortRange string `json:"provider_port_range,omitempty" mapstructure:"provider_port_range"`
 }
 

--- a/providers-sdk/v1/plugin/service_test.go
+++ b/providers-sdk/v1/plugin/service_test.go
@@ -35,6 +35,12 @@ func (c *TestConnection) ParentID() uint32 {
 }
 
 func TestMain(m *testing.M) {
+	// A re-execution of this binary as a go-plugin plugin serves and exits
+	// instead of running tests; see transport_test.go.
+	if servePluginForTransportTests() {
+		return
+	}
+
 	// Prevent "goleak: Errors on successful test run: found unexpected goroutines"
 	opts := []goleak.Option{
 		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),

--- a/providers-sdk/v1/plugin/transport_other_test.go
+++ b/providers-sdk/v1/plugin/transport_other_test.go
@@ -1,0 +1,22 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !windows
+
+package plugin
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPluginTransportIsUnixSocketOffWindows(t *testing.T) {
+	// The port range is passed but must be irrelevant here: off Windows the
+	// coordinator's port handling has no effect by construction, which is why
+	// a malformed provider_port_range only warns on these platforms.
+	addr := startTestPlugin(t, 0, 1)
+	_, ok := addr.(*net.UnixAddr)
+	assert.True(t, ok, "expected a Unix socket, got %T (%s)", addr, addr)
+}

--- a/providers-sdk/v1/plugin/transport_test.go
+++ b/providers-sdk/v1/plugin/transport_test.go
@@ -1,0 +1,74 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package plugin
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-plugin"
+	"github.com/stretchr/testify/require"
+)
+
+// The provider transport is whatever hashicorp/go-plugin picks: a Unix socket
+// off Windows, loopback TCP on it. The coordinator relies on details of that
+// choice which go-plugin does not document, above all that a MinPort of 0 with
+// a non-zero MaxPort makes the plugin bind 127.0.0.1:0 and get an OS-assigned
+// port (see providers/plugin_ports.go). These tests pin that behavior against
+// the vendored version by running a real plugin handshake: the test binary
+// re-executes itself as the plugin, which is the pattern go-plugin's own tests
+// use.
+
+// transportHelperEnv marks a re-execution of the test binary that should serve
+// a plugin instead of running tests.
+const transportHelperEnv = "MQL_PLUGIN_TRANSPORT_HELPER"
+
+// servePluginForTransportTests is called first thing by TestMain. When this
+// process is a re-execution spawned by startTestPlugin it serves a plugin until
+// the client kills it and reports true so TestMain exits without running tests.
+func servePluginForTransportTests() bool {
+	if os.Getenv(transportHelperEnv) != "1" {
+		return false
+	}
+	// Impl is nil on purpose: the tests only need the handshake, never a
+	// provider call.
+	plugin.Serve(&plugin.ServeConfig{
+		HandshakeConfig: Handshake,
+		Plugins:         PluginMap,
+		GRPCServer:      plugin.DefaultGRPCServer,
+		Logger:          hclog.NewNullLogger(),
+	})
+	return true
+}
+
+// startTestPlugin spawns this test binary as a go-plugin plugin with the given
+// port range and returns the address the plugin reported in its handshake.
+func startTestPlugin(t *testing.T, minPort, maxPort uint) net.Addr {
+	t.Helper()
+
+	exe, err := os.Executable()
+	require.NoError(t, err)
+	cmd := exec.Command(exe)
+	cmd.Env = append(os.Environ(), transportHelperEnv+"=1")
+
+	client := plugin.NewClient(&plugin.ClientConfig{
+		HandshakeConfig:  Handshake,
+		Plugins:          PluginMap,
+		Cmd:              cmd,
+		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
+		MinPort:          minPort,
+		MaxPort:          maxPort,
+		Logger:           hclog.NewNullLogger(),
+		StartTimeout:     30 * time.Second,
+	})
+	t.Cleanup(client.Kill)
+
+	addr, err := client.Start()
+	require.NoError(t, err, "plugin handshake failed")
+	return addr
+}

--- a/providers-sdk/v1/plugin/transport_windows_test.go
+++ b/providers-sdk/v1/plugin/transport_windows_test.go
@@ -1,0 +1,41 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package plugin
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// goPluginDefaultMinPort and goPluginDefaultMaxPort are the range go-plugin
+// substitutes when a client leaves both MinPort and MaxPort at zero. It is the
+// range the coordinator's ephemeral default exists to avoid, so the tests spell
+// it out rather than import it from anywhere.
+const (
+	goPluginDefaultMinPort = 10000
+	goPluginDefaultMaxPort = 25000
+)
+
+func TestPluginTransportEphemeralPortOnWindows(t *testing.T) {
+	// The coordinator hands go-plugin MinPort 0 and MaxPort 1 to get an
+	// OS-assigned port. If go-plugin ever starts rejecting port 0 or stops
+	// trying MinPort first, this is the test that says so.
+	addr, ok := startTestPlugin(t, 0, 1).(*net.TCPAddr)
+	require.True(t, ok, "Windows plugin transport must be loopback TCP")
+	assert.NotZero(t, addr.Port, "plugin reported port 0 instead of the port the OS assigned")
+	assert.False(t, addr.Port >= goPluginDefaultMinPort && addr.Port <= goPluginDefaultMaxPort,
+		"port %d is inside go-plugin's default range, the ephemeral request was not honored", addr.Port)
+}
+
+func TestPluginTransportZeroZeroMeansGoPluginDefaultOnWindows(t *testing.T) {
+	// Documents the trap that forces MaxPort to be 1 above: a 0-0 range is not
+	// "ephemeral" to go-plugin, it is "unset", and unset means 10000-25000.
+	addr, ok := startTestPlugin(t, 0, 0).(*net.TCPAddr)
+	require.True(t, ok, "Windows plugin transport must be loopback TCP")
+	assert.GreaterOrEqual(t, addr.Port, goPluginDefaultMinPort)
+	assert.LessOrEqual(t, addr.Port, goPluginDefaultMaxPort)
+}

--- a/providers/plugin_ports.go
+++ b/providers/plugin_ports.go
@@ -4,39 +4,39 @@
 package providers
 
 import (
-	"os"
+	goruntime "runtime"
 	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/cli/config"
 )
 
 // Providers are hashicorp/go-plugin subprocesses. On Linux and macOS the host
 // reaches them over a Unix socket, but go-plugin hard-codes loopback TCP on
-// Windows and lets the client pick the port range. Its own default is
-// 10000-25000, tried in ascending order, so the first provider a scan started
-// (usually os) always took port 10000 and collided with anything else that
-// owns it, and 10000 is a popular one (Webmin, plenty of Java stacks). The
-// range reaches the subprocess as PLUGIN_MIN_PORT/PLUGIN_MAX_PORT appended
-// after the host environment, so setting those on the host changed nothing
-// either.
+// Windows and lets the client pick the port range, which the plugin walks in
+// ascending order until a bind succeeds. That makes the bottom of the range
+// the entire collision surface: a Windows host only ever uses the first few
+// ports above the minimum, one per running provider. go-plugin's own default
+// of 10000-25000 put us on port 10000 (Webmin, plenty of Java stacks), and a
+// fixed minimum of 50000 would have put us on IBM Db2's default listener and
+// on SAP NetWeaver's instance-00 ports.
 //
-// The default below sits in the IANA dynamic range (49152-65535), which no
-// service is supposed to claim as a fixed port. go-plugin skips ports that are
-// busy or excluded (Hyper-V and WSL reserve blocks in that range), and each
-// running provider takes one port, so the range needs room for as many
-// providers as a scan runs at once.
-const (
-	// envPluginMinPort and envPluginMaxPort are go-plugin's own environment
-	// variables. Honoring them on the host makes the values a user sees in a
-	// provider process's environment actually mean something.
-	envPluginMinPort = "PLUGIN_MIN_PORT"
-	envPluginMaxPort = "PLUGIN_MAX_PORT"
+// So by default there is no fixed range: the plugin binds 127.0.0.1:0 and the
+// OS assigns a port from its dynamic range, honoring Hyper-V and WSL port
+// exclusions and spreading across the range instead of clustering at a
+// minimum, which is what every well-behaved local service does. Operators who
+// need a predictable range for host-based tooling can still set one with
+// provider_port_range.
 
-	defaultPluginMinPort uint = 50000
-	defaultPluginMaxPort uint = 65535
-)
+// ephemeralPluginPortRange asks go-plugin for an OS-assigned port. go-plugin
+// substitutes its 10000-25000 default only when both Min and Max are zero, so
+// Max is 1 purely to get past that check. Its listener loop tries
+// 127.0.0.1:<Min> first, and a bind to port 0 always succeeds, so port 1 is
+// never attempted. Verified against the pinned go-plugin version: NewClient in
+// client.go and serverListener_tcp in server.go.
+var ephemeralPluginPortRange = pluginPortRange{Min: 0, Max: 1}
 
 // pluginPortRange is the inclusive loopback TCP port range handed to a
 // provider subprocess. Only Windows uses it; other platforms ignore it.
@@ -44,45 +44,38 @@ type pluginPortRange struct {
 	Min, Max uint
 }
 
-// resolvePluginPortRange decides which ports a provider subprocess may listen on:
-//
-//  1. provider_port_range in mondoo.yml or MONDOO_PROVIDER_PORT_RANGE, as "min-max"
-//  2. PLUGIN_MIN_PORT and PLUGIN_MAX_PORT in the host environment, both required
-//  3. the default range
-//
-// A value that is present but malformed is an error rather than a silent fall
-// back to the default: an operator who set it did so to move away from a
-// collision, and keeping the old range would leave that collision in place
-// unannounced.
+// resolvePluginPortRange decides which ports a provider subprocess may listen
+// on: provider_port_range from mondoo.yml or MONDOO_PROVIDER_PORT_RANGE as
+// "min-max", or an OS-assigned port when unset.
 func resolvePluginPortRange() (pluginPortRange, error) {
-	return resolvePluginPortRangeFrom(config.GetProviderPortRange(), os.Getenv(envPluginMinPort), os.Getenv(envPluginMaxPort))
+	return resolvePluginPortRangeFrom(config.GetProviderPortRange(), goruntime.GOOS == "windows")
 }
 
-// resolvePluginPortRangeFrom is the pure core of resolvePluginPortRange, with
-// the config value and the two environment variables passed in so it can be
-// tested without touching the process environment.
-func resolvePluginPortRangeFrom(configured, envMin, envMax string) (pluginPortRange, error) {
-	if configured = strings.TrimSpace(configured); configured != "" {
-		r, err := parsePluginPortRange(configured)
-		if err != nil {
-			return pluginPortRange{}, errors.Wrapf(err, "invalid %s %q", config.KeyProviderPortRange, configured)
-		}
+// resolvePluginPortRangeFrom is the pure core of resolvePluginPortRange.
+//
+// transportUsesTCP says whether the setting has any effect on this platform.
+// Where it does, a malformed value is an error rather than a silent fall back:
+// an operator who set it did so to move away from a collision, and running on
+// a different range would leave that collision in place unannounced. Where it
+// does not (Unix sockets), the same typo must not take down scans over a
+// setting that never applied, so it is logged and ignored.
+func resolvePluginPortRangeFrom(configured string, transportUsesTCP bool) (pluginPortRange, error) {
+	configured = strings.TrimSpace(configured)
+	if configured == "" {
+		return ephemeralPluginPortRange, nil
+	}
+
+	r, err := parsePluginPortRange(configured)
+	if err == nil {
 		return r, nil
 	}
 
-	envMin, envMax = strings.TrimSpace(envMin), strings.TrimSpace(envMax)
-	if envMin != "" || envMax != "" {
-		if envMin == "" || envMax == "" {
-			return pluginPortRange{}, errors.Newf("%s and %s must be set together", envPluginMinPort, envPluginMaxPort)
-		}
-		r, err := newPluginPortRange(envMin, envMax)
-		if err != nil {
-			return pluginPortRange{}, errors.Wrapf(err, "invalid %s=%q %s=%q", envPluginMinPort, envMin, envPluginMaxPort, envMax)
-		}
-		return r, nil
+	err = errors.Wrapf(err, "invalid %s %q", config.KeyProviderPortRange, configured)
+	if transportUsesTCP {
+		return pluginPortRange{}, err
 	}
-
-	return pluginPortRange{Min: defaultPluginMinPort, Max: defaultPluginMaxPort}, nil
+	log.Warn().Err(err).Msg("ignoring the provider port range, this platform reaches providers over Unix sockets")
+	return ephemeralPluginPortRange, nil
 }
 
 // parsePluginPortRange parses the "min-max" form, for example "50000-50100".
@@ -91,15 +84,11 @@ func parsePluginPortRange(s string) (pluginPortRange, error) {
 	if !ok {
 		return pluginPortRange{}, errors.New("expected the form min-max, for example 50000-50100")
 	}
-	return newPluginPortRange(strings.TrimSpace(minS), strings.TrimSpace(maxS))
-}
-
-func newPluginPortRange(minS, maxS string) (pluginPortRange, error) {
-	minPort, err := parsePort(minS)
+	minPort, err := parsePort(strings.TrimSpace(minS))
 	if err != nil {
 		return pluginPortRange{}, err
 	}
-	maxPort, err := parsePort(maxS)
+	maxPort, err := parsePort(strings.TrimSpace(maxS))
 	if err != nil {
 		return pluginPortRange{}, err
 	}
@@ -109,9 +98,9 @@ func newPluginPortRange(minS, maxS string) (pluginPortRange, error) {
 	return pluginPortRange{Min: minPort, Max: maxPort}, nil
 }
 
-// parsePort accepts 1-65535. Port 0 is rejected because go-plugin reads a
-// 0-0 range as "unset" and falls back to its own 10000-25000 default, which
-// is exactly the range this setting exists to move away from.
+// parsePort accepts 1-65535. Port 0 is rejected: go-plugin reads a 0-0 range
+// as "unset" and falls back to its own 10000-25000 default, and an OS-assigned
+// port is what leaving the setting empty already gives you.
 func parsePort(s string) (uint, error) {
 	p, err := strconv.ParseUint(s, 10, 16)
 	if err != nil {

--- a/providers/plugin_ports_test.go
+++ b/providers/plugin_ports_test.go
@@ -11,65 +11,48 @@ import (
 )
 
 func TestResolvePluginPortRangeFrom(t *testing.T) {
-	t.Run("default when nothing is configured", func(t *testing.T) {
-		r, err := resolvePluginPortRangeFrom("", "", "")
-		require.NoError(t, err)
-		// The whole point of the change: the default must stay out of
-		// go-plugin's own 10000-25000, and inside the IANA dynamic range.
-		assert.Equal(t, pluginPortRange{Min: 50000, Max: 65535}, r)
+	t.Run("unset means an OS-assigned port on every platform", func(t *testing.T) {
+		for _, tcp := range []bool{true, false} {
+			r, err := resolvePluginPortRangeFrom("", tcp)
+			require.NoError(t, err)
+			// Min 0 is what makes go-plugin bind 127.0.0.1:0. Max must stay
+			// non-zero: with both at zero go-plugin silently swaps in its own
+			// 10000-25000 default, the range this whole file exists to leave.
+			assert.Equal(t, uint(0), r.Min)
+			assert.NotEqual(t, uint(0), r.Max)
+		}
 	})
 
-	t.Run("config value wins", func(t *testing.T) {
-		r, err := resolvePluginPortRangeFrom("50000-50100", "", "")
+	t.Run("configured range is used where the transport is TCP", func(t *testing.T) {
+		r, err := resolvePluginPortRangeFrom("50000-50100", true)
 		require.NoError(t, err)
 		assert.Equal(t, pluginPortRange{Min: 50000, Max: 50100}, r)
 	})
 
-	t.Run("config value tolerates whitespace", func(t *testing.T) {
-		r, err := resolvePluginPortRangeFrom(" 50000 - 50100 ", "", "")
+	t.Run("configured range tolerates whitespace", func(t *testing.T) {
+		r, err := resolvePluginPortRangeFrom(" 50000 - 50100 ", true)
 		require.NoError(t, err)
 		assert.Equal(t, pluginPortRange{Min: 50000, Max: 50100}, r)
 	})
 
 	t.Run("single port range is allowed", func(t *testing.T) {
-		r, err := resolvePluginPortRangeFrom("50000-50000", "", "")
+		r, err := resolvePluginPortRangeFrom("50000-50000", true)
 		require.NoError(t, err)
 		assert.Equal(t, pluginPortRange{Min: 50000, Max: 50000}, r)
 	})
 
-	t.Run("config value overrides go-plugin environment", func(t *testing.T) {
-		r, err := resolvePluginPortRangeFrom("50000-50100", "20000", "21000")
-		require.NoError(t, err)
-		assert.Equal(t, pluginPortRange{Min: 50000, Max: 50100}, r)
-	})
-
-	t.Run("malformed config value is an error even when the environment is valid", func(t *testing.T) {
-		_, err := resolvePluginPortRangeFrom("fifty-thousand", "20000", "21000")
+	t.Run("malformed value is an error where the transport is TCP", func(t *testing.T) {
+		_, err := resolvePluginPortRangeFrom("fifty-thousand", true)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "provider_port_range")
 	})
 
-	t.Run("go-plugin environment is honored", func(t *testing.T) {
-		r, err := resolvePluginPortRangeFrom("", "20000", "21000")
+	t.Run("malformed value is ignored where the transport is not TCP", func(t *testing.T) {
+		// A typo in a fleet-wide mondoo.yml must not fail Linux scans over a
+		// Windows-only setting; the resolver logs and uses the default instead.
+		r, err := resolvePluginPortRangeFrom("fifty-thousand", false)
 		require.NoError(t, err)
-		assert.Equal(t, pluginPortRange{Min: 20000, Max: 21000}, r)
-	})
-
-	t.Run("half-set go-plugin environment is an error", func(t *testing.T) {
-		_, err := resolvePluginPortRangeFrom("", "20000", "")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "must be set together")
-
-		_, err = resolvePluginPortRangeFrom("", "", "21000")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "must be set together")
-	})
-
-	t.Run("malformed go-plugin environment is an error", func(t *testing.T) {
-		_, err := resolvePluginPortRangeFrom("", "21000", "20000")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "PLUGIN_MIN_PORT")
-		assert.Contains(t, err.Error(), "greater than")
+		assert.Equal(t, ephemeralPluginPortRange, r)
 	})
 }
 


### PR DESCRIPTION
Follow-up to #10711, addressing three side effects of the fixed 50000-65535 default it introduced.

## Changes

1. **OS-assigned port by default.** go-plugin walks the range from the bottom and stops at the first free port, so the minimum is the entire collision surface: a Windows host only ever uses the first few ports above it. 50000 is IBM Db2's default listener and SAP NetWeaver's instance-00 port, so the fixed range traded one collision for another. The default is now `MinPort 0, MaxPort 1`, which makes the plugin bind `127.0.0.1:0` and take whatever the OS assigns. The OS honors Hyper-V/WSL port exclusions and spreads across the dynamic range instead of clustering. `MaxPort` is 1 rather than 0 because go-plugin reads a 0-0 range as "unset" and substitutes 10000-25000. `provider_port_range` still sets a fixed range for operators who need a predictable one.
2. **Malformed values only fail where they matter.** An invalid `provider_port_range` used to fail provider start on every platform, including Linux and macOS where the setting has no effect. It is now an error on Windows (TCP transport) and a logged, ignored warning elsewhere, so a typo in a fleet-wide `mondoo.yml` cannot take down Linux scans.
3. **No more `PLUGIN_MIN_PORT`/`PLUGIN_MAX_PORT` from the host environment.** Any go-plugin host that runs cnspec inherits those from its parent's client. packer-plugin-mondoo embeds cnspec and is itself a go-plugin child of Packer, so on a Windows Packer host it would have pulled the range straight back to 10000-25000. `MONDOO_PROVIDER_PORT_RANGE` covers the environment case with a name nothing else sets.

## Pinning the go-plugin assumption

The ephemeral default depends on go-plugin behavior its docs don't promise. `providers-sdk/v1/plugin` gains transport tests that run a real plugin handshake by re-executing the test binary as the plugin (the pattern go-plugin's own tests use), hooked into the package's existing goleak `TestMain`:

- **Windows:** `0/1` yields a TCP port outside 10000-25000 and non-zero; `0/0` yields one inside 10000-25000 (documents the trap).
- **Off Windows:** the transport is a Unix socket regardless of the range, which is why a malformed value only warns there.

The Windows CI workflow now also discovers `*_windows_test.go` under `providers-sdk/v1/plugin` and triggers on changes there. **This PR's "Windows Tests" job is the first time the port-0 path executes on Windows**, so please look at it rather than just the green check.

## Verification

- Unit tests for the resolver: unset is ephemeral on both transports, config honored, malformed errors on TCP and warns otherwise, plus the parse table.
- macOS end to end, reading the spawned `os` provider's environment: default gives `PLUGIN_MIN_PORT=0 PLUGIN_MAX_PORT=1`; `MONDOO_PROVIDER_PORT_RANGE=51000-51100` is passed through; a typo logs a warning and the scan proceeds; `PLUGIN_MIN_PORT=20000 PLUGIN_MAX_PORT=21000` on the host is ignored.
- `go test ./providers-sdk/v1/plugin/ -count=3` clean under goleak; `GOOS=windows go vet` on the package; `golangci-lint` 0 issues on all touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
