### PR TITLE
🐛 stackit: fix a credential leak, a wrong exposure verdict, and stale schema docs

### DIFF
--- a/providers/stackit/resources/alb.go
+++ b/providers/stackit/resources/alb.go
@@ -62,7 +62,7 @@ func buildAlbLoadBalancer(runtime *plugin.Runtime, lb *alb.LoadBalancer, region 
 		"errors":                               llx.ArrayData(anySliceToDict(lb.GetErrors()), types.Dict),
 		"loadBalancerSecurityGroup":            llx.DictData(toDict(lb.GetLoadBalancerSecurityGroup())),
 		"targetSecurityGroup":                  llx.DictData(toDict(lb.GetTargetSecurityGroup())),
-		"disableTargetSecurityGroupAssignment": llx.BoolData(lb.GetDisableTargetSecurityGroupAssignment()),
+		"disableTargetSecurityGroupAssignment": llx.BoolDataPtr(lbDisableTargetSecurityGroupAssignment(lb)),
 		"labels":                               labelData(lb.GetLabels()),
 	}
 	return CreateResource(runtime, "stackit.alb.loadBalancer", args)

--- a/providers/stackit/resources/dbaas.go
+++ b/providers/stackit/resources/dbaas.go
@@ -743,7 +743,7 @@ func (r *mqlStackitObservabilityInstance) acl() ([]any, error) {
 }
 
 // fetchGrafana pulls the instance's Grafana configuration once and caches it
-// for the lifetime of this resource, so the four Grafana fields share a
+// for the lifetime of this resource, so the generic OAuth fields share a
 // single API call. Double-check locked like fetchDetail.
 //
 // The response also carries the generic OAuth provider's client secret. Only
@@ -775,7 +775,22 @@ func (r *mqlStackitObservabilityInstance) fetchGrafana() (*observability.Grafana
 	return r.grafana, nil
 }
 
+// The instance detail already carries the two Grafana access flags on its
+// InstanceSensitiveData block, so they are read from the detail every other
+// field shares rather than spending the Grafana-config call on them. That call
+// is only paid when the generic OAuth fields are queried. If the detail was
+// denied, the Grafana endpoint is tried as a fallback before giving up.
+
 func (r *mqlStackitObservabilityInstance) grafanaPublicReadAccess() (bool, error) {
+	d, err := r.fetchDetail()
+	if err != nil {
+		return false, err
+	}
+	if d != nil {
+		if inst, ok := d.GetInstanceOk(); ok && inst != nil {
+			return inst.GetGrafanaPublicReadAccess(), nil
+		}
+	}
 	g, err := r.fetchGrafana()
 	if err != nil || g == nil {
 		return false, err
@@ -784,6 +799,15 @@ func (r *mqlStackitObservabilityInstance) grafanaPublicReadAccess() (bool, error
 }
 
 func (r *mqlStackitObservabilityInstance) grafanaUseStackitSso() (bool, error) {
+	d, err := r.fetchDetail()
+	if err != nil {
+		return false, err
+	}
+	if d != nil {
+		if inst, ok := d.GetInstanceOk(); ok && inst != nil {
+			return inst.GetGrafanaUseStackitSso(), nil
+		}
+	}
 	g, err := r.fetchGrafana()
 	if err != nil || g == nil {
 		return false, err

--- a/providers/stackit/resources/iaas.go
+++ b/providers/stackit/resources/iaas.go
@@ -334,9 +334,9 @@ func (r *mqlStackit) volumes() ([]any, error) {
 // typed-reference field. VolumeSource.Type is one of image, volume, snapshot,
 // or backup. Snapshots and backups are distinct STACKIT resources, so their
 // UUIDs must not be conflated: a backup UUID surfaced as sourceSnapshotId would
-// resolve against the snapshot API and 404. A "volume" clone source (and any
-// unknown type) has no modeled field and yields all-empty IDs.
-func classifyVolumeSource(sourceType, sourceID string) (imageID, snapshotID, backupID string) {
+// resolve against the snapshot API and 404. A "volume" source is a clone of
+// another volume; an unknown type yields all-empty IDs.
+func classifyVolumeSource(sourceType, sourceID string) (imageID, snapshotID, backupID, volumeID string) {
 	switch sourceType {
 	case "image":
 		imageID = sourceID
@@ -344,14 +344,22 @@ func classifyVolumeSource(sourceType, sourceID string) (imageID, snapshotID, bac
 		snapshotID = sourceID
 	case "backup":
 		backupID = sourceID
+	case "volume":
+		volumeID = sourceID
 	}
 	return
 }
 
+type mqlStackitVolumeInternal struct {
+	// cacheSourceVolumeID is the volume this one was cloned from, resolved by
+	// sourceVolume(). Held internally rather than as a raw id field.
+	cacheSourceVolumeID string
+}
+
 func buildVolume(runtime *plugin.Runtime, v *iaas.Volume) (plugin.Resource, error) {
-	var imageID, snapshotID, backupID string
+	var imageID, snapshotID, backupID, sourceVolumeID string
 	if src, ok := v.GetSourceOk(); ok {
-		imageID, snapshotID, backupID = classifyVolumeSource(src.GetType(), src.GetId())
+		imageID, snapshotID, backupID, sourceVolumeID = classifyVolumeSource(src.GetType(), src.GetId())
 	}
 	serverID := v.GetServerId()
 
@@ -387,11 +395,29 @@ func buildVolume(runtime *plugin.Runtime, v *iaas.Volume) (plugin.Resource, erro
 		"updatedAt":            llx.TimeDataPtr(timeOrNil(updatedAt, ok2)),
 		"labels":               labelData(v.GetLabels()),
 	}
-	return CreateResource(runtime, "stackit.volume", args)
+	res, err := CreateResource(runtime, "stackit.volume", args)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlStackitVolume).cacheSourceVolumeID = sourceVolumeID
+	return res, nil
 }
 
 func (r *mqlStackitVolume) id() (string, error) {
 	return "stackit.volume/" + r.Id.Data, nil
+}
+
+func (r *mqlStackitVolume) sourceVolume() (*mqlStackitVolume, error) {
+	if r.cacheSourceVolumeID == "" {
+		return markNull[mqlStackitVolume](&r.SourceVolume)
+	}
+	res, err := NewResource(r.MqlRuntime, "stackit.volume", map[string]*llx.RawData{
+		"id": llx.StringData(r.cacheSourceVolumeID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlStackitVolume), nil
 }
 
 func initStackitVolume(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -997,6 +1023,16 @@ func (r *mqlStackit) securityGroups() ([]any, error) {
 	return out, nil
 }
 
+type mqlStackitSecurityGroupInternal struct {
+	// cacheRules holds the rules the group response carried inline, so that
+	// rules() does not spend a ListSecurityGroupRules call per group. The
+	// exposure walk reads every group's rules for every server, so that call
+	// multiplied. cacheRulesSet distinguishes "the API sent an empty rule
+	// list" (nothing to fetch) from "the API omitted the field" (fetch).
+	cacheRules    []iaas.SecurityGroupRule
+	cacheRulesSet bool
+}
+
 func buildSecurityGroup(runtime *plugin.Runtime, sg *iaas.SecurityGroup) (plugin.Resource, error) {
 	createdAt, ok1 := sg.GetCreatedAtOk()
 	updatedAt, ok2 := sg.GetUpdatedAtOk()
@@ -1009,7 +1045,16 @@ func buildSecurityGroup(runtime *plugin.Runtime, sg *iaas.SecurityGroup) (plugin
 		"updatedAt":   llx.TimeDataPtr(timeOrNil(updatedAt, ok2)),
 		"labels":      labelData(sg.GetLabels()),
 	}
-	return CreateResource(runtime, "stackit.securityGroup", args)
+	res, err := CreateResource(runtime, "stackit.securityGroup", args)
+	if err != nil {
+		return nil, err
+	}
+	if rules, ok := sg.GetRulesOk(); ok {
+		mqlSg := res.(*mqlStackitSecurityGroup)
+		mqlSg.cacheRules = rules
+		mqlSg.cacheRulesSet = true
+	}
+	return res, nil
 }
 
 func (r *mqlStackitSecurityGroup) id() (string, error) {
@@ -1038,67 +1083,74 @@ func initStackitSecurityGroup(runtime *plugin.Runtime, args map[string]*llx.RawD
 }
 
 func (r *mqlStackitSecurityGroup) rules() ([]any, error) {
-	c := conn(r.MqlRuntime)
-	client, err := c.IaaS()
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.DefaultAPI.ListSecurityGroupRules(bgctx(), c.ProjectID(), c.Region(), r.Id.Data).Execute()
-	if err != nil {
-		if isAccessDenied(err) {
-			return []any{}, nil
+	items := r.cacheRules
+	if !r.cacheRulesSet {
+		c := conn(r.MqlRuntime)
+		client, err := c.IaaS()
+		if err != nil {
+			return nil, err
 		}
-		return nil, err
+		resp, err := client.DefaultAPI.ListSecurityGroupRules(bgctx(), c.ProjectID(), c.Region(), r.Id.Data).Execute()
+		if err != nil {
+			if isAccessDenied(err) {
+				return []any{}, nil
+			}
+			return nil, err
+		}
+		items, _ = resp.GetItemsOk()
 	}
-	items, _ := resp.GetItemsOk()
 	out := make([]any, 0, len(items))
 	for i := range items {
-		rule := items[i]
-
-		// icmpType/icmpCode are nullable in the schema: leave them nil (MQL null)
-		// for non-ICMP rules rather than emitting 0, which is a valid ICMP type.
-		var icmpType, icmpCode *int64
-		if icmp, ok := rule.GetIcmpParametersOk(); ok {
-			t := icmp.GetType()
-			code := icmp.GetCode()
-			icmpType = &t
-			icmpCode = &code
-		}
-		var portMin, portMax int64
-		if pr, ok := rule.GetPortRangeOk(); ok {
-			portMin = int64(pr.GetMin())
-			portMax = int64(pr.GetMax())
-		}
-		var protocol string
-		if p, ok := rule.GetProtocolOk(); ok {
-			n, okNum := p.GetNumberOk()
-			protocol = protocolLabel(p.GetName(), derefInt64(n), okNum && n != nil)
-		}
-
-		createdAt, okCreated := rule.GetCreatedAtOk()
-
-		args := map[string]*llx.RawData{
-			"id":                    llx.StringData(rule.GetId()),
-			"securityGroupId":       llx.StringData(r.Id.Data),
-			"direction":             llx.StringData(rule.GetDirection()),
-			"ethertype":             llx.StringData(rule.GetEthertype()),
-			"protocol":              llx.StringData(protocol),
-			"description":           llx.StringData(rule.GetDescription()),
-			"icmpType":              llx.IntDataPtr(icmpType),
-			"icmpCode":              llx.IntDataPtr(icmpCode),
-			"portRangeMin":          llx.IntData(portMin),
-			"portRangeMax":          llx.IntData(portMax),
-			"ipRange":               llx.StringData(rule.GetIpRange()),
-			"remoteSecurityGroupId": llx.StringData(rule.GetRemoteSecurityGroupId()),
-			"createdAt":             llx.TimeDataPtr(timeOrNil(createdAt, okCreated)),
-		}
-		res, err := CreateResource(r.MqlRuntime, "stackit.securityGroup.rule", args)
+		res, err := CreateResource(r.MqlRuntime, "stackit.securityGroup.rule", securityGroupRuleArgs(r.Id.Data, &items[i]))
 		if err != nil {
 			return nil, err
 		}
 		out = append(out, res)
 	}
 	return out, nil
+}
+
+// securityGroupRuleArgs maps one SDK rule onto the stackit.securityGroup.rule
+// fields. It serves both the rules the group response carries inline and the
+// ones ListSecurityGroupRules returns, which share the SecurityGroupRule model.
+func securityGroupRuleArgs(securityGroupID string, rule *iaas.SecurityGroupRule) map[string]*llx.RawData {
+	// icmpType/icmpCode are nullable in the schema: leave them nil (MQL null)
+	// for non-ICMP rules rather than emitting 0, which is a valid ICMP type.
+	var icmpType, icmpCode *int64
+	if icmp, ok := rule.GetIcmpParametersOk(); ok {
+		t := icmp.GetType()
+		code := icmp.GetCode()
+		icmpType = &t
+		icmpCode = &code
+	}
+	var portMin, portMax int64
+	if pr, ok := rule.GetPortRangeOk(); ok {
+		portMin = int64(pr.GetMin())
+		portMax = int64(pr.GetMax())
+	}
+	var protocol string
+	if p, ok := rule.GetProtocolOk(); ok {
+		n, okNum := p.GetNumberOk()
+		protocol = protocolLabel(p.GetName(), derefInt64(n), okNum && n != nil)
+	}
+
+	createdAt, okCreated := rule.GetCreatedAtOk()
+
+	return map[string]*llx.RawData{
+		"id":                    llx.StringData(rule.GetId()),
+		"securityGroupId":       llx.StringData(securityGroupID),
+		"direction":             llx.StringData(rule.GetDirection()),
+		"ethertype":             llx.StringData(rule.GetEthertype()),
+		"protocol":              llx.StringData(protocol),
+		"description":           llx.StringData(rule.GetDescription()),
+		"icmpType":              llx.IntDataPtr(icmpType),
+		"icmpCode":              llx.IntDataPtr(icmpCode),
+		"portRangeMin":          llx.IntData(portMin),
+		"portRangeMax":          llx.IntData(portMax),
+		"ipRange":               llx.StringData(rule.GetIpRange()),
+		"remoteSecurityGroupId": llx.StringData(rule.GetRemoteSecurityGroupId()),
+		"createdAt":             llx.TimeDataPtr(timeOrNil(createdAt, okCreated)),
+	}
 }
 
 // protocolLabel renders a security-group rule protocol as its name, falling

--- a/providers/stackit/resources/iaas_test.go
+++ b/providers/stackit/resources/iaas_test.go
@@ -54,26 +54,82 @@ func TestProtocolLabel(t *testing.T) {
 func TestClassifyVolumeSource(t *testing.T) {
 	const id = "11111111-2222-3333-4444-555555555555"
 	cases := []struct {
-		name                              string
-		sourceType                        string
-		wantImage, wantSnapshot, wantBkup string
+		name                                          string
+		sourceType                                    string
+		wantImage, wantSnapshot, wantBkup, wantVolume string
 	}{
-		{"image source", "image", id, "", ""},
-		{"snapshot source", "snapshot", "", id, ""},
-		{"backup source stays a backup, not a snapshot", "backup", "", "", id},
-		{"volume clone maps to nothing", "volume", "", "", ""},
-		{"unknown type maps to nothing", "something-new", "", "", ""},
+		{"image source", "image", id, "", "", ""},
+		{"snapshot source", "snapshot", "", id, "", ""},
+		{"backup source stays a backup, not a snapshot", "backup", "", "", id, ""},
+		// A clone used to map to nothing, which silently erased where the
+		// volume's data came from.
+		{"volume clone maps to the source volume", "volume", "", "", "", id},
+		{"unknown type maps to nothing", "something-new", "", "", "", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotImage, gotSnapshot, gotBackup := classifyVolumeSource(tc.sourceType, id)
-			if gotImage != tc.wantImage || gotSnapshot != tc.wantSnapshot || gotBackup != tc.wantBkup {
-				t.Fatalf("classifyVolumeSource(%q, id) = (%q, %q, %q), want (%q, %q, %q)",
-					tc.sourceType, gotImage, gotSnapshot, gotBackup,
-					tc.wantImage, tc.wantSnapshot, tc.wantBkup)
+			gotImage, gotSnapshot, gotBackup, gotVolume := classifyVolumeSource(tc.sourceType, id)
+			if gotImage != tc.wantImage || gotSnapshot != tc.wantSnapshot || gotBackup != tc.wantBkup || gotVolume != tc.wantVolume {
+				t.Fatalf("classifyVolumeSource(%q, id) = (%q, %q, %q, %q), want (%q, %q, %q, %q)",
+					tc.sourceType, gotImage, gotSnapshot, gotBackup, gotVolume,
+					tc.wantImage, tc.wantSnapshot, tc.wantBkup, tc.wantVolume)
 			}
 		})
 	}
+}
+
+// TestSecurityGroupRuleArgs pins the rule mapping that both the inline rules
+// on a group response and the ListSecurityGroupRules items go through. The
+// numeric-only protocol and the ICMP null handling are the two places a
+// refactor can silently regress.
+func TestSecurityGroupRuleArgs(t *testing.T) {
+	decode := func(payload string) *iaas.SecurityGroupRule {
+		var r iaas.SecurityGroupRule
+		if err := json.Unmarshal([]byte(payload), &r); err != nil {
+			t.Fatalf("decoding rule: %v", err)
+		}
+		return &r
+	}
+
+	t.Run("tcp ingress rule", func(t *testing.T) {
+		args := securityGroupRuleArgs("sg-1", decode(`{
+			"id": "rule-1", "direction": "ingress", "ethertype": "IPv4",
+			"protocol": {"name": "tcp"}, "portRange": {"min": 22, "max": 22},
+			"ipRange": "0.0.0.0/0", "description": "ssh"
+		}`))
+		if got := args["securityGroupId"].Value; got != "sg-1" {
+			t.Fatalf("securityGroupId = %v, want sg-1", got)
+		}
+		if got := args["protocol"].Value; got != "tcp" {
+			t.Fatalf("protocol = %v, want tcp", got)
+		}
+		if got := args["portRangeMin"].Value; got != int64(22) {
+			t.Fatalf("portRangeMin = %v (%T), want 22", got, got)
+		}
+		if args["icmpType"].Value != nil || args["icmpCode"].Value != nil {
+			t.Fatalf("icmpType/icmpCode = %v/%v, want null on a non-ICMP rule", args["icmpType"].Value, args["icmpCode"].Value)
+		}
+		if got := args["ipRange"].Value; got != "0.0.0.0/0" {
+			t.Fatalf("ipRange = %v", got)
+		}
+	})
+
+	t.Run("numeric-only protocol renders its number", func(t *testing.T) {
+		args := securityGroupRuleArgs("sg-1", decode(`{"id": "rule-2", "direction": "egress", "protocol": {"number": 47}}`))
+		if got := args["protocol"].Value; got != "47" {
+			t.Fatalf("protocol = %v, want 47", got)
+		}
+	})
+
+	t.Run("icmp rule carries type and code", func(t *testing.T) {
+		args := securityGroupRuleArgs("sg-1", decode(`{"id": "rule-3", "direction": "ingress", "protocol": {"name": "icmp"}, "icmpParameters": {"type": 8, "code": 0}}`))
+		if got := args["icmpType"].Value; got != int64(8) {
+			t.Fatalf("icmpType = %v (%T), want 8", got, got)
+		}
+		if got := args["icmpCode"].Value; got != int64(0) {
+			t.Fatalf("icmpCode = %v (%T), want 0 (a real code, not null)", got, got)
+		}
+	})
 }
 
 // --- server posture fields that must stay tri-state -------------------------

--- a/providers/stackit/resources/loadbalancer.go
+++ b/providers/stackit/resources/loadbalancer.go
@@ -104,6 +104,13 @@ func buildLoadBalancer(runtime *plugin.Runtime, lb *loadbalancer.LoadBalancer, r
 	return res, nil
 }
 
+// targetSecurityGroupAssignmentFlag is the slice of a load balancer (network
+// or application) that lbDisableTargetSecurityGroupAssignment reads. Both SDKs
+// generate the same accessor on their LoadBalancer models.
+type targetSecurityGroupAssignmentFlag interface {
+	GetDisableTargetSecurityGroupAssignmentOk() (*bool, bool)
+}
+
 // lbDisableTargetSecurityGroupAssignment reports whether the operator opted
 // out of attaching the managed target security group to the backends, or nil
 // when the API reports no setting.
@@ -112,7 +119,8 @@ func buildLoadBalancer(runtime *plugin.Runtime, lb *loadbalancer.LoadBalancer, r
 // false, so nil is the only honest reading of an absent value. Reporting false
 // would assert that the managed group is being attached on a balancer whose
 // setting was never read, which is the reassuring answer and the wrong one.
-func lbDisableTargetSecurityGroupAssignment(lb *loadbalancer.LoadBalancer) *bool {
+// The network and application load balancers share this reading.
+func lbDisableTargetSecurityGroupAssignment(lb targetSecurityGroupAssignmentFlag) *bool {
 	if lb == nil {
 		return nil
 	}

--- a/providers/stackit/resources/loadbalancer_test.go
+++ b/providers/stackit/resources/loadbalancer_test.go
@@ -8,8 +8,35 @@ import (
 	"reflect"
 	"testing"
 
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 	loadbalancer "github.com/stackitcloud/stackit-sdk-go/services/loadbalancer/v2api"
 )
+
+// TestAlbDisableTargetSecurityGroupAssignmentAbsentIsNull pins the application
+// load balancer to the same tri-state reading as the network one. It used to
+// read the flag through the non-pointer getter, so an absent value came back
+// as false: an assurance that the managed group is attached on a balancer
+// whose setting was never read.
+func TestAlbDisableTargetSecurityGroupAssignmentAbsentIsNull(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		want    *bool
+	}{
+		{"flag absent reads null", `{"name":"alb1"}`, nil},
+		{"operator opted out", `{"name":"alb1","disableTargetSecurityGroupAssignment":true}`, boolPtr(true)},
+		{"managed group attached", `{"name":"alb1","disableTargetSecurityGroupAssignment":false}`, boolPtr(false)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var lb alb.LoadBalancer
+			if err := json.Unmarshal([]byte(tc.payload), &lb); err != nil {
+				t.Fatalf("decoding alb payload: %v", err)
+			}
+			assertBoolPtr(t, "lbDisableTargetSecurityGroupAssignment(alb)", lbDisableTargetSecurityGroupAssignment(&lb), tc.want)
+		})
+	}
+}
 
 func TestListenerSNINames(t *testing.T) {
 	if got := listenerSNINames(nil); len(got) != 0 {

--- a/providers/stackit/resources/sfs.go
+++ b/providers/stackit/resources/sfs.go
@@ -5,6 +5,8 @@ package resources
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	sfs "github.com/stackitcloud/stackit-sdk-go/services/sfs/v1api"
@@ -37,6 +39,7 @@ type sfsExportPolicyData interface {
 	GetId() string
 	GetName() string
 	GetSharesUsingExportPolicy() int32
+	GetRulesOk() ([]sfs.ShareExportPolicyRule, bool)
 	GetLabels() map[string]string
 	GetCreatedAtOk() (*time.Time, bool)
 }
@@ -126,6 +129,12 @@ func (r *mqlStackitSfs) lockId() (string, error) {
 
 // ------------------------- SFS resource pool -------------------------
 
+// sfsResourcePoolArgs maps a pool onto the stackit.sfs.resourcePool fields.
+// The three usage gauges (used, available, used by snapshots) are left out:
+// the SDK documents them as "only available when retrieving a single Resource
+// Pool by ID", so the list response carries zeros for every pool. They are
+// read lazily through fetchSpace, which the init path pre-seeds from the
+// single-pool response it already holds (see sfsResourcePoolSpaceArgs).
 func sfsResourcePoolArgs(region string, rp sfsResourcePoolData) map[string]*llx.RawData {
 	pc := rp.GetPerformanceClass()
 	sp := rp.GetSpace()
@@ -146,9 +155,6 @@ func sfsResourcePoolArgs(region string, rp sfsResourcePoolData) map[string]*llx.
 		"mountPath":                  llx.StringData(rp.GetMountPath()),
 		"countShares":                llx.IntData(rp.GetCountShares()),
 		"sizeGigabytes":              llx.IntData(sp.GetSizeGigabytes()),
-		"usedGigabytes":              llx.FloatData(derefFloat(sp.GetUsedGigabytes())),
-		"availableGigabytes":         llx.FloatData(derefFloat(sp.GetAvailableGigabytes())),
-		"usedBySnapshotsGigabytes":   llx.FloatData(derefFloat(sp.GetUsedBySnapshotsGigabytes())),
 		"ipAcl":                      strSliceData(rp.GetIpAcl()),
 		"snapshotsAreVisible":        llx.BoolData(rp.GetSnapshotsAreVisible()),
 		"snapshotPolicyId":           llx.StringData(snapPolicyID),
@@ -156,6 +162,96 @@ func sfsResourcePoolArgs(region string, rp sfsResourcePoolData) map[string]*llx.
 		"labels":                     labelData(rp.GetLabels()),
 		"createdAt":                  llx.TimeDataPtr(timeOrNil(rp.GetCreatedAtOk())),
 	}
+}
+
+// sfsResourcePoolSpaceArgs adds the usage gauges to a pool's args. Only call
+// it with a pool that came from GetResourcePool; on a list element the gauges
+// are absent and would read as 0.
+func sfsResourcePoolSpaceArgs(args map[string]*llx.RawData, sp sfs.ResourcePoolSpace) map[string]*llx.RawData {
+	args["usedGigabytes"] = llx.FloatData(derefFloat(sp.GetUsedGigabytes()))
+	args["availableGigabytes"] = llx.FloatData(derefFloat(sp.GetAvailableGigabytes()))
+	args["usedBySnapshotsGigabytes"] = llx.FloatData(derefFloat(sp.GetUsedBySnapshotsGigabytes()))
+	return args
+}
+
+type mqlStackitSfsResourcePoolInternal struct {
+	spaceFetched atomic.Bool
+	space        *sfs.ResourcePoolSpace
+	spaceLock    sync.Mutex
+}
+
+// fetchSpace reads the pool's usage gauges through GetResourcePool once and
+// caches them; the three gauge accessors share the call. A nil result with a
+// nil error means the read was denied, and the gauges report null rather
+// than a zero that would read as an empty pool.
+func (r *mqlStackitSfsResourcePool) fetchSpace() (*sfs.ResourcePoolSpace, error) {
+	if r.spaceFetched.Load() {
+		return r.space, nil
+	}
+	r.spaceLock.Lock()
+	defer r.spaceLock.Unlock()
+	if r.spaceFetched.Load() {
+		return r.space, nil
+	}
+	c := conn(r.MqlRuntime)
+	client, err := c.Sfs()
+	if err != nil {
+		return nil, err
+	}
+	region := r.Region.Data
+	if region == "" {
+		region = c.Region()
+	}
+	resp, err := client.DefaultAPI.GetResourcePool(bgctx(), c.ProjectID(), region, r.Id.Data).Execute()
+	if err != nil {
+		if isAccessDenied(err) {
+			r.spaceFetched.Store(true)
+			return nil, nil
+		}
+		return nil, err
+	}
+	if pool, ok := resp.GetResourcePoolOk(); ok && pool != nil {
+		sp := pool.GetSpace()
+		r.space = &sp
+	}
+	r.spaceFetched.Store(true)
+	return r.space, nil
+}
+
+func (r *mqlStackitSfsResourcePool) usedGigabytes() (float64, error) {
+	sp, err := r.fetchSpace()
+	if err != nil {
+		return 0, err
+	}
+	if sp == nil {
+		r.UsedGigabytes.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return derefFloat(sp.GetUsedGigabytes()), nil
+}
+
+func (r *mqlStackitSfsResourcePool) availableGigabytes() (float64, error) {
+	sp, err := r.fetchSpace()
+	if err != nil {
+		return 0, err
+	}
+	if sp == nil {
+		r.AvailableGigabytes.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return derefFloat(sp.GetAvailableGigabytes()), nil
+}
+
+func (r *mqlStackitSfsResourcePool) usedBySnapshotsGigabytes() (float64, error) {
+	sp, err := r.fetchSpace()
+	if err != nil {
+		return 0, err
+	}
+	if sp == nil {
+		r.UsedBySnapshotsGigabytes.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return derefFloat(sp.GetUsedBySnapshotsGigabytes()), nil
 }
 
 func (r *mqlStackitSfsResourcePool) id() (string, error) {
@@ -179,9 +275,14 @@ func (r *mqlStackitSfsResourcePool) shares() ([]any, error) {
 	out := make([]any, 0, len(shares))
 	for i := range shares {
 		sh := shares[i]
-		exportPolicyID := ""
-		if v, ok := sh.GetExportPolicyOk(); ok && v != nil {
-			exportPolicyID = v.GetId()
+		// The share carries its export policy inline, rules included, so the
+		// policy resource is built here rather than re-fetched by id later.
+		var exportPolicy *mqlStackitSfsExportPolicy
+		if v, ok := sh.GetExportPolicyOk(); ok && v != nil && v.GetId() != "" {
+			exportPolicy, err = newSfsExportPolicy(r.MqlRuntime, r.Region.Data, v)
+			if err != nil {
+				return nil, err
+			}
 		}
 		res, err := CreateResource(r.MqlRuntime, "stackit.sfs.share", map[string]*llx.RawData{
 			"id":                      llx.StringData(sh.GetId()),
@@ -196,7 +297,7 @@ func (r *mqlStackitSfsResourcePool) shares() ([]any, error) {
 			return nil, err
 		}
 		share := res.(*mqlStackitSfsShare)
-		share.cacheExportPolicyID = exportPolicyID
+		share.cacheExportPolicy = exportPolicy
 		share.cacheRegion = r.Region.Data
 		out = append(out, share)
 	}
@@ -255,7 +356,10 @@ func initStackitSfsResourcePool(runtime *plugin.Runtime, args map[string]*llx.Ra
 	if !ok {
 		return nil, nil, fmt.Errorf("stackit.sfs.resourcePool with id %q not found", id)
 	}
-	res, err := CreateResource(runtime, "stackit.sfs.resourcePool", sfsResourcePoolArgs(c.Region(), pool))
+	// The single-pool response is the one place the usage gauges are
+	// populated, so seed them here instead of paying fetchSpace later.
+	args = sfsResourcePoolSpaceArgs(sfsResourcePoolArgs(c.Region(), pool), pool.GetSpace())
+	res, err := CreateResource(runtime, "stackit.sfs.resourcePool", args)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -265,8 +369,10 @@ func initStackitSfsResourcePool(runtime *plugin.Runtime, args map[string]*llx.Ra
 // ------------------------- SFS share -------------------------
 
 type mqlStackitSfsShareInternal struct {
-	cacheExportPolicyID string
-	cacheRegion         string
+	// cacheExportPolicy is the policy the share response carried inline,
+	// already built as a resource; nil when the share has no policy.
+	cacheExportPolicy *mqlStackitSfsExportPolicy
+	cacheRegion       string
 }
 
 func (r *mqlStackitSfsShare) id() (string, error) {
@@ -274,23 +380,22 @@ func (r *mqlStackitSfsShare) id() (string, error) {
 }
 
 func (r *mqlStackitSfsShare) exportPolicy() (*mqlStackitSfsExportPolicy, error) {
-	if r.cacheExportPolicyID == "" {
+	if r.cacheExportPolicy == nil {
 		r.ExportPolicy.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	res, err := NewResource(r.MqlRuntime, "stackit.sfs.exportPolicy", map[string]*llx.RawData{
-		"id": llx.StringData(r.cacheExportPolicyID),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.(*mqlStackitSfsExportPolicy), nil
+	return r.cacheExportPolicy, nil
 }
 
 // ------------------------- SFS share export policy -------------------------
 
 type mqlStackitSfsExportPolicyInternal struct {
 	cacheRegion string
+	// cacheRules holds the rules the policy response carried inline. Both
+	// ListShareExportPolicies and the policy nested on a share return them,
+	// so rules() only calls GetShareExportPolicy when the field was omitted.
+	cacheRules    []sfs.ShareExportPolicyRule
+	cacheRulesSet bool
 }
 
 func newSfsExportPolicy(runtime *plugin.Runtime, region string, p sfsExportPolicyData) (*mqlStackitSfsExportPolicy, error) {
@@ -306,6 +411,10 @@ func newSfsExportPolicy(runtime *plugin.Runtime, region string, p sfsExportPolic
 	}
 	ep := res.(*mqlStackitSfsExportPolicy)
 	ep.cacheRegion = region
+	if rules, ok := p.GetRulesOk(); ok {
+		ep.cacheRules = rules
+		ep.cacheRulesSet = true
+	}
 	return ep, nil
 }
 
@@ -314,27 +423,30 @@ func (r *mqlStackitSfsExportPolicy) id() (string, error) {
 }
 
 func (r *mqlStackitSfsExportPolicy) rules() ([]any, error) {
-	c := conn(r.MqlRuntime)
-	client, err := c.Sfs()
-	if err != nil {
-		return nil, err
-	}
-	region := r.cacheRegion
-	if region == "" {
-		region = c.Region()
-	}
-	resp, err := client.DefaultAPI.GetShareExportPolicy(bgctx(), c.ProjectID(), region, r.Id.Data).Execute()
-	if err != nil {
-		if isAccessDenied(err) {
+	rules := r.cacheRules
+	if !r.cacheRulesSet {
+		c := conn(r.MqlRuntime)
+		client, err := c.Sfs()
+		if err != nil {
+			return nil, err
+		}
+		region := r.cacheRegion
+		if region == "" {
+			region = c.Region()
+		}
+		resp, err := client.DefaultAPI.GetShareExportPolicy(bgctx(), c.ProjectID(), region, r.Id.Data).Execute()
+		if err != nil {
+			if isAccessDenied(err) {
+				return []any{}, nil
+			}
+			return nil, err
+		}
+		pol, ok := resp.GetShareExportPolicyOk()
+		if !ok {
 			return []any{}, nil
 		}
-		return nil, err
+		rules, _ = pol.GetRulesOk()
 	}
-	pol, ok := resp.GetShareExportPolicyOk()
-	if !ok {
-		return []any{}, nil
-	}
-	rules, _ := pol.GetRulesOk()
 	out := make([]any, 0, len(rules))
 	for i := range rules {
 		rule := rules[i]

--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -138,7 +138,13 @@ private stackit.server @defaults("id name status machineType") {
   id string
   // Server name
   name string
-  // Server status (ACTIVE, CREATING, ERROR, …)
+  // Server status
+  //
+  // One of ACTIVE, BACKING-UP, CREATING, DEALLOCATED, DEALLOCATING,
+  // DELETED, DELETING, ERROR, INACTIVE, MIGRATING, PAUSED, REBOOT,
+  // REBOOTING, REBUILD, REBUILDING, RESCUE, RESCUING, RESIZING,
+  // RESTORING, SNAPSHOTTING, STARTING, STOPPING, UNRESCUING, or
+  // UPDATING.
   status string
   // Power status (RUNNING, STOPPED, CRASHED, ERROR)
   powerStatus string
@@ -231,7 +237,13 @@ private stackit.volume @defaults("id name size status") {
   description string
   // Size in GiB
   size int
-  // Status (CREATING, AVAILABLE, IN_USE, DELETING, ERROR)
+  // Volume status
+  //
+  // One of ATTACHED, ATTACHING, AVAILABLE, AWAITING-TRANSFER, BACKING-UP,
+  // CREATING, DELETED, DELETING, DETACHING, DOWNLOADING, ERROR,
+  // ERROR_BACKING-UP, ERROR_DELETING, ERROR_RESIZING,
+  // ERROR_RESTORING-BACKUP, ERROR_KMS-ENCRYPTION-PARAMS, MAINTENANCE,
+  // RESERVED, RESIZING, RESTORING-BACKUP, RETYPING, or UPLOADING.
   status string
   // Availability zone
   availabilityZone string
@@ -251,6 +263,12 @@ private stackit.volume @defaults("id name size status") {
   sourceBackupId string
   // Backup the volume was created from (nullable)
   sourceBackup() stackit.backup
+  // Volume this one was cloned from (nullable)
+  //
+  // Set when the volume's source type is `volume`, that is, the volume
+  // was created as a copy of another volume in the project. Null for
+  // volumes created from an image, snapshot, or backup.
+  sourceVolume() stackit.volume
   // Server the volume is attached to (nullable)
   server() stackit.server
   // Attached server UUID (empty if detached)
@@ -302,7 +320,10 @@ private stackit.snapshot @defaults("id name status") {
   id string
   // Snapshot name
   name string
-  // Status (CREATING, AVAILABLE, DELETING, ERROR)
+  // Snapshot status
+  //
+  // One of AVAILABLE, BACKING-UP, CREATING, DELETED, DELETING, ERROR,
+  // RESTORING, UNMANAGING, or UPDATING.
   status string
   // Size in GiB
   size int
@@ -390,7 +411,9 @@ private stackit.image @defaults("id name status diskFormat") {
   id string
   // Image name
   name string
-  // Status (CREATING, AVAILABLE, DELETING, ERROR)
+  // Image status
+  //
+  // One of AVAILABLE, CREATING, DEACTIVATED, DELETED, DELETING, or ERROR.
   status string
   // Disk format (qcow2, raw, iso, …)
   diskFormat string
@@ -402,7 +425,12 @@ private stackit.image @defaults("id name status diskFormat") {
   protected bool
   // Owning project (empty for public images)
   owner string
-  // Image scope (public, private)
+  // Image scope
+  //
+  // One of public (available to every project), local (visible only to
+  // the owning project), projects (shared with specific projects, see
+  // sharedWithProjects), or organization (shared with the whole
+  // organization, see sharedWithOrganization).
   scope string
   // Image checksum
   //
@@ -823,7 +851,7 @@ private stackit.keyPair @defaults("name fingerprint") {
   init(name? string)
   // Key pair name (primary identifier)
   name string
-  // SHA256 fingerprint
+  // MD5 fingerprint of the public key (16 colon-separated hex octets)
   fingerprint string
   // Public key content (OpenSSH format)
   publicKey string
@@ -1013,7 +1041,7 @@ private stackit.ske.cluster @defaults("name kubernetesVersion status") {
   status string
   // Status object (raw): aggregated state, hibernated, errors, credentials rotation, …
   statusDetails dict
-  // Kubernetes minor version (e.g., 1.30)
+  // Kubernetes version of the control plane as a full patch version (e.g., 1.30.4)
   kubernetesVersion string
   // Node pools, one stackit.ske.cluster.nodePool per pool
   nodePools() []stackit.ske.cluster.nodePool
@@ -1303,11 +1331,21 @@ private stackit.sfs.resourcePool @defaults("id name state performanceClass") {
   // Provisioned capacity in gigabytes
   sizeGigabytes int
   // Used capacity in gigabytes
-  usedGigabytes float
+  //
+  // Read per pool, since the API reports usage only on a single-pool
+  // fetch and returns zero for every pool in the list. Null when the
+  // pool could not be read.
+  usedGigabytes() float
   // Available capacity in gigabytes
-  availableGigabytes float
+  //
+  // Read per pool, like usedGigabytes. Null when the pool could not be
+  // read.
+  availableGigabytes() float
   // Capacity consumed by snapshots in gigabytes
-  usedBySnapshotsGigabytes float
+  //
+  // Read per pool, like usedGigabytes. Null when the pool could not be
+  // read.
+  usedBySnapshotsGigabytes() float
   // CIDRs allowed to mount shares in this pool
   ipAcl []string
   // Whether snapshots are visible to clients under the share mount
@@ -1446,7 +1484,7 @@ private stackit.dns.zone @defaults("id dnsName type state") {
   description string
   // Zone type (primary, secondary)
   type string
-  // Visibility (public, private)
+  // Visibility (the API currently defines only public)
   visibility string
   // Lifecycle state (CREATING, CREATE_SUCCEEDED, CREATE_FAILED, DELETING, DELETE_SUCCEEDED, DELETE_FAILED, UPDATING, UPDATE_SUCCEEDED, UPDATE_FAILED)
   state string
@@ -1501,7 +1539,11 @@ private stackit.dns.recordSet @defaults("name type state") {
   zone() stackit.dns.zone
   // Record name (FQDN, e.g., `www.example.com.`)
   name string
-  // Record type (A, AAAA, CNAME, MX, TXT, NS, SRV, …)
+  // Record type
+  //
+  // One of A, AAAA, SOA, CNAME, NS, MX, TXT, SRV, PTR, ALIAS, DNAME,
+  // CAA, DNSKEY, DS, LOC, NAPTR, SSHFP, TLSA, URI, CERT, SVCB, TYPE,
+  // CSYNC, HINFO, or HTTPS.
   type string
   // Record TTL (seconds)
   ttl int
@@ -1638,7 +1680,7 @@ private stackit.mongoDbFlex.instance @defaults("id name version status") {
   // Compute flavor
   //
   // Dict describing the compute flavor backing the instance, with keys
-  // id, cpu, memory, description, and categories.
+  // id, cpu, memory, and description.
   flavor() dict
   // Number of replicas backing the instance
   replicas() int
@@ -2460,11 +2502,13 @@ private stackit.telemetry.router.destination @defaults("id displayName status cr
   // Destination configuration
   //
   // Shape depends on `configType`: `OpenTelemetry` populates an
-  // `openTelemetry` object with `uri` and an optional `basicAuth`
-  // (`username`, `password`) or `bearerToken`; `S3` populates an `s3`
-  // object with `bucket`, `endpoint`, and an optional `accessKey`
-  // (`id`, `secret`). An optional `filter` (same `attributes` shape as
-  // the router filter) narrows what this destination forwards.
+  // `openTelemetry` object with `uri` and, when basic auth is configured,
+  // a `basicAuth` object carrying the `username`; `S3` populates an `s3`
+  // object with `bucket`, `endpoint`, and, when a key is configured, an
+  // `accessKey` object carrying the key `id`. The credential halves
+  // (basic-auth password, bearer token, access-key secret) are never
+  // included. An optional `filter` (same `attributes` shape as the
+  // router filter) narrows what this destination forwards.
   config dict
   // Creation timestamp
   createdAt time
@@ -2899,6 +2943,10 @@ private stackit.alb.customRule @defaults("id action severity") {
   // Log message emitted on a match
   logMsg string
   // Severity recorded for a match
+  //
+  // One of SEVERITY_EMERGENCY, SEVERITY_ALERT, SEVERITY_CRITICAL,
+  // SEVERITY_ERROR, SEVERITY_WARNING, SEVERITY_NOTICE, SEVERITY_INFO, or
+  // SEVERITY_DEBUG.
   severity string
   // Match conditions that must hold for the rule to apply
   conditions() []stackit.alb.customRuleCondition
@@ -2979,13 +3027,19 @@ private stackit.kms.wrappingKey @defaults("displayName state expiresAt") {
   description string
   // Wrapping algorithm (for example rsa_4096_oaep_sha256)
   algorithm string
-  // Purpose the wrapping key serves (for example symmetric_key, asymmetric_key)
+  // Purpose the wrapping key serves
+  //
+  // One of wrap_symmetric_key or wrap_asymmetric_key.
   purpose string
   // Protection level backing the private half (software, hsm)
   protection string
   // Access scope (PUBLIC, SNA)
   accessScope string
-  // Lifecycle state (active, creating, deleted, …)
+  // Lifecycle state
+  //
+  // One of active, creating, expired, deleted, or
+  // key_material_unavailable. An expired wrapping key can no longer
+  // accept key material for import.
   state string
   // Expiration, after which the wrapping key can no longer wrap material
   expiresAt time
@@ -3021,7 +3075,7 @@ private stackit.kms.key @defaults("id displayName state purpose") {
   purpose string
   // Algorithm (e.g., aes_256_gcm, rsa_4096_oaep_sha256, ecdsa_p256_sha256)
   algorithm string
-  // Protection level (software)
+  // Protection level backing the key material (software, hsm)
   protection string
   // Access scope (PUBLIC, SNA)
   accessScope string

--- a/providers/stackit/resources/stackit.lr.go
+++ b/providers/stackit/resources/stackit.lr.go
@@ -834,6 +834,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.volume.sourceBackup": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitVolume).GetSourceBackup()).ToDataRes(types.Resource("stackit.backup"))
 	},
+	"stackit.volume.sourceVolume": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitVolume).GetSourceVolume()).ToDataRes(types.Resource("stackit.volume"))
+	},
 	"stackit.volume.server": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitVolume).GetServer()).ToDataRes(types.Resource("stackit.server"))
 	},
@@ -3497,6 +3500,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"stackit.volume.sourceBackup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitVolume).SourceBackup, ok = plugin.RawToTValue[*mqlStackitBackup](v.Value, v.Error)
+		return
+	},
+	"stackit.volume.sourceVolume": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitVolume).SourceVolume, ok = plugin.RawToTValue[*mqlStackitVolume](v.Value, v.Error)
 		return
 	},
 	"stackit.volume.server": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7998,7 +8005,7 @@ func (c *mqlStackitServer) GetMetadata() *plugin.TValue[map[string]any] {
 type mqlStackitVolume struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlStackitVolumeInternal it will be used here
+	mqlStackitVolumeInternal
 	Id                      plugin.TValue[string]
 	Name                    plugin.TValue[string]
 	Description             plugin.TValue[string]
@@ -8013,6 +8020,7 @@ type mqlStackitVolume struct {
 	SourceSnapshot          plugin.TValue[*mqlStackitSnapshot]
 	SourceBackupId          plugin.TValue[string]
 	SourceBackup            plugin.TValue[*mqlStackitBackup]
+	SourceVolume            plugin.TValue[*mqlStackitVolume]
 	Server                  plugin.TValue[*mqlStackitServer]
 	ServerId                plugin.TValue[string]
 	Encrypted               plugin.TValue[bool]
@@ -8151,6 +8159,22 @@ func (c *mqlStackitVolume) GetSourceBackup() *plugin.TValue[*mqlStackitBackup] {
 		}
 
 		return c.sourceBackup()
+	})
+}
+
+func (c *mqlStackitVolume) GetSourceVolume() *plugin.TValue[*mqlStackitVolume] {
+	return plugin.GetOrCompute[*mqlStackitVolume](&c.SourceVolume, func() (*mqlStackitVolume, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.volume", c.__id, "sourceVolume")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitVolume), nil
+			}
+		}
+
+		return c.sourceVolume()
 	})
 }
 
@@ -9131,7 +9155,7 @@ func (c *mqlStackitPublicIp) GetLabels() *plugin.TValue[map[string]any] {
 type mqlStackitSecurityGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlStackitSecurityGroupInternal it will be used here
+	mqlStackitSecurityGroupInternal
 	Id          plugin.TValue[string]
 	Name        plugin.TValue[string]
 	Description plugin.TValue[string]
@@ -11197,7 +11221,7 @@ func (c *mqlStackitSfs) GetLockId() *plugin.TValue[string] {
 type mqlStackitSfsResourcePool struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlStackitSfsResourcePoolInternal it will be used here
+	mqlStackitSfsResourcePoolInternal
 	Id                         plugin.TValue[string]
 	Name                       plugin.TValue[string]
 	State                      plugin.TValue[string]
@@ -11304,15 +11328,21 @@ func (c *mqlStackitSfsResourcePool) GetSizeGigabytes() *plugin.TValue[int64] {
 }
 
 func (c *mqlStackitSfsResourcePool) GetUsedGigabytes() *plugin.TValue[float64] {
-	return &c.UsedGigabytes
+	return plugin.GetOrCompute[float64](&c.UsedGigabytes, func() (float64, error) {
+		return c.usedGigabytes()
+	})
 }
 
 func (c *mqlStackitSfsResourcePool) GetAvailableGigabytes() *plugin.TValue[float64] {
-	return &c.AvailableGigabytes
+	return plugin.GetOrCompute[float64](&c.AvailableGigabytes, func() (float64, error) {
+		return c.availableGigabytes()
+	})
 }
 
 func (c *mqlStackitSfsResourcePool) GetUsedBySnapshotsGigabytes() *plugin.TValue[float64] {
-	return &c.UsedBySnapshotsGigabytes
+	return plugin.GetOrCompute[float64](&c.UsedBySnapshotsGigabytes, func() (float64, error) {
+		return c.usedBySnapshotsGigabytes()
+	})
 }
 
 func (c *mqlStackitSfsResourcePool) GetIpAcl() *plugin.TValue[[]any] {

--- a/providers/stackit/resources/stackit.lr.versions
+++ b/providers/stackit/resources/stackit.lr.versions
@@ -884,6 +884,7 @@ stackit.volume.sourceBackup 13.4.3
 stackit.volume.sourceBackupId 13.4.3
 stackit.volume.sourceSnapshot 13.4.2
 stackit.volume.sourceSnapshotId 13.0.0
+stackit.volume.sourceVolume 13.7.2
 stackit.volume.status 13.0.0
 stackit.volume.updatedAt 13.0.0
 stackit.volumes 13.0.0

--- a/providers/stackit/resources/stackit_exposure.go
+++ b/providers/stackit/resources/stackit_exposure.go
@@ -220,16 +220,23 @@ func lbExposure(externalAddress string, privateNetworkOnly bool, options any) (i
 // dbaasInstanceReachable reports whether a DBaaS-style managed instance
 // (OpenSearch, MariaDB, Redis, RabbitMQ, LogMe) is reachable from the internet.
 // These instances surface their networking through the free-form `parameters`
-// blob: `enable_public_access` toggles a public endpoint, and `sgw_acl` is the
-// source-IP allow-list. The instance is reachable when public access is on and
-// the allow-list admits any address (or is absent).
+// blob, and the SDK's InstanceParameters model documents exactly one network
+// key on it: `sgw_acl`, the comma-separated CIDR allow-list ("IP networks
+// which are allowed to access this instance"). The instance is reachable when
+// that list admits any address, or is absent.
+//
+// An `enable_public_access` key is honored only when the API actually sends
+// it: an explicit false short-circuits to "not reachable". No engine's
+// InstanceParameters model declares the key, so it is usually absent, and an
+// absent key must not be read as false. Doing so reported every CF-broker
+// instance as unreachable regardless of its allow-list, which is the
+// reassuring answer and the wrong one.
 func dbaasInstanceReachable(parameters any) bool {
 	params, ok := parameters.(map[string]any)
 	if !ok {
 		return false
 	}
-	publicAccess := dictBool(params["enable_public_access"])
-	if !publicAccess {
+	if v, present := params["enable_public_access"]; present && !dictBool(v) {
 		return false
 	}
 	return aclAllowsAnyAddress(dictStrSlice(params["sgw_acl"]))

--- a/providers/stackit/resources/stackit_exposure_test.go
+++ b/providers/stackit/resources/stackit_exposure_test.go
@@ -211,8 +211,14 @@ func TestDbaasInstanceReachable(t *testing.T) {
 		{"public + no acl", map[string]any{"enable_public_access": true}, true},
 		{"public + restricted acl", map[string]any{"enable_public_access": true, "sgw_acl": "10.0.0.0/8"}, false},
 		{"public string true", map[string]any{"enable_public_access": "true"}, true},
-		{"not public", map[string]any{"enable_public_access": false, "sgw_acl": "0.0.0.0/0"}, false},
-		{"missing public flag", map[string]any{"sgw_acl": "0.0.0.0/0"}, false},
+		{"explicit not public overrides an open acl", map[string]any{"enable_public_access": false, "sgw_acl": "0.0.0.0/0"}, false},
+		{"explicit string false overrides an open acl", map[string]any{"enable_public_access": "false", "sgw_acl": "0.0.0.0/0"}, false},
+		// The API does not send enable_public_access (no InstanceParameters
+		// model declares it), so the verdict has to come from sgw_acl alone.
+		// Reading the absent key as false made every instance unreachable.
+		{"absent public flag + open acl is reachable", map[string]any{"sgw_acl": "0.0.0.0/0"}, true},
+		{"absent public flag + restricted acl", map[string]any{"sgw_acl": "10.0.0.0/8"}, false},
+		{"absent public flag + no acl is reachable", map[string]any{}, true},
 		{"acl as list", map[string]any{"enable_public_access": true, "sgw_acl": []any{"::/0"}}, true},
 		{"nil params", nil, false},
 	}

--- a/providers/stackit/resources/telemetry.go
+++ b/providers/stackit/resources/telemetry.go
@@ -105,7 +105,7 @@ func (r *mqlStackitTelemetryRouter) destinations() ([]any, error) {
 				"description":    llx.StringData(d.GetDescription()),
 				"status":         llx.StringData(string(d.GetStatus())),
 				"credentialType": llx.StringData(string(d.GetCredentialType())),
-				"config":         llx.DictData(toDict(d.GetConfig())),
+				"config":         llx.DictData(redactDestinationConfig(toDict(d.GetConfig()))),
 				"createdAt":      llx.TimeDataPtr(telemetryTime(d.GetCreationTimeOk())),
 			})
 			if err != nil {
@@ -119,6 +119,33 @@ func (r *mqlStackitTelemetryRouter) destinations() ([]any, error) {
 		}
 	}
 	return out, nil
+}
+
+// redactDestinationConfig strips the forwarding credentials out of a
+// destination's config dict before it reaches MQL. The SDK's DestinationConfig
+// carries them inline, and a wholesale marshal of the struct surfaced them:
+// `openTelemetry.basicAuth.password`, `openTelemetry.bearerToken`, and
+// `s3.accessKey.secret`. The identifying halves (`basicAuth.username`,
+// `accessKey.id`) and the endpoints stay, so "where does telemetry leave the
+// project, and how does the router authenticate" remains answerable without
+// the secret itself. The input is returned unchanged when it is not a dict.
+func redactDestinationConfig(cfg any) any {
+	m, ok := cfg.(map[string]any)
+	if !ok {
+		return cfg
+	}
+	if otel, ok := m["openTelemetry"].(map[string]any); ok {
+		delete(otel, "bearerToken")
+		if auth, ok := otel["basicAuth"].(map[string]any); ok {
+			delete(auth, "password")
+		}
+	}
+	if s3, ok := m["s3"].(map[string]any); ok {
+		if key, ok := s3["accessKey"].(map[string]any); ok {
+			delete(key, "secret")
+		}
+	}
+	return m
 }
 
 func (r *mqlStackitTelemetryRouterDestination) id() (string, error) {

--- a/providers/stackit/resources/telemetry_test.go
+++ b/providers/stackit/resources/telemetry_test.go
@@ -1,0 +1,111 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+
+	trouter "github.com/stackitcloud/stackit-sdk-go/services/telemetryrouter/v1betaapi"
+)
+
+// decodeDestinationConfig builds the SDK struct from a payload shaped like the
+// ListDestinations response, then runs it through the same toDict marshal the
+// provider uses, so the test exercises the exact key names the redaction has
+// to know about rather than a hand-built map.
+func decodeDestinationConfig(t *testing.T, payload string) map[string]any {
+	t.Helper()
+	var cfg trouter.DestinationConfig
+	if err := json.Unmarshal([]byte(payload), &cfg); err != nil {
+		t.Fatalf("decoding destination config: %v", err)
+	}
+	m, ok := toDict(cfg).(map[string]any)
+	if !ok {
+		t.Fatalf("toDict(DestinationConfig) = %T, want map", toDict(cfg))
+	}
+	return m
+}
+
+// TestRedactDestinationConfigStripsSecrets pins the leak this guards against:
+// the destination config used to be a raw marshal of DestinationConfig, which
+// put the OTLP basic-auth password, the bearer token, and the S3 secret key
+// into the `config` dict of every stackit.telemetry.router.destination.
+func TestRedactDestinationConfigStripsSecrets(t *testing.T) {
+	t.Run("open telemetry basic auth keeps the username, drops the password", func(t *testing.T) {
+		got := redactDestinationConfig(decodeDestinationConfig(t, `{
+			"configType": "OpenTelemetry",
+			"openTelemetry": {
+				"uri": "https://otel.example.test:4318",
+				"basicAuth": {"username": "router", "password": "hunter2"}
+			}
+		}`)).(map[string]any)
+		otel := got["openTelemetry"].(map[string]any)
+		auth := otel["basicAuth"].(map[string]any)
+		if _, leaked := auth["password"]; leaked {
+			t.Fatalf("basicAuth.password survived redaction: %v", auth)
+		}
+		if auth["username"] != "router" {
+			t.Fatalf("basicAuth.username = %v, want router", auth["username"])
+		}
+		if otel["uri"] != "https://otel.example.test:4318" {
+			t.Fatalf("uri = %v, want the endpoint to survive", otel["uri"])
+		}
+	})
+
+	t.Run("open telemetry bearer token is dropped", func(t *testing.T) {
+		got := redactDestinationConfig(decodeDestinationConfig(t, `{
+			"configType": "OpenTelemetry",
+			"openTelemetry": {"uri": "https://otel.example.test", "bearerToken": "eyJhbGciOi"}
+		}`)).(map[string]any)
+		otel := got["openTelemetry"].(map[string]any)
+		if _, leaked := otel["bearerToken"]; leaked {
+			t.Fatalf("bearerToken survived redaction: %v", otel)
+		}
+	})
+
+	t.Run("s3 access key keeps the id, drops the secret", func(t *testing.T) {
+		got := redactDestinationConfig(decodeDestinationConfig(t, `{
+			"configType": "S3",
+			"s3": {
+				"bucket": "telemetry-archive",
+				"endpoint": "https://object.storage.example.test",
+				"accessKey": {"id": "AKIA-EXAMPLE", "secret": "wJalrXUtnFEMI"}
+			}
+		}`)).(map[string]any)
+		s3 := got["s3"].(map[string]any)
+		key := s3["accessKey"].(map[string]any)
+		if _, leaked := key["secret"]; leaked {
+			t.Fatalf("accessKey.secret survived redaction: %v", key)
+		}
+		if key["id"] != "AKIA-EXAMPLE" {
+			t.Fatalf("accessKey.id = %v, want AKIA-EXAMPLE", key["id"])
+		}
+		if s3["bucket"] != "telemetry-archive" || s3["endpoint"] != "https://object.storage.example.test" {
+			t.Fatalf("bucket/endpoint did not survive: %v", s3)
+		}
+	})
+
+	t.Run("config without credentials is left intact", func(t *testing.T) {
+		got := redactDestinationConfig(decodeDestinationConfig(t, `{
+			"configType": "OpenTelemetry",
+			"openTelemetry": {"uri": "https://otel.example.test"},
+			"filter": {"attributes": [{"key": "env", "level": "resource", "matcher": "equals", "values": ["prod"]}]}
+		}`)).(map[string]any)
+		if got["configType"] != "OpenTelemetry" {
+			t.Fatalf("configType = %v", got["configType"])
+		}
+		if _, ok := got["filter"].(map[string]any); !ok {
+			t.Fatalf("filter was dropped: %v", got)
+		}
+	})
+
+	t.Run("non-dict input is returned unchanged", func(t *testing.T) {
+		if got := redactDestinationConfig(nil); got != nil {
+			t.Fatalf("redactDestinationConfig(nil) = %v, want nil", got)
+		}
+		if got := redactDestinationConfig("opaque"); got != "opaque" {
+			t.Fatalf("redactDestinationConfig(string) = %v, want the input back", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes found by the SDK-response-versus-schema sweep across every STACKIT module the provider imports. No new API surface beyond one typed accessor that closes a data-loss gap.

**Credential leak**
- `stackit.telemetry.router.destination.config` was a wholesale marshal of the SDK's `DestinationConfig`, which carries the OTLP basic-auth password, the bearer token, and the S3 access-key secret inline. The dict is now redacted before it reaches MQL. Usernames, access-key ids, endpoints, and the filter survive, so "where does telemetry leave the project and how does the router authenticate" is still answerable. The field description no longer lists the secret keys. Pinned by `TestRedactDestinationConfigStripsSecrets`, which decodes a response-shaped payload through the same `toDict` path the provider uses.

**Wrong exposure verdict**
- `internetReachable` on the five CF-broker DBaaS instances gated on `parameters["enable_public_access"]`, and read an absent key as false. No engine's `InstanceParameters` model declares that key; the only network key the SDK documents is `sgw_acl` ("IP networks in CIDR notation which are allowed to access this instance"). So every instance read as unreachable regardless of an open allow-list. The verdict now comes from `sgw_acl`, with an explicit `false` on `enable_public_access` still honored when the API does send it. Test cases added for the absent-key path.

**Zero where the API never sent a value**
- `stackit.sfs.resourcePool` `usedGigabytes`, `availableGigabytes`, `usedBySnapshotsGigabytes` were mapped from `ListResourcePools`, whose `ResourcePoolSpace` doc says they are "only available when retrieving a single Resource Pool by ID". Every pool reached through the list read as empty. The three fields are now computed per pool through `GetResourcePool` (one call shared by all three, double-check locked), seeded for free on the `init(id:)` path, and null rather than zero when the pool cannot be read. Static-to-computed is not a type change; the field names and types are unchanged.

**Absent boolean read as false**
- `stackit.alb.loadBalancer.disableTargetSecurityGroupAssignment` used the non-pointer getter. It now goes through the same `lbDisableTargetSecurityGroupAssignment` helper as the network load balancer (made an interface over the shared SDK accessor) and reports null when the API omits the flag. Test added on an ALB payload.

**Lost provenance**
- `classifyVolumeSource` dropped the `volume` source type, so a cloned volume reported no origin at all. The id is cached internally and exposed as `stackit.volume.sourceVolume()` (13.7.2). Only the typed accessor is added, no raw id field.

**Redundant API calls**
- `securityGroup.rules()` issued `ListSecurityGroupRules` per group although `SecurityGroup.Rules` is inline on the group response; the exposure walk reads every group's rules for every server, so this multiplied. The inline rules are cached and the call is made only when the API omitted the field. The rule mapping moved to `securityGroupRuleArgs`, pinned by a new table test (numeric-only protocol, ICMP null handling).
- `sfs.exportPolicy.rules()` re-fetched rules that `ListShareExportPolicies` and the policy nested on each share already return; both paths now seed the rules, and a share builds its policy resource from the nested object instead of resolving it by id.
- `observability.instance.grafanaPublicReadAccess` / `grafanaUseStackitSso` spent `GetGrafanaConfigs` on two flags already on `GetInstanceResponse.Instance`; they read the detail now, and the Grafana call is only paid for the generic-OAuth fields (with the Grafana endpoint kept as a fallback if the detail was denied).

**Schema documentation drift** (verified against the SDK's model comments and enum constants)
- `image.scope` is `public`, `local`, `projects`, `organization`, not `public`/`private`, so a policy comparing to `"private"` could never match.
- `volume.status` listed `IN_USE`, which does not exist; full lists for image, volume, server, and snapshot status.
- `keyPair.fingerprint` is MD5, not SHA256.
- `kms.wrappingKey.purpose` values are `wrap_symmetric_key`/`wrap_asymmetric_key`; wrapping-key state gains `expired` and `key_material_unavailable`; `kms.key.protection` includes `hsm`.
- `dns.zone.visibility` only defines `public`; `dns.recordSet.type` lists all 25 types (CAA, DS, TLSA, SSHFP, HTTPS included).
- `alb.customRule.severity` enumerates the `SEVERITY_*` values; `mongoDbFlex.instance.flavor` no longer promises a `categories` key the v2 model lacks; `ske.cluster.kubernetesVersion` is a full patch version.

## Verification

Run inside `providers/stackit/`:

- `./mqlr generate` twice (two new Internal structs), no breaking change reported
- `go build ./...`, `go vet ./...` clean
- `go test ./...` passes, including the new and updated tests
- `gofmt -l .` empty

Not verified against a live STACKIT project (no credentials on this machine). In particular the `enable_public_access` finding rests on the SDK models, not on an observed response; the fix is safe either way because an explicit value is still honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
