### PR TITLE
🧹 stackit: refresh SDK modules to their latest releases

### DIFF
--- a/providers/stackit/go.mod
+++ b/providers/stackit/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.14.1
 	github.com/stackitcloud/stackit-sdk-go/services/rabbitmq v1.3.1
 	github.com/stackitcloud/stackit-sdk-go/services/redis v1.4.1
-	github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.25.1
+	github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.26.0
 	github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.19.1
 	github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.7.2
 	github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.5.5
@@ -35,7 +35,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.18.1
 	github.com/stackitcloud/stackit-sdk-go/services/telemetrylink v0.5.2
 	github.com/stackitcloud/stackit-sdk-go/services/telemetryrouter v0.5.2
-	github.com/stackitcloud/stackit-sdk-go/services/vpn v0.15.1
+	github.com/stackitcloud/stackit-sdk-go/services/vpn v0.15.2
 	github.com/stretchr/testify v1.12.1
 	go.mondoo.com/mql v0.0.0-20260908144452-0bda209d1d40
 )

--- a/providers/stackit/go.sum
+++ b/providers/stackit/go.sum
@@ -440,8 +440,8 @@ github.com/stackitcloud/stackit-sdk-go/services/rabbitmq v1.3.1 h1:6t+EJTR9HOFZG
 github.com/stackitcloud/stackit-sdk-go/services/rabbitmq v1.3.1/go.mod h1:oGcpMIs2H/ldTQlTkYJUY4ZaVNi3MMRSMz0XpLDSKcU=
 github.com/stackitcloud/stackit-sdk-go/services/redis v1.4.1 h1:s3mXo6FGNEeMWqVPq7yaDgcOakEejRP7X9l7OaK7PEE=
 github.com/stackitcloud/stackit-sdk-go/services/redis v1.4.1/go.mod h1:6ihYZA22kityLgM0Pp7qROOomcZeUV0OsayOrd5vVe4=
-github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.25.1 h1:uZrKH0JLZwHmS8sI+//YE2hWDfVxQ1Q3pAf35BZZ6i4=
-github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.25.1/go.mod h1:Y5EM8b9qe/+AKI2LJoFvI0PzkyHO5RiW8nQuQaaNaFA=
+github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.26.0 h1:TzmBTja200jx6An39UPYBZPvZvLFgk3g1S0XZ1vDeBI=
+github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.26.0/go.mod h1:Y5EM8b9qe/+AKI2LJoFvI0PzkyHO5RiW8nQuQaaNaFA=
 github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.19.1 h1:Mym5vqa3YaF42LbqlVXDFYf/evsNU76l0wpUPGEu+0U=
 github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.19.1/go.mod h1:oFbKTkCFtp/RVjTeuv5caSuuEnf3/JG8zRDB4nbLYes=
 github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.7.2 h1:yx7qrsELMaxpc1tpZezYXrhHH9YLEUlVDwBMPa7/Ekc=
@@ -460,8 +460,8 @@ github.com/stackitcloud/stackit-sdk-go/services/telemetrylink v0.5.2 h1:Jqz+Y3IO
 github.com/stackitcloud/stackit-sdk-go/services/telemetrylink v0.5.2/go.mod h1:JyuStufMDibWblEo4wPOrh3B02aMgIUEhDF7YK5WGas=
 github.com/stackitcloud/stackit-sdk-go/services/telemetryrouter v0.5.2 h1:su5M+lv0+fsPjSY1KdC8sxoE8cB5kwNx8bSpEA6bxZE=
 github.com/stackitcloud/stackit-sdk-go/services/telemetryrouter v0.5.2/go.mod h1:G1irvS3PFNNnf5t5ub1UUl2Iha+lv2RYu6l/rx79tcM=
-github.com/stackitcloud/stackit-sdk-go/services/vpn v0.15.1 h1:eiUDfelmjs37SUBAWrebYK+tLfRKsGM7Gqan4aGtH2o=
-github.com/stackitcloud/stackit-sdk-go/services/vpn v0.15.1/go.mod h1:3OHHiMoNDwI63Vtvf5B/2Hc2hLlaCyTvPwg8N6T957s=
+github.com/stackitcloud/stackit-sdk-go/services/vpn v0.15.2 h1:82VZJaJPwcBKSj8WV8v0ujBvbkbMxFXIvvv0wU+0Be0=
+github.com/stackitcloud/stackit-sdk-go/services/vpn v0.15.2/go.mod h1:3OHHiMoNDwI63Vtvf5B/2Hc2hLlaCyTvPwg8N6T957s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=


### PR DESCRIPTION
## Summary

Backwards-compatible refresh of the two STACKIT SDK modules the weekly deps refresh (#10725) did not bring current. No Go source changes; the diff is `go.mod`/`go.sum` only.

| module | from | to |
|---|---|---|
| resourcemanager | v0.25.1 | v0.26.0 |
| vpn | v0.15.1 | v0.15.2 |

**What changed upstream, and why none of it reaches a shipped field**

- `resourcemanager` v0.26.0 removes the unused `ContainerSearchResult` struct and its enum. An exported-symbol diff shows no other removal, rename, or retype. The provider references only `APIClient`, `NewAPIClient`, `GetProjectResponse`, and two constructors, none affected.
- `vpn` v0.15.2 retypes `NetworkConfig.PredefinedNetworkPrefix` from `[]string` to `*string` and adds an `ASNNot` enum. The provider does not read `NetworkConfig`, and `stackit.vpn.gateway` exposes no dict that would serialize it.

**Held back on purpose**

- `serviceaccount` stays pinned at v0.20.1. v0.21.0 deletes `ListAccessTokens` and the `AccessToken` model with no replacement, and that call backs the shipped `stackit.serviceAccount.accessTokens` field (13.0.0). Moving off it is a deprecation decision, not a bump. #10725 had overridden this pin; it was restored there before merge.

## Verification

Run inside `providers/stackit/` after rebasing onto the merged #10725:

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` passes (connection, resources)
- `gofmt -l .` empty
- `go mod tidy` produced no deltas outside the two modules

Not verified against a live STACKIT project: neither bump changes a request or response shape the provider uses, so the claims above rest on the compiler and the upstream changelogs, not on an API response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
