### PR TITLE
🐛 selfupdate: select the artifact by filename, not by its download url

### DIFF
--- a/cli/selfupdate/release_file_test.go
+++ b/cli/selfupdate/release_file_test.go
@@ -99,3 +99,28 @@ func TestDownloadRejectsNonUrlTarget(t *testing.T) {
 	assert.Contains(t, err.Error(), "no download url")
 	assert.Contains(t, err.Error(), name)
 }
+
+// TestSelectionDoesNotConstrainTheDownloadUrl covers a manifest whose url is a
+// service route rather than a path ending in the artifact name.
+//
+// Whoever serves the manifest decides where the bytes come from. Selection has
+// to answer "which artifact is mine" from the filename, or that decision would
+// be constrained by a naming rule the client happens to use for matching.
+func TestSelectionDoesNotConstrainTheDownloadUrl(t *testing.T) {
+	ext := "tar.gz"
+	if runtime.GOOS == "windows" {
+		ext = "zip"
+	}
+	name := "cnspec_13.38.1_" + runtime.GOOS + "_" + runtime.GOARCH + "." + ext
+	serviceURL := "https://install.mondoo.com/package/cnspec/" + runtime.GOOS + "/" + runtime.GOARCH + "/" + ext + "/latest/download"
+
+	rel := &Release{Name: "cnspec", Version: "13.38.1", Files: []ReleaseFile{
+		{Filename: "cnspec_13.38.1_someos_somearch." + ext, Url: "https://install.mondoo.com/other/download"},
+		{Filename: name, Url: serviceURL},
+	}}
+
+	got := getPlatformFile(rel, "cnspec")
+	require.NotNil(t, got, "a url that does not end in the artifact name must not break selection")
+	assert.Equal(t, name, got.Filename)
+	assert.Equal(t, serviceURL, got.downloadTarget())
+}

--- a/cli/selfupdate/selfupdate.go
+++ b/cli/selfupdate/selfupdate.go
@@ -452,11 +452,16 @@ func getPlatformFile(release *Release, binaryName string) *ReleaseFile {
 	suffix := fmt.Sprintf("%s_%s_%s_%s.%s", binaryName, release.Version, goos, goarch, ext)
 
 	for i := range release.Files {
-		// Match against the download target rather than Filename. Both end in
-		// the artifact name, but Filename is the plain name in some documents
-		// and the full URL in others, and only the target is guaranteed to be
-		// the thing actually fetched.
-		if strings.HasSuffix(release.Files[i].downloadTarget(), suffix) {
+		// Match on Filename, which names the artifact in both document shapes:
+		// the plain name in one, the fully qualified URL in the other, and both
+		// end in it.
+		//
+		// Not on the download target. Which artifact this is and where to fetch
+		// it are separate questions, and answering the first with the second
+		// requires the URL to end in the artifact name. That is true of the
+		// release bucket's layout but need not be true of whoever serves the
+		// manifest, and it is not the client's place to constrain that.
+		if strings.HasSuffix(release.Files[i].Filename, suffix) {
 			return &release.Files[i]
 		}
 	}


### PR DESCRIPTION
## The problem

#10726 moved platform selection onto the download target, along with the download itself:

```go
// Match against the download target rather than Filename...
if strings.HasSuffix(release.Files[i].downloadTarget(), suffix) {
```

That was right for the download and wrong for selection. Matching on the URL means the URL has to end in the artifact name, so whoever serves the manifest can no longer choose the shape of the URLs it publishes without breaking clients — a constraint the client has no business imposing.

| field | bucket document | normalized document | a service route |
|---|---|---|---|
| `filename` | ends in artifact name ✅ | ends in artifact name ✅ | — |
| `url` | ✅ | ✅ | ❌ selection finds nothing |

## The change

Which artifact this is, and where to fetch it, are separate questions.

`filename` answers the first in both document shapes — the plain name in one, the fully qualified URL in the other, and both end in the artifact name — so matching there works everywhere and constrains nothing about the URL.

The download still reads `url`, with the fallback and the non-URL guard from #10726 unchanged.

## Test

A manifest whose `url` is a service route rather than a path ending in the artifact name. Before this change it selected nothing; the failure would have looked like "no release file found for this platform" while the entry was sitting right there.
