### PR TITLE
✨ hashivault: make the KV v2 mount path configurable

### DIFF
--- a/vault/hashivault/hashivault.go
+++ b/vault/hashivault/hashivault.go
@@ -17,14 +17,46 @@ import (
 
 var errNotImplemented = errors.New("not implemented") //nolint:unused
 
-func New(serverURL string, token string) *Vault {
-	log.Debug().Bool("token-sec", len(token) > 0).Msgf("Using HashiCorp Vault at %s", serverURL)
-	return &Vault{
+// DefaultMount is the path Vault mounts the KV v2 secrets engine at unless it
+// is enabled somewhere else.
+const DefaultMount = "secret"
+
+// Option configures the Vault client.
+type Option func(*Vault)
+
+// WithMount sets the path the KV v2 secrets engine is mounted at.
+//
+// Vault allows a KV v2 engine to be enabled at any path
+// (`vault secrets enable -path=<path> kv-v2`), and Vault-compatible services
+// do not all use the default: some mount the engine per instance, so the path
+// is only known at configuration time.
+//
+// An empty mount leaves the default in place, so callers can pass an unset
+// configuration value through without having to check it first.
+func WithMount(mount string) Option {
+	return func(v *Vault) {
+		if m := strings.Trim(mount, "/"); m != "" {
+			v.Mount = m
+		}
+	}
+}
+
+func New(serverURL string, token string, opts ...Option) *Vault {
+	v := &Vault{
 		Token: token,
+		Mount: DefaultMount,
 		APIConfig: api.Config{
 			Address: serverURL,
 		},
 	}
+	for _, opt := range opts {
+		opt(v)
+	}
+	log.Debug().
+		Bool("token-sec", len(token) > 0).
+		Str("mount", v.Mount).
+		Msgf("Using HashiCorp Vault at %s", serverURL)
+	return v
 }
 
 type Vault struct {
@@ -32,6 +64,9 @@ type Vault struct {
 	// See https://www.vaultproject.io/docs/concepts/tokens.html for more
 	// information.
 	Token string
+	// Mount is the path the KV v2 secrets engine is mounted at, without
+	// surrounding slashes. Defaults to DefaultMount.
+	Mount string
 	// APIConfig is used to configure the creation of the client.
 	APIConfig api.Config
 }
@@ -52,9 +87,13 @@ func (v *Vault) client() (*api.Client, error) {
 	return c, nil
 }
 
-func vaultSecretId(key string) string {
-	base := "secret/data/"
-	return base + key
+// secretPath builds the KV v2 read path for a key: <mount>/data/<key>.
+func (v *Vault) secretPath(key string) string {
+	mount := v.Mount
+	if mount == "" {
+		mount = DefaultMount
+	}
+	return mount + "/data/" + key
 }
 
 // we need to remove the leading // from mrns, this should not be done here, therefore we just throw an error
@@ -78,7 +117,7 @@ func (v *Vault) Get(ctx context.Context, id *vault.SecretID) (*vault.Secret, err
 		return nil, err
 	}
 
-	secret, err := c.Logical().Read(vaultSecretId(id.Key))
+	secret, err := c.Logical().Read(v.secretPath(id.Key))
 	if err != nil {
 		return nil, vault.NotFoundError
 	}

--- a/vault/hashivault/hashivault_test.go
+++ b/vault/hashivault/hashivault_test.go
@@ -31,11 +31,11 @@ func TestHashiVault(t *testing.T) {
 		"key":  "value",
 		"key2": "value2",
 	}
-	id, err := set(c, key, fields)
+	v := New(endpoint, token)
+	id, err := set(v, c, key, fields)
 	require.NoError(t, err)
 
 	// get secret
-	v := New(endpoint, token)
 	newCred, err := v.Get(ctx, id)
 	require.NoError(t, err)
 
@@ -59,7 +59,7 @@ func client(endpoint string, token string) (*api.Client, error) {
 	return c, nil
 }
 
-func set(c *api.Client, key string, fields map[string]string) (*vault.SecretID, error) {
+func set(v *Vault, c *api.Client, key string, fields map[string]string) (*vault.SecretID, error) {
 	err := validKey(key)
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func set(c *api.Client, key string, fields map[string]string) (*vault.SecretID, 
 	}
 
 	// store secret
-	_, err = c.Logical().Write(vaultSecretId(key), secretData)
+	_, err = c.Logical().Write(v.secretPath(key), secretData)
 	if err != nil {
 		return nil, err
 	}

--- a/vault/hashivault/mount_test.go
+++ b/vault/hashivault/mount_test.go
@@ -1,0 +1,105 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package hashivault
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/providers-sdk/v1/vault"
+)
+
+func TestSecretPath(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts []Option
+		key  string
+		want string
+	}{
+		{
+			name: "default mount",
+			key:  "my-secret",
+			want: "secret/data/my-secret",
+		},
+		{
+			name: "custom mount",
+			opts: []Option{WithMount("kv")},
+			key:  "my-secret",
+			want: "kv/data/my-secret",
+		},
+		{
+			// Vault paths are written with and without slashes in docs and CLI
+			// output, so accept either rather than producing "kv//data/x".
+			name: "surrounding slashes are trimmed",
+			opts: []Option{WithMount("/kv/")},
+			key:  "my-secret",
+			want: "kv/data/my-secret",
+		},
+		{
+			// A mount is often read straight from configuration, so an unset
+			// value must fall back rather than build an invalid path.
+			name: "empty mount keeps the default",
+			opts: []Option{WithMount("")},
+			key:  "my-secret",
+			want: "secret/data/my-secret",
+		},
+		{
+			name: "nested key",
+			opts: []Option{WithMount("kv")},
+			key:  "team/service/token",
+			want: "kv/data/team/service/token",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := New("http://127.0.0.1:8200", "token", tc.opts...)
+			assert.Equal(t, tc.want, v.secretPath(tc.key))
+		})
+	}
+}
+
+// A zero-value Vault must still produce a valid path: the struct is exported,
+// so it can be constructed without New.
+func TestSecretPathZeroValue(t *testing.T) {
+	v := &Vault{}
+	assert.Equal(t, "secret/data/my-secret", v.secretPath("my-secret"))
+}
+
+func TestRegisteredVaultUsesConfiguredMount(t *testing.T) {
+	newVault := func(opts map[string]string) *Vault {
+		v, err := vault.New(&vault.VaultConfiguration{
+			Name:    "test",
+			Type:    vault.VaultType_HashiCorp,
+			Options: opts,
+		})
+		if err != nil {
+			t.Fatalf("vault.New: %v", err)
+		}
+		hv, ok := v.(*Vault)
+		if !ok {
+			t.Fatalf("expected *hashivault.Vault, got %T", v)
+		}
+		return hv
+	}
+
+	t.Run("mount option is honoured", func(t *testing.T) {
+		hv := newVault(map[string]string{
+			"url":   "http://127.0.0.1:8200",
+			"token": "token",
+			"mount": "kv",
+		})
+		assert.Equal(t, "kv", hv.Mount)
+		assert.Equal(t, "kv/data/x", hv.secretPath("x"))
+	})
+
+	// Existing configurations carry no "mount" key at all; they must keep
+	// reading from secret/.
+	t.Run("configuration without a mount is unchanged", func(t *testing.T) {
+		hv := newVault(map[string]string{
+			"url":   "http://127.0.0.1:8200",
+			"token": "token",
+		})
+		assert.Equal(t, DefaultMount, hv.Mount)
+		assert.Equal(t, "secret/data/x", hv.secretPath("x"))
+	})
+}

--- a/vault/hashivault/register.go
+++ b/vault/hashivault/register.go
@@ -9,6 +9,11 @@ import (
 
 func init() {
 	vault.Register(vault.VaultType_HashiCorp, func(cfg *vault.VaultConfiguration) (vault.Vault, error) {
-		return New(cfg.Options["url"], cfg.Options["token"]), nil
+		return New(
+			cfg.Options["url"],
+			cfg.Options["token"],
+			// Empty is ignored, so an unset "mount" keeps the default.
+			WithMount(cfg.Options["mount"]),
+		), nil
 	})
 }


### PR DESCRIPTION
## The problem

`hashivault` builds every read path as `secret/data/<key>`:

```go
func vaultSecretId(key string) string {
	base := "secret/data/"
	return base + key
}
```

`secret/` is only Vault's *default* mount. A KV v2 engine can be enabled anywhere:

```sh
vault secrets enable -path=kv kv-v2
```

and Vault-compatible services don't all use the default — some mount the engine per instance, so the path is only known at configuration time. Against any of those, every read asks for a path that doesn't exist and fails, with an error that points at the secret rather than at the mount.

## The change

A `mount` option, threaded through a functional option so the exported `New()` stays source-compatible:

```go
New(url, token)                    // secret/data/<key>, exactly as before
New(url, token, WithMount("kv"))   // kv/data/<key>
```

Configuration uses the same key:

```yaml
options:
  url:   https://vault.example.com
  token: ...
  mount: kv          # optional
```

## Backward compatibility

- `New()` gains a variadic parameter, so existing call sites compile unchanged.
- An **absent or empty** `mount` keeps `secret`, so existing configurations behave identically — and a caller can pass an unset config value straight through without checking it first.
- Surrounding slashes are trimmed: Vault paths appear both with and without them in docs and CLI output, and `kv//data/x` is not a valid path.

## Tests

`vault/hashivault/mount_test.go` — these run in CI; the existing `hashivault_test.go` is behind the `debugtest` tag and needs a live Vault.

- default mount, custom mount, slash trimming, empty-mount fallback, nested keys
- a **zero-value** `Vault` still builds a valid path — the struct is exported, so it can be constructed without `New`
- the registry wiring **in both directions**: a configured `mount` is honoured, and a configuration carrying no `mount` key still reads from `secret/`

The `debugtest` file is updated for the moved helper and still compiles (`go vet -tags debugtest`).

Note: `go build ./providers/...` fails on this branch for an unrelated, pre-existing reason — `providers/mock_*.go` import `go.mondoo.com/mql/v13/...` while `main`'s module path is unversioned. Same failure with and without this change.
