### PR TITLE
🧹 stackit: deprecate serviceAccount.accessTokens and unpin the serviceaccount SDK

### DIFF
--- a/providers/stackit/go.mod
+++ b/providers/stackit/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.19.1
 	github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.7.2
 	github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.5.5
-	github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.20.1 // pinned: v0.21.0 removes ListAccessTokens, which backs stackit.serviceAccount.accessTokens
+	github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.21.0
 	github.com/stackitcloud/stackit-sdk-go/services/sfs v0.11.2
 	github.com/stackitcloud/stackit-sdk-go/services/ske v1.21.2
 	github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex v1.18.1

--- a/providers/stackit/go.sum
+++ b/providers/stackit/go.sum
@@ -448,8 +448,8 @@ github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.7.2 h1:yx7qrsELM
 github.com/stackitcloud/stackit-sdk-go/services/serverbackup v1.7.2/go.mod h1:s9KkDLNLNVVwXy0tSCvO0dEFsxdaEAYpRVLTuffRVJ8=
 github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.5.5 h1:MjZnz7YJfBCUtYKaergQkH0ViSOA6wrxVzDX0KryxJc=
 github.com/stackitcloud/stackit-sdk-go/services/serverupdate v1.5.5/go.mod h1:HKXnp6C9LgkOXAGAlaYN0rVqNY2ue5oIKIPbtUzqqvc=
-github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.20.1 h1:zVVA/Puge2PK3G8lrGGolnQzxYwwsNUgfMyyRUUQc44=
-github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.20.1/go.mod h1:xJNa86o89czK2o60+s46vz8+NSKDTbQduFGFaztJnsA=
+github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.21.0 h1:zzUYsqXSzQ/Quk8OHg4cDQQv8hKMsENfvoyFcW9HuSM=
+github.com/stackitcloud/stackit-sdk-go/services/serviceaccount v0.21.0/go.mod h1:fQGmFw92eCrJ1GC33IeJSeFGBWOosfLekSDhM1T7szI=
 github.com/stackitcloud/stackit-sdk-go/services/sfs v0.11.2 h1:t2IsBrbZBbi26yRna07zUt9ZYaK60IWpnDbP8ETthjk=
 github.com/stackitcloud/stackit-sdk-go/services/sfs v0.11.2/go.mod h1:qXoH35kVrzVH3MLhlGcL5VlVHIpHool2eKMkggZbHEY=
 github.com/stackitcloud/stackit-sdk-go/services/ske v1.21.2 h1:4ApmRQGkcf/G/h1s19QsqH/vqE3oqfrdG1J/3/40iEM=

--- a/providers/stackit/resources/serviceaccount.go
+++ b/providers/stackit/resources/serviceaccount.go
@@ -77,40 +77,14 @@ func initStackitServiceAccount(runtime *plugin.Runtime, args map[string]*llx.Raw
 	return nil, nil, fmt.Errorf("stackit.serviceAccount with email %q not found", email)
 }
 
+// accessTokens reports an empty list. STACKIT retired long-lived service
+// account access tokens on 17 December 2025 and removed the access-token
+// endpoints from the service account API (spec commits of 2026-08-27 and
+// 2026-09-04), so no service account can hold one and there is nothing left
+// to list. The field is kept, deprecated, so existing queries keep compiling;
+// `keys` carries the successor credentials.
 func (r *mqlStackitServiceAccount) accessTokens() ([]any, error) {
-	c := conn(r.MqlRuntime)
-	client, err := c.ServiceAccount()
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.DefaultAPI.ListAccessTokens(bgctx(), r.ProjectId.Data, r.Email.Data).Execute()
-	if err != nil {
-		if isAccessDenied(err) {
-			return []any{}, nil
-		}
-		return nil, err
-	}
-	items, _ := resp.GetItemsOk()
-	out := make([]any, 0, len(items))
-	for i := range items {
-		out = append(out, serviceAccountTokenEntry(&items[i]))
-	}
-	return out, nil
-}
-
-// serviceAccountTokenEntry maps an access-token metadata record into a
-// dict-native map. Timestamps are RFC3339 strings (a `dict` cannot carry a
-// *time.Time) so the entry serializes cleanly for the `accessTokens []dict`
-// field.
-func serviceAccountTokenEntry(t *serviceaccount.AccessTokenMetadata) map[string]any {
-	createdAt, ok1 := t.GetCreatedAtOk()
-	validUntil, ok2 := t.GetValidUntilOk()
-	return map[string]any{
-		"id":         t.GetId(),
-		"active":     t.GetActive(),
-		"createdAt":  rfc3339OrNil(createdAt, ok1),
-		"validUntil": rfc3339OrNil(validUntil, ok2),
-	}
+	return []any{}, nil
 }
 
 func (r *mqlStackitServiceAccount) keys() ([]any, error) {

--- a/providers/stackit/resources/serviceaccount_test.go
+++ b/providers/stackit/resources/serviceaccount_test.go
@@ -57,27 +57,3 @@ func TestServiceAccountKeyEntry(t *testing.T) {
 
 	assertDictSerializable(t, []any{entry})
 }
-
-func TestServiceAccountTokenEntry(t *testing.T) {
-	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
-	valid := now.Add(24 * time.Hour)
-	tok := &serviceaccount.AccessTokenMetadata{}
-	tok.SetId("tok-1")
-	tok.SetActive(true)
-	tok.SetCreatedAt(now)
-	tok.SetValidUntil(valid)
-
-	entry := serviceAccountTokenEntry(tok)
-
-	if got, ok := entry["createdAt"].(string); !ok || got != now.Format(time.RFC3339) {
-		t.Fatalf("createdAt = %v (%T), want RFC3339 %q", entry["createdAt"], entry["createdAt"], now.Format(time.RFC3339))
-	}
-	if got, ok := entry["validUntil"].(string); !ok || got != valid.Format(time.RFC3339) {
-		t.Fatalf("validUntil = %v (%T), want RFC3339 %q", entry["validUntil"], entry["validUntil"], valid.Format(time.RFC3339))
-	}
-	if got, ok := entry["active"].(bool); !ok || !got {
-		t.Fatalf("active = %v (%T), want bool true", entry["active"], entry["active"])
-	}
-
-	assertDictSerializable(t, []any{entry})
-}

--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -2607,8 +2607,8 @@ private stackit.modelServing.model @defaults("name type category") {
 // principal used by automation and SDK callers to authenticate
 // against STACKIT APIs. Service accounts are keyed by their email
 // address, for example `stackit.serviceAccount(email: "...")`, and
-// expose the project they belong to along with the access tokens and
-// long-lived keys issued for authentication (useful for auditing
+// expose the project they belong to along with the keys and federated
+// identity providers issued for authentication (useful for auditing
 // credential age and active status).
 private stackit.serviceAccount @defaults("email projectId") {
   init(email? string)
@@ -2618,11 +2618,14 @@ private stackit.serviceAccount @defaults("email projectId") {
   projectId string
   // Internal service-account ID (UUID), if returned by the API
   id string
-  // Access tokens issued for this service account
+  // Long-lived access tokens issued for this service account
   //
-  // Each entry has `id`, `active` (whether the token is currently
-  // valid), `createdAt`, and `validUntil`.
-  accessTokens() []dict
+  // Deprecated in favor of keys. STACKIT retired long-lived service
+  // account access tokens on 17 December 2025 and removed the
+  // access-token endpoints from the service account API, so this
+  // field always reports an empty list. Audit credential age and
+  // active status through `keys` and `federatedIdentityProviders`.
+  accessTokens() @maturity("deprecated") @replaced_by("stackit.serviceAccount.keys") []dict
   // Long-lived keys associated with this service account
   //
   // Each entry has `id`, `keyType`, `keyAlgorithm`, `keyOrigin`,


### PR DESCRIPTION
## Summary

Deprecates `stackit.serviceAccount.accessTokens` and unpins the serviceaccount SDK.

**Why the field has nothing left to report**

- STACKIT's Jul 2025 release note retired long-lived service account access tokens effective 17 December 2025; no new tokens can be created since then and the key flow is the replacement.
- On 2026-08-27 STACKIT deleted the `/access-tokens` list, create, and delete paths from the public service-account v2 OpenAPI spec, and on 2026-09-04 the `AccessToken` schemas. The endpoint the provider called is no longer part of the API.
- serviceaccount SDK v0.21.0 is the generator catching up: it removes `ListAccessTokens` and the `AccessToken` model with no replacement. That is why the module has been pinned at v0.20.1 since #10708 and why the weekly deps bot kept trying to move it (#10725).

**What changes**

- `accessTokens()` is marked `@maturity("deprecated")` with `@replaced_by("stackit.serviceAccount.keys")`, and its description says why. The `.lr.versions` entry stays at 13.0.0.
- The accessor returns an empty list instead of calling the removed endpoint. Existing queries keep compiling, and an empty list is the truthful reading: after 17 December 2025 a service account cannot hold a long-lived token, so a policy asking for active tokens gets the right answer. `keys` already carries the successor credentials with `active`, `createdAt`, and `validUntil`.
- `serviceAccountTokenEntry` and its unit test are removed with the call they served. `rfc3339OrNil` stays; `keys` still uses it.
- serviceaccount moves to v0.21.0 and the pin comment goes away, so the weekly deps refresh stops fighting it.

**Not done here**

- The claude provider's anthropic-sdk-go pin (`claude.userProfile.relationship`) is the other pin the deps bot overrides. It is a different case, the SDK dropping a field rather than the vendor dropping an endpoint, and needs its own decision.

## Verification

Run inside `providers/stackit/`:

- `./mqlr generate` clean; `@replaced_by` target validated by the generator; no `.lr.go` change (deprecation annotations do not affect codegen)
- `go build ./...`, `go vet ./...` clean
- `go test ./...` passes
- `gofmt -l .` empty

Not verified against a live STACKIT project (no credentials on this machine). The evidence that the endpoint is gone is the spec history, not an API response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
