### PR TITLE
🐛 sbom: keep the dependency graph and its refs across an import

### DIFF
--- a/sbom/cyclonedx.go
+++ b/sbom/cyclonedx.go
@@ -330,6 +330,14 @@ func (ccx *CycloneDX) convertCycloneDxToSbom(bom *cyclonedx.BOM) (*Sbom, error) 
 			Version:     component.Version,
 			Purl:        component.PackageURL,
 			Description: component.Description,
+			// The document's own identity for this component, kept because it
+			// is what `dependencies` keys on. A producer chooses its own
+			// bom-refs -- a purl, a UUID, an internal id -- and dropping them
+			// while keeping the edges verbatim left every edge naming a
+			// component the consumer could no longer resolve. BomRefFor
+			// prefers this field, so a render/parse/render round-trip now also
+			// preserves the refs instead of rewriting them.
+			BomRef: component.BOMRef,
 		}
 
 		// parse purl to gather package type

--- a/sbom/dependency_graph_test.go
+++ b/sbom/dependency_graph_test.go
@@ -148,3 +148,29 @@ func TestSpdxHashes(t *testing.T) {
 	assert.Contains(t, data, "SHA512")
 	assert.Contains(t, data, testHashHex)
 }
+
+// TestSpdxParseKeepsPackagesWithoutAPurpose pins the import against an optional
+// field. primary_package_purpose is OPTIONAL in SPDX 2.3 and most producers
+// omit it -- mql's own SPDX renderer among them -- but the import keyed on it
+// and dropped every package whose purpose was unstated.
+//
+// The failure was silent in the worst way: Render then Parse of this
+// three-package SBOM returned ZERO packages, so `xgrep scan --sbom <spdx>` read
+// a real document as a project with no dependencies rather than as one it could
+// not interpret. Verified against the parent commit, where this returns 0.
+func TestSpdxParseKeepsPackagesWithoutAPurpose(t *testing.T) {
+	out := bytes.Buffer{}
+	require.NoError(t, sbom.NewSPDX(sbom.FormatSpdxJSON).Render(&out, graphBom()))
+	// The fixture states no purpose for any package, which is the ordinary case.
+	assert.NotContains(t, out.String(), "primaryPackagePurpose")
+
+	got, err := sbom.NewProtobom().Parse(bytes.NewReader(out.Bytes()))
+	require.NoError(t, err)
+	require.Len(t, got.GetPackages(), 3, "every rendered package should survive the round trip")
+
+	names := []string{}
+	for _, p := range got.GetPackages() {
+		names = append(names, p.GetName())
+	}
+	assert.ElementsMatch(t, []string{"app", "left-pad", "jest"}, names)
+}

--- a/sbom/dependency_graph_test.go
+++ b/sbom/dependency_graph_test.go
@@ -233,3 +233,80 @@ func TestSpdxDependencyGraphReadsDependencyOf(t *testing.T) {
 	assert.Equal(t, "pkg:npm/app@1.0.0", got.Dependencies[0].Ref)
 	assert.Equal(t, []string{"pkg:npm/left-pad@1.3.0"}, got.Dependencies[0].DependencyRefs)
 }
+
+// TestCycloneDXParseKeepsTheBomRef pins the identity the `dependencies` section
+// keys on.
+//
+// CycloneDX states edges by `bom-ref`, and a producer is free to choose one --
+// a purl, a UUID, an internal id. The reader dropped `bom-ref` while keeping
+// the edges verbatim, so for any producer that does not happen to use purls as
+// bom-refs, every edge referenced a component the consumer could no longer
+// identify. The graph parsed, and then correlated with nothing.
+func TestCycloneDXParseKeepsTheBomRef(t *testing.T) {
+	doc := `{
+  "bomFormat": "CycloneDX", "specVersion": "1.5", "version": 1,
+  "metadata": {"component": {"type": "application", "name": "app", "version": "1.0.0"}},
+  "components": [
+    {"bom-ref": "3f2504e0-4f89-11d3-9a0c-0305e82c3301", "type": "library",
+     "name": "left-pad", "version": "1.3.0", "purl": "pkg:npm/left-pad@1.3.0"},
+    {"bom-ref": "7c9e6679-7425-40de-944b-e07fc1f90ae7", "type": "library",
+     "name": "right-pad", "version": "2.0.0", "purl": "pkg:npm/right-pad@2.0.0"}
+  ],
+  "dependencies": [
+    {"ref": "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+     "dependsOn": ["7c9e6679-7425-40de-944b-e07fc1f90ae7"]}
+  ]
+}`
+	out, err := sbom.New(sbom.FormatCycloneDxJSON).Parse(strings.NewReader(doc))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	byRef := map[string]*sbom.Package{}
+	for _, p := range out.Packages {
+		byRef[p.BomRef] = p
+	}
+	if len(byRef) != 2 {
+		t.Fatalf("every component's bom-ref must survive the read, got %v", byRef)
+	}
+	// The edge is only usable if its endpoints resolve to components.
+	if len(out.Dependencies) != 1 {
+		t.Fatalf("expected the one dependency entry, got %d", len(out.Dependencies))
+	}
+	from, ok := byRef[out.Dependencies[0].Ref]
+	if !ok {
+		t.Fatalf("edge source %q resolves to no component", out.Dependencies[0].Ref)
+	}
+	if from.Purl != "pkg:npm/left-pad@1.3.0" {
+		t.Errorf("edge source resolved to %q", from.Purl)
+	}
+	to, ok := byRef[out.Dependencies[0].DependencyRefs[0]]
+	if !ok {
+		t.Fatalf("edge target %q resolves to no component", out.Dependencies[0].DependencyRefs[0])
+	}
+	if to.Purl != "pkg:npm/right-pad@2.0.0" {
+		t.Errorf("edge target resolved to %q", to.Purl)
+	}
+}
+
+// TestCycloneDXRoundTripPreservesTheProducersRefs is the second half of keeping
+// bom-ref: a document read and written back keeps the identities it arrived
+// with, rather than having every ref rewritten to a purl. Anything holding a
+// reference INTO the document -- an attestation, a VEX statement, a reviewer's
+// note -- still resolves afterwards.
+func TestCycloneDXRoundTripPreservesTheProducersRefs(t *testing.T) {
+	doc := `{
+  "bomFormat": "CycloneDX", "specVersion": "1.5", "version": 1,
+  "metadata": {"component": {"type": "application", "name": "app", "version": "1.0.0"}},
+  "components": [
+    {"bom-ref": "3f2504e0-4f89-11d3-9a0c-0305e82c3301", "type": "library",
+     "name": "left-pad", "version": "1.3.0", "purl": "pkg:npm/left-pad@1.3.0"}
+  ]
+}`
+	in, err := sbom.New(sbom.FormatCycloneDxJSON).Parse(strings.NewReader(doc))
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, sbom.New(sbom.FormatCycloneDxJSON).Render(&buf, in))
+	assert.Contains(t, buf.String(), "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+		"the producer's bom-ref must survive a render, not be rewritten to a purl")
+}

--- a/sbom/dependency_graph_test.go
+++ b/sbom/dependency_graph_test.go
@@ -174,3 +174,62 @@ func TestSpdxParseKeepsPackagesWithoutAPurpose(t *testing.T) {
 	}
 	assert.ElementsMatch(t, []string{"app", "left-pad", "jest"}, names)
 }
+
+// TestSpdxDependencyGraphRoundTrips is the read half of TestSpdxDependencyGraph
+// above, which only ever asserted that a DEPENDS_ON relationship was WRITTEN.
+//
+// The graph was write-only on the SPDX side: the renderer emitted every edge
+// and the parser read nodes alone, so a document round-tripped through SPDX
+// arrived with its packages intact and its dependency structure silently gone.
+// CycloneDX kept the graph (#10659); SPDX dropped it. Against the parent commit
+// this fails with an empty Dependencies.
+func TestSpdxDependencyGraphRoundTrips(t *testing.T) {
+	out := bytes.Buffer{}
+	require.NoError(t, sbom.NewSPDX(sbom.FormatSpdxJSON).Render(&out, graphBom()))
+
+	got, err := sbom.NewProtobom().Parse(bytes.NewReader(out.Bytes()))
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	require.Len(t, got.Dependencies, 1, "the DEPENDS_ON relationship should come back as one edge")
+	assert.Equal(t, "pkg:npm/app@1.0.0", got.Dependencies[0].Ref)
+	assert.Equal(t, []string{"pkg:npm/left-pad@1.3.0"}, got.Dependencies[0].DependencyRefs)
+}
+
+// TestSpdxDependencyGraphReadsDependencyOf pins the inverted spelling. SPDX
+// states the same fact two ways -- DEPENDS_ON and DEPENDENCY_OF -- and a
+// producer may emit either, so a reader that understands only one silently
+// loses half the documents in the wild. The direction matters: a dependencyOf
+// edge names the DEPENDENCY as its source, so importing it unreversed would
+// invert the graph and make a library depend on the application.
+//
+// Built through protobom rather than through the renderer, because mql's SPDX
+// renderer only ever writes DEPENDS_ON.
+func TestSpdxDependencyGraphReadsDependencyOf(t *testing.T) {
+	doc := `{
+	  "spdxVersion": "SPDX-2.3",
+	  "dataLicense": "CC0-1.0",
+	  "SPDXID": "SPDXRef-DOCUMENT",
+	  "name": "app",
+	  "documentNamespace": "https://example.com/app",
+	  "creationInfo": {"created": "2026-09-08T00:00:00Z", "creators": ["Tool: test-1"]},
+	  "packages": [
+	    {"SPDXID": "SPDXRef-App", "name": "app", "versionInfo": "1.0.0", "downloadLocation": "NOASSERTION",
+	     "externalRefs": [{"referenceCategory": "PACKAGE-MANAGER", "referenceType": "purl", "referenceLocator": "pkg:npm/app@1.0.0"}]},
+	    {"SPDXID": "SPDXRef-LeftPad", "name": "left-pad", "versionInfo": "1.3.0", "downloadLocation": "NOASSERTION",
+	     "externalRefs": [{"referenceCategory": "PACKAGE-MANAGER", "referenceType": "purl", "referenceLocator": "pkg:npm/left-pad@1.3.0"}]}
+	  ],
+	  "relationships": [
+	    {"spdxElementId": "SPDXRef-LeftPad", "relatedSpdxElement": "SPDXRef-App", "relationshipType": "DEPENDENCY_OF"}
+	  ]
+	}`
+
+	got, err := sbom.NewProtobom().Parse(strings.NewReader(doc))
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	require.Len(t, got.Dependencies, 1)
+	// app depends on left-pad, NOT the reverse.
+	assert.Equal(t, "pkg:npm/app@1.0.0", got.Dependencies[0].Ref)
+	assert.Equal(t, []string{"pkg:npm/left-pad@1.3.0"}, got.Dependencies[0].DependencyRefs)
+}

--- a/sbom/protobom.go
+++ b/sbom/protobom.go
@@ -5,6 +5,8 @@ package sbom
 
 import (
 	"io"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/package-url/packageurl-go"
@@ -159,6 +161,11 @@ func (s *Protobom) convertToSbom(doc *protobom_sbom.Document) *Sbom {
 		return bom // no nodes, return empty SBOM
 	}
 
+	// Node ID -> the bom-ref the package will be known by, so the edges below
+	// can be translated out of protobom's node space into the same reference
+	// space Sbom.Dependencies uses everywhere else (BomRefFor).
+	refByNode := map[string]string{}
+
 	for _, node := range doc.GetNodeList().GetNodes() {
 		pkg := &Package{
 			Name:    node.Name,
@@ -214,7 +221,82 @@ func (s *Protobom) convertToSbom(doc *protobom_sbom.Document) *Sbom {
 			bom.Asset.Platform.Cpes = pkg.Cpes
 		}
 		bom.Packages = append(bom.Packages, pkg)
+		// Only a node that became a package can be an edge endpoint: an edge
+		// naming anything else is dropped below rather than emitted as a
+		// reference to something the SBOM does not contain.
+		if id := node.GetId(); id != "" {
+			refByNode[id] = BomRefFor(pkg)
+		}
 	}
 
+	bom.Dependencies = protobomDependencies(doc, refByNode)
+
 	return bom
+}
+
+// protobomDependencies reads the package->package graph out of a protobom
+// document's edges, the read counterpart to the SPDX renderer's DEPENDS_ON
+// relationships (spdx.go).
+//
+// Without this the graph was write-only on the SPDX side: the renderer emitted
+// every edge and the parser read nodes alone, so an SBOM round-tripped through
+// SPDX lost its dependency structure entirely while CycloneDX kept it. The
+// CycloneDX reader gained its counterpart in #10659; this is the same fix on
+// the other format, and the two now agree.
+//
+// Both directions are read because a producer may state either and they carry
+// the same fact: SPDX has DEPENDS_ON and DEPENDENCY_OF, and protobom maps them
+// to Edge_dependsOn and Edge_dependencyOf. A dependencyOf edge is INVERTED on
+// import -- its `From` is the dependency and each `To` is a dependent -- so
+// that both spellings land in one direction downstream.
+//
+// Deliberately NOT read: Edge_devDependency and the other typed edges. This
+// field carries the production dependency graph, and folding a dev-scoped edge
+// into it would state that a dev-only package is depended on in production,
+// which is a stronger claim than the document made.
+func protobomDependencies(doc *protobom_sbom.Document, refByNode map[string]string) []*Dependency {
+	if doc.GetNodeList() == nil || len(refByNode) == 0 {
+		return nil
+	}
+	// Accumulated by source ref, since two edges may share one `From` and a
+	// dependencyOf edge contributes to a `From` that is not its own.
+	refs := map[string][]string{}
+	seen := map[[2]string]bool{}
+	add := func(from, to string) {
+		if from == "" || to == "" || from == to || seen[[2]string{from, to}] {
+			return
+		}
+		seen[[2]string{from, to}] = true
+		refs[from] = append(refs[from], to)
+	}
+
+	for _, e := range doc.GetNodeList().GetEdges() {
+		from, ok := refByNode[e.GetFrom()]
+		if !ok {
+			continue
+		}
+		for _, toNode := range e.GetTo() {
+			to, ok := refByNode[toNode]
+			if !ok {
+				continue
+			}
+			switch e.GetType() {
+			case protobom_sbom.Edge_dependsOn:
+				add(from, to)
+			case protobom_sbom.Edge_dependencyOf:
+				add(to, from)
+			}
+		}
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+	// Sorted so a document's edge order does not decide the output's, which
+	// keeps a re-render byte-stable and a test assertable.
+	out := make([]*Dependency, 0, len(refs))
+	for _, from := range slices.Sorted(maps.Keys(refs)) {
+		slices.Sort(refs[from])
+		out = append(out, &Dependency{Ref: from, DependencyRefs: refs[from]})
+	}
+	return out
 }

--- a/sbom/protobom.go
+++ b/sbom/protobom.go
@@ -184,21 +184,36 @@ func (s *Protobom) convertToSbom(doc *protobom_sbom.Document) *Sbom {
 			pkg.Cpes = nil
 		}
 
-		purposes := node.GetPrimaryPurpose()
-		if len(purposes) > 0 {
-			switch purposes[0] {
-			case protobom_sbom.Purpose_OPERATING_SYSTEM:
-				bom.Asset.Platform = &Platform{
-					Name:    pkg.Name,
-					Version: pkg.Version,
-					Title:   pkg.Description,
-				}
-				bom.Asset.Platform.Family = familyMap[pkg.Name]
-				bom.Asset.Platform.Cpes = pkg.Cpes
-			case protobom_sbom.Purpose_APPLICATION:
-				bom.Packages = append(bom.Packages, pkg)
-			}
+		// A FILE node describes a file inside a package, not a package, so it is
+		// the one thing that must not become one.
+		if node.GetType() == protobom_sbom.Node_FILE {
+			continue
 		}
+
+		// primary_package_purpose is OPTIONAL in SPDX 2.3 and most producers omit
+		// it -- mql's own SPDX renderer among them. Keying the import on it
+		// dropped EVERY package whose purpose was unstated, so an SPDX document
+		// round-tripped through this package arrived empty: `Render` then `Parse`
+		// of a three-package SBOM returned zero. `xgrep scan --sbom <spdx>` read
+		// that as a project with no dependencies rather than as a document it
+		// could not interpret, which is the silent-empty failure the format's
+		// optional fields are most likely to produce.
+		//
+		// The node TYPE is the discriminator that always holds: protobom states
+		// PACKAGE or FILE for every node, where purpose is advisory. Purpose is
+		// still read, for the one thing it uniquely says -- that a package is the
+		// operating system, which makes it the asset's platform as well.
+		if purposes := node.GetPrimaryPurpose(); len(purposes) > 0 &&
+			purposes[0] == protobom_sbom.Purpose_OPERATING_SYSTEM {
+			bom.Asset.Platform = &Platform{
+				Name:    pkg.Name,
+				Version: pkg.Version,
+				Title:   pkg.Description,
+			}
+			bom.Asset.Platform.Family = familyMap[pkg.Name]
+			bom.Asset.Platform.Cpes = pkg.Cpes
+		}
+		bom.Packages = append(bom.Packages, pkg)
 	}
 
 	return bom


### PR DESCRIPTION
Three bugs on the SBOM import path, found while making `Sbom.Dependencies` usable downstream. All pre-existing on `main`, and separable as three commits.

Two are on SPDX (the second cannot fire without the first, which is why they are together); the third is the CycloneDX identity the graph keys on. Together they mean a dependency graph read out of either format is actually usable by a consumer.

The CycloneDX graph decode itself landed in #10659.

## 1. `5487012` — an SPDX package survives an unstated primary purpose

**`Render` then `Parse` of a three-package SBOM returned ZERO packages**, through this repo's own SPDX renderer.

The import keyed on `primary_package_purpose`, keeping only `OPERATING_SYSTEM` and `APPLICATION`. That field is **optional in SPDX 2.3** and most producers omit it — `sbom/spdx.go` among them — so every package whose purpose was unstated was dropped on the floor.

The failure mode is the dangerous one. A consumer reads a real document as *a project with no dependencies*, rather than as one it could not interpret: an empty result that looks like a clean bill of health rather than a parse gap.

`Node.Type` is the discriminator that always holds — protobom states `PACKAGE` or `FILE` for every node, where purpose is advisory. So a `FILE` node is skipped and everything else becomes a package. Purpose is still read for the one thing it uniquely says: that a package is the operating system, which makes it the asset's platform as well.

`TestSpdxParseKeepsPackagesWithoutAPurpose` asserts both halves — that the fixture states no purpose (so it cannot pass by the fixture drifting into one) and that all three packages survive. It returns 0 against the parent commit.

## 2. `37c362c` — read the SPDX dependency graph on import

The package→package graph was **write-only** on this side. `sbom/spdx.go:193` emits every edge as a `DEPENDS_ON` relationship; the parser read nodes alone. A document round-tripped through SPDX arrived with its packages intact and its dependency structure silently gone, while CycloneDX kept it.

Both spellings are read, because a producer may state either and they carry the same fact: SPDX has `DEPENDS_ON` and `DEPENDENCY_OF`, which protobom maps to `Edge_dependsOn` and `Edge_dependencyOf`. **A `dependencyOf` edge is inverted on import** — its `From` is the dependency and each `To` is a dependent — so both land in one direction downstream. Getting that backwards would make a library depend on the application, which is a plausible-looking graph pointing the wrong way, so it is pinned by its own test rather than left to review.

**Deliberately not read:** `Edge_devDependency` and the other typed edges. This field carries the production dependency graph, and folding a dev-scoped edge into it would state that a dev-only package is depended on in production — a stronger claim than the document made.

Output is sorted by source ref and by target, so a document's edge order does not decide the output's and a re-render stays byte-stable.

## 3. `49faae0` — CycloneDX import keeps each component's `bom-ref`

CycloneDX states its dependency graph by `bom-ref`, and a producer chooses its own: a purl, a UUID, an internal id. The reader dropped `bom-ref` while keeping the `dependencies` entries **verbatim** — so for any producer that does not happen to spell bom-refs as purls, and UUIDs are common, every edge named a component the consumer could no longer resolve. The graph parsed, and correlated with nothing.

cyclonedx-maven-plugin's purl-shaped refs worked by coincidence. Nothing else did.

Two consequences, one test each:

- **An edge's endpoints resolve to components again** — the only thing that makes the graph usable at all.
- **A parse/render round-trip preserves the identities the document arrived with**, because `BomRefFor` prefers `Package.BomRef`. Previously every ref was rewritten to a purl, so anything holding a reference *into* the document — an attestation, a VEX statement — stopped resolving.

## Verification

- `go build ./...` clean; `go test ./sbom/...` green.
- **All 17 SPDX tests pass**, including the pre-existing syft, Alpine and GitHub-dependency-graph fixtures — commit 1 changes which nodes become packages, so those were the ones at risk.
- **Five mutations, all red:**

| mutation | fails |
|---|---|
| `dependencyOf` arm removed | `TestSpdxDependencyGraphReadsDependencyOf` |
| `dependencyOf` direction inverted | `TestSpdxDependencyGraphReadsDependencyOf` |
| SPDX edge decode returns nil (the parent's behaviour) | both SPDX graph tests |
| `BomRef` assignment removed | `TestCycloneDXParseKeepsTheBomRef` |
| — same — | `TestCycloneDXRoundTripPreservesTheProducersRefs` |

The `DEPENDENCY_OF` test builds its document by hand rather than through the renderer, because this repo's SPDX renderer only ever writes `DEPENDS_ON` — a round-trip could not reach that path.

## Why now

Downstream work (xgrep, ADR-0736 D1) ingests a build-produced CycloneDX/SPDX file *alongside* a source tree, so the SBOM supplies the inventory and the tree supplies the imports. That needs `Sbom.Dependencies` populated on import **and** its refs resolvable to components. CycloneDX had the first and not the second; SPDX silently had neither, and the package loss meant an SPDX document contributed nothing at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)