### PR TITLE
✨ selfupdate: read the download target from the url field

### DIFF
--- a/cli/selfupdate/release_file_test.go
+++ b/cli/selfupdate/release_file_test.go
@@ -1,0 +1,101 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package selfupdate
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDownloadTarget pins which field the download is fetched from.
+//
+// filename is the plain artifact name in some manifests and the fully qualified
+// URL in others, which is why url exists and is preferred. The fallback keeps
+// working against manifests published before url did.
+func TestDownloadTarget(t *testing.T) {
+	const url = "https://releases.mondoo.com/cnspec/13.38.1/cnspec_13.38.1_darwin_arm64.tar.gz"
+
+	t.Run("url wins when present", func(t *testing.T) {
+		f := ReleaseFile{Filename: "cnspec_13.38.1_darwin_arm64.tar.gz", Url: url}
+		assert.Equal(t, url, f.downloadTarget())
+	})
+
+	t.Run("falls back to filename when url is absent", func(t *testing.T) {
+		// How every latest.json looked before the url field existed.
+		f := ReleaseFile{Filename: url}
+		assert.Equal(t, url, f.downloadTarget())
+	})
+
+	t.Run("url is preferred even when filename also holds a url", func(t *testing.T) {
+		f := ReleaseFile{Filename: "https://mirror.example.com/old.tar.gz", Url: url}
+		assert.Equal(t, url, f.downloadTarget())
+	})
+}
+
+// TestGetPlatformFileSelection covers picking this platform's artifact out of a
+// manifest, in each shape a manifest can arrive in.
+func TestGetPlatformFileSelection(t *testing.T) {
+	ext := "tar.gz"
+	if runtime.GOOS == "windows" {
+		ext = "zip"
+	}
+	name := "cnspec_13.38.1_" + runtime.GOOS + "_" + runtime.GOARCH + "." + ext
+	const base = "https://releases.mondoo.com/cnspec/13.38.1/"
+
+	t.Run("normalized manifest: plain filename plus url", func(t *testing.T) {
+		// The shape the install service serves once filenames are normalized.
+		// Selection must not depend on filename carrying the URL.
+		rel := &Release{Version: "13.38.1", Files: []ReleaseFile{
+			{Filename: "cnspec_13.38.1_other_arch.tar.gz", Url: base + "cnspec_13.38.1_other_arch.tar.gz"},
+			{Filename: name, Url: base + name},
+		}}
+		got := getPlatformFile(rel, "cnspec")
+		require.NotNil(t, got, "no entry selected for %s_%s", runtime.GOOS, runtime.GOARCH)
+		assert.Equal(t, base+name, got.downloadTarget())
+	})
+
+	t.Run("legacy manifest: filename carries the url", func(t *testing.T) {
+		rel := &Release{Version: "13.38.1", Files: []ReleaseFile{
+			{Filename: base + "cnspec_13.38.1_other_arch.tar.gz"},
+			{Filename: base + name},
+		}}
+		got := getPlatformFile(rel, "cnspec")
+		require.NotNil(t, got)
+		assert.Equal(t, base+name, got.downloadTarget())
+	})
+
+	t.Run("no entry for this platform", func(t *testing.T) {
+		rel := &Release{Version: "13.38.1", Files: []ReleaseFile{
+			{Filename: "cnspec_13.38.1_someos_somearch.tar.gz", Url: base + "cnspec_13.38.1_someos_somearch.tar.gz"},
+		}}
+		assert.Nil(t, getPlatformFile(rel, "cnspec"))
+	})
+}
+
+// TestDownloadRejectsNonUrlTarget covers a manifest that carries only a plain
+// filename and no url. There is no download target in that document, and the
+// error has to say so: passing the bare name through fails later as a URL parse
+// error, which points at the request rather than at the manifest.
+func TestDownloadRejectsNonUrlTarget(t *testing.T) {
+	ext := "tar.gz"
+	if runtime.GOOS == "windows" {
+		ext = "zip"
+	}
+	name := "cnspec_13.38.1_" + runtime.GOOS + "_" + runtime.GOARCH + "." + ext
+
+	rel := &Release{Name: "cnspec", Version: "13.38.1", Files: []ReleaseFile{{Filename: name}}}
+
+	// Selection still succeeds - a plain name satisfies the suffix match - so
+	// the guard has to be at the download, not at selection.
+	require.NotNil(t, getPlatformFile(rel, "cnspec"))
+
+	_, err := downloadAndInstall(context.Background(), rel, t.TempDir(), "cnspec")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no download url")
+	assert.Contains(t, err.Error(), name)
+}

--- a/cli/selfupdate/selfupdate.go
+++ b/cli/selfupdate/selfupdate.go
@@ -73,9 +73,31 @@ type Release struct {
 
 // ReleaseFile represents a downloadable release file
 type ReleaseFile struct {
+	// Filename is the artifact name. It is the plain name in some documents and
+	// the fully qualified download URL in others, so it is not a reliable
+	// download target on its own; see downloadTarget.
 	Filename string `json:"filename"`
+	// Url is the fully qualified download URL. It is absent only on manifests
+	// published before the field existed.
+	Url      string `json:"url"`
 	Platform string `json:"platform"` // e.g., "linux_amd64", "darwin_arm64"
 	Hash     string `json:"hash"`     // SHA256 hash
+}
+
+// downloadTarget is the URL to fetch this artifact from.
+//
+// Url is the field that means the same thing in every document and is preferred.
+// It is empty only for a manifest published before the field existed, in which
+// case Filename carries the fully qualified URL instead - that is what
+// latest.json has always held, and what this code read before Url existed. A
+// document where Filename is the plain name and Url is absent has no download
+// target at all; downloadAndInstall rejects that rather than fetching a bare
+// name.
+func (f *ReleaseFile) downloadTarget() string {
+	if f.Url != "" {
+		return f.Url
+	}
+	return f.Filename
 }
 
 // updatePreflight runs the guards shared by every self-update entry point and
@@ -430,8 +452,11 @@ func getPlatformFile(release *Release, binaryName string) *ReleaseFile {
 	suffix := fmt.Sprintf("%s_%s_%s_%s.%s", binaryName, release.Version, goos, goarch, ext)
 
 	for i := range release.Files {
-		// Match by suffix since Filename is a full URL
-		if strings.HasSuffix(release.Files[i].Filename, suffix) {
+		// Match against the download target rather than Filename. Both end in
+		// the artifact name, but Filename is the plain name in some documents
+		// and the full URL in others, and only the target is guaranteed to be
+		// the thing actually fetched.
+		if strings.HasSuffix(release.Files[i].downloadTarget(), suffix) {
 			return &release.Files[i]
 		}
 	}
@@ -446,8 +471,15 @@ func downloadAndInstall(ctx context.Context, release *Release, destPath string, 
 		return "", errors.Newf("no release file found for platform %s_%s", runtime.GOOS, runtime.GOARCH)
 	}
 
-	// The Filename field contains the full download URL
-	downloadURL := file.Filename
+	downloadURL := file.downloadTarget()
+	// A manifest that carries no url and only a plain filename has no download
+	// target. Left alone this reaches http.NewRequestWithContext as a bare name
+	// and fails as a URL parse error, which points at the request rather than at
+	// the manifest that is actually wrong.
+	if !strings.HasPrefix(downloadURL, "http://") && !strings.HasPrefix(downloadURL, "https://") {
+		return "", errors.Newf("release manifest has no download url for %s_%s: %q is not a url",
+			runtime.GOOS, runtime.GOARCH, downloadURL)
+	}
 
 	log.Debug().Str("url", downloadURL).Msg("self-update: downloading")
 


### PR DESCRIPTION
## The problem

`selfupdate` reads the download URL out of `filename`:

```go
// The Filename field contains the full download URL
downloadURL := file.Filename
```

That is true of `latest.json`, where `filename` has always been fully qualified — but it is a property of one document, not of the format. A version's `artifacts.json` carries the plain artifact name in the same field. The release tooling now publishes an explicit `url` field precisely because one field meaning two different things is not something a consumer can reason about without knowing which document it is holding.

## The change

Prefer `url`, fall back to `filename` when it is absent:

```go
func (f *ReleaseFile) downloadTarget() string {
	if f.Url != "" {
		return f.Url
	}
	return f.Filename
}
```

Strictly additive. Every manifest published so far still resolves, including ones served straight from a release bucket that predates the field.

Selection moves to the same accessor. Matching on `filename` would keep working by accident — both forms end in the artifact name — but only the download target is guaranteed to be the thing actually fetched, so that is what the suffix is matched against. Otherwise selection quietly depends on the deprecated field.

## Rejecting a manifest with no download target

A document carrying only a plain `filename` and no `url` has no download target at all. Previously the bare name reached `http.NewRequestWithContext` and failed as a URL parse error, which points at the request rather than at the manifest that is actually wrong. It is now rejected up front:

```
release manifest has no download url for darwin_arm64: "cnspec_13.38.1_darwin_arm64.tar.gz" is not a url
```

The guard has to sit at the download rather than at selection, because selection still succeeds — a plain name satisfies the suffix match trivially. That is covered by a test.

## Why now

It unblocks normalizing `filename` to the plain name at the API boundary, which is the direction the release format is heading.

Doing that first would have failed in a way that is hard to trace: a bare name satisfies `strings.HasSuffix(filename, "cnspec_13.38.1_darwin_arm64.tar.gz")`, so selection succeeds and the error only appears later, at the fetch.

There are no consumers of a normalized manifest yet, so landing this first closes the window before it opens. Whatever cnspec release starts reading normalized manifests needs to contain this change.

## Tests

`downloadTarget` across all three shapes (url present, url absent, both present); `getPlatformFile` selecting from a normalized manifest, a legacy one, and one with no entry for this platform; and the no-download-target case, which asserts selection still matches and the download is what rejects it.
