### PR TITLE
🐛 providers: enable mTLS on the Windows plugin transport

### DIFF
--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -419,10 +419,11 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 			AllowedProtocols: []plugin.Protocol{
 				plugin.ProtocolNetRPC, plugin.ProtocolGRPC,
 			},
-			Logger:  pluginLogger,
-			Stderr:  crashLog,
-			MinPort: ports.Min,
-			MaxPort: ports.Max,
+			Logger:   pluginLogger,
+			Stderr:   crashLog,
+			MinPort:  ports.Min,
+			MaxPort:  ports.Max,
+			AutoMTLS: providerTransportUsesMTLS(),
 		})
 
 		// Connect via RPC

--- a/providers/plugin_ports.go
+++ b/providers/plugin_ports.go
@@ -44,6 +44,28 @@ type pluginPortRange struct {
 	Min, Max uint
 }
 
+// providerTransportUsesMTLS reports whether the host should negotiate go-plugin
+// AutoMTLS with its provider subprocesses.
+//
+// It is gated to Windows for the same reason the port handling above is: there
+// the transport is loopback TCP, connectable by any local process regardless of
+// user. Without mutual TLS, a standard user could reach a running provider's
+// gRPC API on that port and drive it at the provider's privileges (for example
+// run a command through the live local connection, which under the cnspec
+// Windows service is the service account). AutoMTLS makes the host mint a
+// one-time certificate, hand it to the plugin, and refuse every connection that
+// does not present it; the provider side negotiates this automatically in
+// plugin.Serve, so already-installed provider binaries keep working.
+//
+// On Linux and macOS the transport is a Unix socket writable only by its owner,
+// which already restricts it to the user the provider runs as, so mTLS would
+// add a handshake with no security gain. The Windows cost is negligible: a full
+// CIS Microsoft Windows Server 2022 Benchmark scan measured under 0.2% median
+// difference with it on.
+func providerTransportUsesMTLS() bool {
+	return goruntime.GOOS == "windows"
+}
+
 // resolvePluginPortRange decides which ports a provider subprocess may listen
 // on: provider_port_range from mondoo.yml or MONDOO_PROVIDER_PORT_RANGE as
 // "min-max", or an OS-assigned port when unset.


### PR DESCRIPTION
Enables mutual TLS on the host-to-provider plugin transport, gated to Windows.

## Why

Providers are hashicorp/go-plugin subprocesses. On Windows go-plugin uses loopback TCP for the host-to-provider transport, whereas Linux and macOS use a Unix socket. The Unix socket is writable only by its owner, so it is already restricted to the user the provider runs as. The Windows TCP listener has no such restriction: it is connectable by any local process regardless of user, and the gRPC surface on it is unauthenticated. A local caller could therefore reach a running provider and drive it at the provider's privileges, which under the cnspec Windows service is the service account.

## What

Set `AutoMTLS` on the plugin `ClientConfig`, gated by `providerTransportUsesMTLS()` (`runtime.GOOS == "windows"`). go-plugin's AutoMTLS makes the host mint a one-time certificate, hand it to the plugin, and refuse any connection that does not present it. The provider side negotiates this automatically inside `plugin.Serve`, so **already-installed provider binaries keep working** with an updated host.

Linux and macOS keep their owner-only Unix socket and are left untouched by the gate, so they pay no handshake cost.

## Performance

Measured on a real Windows Server 2022 VM (EC2 m5.large), scanning as the service account, with plain vs mTLS driven by a toggle on the same binary:

| Scenario | pairs | plain median | mTLS median | delta |
|---|---|---|---|---|
| CIS Windows Server 2022 L1, full scan | 7 | 53.09s | 53.18s | +0.17% |
| CIS Windows Server 2022 L2, full scan | 5 | 24.63s | 24.66s | +0.11% |
| provider startup only | 10 | 6.80s | 6.83s | +0.53% |

All deltas are within run-to-run noise. The cost is one keygen plus handshake per provider start, paid once per scan, not per check.

## Verification

- Windows VM, end to end: confirmed the provider listener completes a mutually authenticated TLS 1.3 handshake, and that a local connection without the client certificate is refused.
- macOS: confirmed the gate leaves the transport a plaintext Unix socket with no client cert passed, i.e. Unix hosts are unaffected.
- `go vet` clean on `GOOS=windows` and `GOOS=darwin`; `golangci-lint` 0 issues; provider tests pass.

## Follow-up

Only single-asset scans were benchmarked, so the per-`Connect` broker handshake in a many-assets-per-process run is not yet measured. It does not affect this Windows-only change, but it is the thing to check before extending mTLS to the Unix transports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
