### PR TITLE
🌟 sca: read the dependency graphs packages.lock.json and Gemfile.lock already state

### DIFF
--- a/providers/os/resources/languages/dotnet/packageslockjson/extractor.go
+++ b/providers/os/resources/languages/dotnet/packageslockjson/extractor.go
@@ -6,6 +6,7 @@ package packageslockjson
 import (
 	"encoding/json"
 	"io"
+	"sort"
 
 	"go.mondoo.com/mql/providers/os/resources/languages"
 	"go.mondoo.com/mql/providers/os/resources/languages/dotnet"
@@ -37,10 +38,16 @@ func (e *Extractor) Parse(r io.Reader, filename string) (languages.Bom, error) {
 }
 
 // allPackages returns a deduplicated list of packages across all target frameworks.
+//
+// Target frameworks are visited in sorted order so "first occurrence wins" is a
+// rule rather than a coin toss. They usually agree on versions, but a project
+// that multi-targets can resolve a package differently per framework, and
+// ranging the map directly made WHICH version got inventoried depend on Go's
+// map iteration order -- a different SBOM from the same file on the same commit.
 func (l *packagesLock) allPackages() map[string]packagesLockPackage {
 	seen := make(map[string]packagesLockPackage)
-	for _, framework := range l.Dependencies {
-		for name, pkg := range framework {
+	for _, tfm := range l.frameworks() {
+		for name, pkg := range l.Dependencies[tfm] {
 			// First occurrence wins (frameworks typically have the same versions)
 			if _, ok := seen[name]; !ok {
 				seen[name] = pkg
@@ -50,6 +57,49 @@ func (l *packagesLock) allPackages() map[string]packagesLockPackage {
 	return seen
 }
 
+// frameworks returns the target framework monikers in sorted order.
+func (l *packagesLock) frameworks() []string {
+	out := make([]string, 0, len(l.Dependencies))
+	for tfm := range l.Dependencies {
+		out = append(out, tfm)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// dependsOnRefs turns one entry's `dependencies` map into purls of the packages
+// that satisfy it.
+//
+// Resolution is by id against the SAME package set this file emits, never from
+// the version written beside the id: that version is a minimum constraint, so
+// building a purl from it would name a package that is not in the inventory and
+// produce an edge pointing at nothing. Looking the id up in `all` also keeps the
+// graph self-consistent with the packages -- an edge's target is a node that
+// exists -- which is what the reachability classifier requires before it will
+// draw a negative verdict from the graph's shape.
+//
+// An id with no entry is dropped rather than synthesised. It means the lockfile
+// named a dependency it did not resolve, and inventing the node would assert a
+// package the project does not restore.
+func dependsOnRefs(deps map[string]string, all map[string]packagesLockPackage) []string {
+	if len(deps) == 0 {
+		return nil
+	}
+	var refs []string
+	for name := range deps {
+		target, ok := all[name]
+		if !ok || target.Resolved == "" {
+			continue
+		}
+		refs = append(refs, dotnet.NewPackageUrl(name, target.Resolved))
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+	sort.Strings(refs)
+	return refs
+}
+
 // Root returns nil — packages.lock.json does not contain root project info.
 func (l *packagesLock) Root() *languages.Package {
 	return nil
@@ -57,10 +107,11 @@ func (l *packagesLock) Root() *languages.Package {
 
 // Direct returns packages with type "Direct".
 func (l *packagesLock) Direct() languages.Packages {
+	all := l.allPackages()
 	var direct languages.Packages
-	for name, pkg := range l.allPackages() {
+	for name, pkg := range all {
 		if pkg.isDirect() {
-			direct = append(direct, makePackage(name, pkg.Resolved, l.evidence))
+			direct = append(direct, makePackage(name, pkg, all, l.evidence))
 		}
 	}
 	return direct
@@ -68,19 +119,22 @@ func (l *packagesLock) Direct() languages.Packages {
 
 // Transitive returns all packages (both direct and transitive).
 func (l *packagesLock) Transitive() languages.Packages {
-	var all languages.Packages
-	for name, pkg := range l.allPackages() {
-		all = append(all, makePackage(name, pkg.Resolved, l.evidence))
+	all := l.allPackages()
+	var out languages.Packages
+	for name, pkg := range all {
+		out = append(out, makePackage(name, pkg, all, l.evidence))
 	}
-	return all
+	return out
 }
 
-func makePackage(name, version string, evidence []string) *languages.Package {
+func makePackage(name string, pkg packagesLockPackage, all map[string]packagesLockPackage, evidence []string) *languages.Package {
+	version := pkg.Resolved
 	return &languages.Package{
 		Name:         name,
 		Version:      version,
 		Purl:         dotnet.NewPackageUrl(name, version),
 		Cpes:         dotnet.NewCpes(name, version),
 		EvidenceList: dotnet.NewEvidenceList(evidence),
+		DependsOn:    dependsOnRefs(pkg.Dependencies, all),
 	}
 }

--- a/providers/os/resources/languages/dotnet/packageslockjson/extractor_test.go
+++ b/providers/os/resources/languages/dotnet/packageslockjson/extractor_test.go
@@ -48,3 +48,95 @@ func TestPackagesLockJsonExtractor(t *testing.T) {
 	assert.Equal(t, "8.0.0", p.Version)
 	assert.Equal(t, "pkg:nuget/System.Text.Json@8.0.0", p.Purl)
 }
+
+// TestPackagesLockJsonDependencyEdges pins the .NET package->package graph.
+//
+// packages.lock.json states each entry's own `dependencies`, and it was parsed
+// and discarded: a consumer knew WHICH packages a project restores and nothing
+// about what reaches what, so no transitive package could be ruled in or out.
+func TestPackagesLockJsonDependencyEdges(t *testing.T) {
+	f, err := os.Open("./testdata/simple.packages.lock.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	info, err := (&Extractor{}).Parse(f, "packages.lock.json")
+	require.NoError(t, err)
+	all := info.Transitive()
+
+	serilog := all.Find("Serilog")
+	require.NotNil(t, serilog)
+	// The edge target carries the RESOLVED version (5.0.1), never the minimum
+	// constraint written beside the id in `dependencies` (4.0.0). A purl built
+	// from the constraint names a package that is not in this inventory, so the
+	// edge would point at nothing.
+	assert.Equal(t, []string{"pkg:nuget/Serilog.Sinks.Console@5.0.1"}, serilog.DependsOn,
+		"edges resolve by id against the package set, not from the minimum-version constraint")
+
+	console := all.Find("Serilog.Sinks.Console")
+	require.NotNil(t, console)
+	assert.Equal(t, []string{"pkg:nuget/System.Text.Json@8.0.0"}, console.DependsOn)
+
+	// A leaf states no dependencies and must carry no edges rather than an
+	// empty slice, so "has no dependencies" and "was never asked" stay distinct
+	// downstream.
+	stj := all.Find("System.Text.Json")
+	require.NotNil(t, stj)
+	assert.Nil(t, stj.DependsOn)
+
+	// Direct() reports the same edges: it is the same package, and a consumer
+	// that reads only the direct set must not see a different graph.
+	direct := info.Direct()
+	require.NotNil(t, direct.Find("Serilog"))
+	assert.Equal(t, serilog.DependsOn, direct.Find("Serilog").DependsOn)
+}
+
+// TestPackagesLockJsonDropsUnresolvedEdgeTargets: `Serilog` names
+// `NotRestored.Package` in its dependencies and the lockfile resolves no such
+// entry. Synthesising the node would assert a package the project does not
+// restore, and the reachability classifier reads an edge's target as a package
+// that exists.
+func TestPackagesLockJsonDropsUnresolvedEdgeTargets(t *testing.T) {
+	f, err := os.Open("./testdata/simple.packages.lock.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	info, err := (&Extractor{}).Parse(f, "packages.lock.json")
+	require.NoError(t, err)
+
+	serilog := info.Transitive().Find("Serilog")
+	require.NotNil(t, serilog)
+	for _, ref := range serilog.DependsOn {
+		assert.NotContains(t, ref, "NotRestored",
+			"a dependency the lockfile did not resolve must not become an edge")
+	}
+	assert.Nil(t, info.Transitive().Find("NotRestored.Package"),
+		"and it must not become a package either")
+}
+
+// TestPackagesLockJsonMultiFrameworkIsDeterministic guards a coin toss.
+//
+// A multi-targeting project can resolve one package to different versions per
+// target framework. The framework map was ranged directly, so WHICH version got
+// inventoried depended on Go's map iteration order — the same file, on the same
+// commit, producing a different SBOM between runs. Sorted order makes
+// first-occurrence-wins a rule.
+func TestPackagesLockJsonMultiFrameworkIsDeterministic(t *testing.T) {
+	first := ""
+	for i := 0; i < 20; i++ {
+		f, err := os.Open("./testdata/multiframework.packages.lock.json")
+		require.NoError(t, err)
+		info, err := (&Extractor{}).Parse(f, "packages.lock.json")
+		_ = f.Close()
+		require.NoError(t, err)
+
+		p := info.Transitive().Find("Contoso.Core")
+		require.NotNil(t, p)
+		if first == "" {
+			first = p.Version
+			continue
+		}
+		require.Equal(t, first, p.Version, "the inventoried version must not depend on map iteration order")
+	}
+	// net472 sorts before net9.0, so it is the one that wins.
+	assert.Equal(t, "1.0.0", first)
+}

--- a/providers/os/resources/languages/dotnet/packageslockjson/parser.go
+++ b/providers/os/resources/languages/dotnet/packageslockjson/parser.go
@@ -18,6 +18,17 @@ type packagesLockPackage struct {
 	Requested   string `json:"requested"`
 	Resolved    string `json:"resolved"`
 	ContentHash string `json:"contentHash"`
+	// Dependencies is the package's own direct dependencies, as id -> minimum
+	// version. NuGet writes it for every entry it resolved, and it is the .NET
+	// package->package graph: without it a consumer knows WHICH packages a
+	// project restores but nothing about what reaches what, so a transitive
+	// package can be neither ruled in nor ruled out.
+	//
+	// The version here is a MINIMUM ("8.0.0" means >= 8.0.0), not the version
+	// that was resolved. The resolved one is on the sibling entry under the same
+	// target framework, which is why edges are resolved by id against the
+	// package set rather than read from this value.
+	Dependencies map[string]string `json:"dependencies"`
 }
 
 // isDirect returns true if this is a directly referenced package.

--- a/providers/os/resources/languages/dotnet/packageslockjson/testdata/multiframework.packages.lock.json
+++ b/providers/os/resources/languages/dotnet/packageslockjson/testdata/multiframework.packages.lock.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net9.0": {
+      "Contoso.Core": {
+        "type": "Direct",
+        "requested": "[2.0.0, )",
+        "resolved": "2.0.0",
+        "contentHash": "n9"
+      }
+    },
+    "net472": {
+      "Contoso.Core": {
+        "type": "Direct",
+        "requested": "[1.0.0, )",
+        "resolved": "1.0.0",
+        "contentHash": "n4"
+      }
+    }
+  }
+}

--- a/providers/os/resources/languages/dotnet/packageslockjson/testdata/simple.packages.lock.json
+++ b/providers/os/resources/languages/dotnet/packageslockjson/testdata/simple.packages.lock.json
@@ -12,12 +12,19 @@
         "type": "Direct",
         "requested": "[3.1.1, )",
         "resolved": "3.1.1",
-        "contentHash": "abc123def456"
+        "contentHash": "abc123def456",
+        "dependencies": {
+          "Serilog.Sinks.Console": "4.0.0",
+          "NotRestored.Package": "1.0.0"
+        }
       },
       "Serilog.Sinks.Console": {
         "type": "Transitive",
         "resolved": "5.0.1",
-        "contentHash": "xyz789"
+        "contentHash": "xyz789",
+        "dependencies": {
+          "System.Text.Json": "8.0.0"
+        }
       },
       "System.Text.Json": {
         "type": "Transitive",

--- a/providers/os/resources/languages/ruby/gemfilelock/extractor.go
+++ b/providers/os/resources/languages/ruby/gemfilelock/extractor.go
@@ -6,6 +6,7 @@ package gemfilelock
 import (
 	"bufio"
 	"io"
+	"sort"
 	"strings"
 
 	"go.mondoo.com/mql/providers/os/resources/languages"
@@ -92,9 +93,21 @@ func parseGemfileLock(r io.Reader) (*gemfileLock, error) {
 				continue
 			}
 
-			// Top-level gems are indented 4 spaces: "    name (version)"
-			// Sub-dependencies are indented 6+ spaces — skip them
-			if !strings.HasPrefix(line, "    ") || strings.HasPrefix(line, "      ") {
+			// Top-level gems are indented 4 spaces: "    name (version)".
+			// Sub-dependencies are indented 6+ and belong to the gem above them.
+			if !strings.HasPrefix(line, "    ") {
+				continue
+			}
+			if strings.HasPrefix(line, "      ") {
+				// A dependency line of the gem most recently appended. Bundler
+				// always writes them directly beneath their gem, so the last
+				// entry is the owner; a stray one before any gem has no owner
+				// and is dropped rather than guessed at.
+				if n := len(lock.Gems); n > 0 && trimmed != "" {
+					if name := gemDepName(trimmed); name != "" {
+						lock.Gems[n-1].Deps = append(lock.Gems[n-1].Deps, name)
+					}
+				}
 				continue
 			}
 
@@ -127,6 +140,59 @@ func parseGemfileLock(r io.Reader) (*gemfileLock, error) {
 	}
 
 	return lock, nil
+}
+
+// gemDepName takes the gem name from a dependency line beneath a spec entry,
+// which is written as `rack` or `rack (~> 2.2)`. Only the name is kept: the
+// parenthesised part is a REQUIREMENT, and the version Bundler actually resolved
+// is on that gem's own spec entry, which is where dependsOnRefs looks it up.
+func gemDepName(line string) string {
+	name, _, _ := strings.Cut(line, " ")
+	return strings.TrimSuffix(strings.TrimSpace(name), "!")
+}
+
+// dependsOnRefs turns one gem's dependency names into purls of the gems that
+// satisfy them.
+//
+// Resolved by name against the same gem set this file emits, so an edge's target
+// is always a package that exists. A name with no spec entry is dropped rather
+// than synthesised: it means the lock referenced a gem it did not resolve here
+// (a git or path source, which this extractor does not inventory), and inventing
+// the node would assert a package the project does not install from RubyGems.
+func dependsOnRefs(deps []string, byName map[string]gemEntry) []string {
+	if len(deps) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	var refs []string
+	for _, name := range deps {
+		target, ok := byName[name]
+		if !ok || target.Version == "" {
+			continue
+		}
+		ref := ruby.NewPackageUrl(target.Name, target.Version)
+		if seen[ref] {
+			continue
+		}
+		seen[ref] = true
+		refs = append(refs, ref)
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+	sort.Strings(refs)
+	return refs
+}
+
+// gemsByName indexes the resolved gems for edge resolution.
+func (l *gemfileLock) gemsByName() map[string]gemEntry {
+	out := make(map[string]gemEntry, len(l.Gems))
+	for _, g := range l.Gems {
+		if _, dup := out[g.Name]; !dup {
+			out[g.Name] = g
+		}
+	}
+	return out
 }
 
 // parseGemEntry parses "name (version)" or "name (version-platform)" from a GEM specs line.
@@ -179,10 +245,11 @@ func (l *gemfileLock) Root() *languages.Package {
 
 // Direct returns gems listed in the DEPENDENCIES section.
 func (l *gemfileLock) Direct() languages.Packages {
+	byName := l.gemsByName()
 	var direct languages.Packages
 	for _, gem := range l.Gems {
 		if l.DirectDeps[gem.Name] {
-			direct = append(direct, makePackage(gem, l.evidence))
+			direct = append(direct, makePackage(gem, byName, l.evidence))
 		}
 	}
 	return direct
@@ -190,19 +257,21 @@ func (l *gemfileLock) Direct() languages.Packages {
 
 // Transitive returns all resolved gems.
 func (l *gemfileLock) Transitive() languages.Packages {
+	byName := l.gemsByName()
 	var all languages.Packages
 	for _, gem := range l.Gems {
-		all = append(all, makePackage(gem, l.evidence))
+		all = append(all, makePackage(gem, byName, l.evidence))
 	}
 	return all
 }
 
-func makePackage(gem gemEntry, evidence []string) *languages.Package {
+func makePackage(gem gemEntry, byName map[string]gemEntry, evidence []string) *languages.Package {
 	return &languages.Package{
 		Name:         gem.Name,
 		Version:      gem.Version,
 		Purl:         ruby.NewPackageUrl(gem.Name, gem.Version),
 		Cpes:         ruby.NewCpes(gem.Name, gem.Version),
 		EvidenceList: ruby.NewEvidenceList(evidence),
+		DependsOn:    dependsOnRefs(gem.Deps, byName),
 	}
 }

--- a/providers/os/resources/languages/ruby/gemfilelock/extractor_test.go
+++ b/providers/os/resources/languages/ruby/gemfilelock/extractor_test.go
@@ -63,8 +63,84 @@ func TestGemfileLockExtractor(t *testing.T) {
 }
 
 func TestParseGemEntry(t *testing.T) {
-	assert.Equal(t, gemEntry{"rack", "3.0.8"}, parseGemEntry("rack (3.0.8)"))
-	assert.Equal(t, gemEntry{"nokogiri", "1.16.2"}, parseGemEntry("nokogiri (1.16.2-x86_64-linux)"))
-	assert.Equal(t, gemEntry{"puma", "6.4.2"}, parseGemEntry("puma (6.4.2)"))
+	assert.Equal(t, gemEntry{Name: "rack", Version: "3.0.8"}, parseGemEntry("rack (3.0.8)"))
+	assert.Equal(t, gemEntry{Name: "nokogiri", Version: "1.16.2"}, parseGemEntry("nokogiri (1.16.2-x86_64-linux)"))
+	assert.Equal(t, gemEntry{Name: "puma", Version: "6.4.2"}, parseGemEntry("puma (6.4.2)"))
 	assert.Equal(t, gemEntry{}, parseGemEntry("invalid line"))
+}
+
+// TestGemfileLockDependencyEdges pins the RubyGems package->package graph.
+//
+// Bundler writes each gem's own dependencies beneath it in the specs section,
+// and the parser skipped every line indented past the gem — so a consumer saw
+// which gems a project resolves and nothing about which of them any other gem
+// pulls in.
+func TestGemfileLockDependencyEdges(t *testing.T) {
+	f, err := os.Open("./testdata/simple.Gemfile.lock")
+	require.NoError(t, err)
+	defer f.Close()
+
+	info, err := (&Extractor{}).Parse(f, "Gemfile.lock")
+	require.NoError(t, err)
+	all := info.Transitive()
+
+	ac := all.Find("actioncable")
+	require.NotNil(t, ac)
+	// `nio4r (~> 2.0)` is a REQUIREMENT; 2.7.0 is what Bundler resolved, and it
+	// is on nio4r's own spec entry. An edge built from the requirement would
+	// name pkg:gem/nio4r@2.0 — a package that is not in this inventory, so the
+	// edge would point at nothing.
+	assert.Equal(t, []string{
+		"pkg:gem/actionpack@7.1.3",
+		"pkg:gem/nio4r@2.7.0",
+		"pkg:gem/websocket-driver@0.7.6",
+	}, ac.DependsOn, "edges resolve by name against the gem set, not from the requirement")
+
+	assert.Equal(t, []string{"pkg:gem/rack@3.0.8"}, all.Find("actionpack").DependsOn)
+	assert.Equal(t, []string{"pkg:gem/websocket-extensions@0.1.5"}, all.Find("websocket-driver").DependsOn)
+	assert.Equal(t, []string{"pkg:gem/nio4r@2.7.0"}, all.Find("puma").DependsOn)
+
+	// A leaf gem states no dependencies and carries no edges, so "depends on
+	// nothing" and "was never read" stay distinct downstream.
+	assert.Nil(t, all.Find("rack").DependsOn)
+	assert.Nil(t, all.Find("nokogiri").DependsOn)
+
+	// Direct() must report the same graph as Transitive(): it is the same gem.
+	direct := info.Direct()
+	require.NotNil(t, direct.Find("actioncable"))
+	assert.Equal(t, ac.DependsOn, direct.Find("actioncable").DependsOn)
+}
+
+// TestGemfileLockDependencyLinesAreNotGems is the other half of reading those
+// lines: they must feed the graph WITHOUT becoming packages. Counting
+// `nio4r (~> 2.0)` as a gem would inventory a version the project does not
+// install, three times over in this fixture.
+func TestGemfileLockDependencyLinesAreNotGems(t *testing.T) {
+	f, err := os.Open("./testdata/simple.Gemfile.lock")
+	require.NoError(t, err)
+	defer f.Close()
+
+	info, err := (&Extractor{}).Parse(f, "Gemfile.lock")
+	require.NoError(t, err)
+
+	all := info.Transitive()
+	assert.Equal(t, 8, len(all), "the specs section resolves 8 gems; dependency lines are edges, not entries")
+	for _, p := range all {
+		assert.NotContains(t, p.Version, "~", "a requirement must never become a version")
+		assert.NotContains(t, p.Version, ">", "a requirement must never become a version")
+	}
+}
+
+func TestGemDepName(t *testing.T) {
+	cases := map[string]string{
+		"rack (~> 2.2)":               "rack",
+		"rack":                        "rack",
+		"actionpack (= 7.1.3)":        "actionpack",
+		"websocket-driver (>= 0.6.1)": "websocket-driver",
+		"mygem!":                      "mygem",
+		"":                            "",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, gemDepName(in), "gemDepName(%q)", in)
+	}
 }

--- a/providers/os/resources/languages/ruby/gemfilelock/parser.go
+++ b/providers/os/resources/languages/ruby/gemfilelock/parser.go
@@ -20,4 +20,13 @@ type gemfileLock struct {
 type gemEntry struct {
 	Name    string
 	Version string
+	// Deps are the gem names listed beneath this entry in the specs section --
+	// its own runtime dependencies, as Bundler resolved them. Names only: the
+	// constraint written beside each one (`rack (~> 2.2)`) is a requirement, not
+	// the resolved version, which is on that gem's own spec entry.
+	//
+	// This is the RubyGems package->package graph. Bundler writes it into every
+	// Gemfile.lock and the parser skipped past it, so a consumer could see which
+	// gems a project resolves but not which of them any other gem pulls in.
+	Deps []string
 }


### PR DESCRIPTION
Both lockfiles carry a package→package dependency graph, and both extractors parsed past it. So a consumer could see **which** packages a project resolves and nothing about **what reaches what** — which for .NET means the classes that separate "a transitive your code reaches" from "one nothing reaches" were unreachable for the whole ecosystem.

Two commits, separable.

## 1. `c159999` — .NET, and it changes real verdicts

Every entry in `packages.lock.json` carries its own `dependencies` map. `packagesLockPackage` had no field for it.

Two things this had to get right, each with a test that fails without it:

- **The edge target is the RESOLVED version**, not the one written beside the id. That value is a *minimum constraint* (`"5.0.0"` means `>= 5.0.0`); the version actually restored is on the sibling entry. A purl built from the constraint names a package that is not in the inventory, so every edge would point at nothing. Edges resolve by id against the same package set this file emits, which also guarantees an edge's target is a node that exists.
- **An unresolved id is dropped, not synthesised.** It means the lockfile named a dependency it did not resolve; inventing the node would assert a package the project does not restore.

Measured end to end through xgrep on a project whose lockfile states the graph:

```
before: 1 imported, 1 direct-unused, 3 transitive (undetermined), 0 demoted
after:  1 imported, 1 direct-unused, 2 transitive-reachable, 1 transitive-orphaned
```

The orphan is `AWSSDK.Core`, reached only from a package nothing imports. The two reachable ones are found through the imported `Serilog`, the second at **two hops** — so the traversal follows the graph rather than one level of it. That is a filtering decision the ecosystem could not make before, not a relabel.

**Also fixes a nondeterminism** found while reading `allPackages`: the target-framework map was ranged directly, so on a project that multi-targets and resolves one package differently per framework, *which* version got inventoried depended on Go's map iteration order — the same file, on the same commit, yielding a different SBOM between runs. Sorted iteration makes first-occurrence-wins a rule rather than a coin toss.

## 2. `5f1be91` — RubyGems, and what it does not change

Bundler lists each gem's own runtime dependencies beneath it in the specs section. The parser skipped every line indented past a gem (its comment said so), and `gemEntry` held only `Name` and `Version`.

Those lines now feed the graph **without becoming packages**, which is the pairing that matters. `nio4r (~> 2.0)` is a requirement; the version Bundler resolved is on `nio4r`'s own spec entry. An edge built from the requirement would name `pkg:gem/nio4r@2.0`, a package not in the inventory — and counting the line as a gem would inventory a version the project does not install. Both directions have a test.

**No keep-or-drop decision changes today, and that is worth stating rather than leaving to be discovered.** RubyGems withholds every negative verdict (xgrep ADR-0721) because `Bundler.require` and Zeitwerk can enter a gem with no `require` anywhere in the tree, so an unreached gem answers `unknown`, not `transitive-orphaned`:

```
before: sinatra imported, rack transitive,           unusedgem unknown
after:  sinatra imported, rack transitive-reachable, unusedgem unknown
```

`rack` becomes a grounded positive instead of an undetermined one; nothing filters differently. The value is that the graph exists at all — it is what the withholding gate needs before it can ever be narrowed, and until then it makes the reported class true rather than merely safe.

## Verification

- `go build ./...` clean; `go test ./providers/os/resources/languages/...` green.
- The existing .NET and Ruby extractor tests pass unchanged. Three positional `gemEntry{...}` literals in the Ruby test were converted to field-keyed form for the new field.
- **8 mutations, all red:**

| mutation | fails |
|---|---|
| .NET edge target built from the minimum constraint | `TestPackagesLockJsonDependencyEdges` |
| .NET unresolved ids synthesised instead of dropped | `TestPackagesLockJsonDropsUnresolvedEdgeTargets` |
| .NET `DependsOn` never populated | `TestPackagesLockJsonDependencyEdges` |
| framework order back to a raw map range | `TestPackagesLockJsonMultiFrameworkIsDeterministic` |
| gem dependency lines skipped again | `TestGemfileLockDependencyEdges` |
| gem edge built from the requirement | `TestGemfileLockDependencyEdges` |
| `gemDepName` keeping the requirement text | `TestGemDepName` |
| gem dependency lines also appended as gems | `TestGemfileLockDependencyLinesAreNotGems` |

## Downstream

xgrep needs **no code change** — its `sca.DependencyEdges` already reads `Package.DependsOn` into the dependency graph, so a pin bump is the whole wiring.

One gap worth naming: no pinned benchmark corpus can measure the .NET half. The `orchard` corpus uses `packages.config`, which carries no graph at all, so putting a number in the ledger needs a modern .NET corpus with a committed `packages.lock.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)