### PR TITLE
✨ stackit: typed encryption and root-disk edges on servers, volumes, and Secrets Manager

### DIFF
--- a/providers/stackit/resources/dbaas.go
+++ b/providers/stackit/resources/dbaas.go
@@ -11,6 +11,7 @@ import (
 	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
 	observability "github.com/stackitcloud/stackit-sdk-go/services/observability/v1api"
 	postgresflex "github.com/stackitcloud/stackit-sdk-go/services/postgresflex/v2api"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
 	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 	"go.mondoo.com/mql/llx"
 	"go.mondoo.com/mql/providers-sdk/v1/plugin"
@@ -502,18 +503,7 @@ func (r *mqlStackitSecretsManager) instances() ([]any, error) {
 	items, _ := resp.GetInstancesOk()
 	out := make([]any, 0, len(items))
 	for i := range items {
-		inst := items[i]
-		args := map[string]*llx.RawData{
-			"id":                 llx.StringData(inst.GetId()),
-			"name":               llx.StringData(inst.GetName()),
-			"state":              llx.StringData(inst.GetState()),
-			"apiUrl":             llx.StringData(inst.GetApiUrl()),
-			"secretsEngine":      llx.StringData(inst.GetSecretsEngine()),
-			"secretCount":        llx.IntData(int64(inst.GetSecretCount())),
-			"creationStartedAt":  llx.TimeDataPtr(parseDnsTime(inst.GetCreationStartDate())),
-			"creationFinishedAt": llx.TimeDataPtr(parseDnsTime(inst.GetCreationFinishedDate())),
-		}
-		res, err := CreateResource(r.MqlRuntime, "stackit.secretsManager.instance", args)
+		res, err := buildSecretsManagerInstance(r.MqlRuntime, &items[i])
 		if err != nil {
 			return nil, err
 		}
@@ -522,8 +512,102 @@ func (r *mqlStackitSecretsManager) instances() ([]any, error) {
 	return out, nil
 }
 
+type mqlStackitSecretsManagerInstanceInternal struct {
+	// cacheKmsKey is the customer-managed key reference the instance
+	// carries, resolved by the encryptionKey* accessors. Nil when the vault
+	// relies on platform-managed encryption.
+	cacheKmsKey *secretsmanager.KmsKeyPayload
+}
+
+// buildSecretsManagerInstance maps an instance record onto the resource. The
+// list and the single-instance endpoints return the same model, so both
+// creation paths share it.
+func buildSecretsManagerInstance(runtime *plugin.Runtime, inst *secretsmanager.Instance) (plugin.Resource, error) {
+	kmsKey, hasKmsKey := inst.GetKmsKeyOk()
+	var keyVersion int64
+	if hasKmsKey && kmsKey != nil {
+		keyVersion = kmsKey.GetKeyVersion()
+	}
+	res, err := CreateResource(runtime, "stackit.secretsManager.instance", map[string]*llx.RawData{
+		"id":                   llx.StringData(inst.GetId()),
+		"name":                 llx.StringData(inst.GetName()),
+		"state":                llx.StringData(inst.GetState()),
+		"apiUrl":               llx.StringData(inst.GetApiUrl()),
+		"secretsEngine":        llx.StringData(inst.GetSecretsEngine()),
+		"secretCount":          llx.IntData(int64(inst.GetSecretCount())),
+		"creationStartedAt":    llx.TimeDataPtr(parseDnsTime(inst.GetCreationStartDate())),
+		"creationFinishedAt":   llx.TimeDataPtr(parseDnsTime(inst.GetCreationFinishedDate())),
+		"encryptionKeyVersion": llx.IntData(keyVersion),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if hasKmsKey && kmsKey != nil {
+		res.(*mqlStackitSecretsManagerInstance).cacheKmsKey = kmsKey
+	}
+	return res, nil
+}
+
 func (r *mqlStackitSecretsManagerInstance) id() (string, error) {
 	return "stackit.secretsManager.instance/" + r.Id.Data, nil
+}
+
+// encryptionKey resolves the customer-managed key that encrypts the vault.
+// Null when the instance relies on platform-managed encryption. The instance
+// names the ring, so the lookup reads that one ring's key list.
+func (r *mqlStackitSecretsManagerInstance) encryptionKey() (*mqlStackitKmsKey, error) {
+	k := r.cacheKmsKey
+	if k == nil {
+		return markNull[mqlStackitKmsKey](&r.EncryptionKey)
+	}
+	return kmsKeyInRingRef(r.MqlRuntime, k.GetKeyRingId(), k.GetKeyId(), &r.EncryptionKey)
+}
+
+// encryptionKeyRing resolves the key ring that holds the vault's
+// customer-managed key. Null for platform-managed encryption.
+func (r *mqlStackitSecretsManagerInstance) encryptionKeyRing() (*mqlStackitKmsKeyRing, error) {
+	k := r.cacheKmsKey
+	if k == nil {
+		return markNull[mqlStackitKmsKeyRing](&r.EncryptionKeyRing)
+	}
+	return kmsKeyRingRef(r.MqlRuntime, k.GetKeyRingId(), &r.EncryptionKeyRing)
+}
+
+// encryptionKeyVersionRef resolves the generation of key material the vault
+// is pinned to. Version numbers start at 1, so 0 means nothing is pinned.
+func (r *mqlStackitSecretsManagerInstance) encryptionKeyVersionRef() (*mqlStackitKmsKeyVersion, error) {
+	field := &r.EncryptionKeyVersionRef
+	number := r.EncryptionKeyVersion.Data
+	if number == 0 {
+		return markNull[mqlStackitKmsKeyVersion](field)
+	}
+	key := r.GetEncryptionKey()
+	if key.Error != nil {
+		return nil, key.Error
+	}
+	if key.Data == nil {
+		return markNull[mqlStackitKmsKeyVersion](field)
+	}
+	versions := key.Data.GetVersions()
+	if versions.Error != nil {
+		return nil, versions.Error
+	}
+	v := findKmsKeyVersion(versions.Data, number)
+	if v == nil {
+		return markNull[mqlStackitKmsKeyVersion](field)
+	}
+	return v, nil
+}
+
+// encryptionKeyServiceAccount resolves the service account the vault uses
+// to reach its customer-managed key. Null for platform-managed encryption,
+// and null when the account is not one of this project's.
+func (r *mqlStackitSecretsManagerInstance) encryptionKeyServiceAccount() (*mqlStackitServiceAccount, error) {
+	k := r.cacheKmsKey
+	if k == nil {
+		return markNull[mqlStackitServiceAccount](&r.EncryptionKeyServiceAccount)
+	}
+	return serviceAccountRef(r.MqlRuntime, k.GetServiceAccountEmail(), &r.EncryptionKeyServiceAccount)
 }
 
 func (r *mqlStackitSecretsManagerInstance) acls() ([]any, error) {
@@ -1418,16 +1502,7 @@ func initStackitSecretsManagerInstance(runtime *plugin.Runtime, args map[string]
 	if inst == nil {
 		return nil, nil, fmt.Errorf("stackit.secretsManager.instance with id %q not found", id)
 	}
-	res, err := CreateResource(runtime, "stackit.secretsManager.instance", map[string]*llx.RawData{
-		"id":                 llx.StringData(inst.GetId()),
-		"name":               llx.StringData(inst.GetName()),
-		"state":              llx.StringData(inst.GetState()),
-		"apiUrl":             llx.StringData(inst.GetApiUrl()),
-		"secretsEngine":      llx.StringData(inst.GetSecretsEngine()),
-		"secretCount":        llx.IntData(int64(inst.GetSecretCount())),
-		"creationStartedAt":  llx.TimeDataPtr(parseDnsTime(inst.GetCreationStartDate())),
-		"creationFinishedAt": llx.TimeDataPtr(parseDnsTime(inst.GetCreationFinishedDate())),
-	})
+	res, err := buildSecretsManagerInstance(runtime, inst)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/stackit/resources/helpers.go
+++ b/providers/stackit/resources/helpers.go
@@ -385,6 +385,82 @@ func kmsKeyRef(runtime *plugin.Runtime, id string, field *plugin.TValue[*mqlStac
 	return key, nil
 }
 
+// kmsKeyRingRef resolves a key ring by UUID, marking the field null when the
+// id is empty or the ring is not readable from this project (a ring that lives
+// in another project answers 404 to GetKeyRing).
+func kmsKeyRingRef(runtime *plugin.Runtime, id string, field *plugin.TValue[*mqlStackitKmsKeyRing]) (*mqlStackitKmsKeyRing, error) {
+	if id == "" {
+		return markNull[mqlStackitKmsKeyRing](field)
+	}
+	res, err := NewResource(runtime, "stackit.kms.keyRing", map[string]*llx.RawData{
+		"id": llx.StringData(id),
+	})
+	if err != nil {
+		if isNotFound(err) || isAccessDenied(err) {
+			return markNull[mqlStackitKmsKeyRing](field)
+		}
+		return nil, err
+	}
+	return res.(*mqlStackitKmsKeyRing), nil
+}
+
+// kmsKeyInRingRef resolves a key by UUID through the ring that holds it, which
+// costs one ring's key list rather than the walk over every ring that
+// kmsKeyRef performs. It falls back to that walk when the ring is unknown, and
+// marks the field null when the key id is empty or the ring's list does not
+// carry the key.
+func kmsKeyInRingRef(runtime *plugin.Runtime, ringID, keyID string, field *plugin.TValue[*mqlStackitKmsKey]) (*mqlStackitKmsKey, error) {
+	if keyID == "" {
+		return markNull[mqlStackitKmsKey](field)
+	}
+	if ringID == "" {
+		return kmsKeyRef(runtime, keyID, field)
+	}
+	var ringField plugin.TValue[*mqlStackitKmsKeyRing]
+	ring, err := kmsKeyRingRef(runtime, ringID, &ringField)
+	if err != nil {
+		return nil, err
+	}
+	if ring == nil {
+		return markNull[mqlStackitKmsKey](field)
+	}
+	keys := ring.GetKeys()
+	if keys.Error != nil {
+		return nil, keys.Error
+	}
+	key, ok := indexKmsKeysByID(keys.Data)[keyID]
+	if !ok || key == nil {
+		return markNull[mqlStackitKmsKey](field)
+	}
+	return key, nil
+}
+
+// serviceAccountRef resolves a service account by email against the project's
+// service-account list, marking the field null when the email is empty or the
+// account is not one of this project's. A key-encryption key held in another
+// project is used through a service account of that project, which this
+// connection cannot list.
+func serviceAccountRef(runtime *plugin.Runtime, email string, field *plugin.TValue[*mqlStackitServiceAccount]) (*mqlStackitServiceAccount, error) {
+	if email == "" {
+		return markNull[mqlStackitServiceAccount](field)
+	}
+	root, err := CreateResource(runtime, "stackit", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	accounts := root.(*mqlStackit).GetServiceAccounts()
+	if accounts.Error != nil {
+		return nil, accounts.Error
+	}
+	for _, a := range accounts.Data {
+		sa, ok := a.(*mqlStackitServiceAccount)
+		if ok && sa.Email.Data == email {
+			return sa, nil
+		}
+	}
+	return markNull[mqlStackitServiceAccount](field)
+}
+
 // iamRoleRef resolves a project role by name, marking the given field null when
 // the name is empty or the role catalog does not define it.
 //

--- a/providers/stackit/resources/iaas.go
+++ b/providers/stackit/resources/iaas.go
@@ -50,6 +50,26 @@ func (r *mqlStackit) servers() ([]any, error) {
 type mqlStackitServerInternal struct {
 	cacheServiceAccountMails []string
 	cacheNics                []any
+	// cacheBootVolumeID is the volume the server boots from, resolved by
+	// bootVolume(). Empty when the server boots straight from an image.
+	cacheBootVolumeID string
+}
+
+// bootVolume resolves the volume that holds the server's root disk, so a
+// check can ask about the OS disk specifically (its encryption key, its
+// image, whether it is a clone) rather than about the undifferentiated set
+// in volumes. Null when the server boots straight from an image.
+func (r *mqlStackitServer) bootVolume() (*mqlStackitVolume, error) {
+	if r.cacheBootVolumeID == "" {
+		return markNull[mqlStackitVolume](&r.BootVolume)
+	}
+	res, err := NewResource(r.MqlRuntime, "stackit.volume", map[string]*llx.RawData{
+		"id": llx.StringData(r.cacheBootVolumeID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlStackitVolume), nil
 }
 
 // serverAgentProvisioned reports whether the STACKIT server agent is
@@ -157,6 +177,9 @@ func buildServer(runtime *plugin.Runtime, s *iaas.Server) (plugin.Resource, erro
 		return nil, err
 	}
 	mqlServer := res.(*mqlStackitServer)
+	if boot, ok := s.GetBootVolumeOk(); ok && boot != nil {
+		mqlServer.cacheBootVolumeID = boot.GetId()
+	}
 	mqlServer.cacheServiceAccountMails = s.GetServiceAccountMails()
 	mqlServer.cacheNics = nics
 	return res, nil
@@ -354,6 +377,51 @@ type mqlStackitVolumeInternal struct {
 	// cacheSourceVolumeID is the volume this one was cloned from, resolved by
 	// sourceVolume(). Held internally rather than as a raw id field.
 	cacheSourceVolumeID string
+	// cacheEncryption is the customer-managed-key reference the volume
+	// carries, resolved by the encryptionKey* accessors.
+	cacheEncryption volumeEncryption
+}
+
+// volumeEncryption is the customer-managed key-encryption-key reference on a
+// volume: which KMS key and version wrap the data-encryption key, the ring
+// that holds the key, the project that owns it (empty when the API leaves it
+// out, meaning the volume's own project), and the service account the
+// platform uses to unwrap with it.
+type volumeEncryption struct {
+	keyID          string
+	keyVersion     int64
+	keyRingID      string
+	projectID      string
+	serviceAccount string
+}
+
+// volumeEncryptionOf extracts the key-encryption-key reference from a volume.
+// The whole block is absent on a platform-managed volume, and every field
+// reads empty then.
+func volumeEncryptionOf(v *iaas.Volume) volumeEncryption {
+	var enc volumeEncryption
+	if v == nil {
+		return enc
+	}
+	ep, ok := v.GetEncryptionParametersOk()
+	if !ok || ep == nil {
+		return enc
+	}
+	enc.keyID = ep.GetKekKeyId()
+	enc.keyVersion = ep.GetKekKeyVersion()
+	enc.keyRingID = ep.GetKekKeyringId()
+	enc.serviceAccount = ep.GetServiceAccount()
+	if p, ok := ep.GetKekProjectIdOk(); ok && p != nil {
+		enc.projectID = *p
+	}
+	return enc
+}
+
+// crossProject reports whether the key lives in a project other than the
+// one this connection reads, in which case neither the ring nor the service
+// account can be resolved here.
+func (e volumeEncryption) crossProject(ownProjectID string) bool {
+	return e.projectID != "" && e.projectID != ownProjectID
 }
 
 func buildVolume(runtime *plugin.Runtime, v *iaas.Volume) (plugin.Resource, error) {
@@ -362,45 +430,65 @@ func buildVolume(runtime *plugin.Runtime, v *iaas.Volume) (plugin.Resource, erro
 		imageID, snapshotID, backupID, sourceVolumeID = classifyVolumeSource(src.GetType(), src.GetId())
 	}
 	serverID := v.GetServerId()
-
-	var (
-		kekKeyID      string
-		kekKeyVersion int64
-	)
-	if ep, ok := v.GetEncryptionParametersOk(); ok {
-		kekKeyID = ep.GetKekKeyId()
-		kekKeyVersion = ep.GetKekKeyVersion()
-	}
+	enc := volumeEncryptionOf(v)
+	kekKeyID := enc.keyID
+	kekKeyVersion := enc.keyVersion
 
 	createdAt, ok1 := v.GetCreatedAtOk()
 	updatedAt, ok2 := v.GetUpdatedAtOk()
 
 	args := map[string]*llx.RawData{
-		"id":                   llx.StringData(v.GetId()),
-		"name":                 llx.StringData(v.GetName()),
-		"description":          llx.StringData(v.GetDescription()),
-		"size":                 llx.IntData(int64(v.GetSize())),
-		"status":               llx.StringData(v.GetStatus()),
-		"availabilityZone":     llx.StringData(v.GetAvailabilityZone()),
-		"performanceClass":     llx.StringData(v.GetPerformanceClass()),
-		"bootable":             llx.BoolData(v.GetBootable()),
-		"imageId":              llx.StringData(imageID),
-		"sourceSnapshotId":     llx.StringData(snapshotID),
-		"sourceBackupId":       llx.StringData(backupID),
-		"serverId":             llx.StringData(serverID),
-		"encrypted":            llx.BoolData(v.GetEncrypted()),
-		"encryptionKeyId":      llx.StringData(kekKeyID),
-		"encryptionKeyVersion": llx.IntData(kekKeyVersion),
-		"createdAt":            llx.TimeDataPtr(timeOrNil(createdAt, ok1)),
-		"updatedAt":            llx.TimeDataPtr(timeOrNil(updatedAt, ok2)),
-		"labels":               labelData(v.GetLabels()),
+		"id":                     llx.StringData(v.GetId()),
+		"name":                   llx.StringData(v.GetName()),
+		"description":            llx.StringData(v.GetDescription()),
+		"size":                   llx.IntData(int64(v.GetSize())),
+		"status":                 llx.StringData(v.GetStatus()),
+		"availabilityZone":       llx.StringData(v.GetAvailabilityZone()),
+		"performanceClass":       llx.StringData(v.GetPerformanceClass()),
+		"bootable":               llx.BoolData(v.GetBootable()),
+		"imageId":                llx.StringData(imageID),
+		"sourceSnapshotId":       llx.StringData(snapshotID),
+		"sourceBackupId":         llx.StringData(backupID),
+		"serverId":               llx.StringData(serverID),
+		"encrypted":              llx.BoolData(v.GetEncrypted()),
+		"encryptionKeyId":        llx.StringData(kekKeyID),
+		"encryptionKeyVersion":   llx.IntData(kekKeyVersion),
+		"createdAt":              llx.TimeDataPtr(timeOrNil(createdAt, ok1)),
+		"updatedAt":              llx.TimeDataPtr(timeOrNil(updatedAt, ok2)),
+		"labels":                 labelData(v.GetLabels()),
+		"encryptionKeyProjectId": llx.StringData(enc.projectID),
 	}
 	res, err := CreateResource(runtime, "stackit.volume", args)
 	if err != nil {
 		return nil, err
 	}
-	res.(*mqlStackitVolume).cacheSourceVolumeID = sourceVolumeID
+	mqlVolume := res.(*mqlStackitVolume)
+	mqlVolume.cacheSourceVolumeID = sourceVolumeID
+	mqlVolume.cacheEncryption = enc
 	return res, nil
+}
+
+// encryptionKeyRing resolves the key ring that holds the volume's
+// key-encryption key. Null for a platform-managed volume, and null when the
+// key lives in another project, whose rings this connection cannot read.
+func (r *mqlStackitVolume) encryptionKeyRing() (*mqlStackitKmsKeyRing, error) {
+	enc := r.cacheEncryption
+	if enc.crossProject(conn(r.MqlRuntime).ProjectID()) {
+		return markNull[mqlStackitKmsKeyRing](&r.EncryptionKeyRing)
+	}
+	return kmsKeyRingRef(r.MqlRuntime, enc.keyRingID, &r.EncryptionKeyRing)
+}
+
+// encryptionKeyServiceAccount resolves the service account the platform uses
+// to unwrap the volume's data-encryption key with the customer-managed key.
+// Null for a platform-managed volume, and null when the key and its service
+// account belong to another project.
+func (r *mqlStackitVolume) encryptionKeyServiceAccount() (*mqlStackitServiceAccount, error) {
+	enc := r.cacheEncryption
+	if enc.crossProject(conn(r.MqlRuntime).ProjectID()) {
+		return markNull[mqlStackitServiceAccount](&r.EncryptionKeyServiceAccount)
+	}
+	return serviceAccountRef(r.MqlRuntime, enc.serviceAccount, &r.EncryptionKeyServiceAccount)
 }
 
 func (r *mqlStackitVolume) id() (string, error) {
@@ -494,9 +582,15 @@ func (r *mqlStackitVolume) sourceBackup() (*mqlStackitBackup, error) {
 }
 
 // encryptionKey resolves the customer-managed key that wraps the volume's
-// data-encryption key. Null for a platform-managed volume.
+// data-encryption key. Null for a platform-managed volume, and null when the
+// key lives in another project. The volume names the ring that holds the
+// key, so the lookup reads that one ring instead of walking every ring.
 func (r *mqlStackitVolume) encryptionKey() (*mqlStackitKmsKey, error) {
-	return kmsKeyRef(r.MqlRuntime, r.EncryptionKeyId.Data, &r.EncryptionKey)
+	enc := r.cacheEncryption
+	if enc.crossProject(conn(r.MqlRuntime).ProjectID()) {
+		return markNull[mqlStackitKmsKey](&r.EncryptionKey)
+	}
+	return kmsKeyInRingRef(r.MqlRuntime, enc.keyRingID, r.EncryptionKeyId.Data, &r.EncryptionKey)
 }
 
 // encryptionKeyVersionRef resolves the exact generation of key material the

--- a/providers/stackit/resources/iaas_test.go
+++ b/providers/stackit/resources/iaas_test.go
@@ -132,6 +132,69 @@ func TestSecurityGroupRuleArgs(t *testing.T) {
 	})
 }
 
+// TestVolumeEncryptionOf pins the key-encryption-key reference read off a
+// volume: every part of it reads empty on a platform-managed volume, and the
+// optional owning project is empty rather than zero-valued when absent, since
+// an empty projectID is what marks the key as belonging to this project.
+func TestVolumeEncryptionOf(t *testing.T) {
+	decode := func(payload string) *iaas.Volume {
+		var v iaas.Volume
+		if err := json.Unmarshal([]byte(payload), &v); err != nil {
+			t.Fatalf("decoding volume: %v", err)
+		}
+		return &v
+	}
+
+	t.Run("customer-managed key in the volume's own project", func(t *testing.T) {
+		enc := volumeEncryptionOf(decode(`{
+			"id": "vol-1", "availabilityZone": "eu01-1", "encrypted": true,
+			"encryptionParameters": {
+				"kekKeyId": "key-1", "kekKeyVersion": 3, "kekKeyringId": "ring-1",
+				"serviceAccount": "kek@sa.stackit.cloud"
+			}
+		}`))
+		want := volumeEncryption{keyID: "key-1", keyVersion: 3, keyRingID: "ring-1", serviceAccount: "kek@sa.stackit.cloud"}
+		if enc != want {
+			t.Fatalf("volumeEncryptionOf = %+v, want %+v", enc, want)
+		}
+		if enc.crossProject("proj-a") {
+			t.Fatal("a key with no project id must read as the volume's own project")
+		}
+	})
+
+	t.Run("key held in another project", func(t *testing.T) {
+		enc := volumeEncryptionOf(decode(`{
+			"id": "vol-2", "availabilityZone": "eu01-1",
+			"encryptionParameters": {"kekKeyId": "key-2", "kekKeyVersion": 1, "kekKeyringId": "ring-2", "kekProjectId": "proj-b", "serviceAccount": "kek@sa.stackit.cloud"}
+		}`))
+		if enc.projectID != "proj-b" {
+			t.Fatalf("projectID = %q, want proj-b", enc.projectID)
+		}
+		if !enc.crossProject("proj-a") {
+			t.Fatal("a key in proj-b must read as cross-project from proj-a")
+		}
+		if enc.crossProject("proj-b") {
+			t.Fatal("a key in proj-b is not cross-project from proj-b itself")
+		}
+	})
+
+	t.Run("platform-managed volume has no reference at all", func(t *testing.T) {
+		enc := volumeEncryptionOf(decode(`{"id": "vol-3", "availabilityZone": "eu01-1", "encrypted": true}`))
+		if enc != (volumeEncryption{}) {
+			t.Fatalf("volumeEncryptionOf = %+v, want all empty", enc)
+		}
+		if enc.crossProject("proj-a") {
+			t.Fatal("an absent key must not read as cross-project")
+		}
+	})
+
+	t.Run("nil volume", func(t *testing.T) {
+		if enc := volumeEncryptionOf(nil); enc != (volumeEncryption{}) {
+			t.Fatalf("volumeEncryptionOf(nil) = %+v, want all empty", enc)
+		}
+	})
+}
+
 // --- server posture fields that must stay tri-state -------------------------
 
 // decodeServer builds an iaas.Server from a payload shaped like the one the

--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -182,6 +182,14 @@ private stackit.server @defaults("id name status machineType") {
   // when the server boots straight from an image and so has no boot volume,
   // and when the API reports no setting for it.
   bootVolumeDeleteOnTermination bool
+  // Volume holding the root disk (nullable)
+  //
+  // The volume the server boots from, so a check can ask about the OS
+  // disk specifically rather than the whole set in volumes: whether it is
+  // encrypted with a customer-managed key (encryptionKey), which image it
+  // was built from, or whether it is a clone. Null when the server boots
+  // straight from an image and has no boot volume.
+  bootVolume() stackit.volume
   // Security group IDs attached to the server
   securityGroupIds []string
   // Security groups attached to the server
@@ -299,6 +307,27 @@ private stackit.volume @defaults("id name size status") {
   // it rather than the newest one. Null when no version is pinned or when
   // that generation is no longer listed on the key.
   encryptionKeyVersionRef() stackit.kms.key.version
+  // Key ring holding the key that wraps the volume (nullable)
+  //
+  // Null for a platform-managed volume, and null when the key lives in
+  // another project (see encryptionKeyProjectId), whose rings this
+  // connection cannot read.
+  encryptionKeyRing() stackit.kms.keyRing
+  // Project that owns the key-encryption key
+  //
+  // Set when the volume is wrapped with a key from a different project,
+  // which only privileged internal projects may do. Empty when the key
+  // belongs to the volume's own project or the volume is platform-managed.
+  // A non-empty value means the volume's confidentiality depends on that
+  // project's access control rather than this one's.
+  encryptionKeyProjectId string
+  // Service account allowed to unwrap the volume key (nullable)
+  //
+  // The service account the platform uses to unwrap the volume's
+  // data-encryption key with the customer-managed key, which is who the
+  // key's access is granted to. Null for a platform-managed volume, and
+  // null when the account belongs to another project.
+  encryptionKeyServiceAccount() stackit.serviceAccount
   // Creation timestamp
   createdAt time
   // Last update timestamp
@@ -2252,6 +2281,32 @@ private stackit.secretsManager.instance @defaults("id name state") {
   users() []stackit.secretsManager.user
   // Approles that hold machine credentials on the instance
   approles() []stackit.secretsManager.approle
+  // Customer-managed key that encrypts the vault (nullable)
+  //
+  // Key from Key Management Service the instance is encrypted with. Null
+  // when the vault relies on platform-managed encryption, and null when
+  // the key is no longer present on its ring. Follow it to read the key
+  // state and whether it is importOnly.
+  encryptionKey() stackit.kms.key
+  // Key ring holding the vault's encryption key (nullable)
+  //
+  // Null for platform-managed encryption.
+  encryptionKeyRing() stackit.kms.keyRing
+  // Version number of the key material the vault is pinned to; 0 when unset
+  encryptionKeyVersion int
+  // Key version pinned by the vault (nullable)
+  //
+  // Generation of the key material identified by encryptionKeyVersion, so
+  // the vault can be checked against the state of the exact version that
+  // encrypts it. Null when no version is pinned or when that generation is
+  // no longer listed on the key.
+  encryptionKeyVersionRef() stackit.kms.key.version
+  // Service account the vault uses to reach its key (nullable)
+  //
+  // The identity granted use of the customer-managed key on the vault's
+  // behalf. Null for platform-managed encryption, and null when the account
+  // is not one of this project's.
+  encryptionKeyServiceAccount() stackit.serviceAccount
 }
 
 // STACKIT Secrets Manager user

--- a/providers/stackit/resources/stackit.lr.go
+++ b/providers/stackit/resources/stackit.lr.go
@@ -753,6 +753,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.server.bootVolumeDeleteOnTermination": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitServer).GetBootVolumeDeleteOnTermination()).ToDataRes(types.Bool)
 	},
+	"stackit.server.bootVolume": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitServer).GetBootVolume()).ToDataRes(types.Resource("stackit.volume"))
+	},
 	"stackit.server.securityGroupIds": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitServer).GetSecurityGroupIds()).ToDataRes(types.Array(types.String))
 	},
@@ -857,6 +860,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"stackit.volume.encryptionKeyVersionRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitVolume).GetEncryptionKeyVersionRef()).ToDataRes(types.Resource("stackit.kms.key.version"))
+	},
+	"stackit.volume.encryptionKeyRing": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitVolume).GetEncryptionKeyRing()).ToDataRes(types.Resource("stackit.kms.keyRing"))
+	},
+	"stackit.volume.encryptionKeyProjectId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitVolume).GetEncryptionKeyProjectId()).ToDataRes(types.String)
+	},
+	"stackit.volume.encryptionKeyServiceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitVolume).GetEncryptionKeyServiceAccount()).ToDataRes(types.Resource("stackit.serviceAccount"))
 	},
 	"stackit.volume.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitVolume).GetCreatedAt()).ToDataRes(types.Time)
@@ -2382,6 +2394,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.secretsManager.instance.approles": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitSecretsManagerInstance).GetApproles()).ToDataRes(types.Array(types.Resource("stackit.secretsManager.approle")))
 	},
+	"stackit.secretsManager.instance.encryptionKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitSecretsManagerInstance).GetEncryptionKey()).ToDataRes(types.Resource("stackit.kms.key"))
+	},
+	"stackit.secretsManager.instance.encryptionKeyRing": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitSecretsManagerInstance).GetEncryptionKeyRing()).ToDataRes(types.Resource("stackit.kms.keyRing"))
+	},
+	"stackit.secretsManager.instance.encryptionKeyVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitSecretsManagerInstance).GetEncryptionKeyVersion()).ToDataRes(types.Int)
+	},
+	"stackit.secretsManager.instance.encryptionKeyVersionRef": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitSecretsManagerInstance).GetEncryptionKeyVersionRef()).ToDataRes(types.Resource("stackit.kms.key.version"))
+	},
+	"stackit.secretsManager.instance.encryptionKeyServiceAccount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitSecretsManagerInstance).GetEncryptionKeyServiceAccount()).ToDataRes(types.Resource("stackit.serviceAccount"))
+	},
 	"stackit.secretsManager.user.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitSecretsManagerUser).GetId()).ToDataRes(types.String)
 	},
@@ -3390,6 +3417,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlStackitServer).BootVolumeDeleteOnTermination, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"stackit.server.bootVolume": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitServer).BootVolume, ok = plugin.RawToTValue[*mqlStackitVolume](v.Value, v.Error)
+		return
+	},
 	"stackit.server.securityGroupIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitServer).SecurityGroupIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -3532,6 +3563,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"stackit.volume.encryptionKeyVersionRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitVolume).EncryptionKeyVersionRef, ok = plugin.RawToTValue[*mqlStackitKmsKeyVersion](v.Value, v.Error)
+		return
+	},
+	"stackit.volume.encryptionKeyRing": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitVolume).EncryptionKeyRing, ok = plugin.RawToTValue[*mqlStackitKmsKeyRing](v.Value, v.Error)
+		return
+	},
+	"stackit.volume.encryptionKeyProjectId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitVolume).EncryptionKeyProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.volume.encryptionKeyServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitVolume).EncryptionKeyServiceAccount, ok = plugin.RawToTValue[*mqlStackitServiceAccount](v.Value, v.Error)
 		return
 	},
 	"stackit.volume.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5794,6 +5837,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlStackitSecretsManagerInstance).Approles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"stackit.secretsManager.instance.encryptionKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitSecretsManagerInstance).EncryptionKey, ok = plugin.RawToTValue[*mqlStackitKmsKey](v.Value, v.Error)
+		return
+	},
+	"stackit.secretsManager.instance.encryptionKeyRing": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitSecretsManagerInstance).EncryptionKeyRing, ok = plugin.RawToTValue[*mqlStackitKmsKeyRing](v.Value, v.Error)
+		return
+	},
+	"stackit.secretsManager.instance.encryptionKeyVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitSecretsManagerInstance).EncryptionKeyVersion, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"stackit.secretsManager.instance.encryptionKeyVersionRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitSecretsManagerInstance).EncryptionKeyVersionRef, ok = plugin.RawToTValue[*mqlStackitKmsKeyVersion](v.Value, v.Error)
+		return
+	},
+	"stackit.secretsManager.instance.encryptionKeyServiceAccount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitSecretsManagerInstance).EncryptionKeyServiceAccount, ok = plugin.RawToTValue[*mqlStackitServiceAccount](v.Value, v.Error)
+		return
+	},
 	"stackit.secretsManager.user.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitSecretsManagerUser).__id, ok = v.Value.(string)
 		return
@@ -7693,6 +7756,7 @@ type mqlStackitServer struct {
 	VolumeIds                     plugin.TValue[[]any]
 	Volumes                       plugin.TValue[[]any]
 	BootVolumeDeleteOnTermination plugin.TValue[bool]
+	BootVolume                    plugin.TValue[*mqlStackitVolume]
 	SecurityGroupIds              plugin.TValue[[]any]
 	SecurityGroups                plugin.TValue[[]any]
 	Exposure                      plugin.TValue[*mqlStackitNetworkExposure]
@@ -7853,6 +7917,22 @@ func (c *mqlStackitServer) GetBootVolumeDeleteOnTermination() *plugin.TValue[boo
 	return &c.BootVolumeDeleteOnTermination
 }
 
+func (c *mqlStackitServer) GetBootVolume() *plugin.TValue[*mqlStackitVolume] {
+	return plugin.GetOrCompute[*mqlStackitVolume](&c.BootVolume, func() (*mqlStackitVolume, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.server", c.__id, "bootVolume")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitVolume), nil
+			}
+		}
+
+		return c.bootVolume()
+	})
+}
+
 func (c *mqlStackitServer) GetSecurityGroupIds() *plugin.TValue[[]any] {
 	return &c.SecurityGroupIds
 }
@@ -8006,31 +8086,34 @@ type mqlStackitVolume struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlStackitVolumeInternal
-	Id                      plugin.TValue[string]
-	Name                    plugin.TValue[string]
-	Description             plugin.TValue[string]
-	Size                    plugin.TValue[int64]
-	Status                  plugin.TValue[string]
-	AvailabilityZone        plugin.TValue[string]
-	PerformanceClass        plugin.TValue[string]
-	Bootable                plugin.TValue[bool]
-	ImageId                 plugin.TValue[string]
-	Image                   plugin.TValue[*mqlStackitImage]
-	SourceSnapshotId        plugin.TValue[string]
-	SourceSnapshot          plugin.TValue[*mqlStackitSnapshot]
-	SourceBackupId          plugin.TValue[string]
-	SourceBackup            plugin.TValue[*mqlStackitBackup]
-	SourceVolume            plugin.TValue[*mqlStackitVolume]
-	Server                  plugin.TValue[*mqlStackitServer]
-	ServerId                plugin.TValue[string]
-	Encrypted               plugin.TValue[bool]
-	EncryptionKeyId         plugin.TValue[string]
-	EncryptionKey           plugin.TValue[*mqlStackitKmsKey]
-	EncryptionKeyVersion    plugin.TValue[int64]
-	EncryptionKeyVersionRef plugin.TValue[*mqlStackitKmsKeyVersion]
-	CreatedAt               plugin.TValue[*time.Time]
-	UpdatedAt               plugin.TValue[*time.Time]
-	Labels                  plugin.TValue[map[string]any]
+	Id                          plugin.TValue[string]
+	Name                        plugin.TValue[string]
+	Description                 plugin.TValue[string]
+	Size                        plugin.TValue[int64]
+	Status                      plugin.TValue[string]
+	AvailabilityZone            plugin.TValue[string]
+	PerformanceClass            plugin.TValue[string]
+	Bootable                    plugin.TValue[bool]
+	ImageId                     plugin.TValue[string]
+	Image                       plugin.TValue[*mqlStackitImage]
+	SourceSnapshotId            plugin.TValue[string]
+	SourceSnapshot              plugin.TValue[*mqlStackitSnapshot]
+	SourceBackupId              plugin.TValue[string]
+	SourceBackup                plugin.TValue[*mqlStackitBackup]
+	SourceVolume                plugin.TValue[*mqlStackitVolume]
+	Server                      plugin.TValue[*mqlStackitServer]
+	ServerId                    plugin.TValue[string]
+	Encrypted                   plugin.TValue[bool]
+	EncryptionKeyId             plugin.TValue[string]
+	EncryptionKey               plugin.TValue[*mqlStackitKmsKey]
+	EncryptionKeyVersion        plugin.TValue[int64]
+	EncryptionKeyVersionRef     plugin.TValue[*mqlStackitKmsKeyVersion]
+	EncryptionKeyRing           plugin.TValue[*mqlStackitKmsKeyRing]
+	EncryptionKeyProjectId      plugin.TValue[string]
+	EncryptionKeyServiceAccount plugin.TValue[*mqlStackitServiceAccount]
+	CreatedAt                   plugin.TValue[*time.Time]
+	UpdatedAt                   plugin.TValue[*time.Time]
+	Labels                      plugin.TValue[map[string]any]
 }
 
 // createStackitVolume creates a new instance of this resource
@@ -8239,6 +8322,42 @@ func (c *mqlStackitVolume) GetEncryptionKeyVersionRef() *plugin.TValue[*mqlStack
 		}
 
 		return c.encryptionKeyVersionRef()
+	})
+}
+
+func (c *mqlStackitVolume) GetEncryptionKeyRing() *plugin.TValue[*mqlStackitKmsKeyRing] {
+	return plugin.GetOrCompute[*mqlStackitKmsKeyRing](&c.EncryptionKeyRing, func() (*mqlStackitKmsKeyRing, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.volume", c.__id, "encryptionKeyRing")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitKmsKeyRing), nil
+			}
+		}
+
+		return c.encryptionKeyRing()
+	})
+}
+
+func (c *mqlStackitVolume) GetEncryptionKeyProjectId() *plugin.TValue[string] {
+	return &c.EncryptionKeyProjectId
+}
+
+func (c *mqlStackitVolume) GetEncryptionKeyServiceAccount() *plugin.TValue[*mqlStackitServiceAccount] {
+	return plugin.GetOrCompute[*mqlStackitServiceAccount](&c.EncryptionKeyServiceAccount, func() (*mqlStackitServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.volume", c.__id, "encryptionKeyServiceAccount")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitServiceAccount), nil
+			}
+		}
+
+		return c.encryptionKeyServiceAccount()
 	})
 }
 
@@ -13886,18 +14005,23 @@ func (c *mqlStackitSecretsManager) GetInstances() *plugin.TValue[[]any] {
 type mqlStackitSecretsManagerInstance struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlStackitSecretsManagerInstanceInternal it will be used here
-	Id                 plugin.TValue[string]
-	Name               plugin.TValue[string]
-	State              plugin.TValue[string]
-	ApiUrl             plugin.TValue[string]
-	SecretsEngine      plugin.TValue[string]
-	SecretCount        plugin.TValue[int64]
-	CreationStartedAt  plugin.TValue[*time.Time]
-	CreationFinishedAt plugin.TValue[*time.Time]
-	Acls               plugin.TValue[[]any]
-	Users              plugin.TValue[[]any]
-	Approles           plugin.TValue[[]any]
+	mqlStackitSecretsManagerInstanceInternal
+	Id                          plugin.TValue[string]
+	Name                        plugin.TValue[string]
+	State                       plugin.TValue[string]
+	ApiUrl                      plugin.TValue[string]
+	SecretsEngine               plugin.TValue[string]
+	SecretCount                 plugin.TValue[int64]
+	CreationStartedAt           plugin.TValue[*time.Time]
+	CreationFinishedAt          plugin.TValue[*time.Time]
+	Acls                        plugin.TValue[[]any]
+	Users                       plugin.TValue[[]any]
+	Approles                    plugin.TValue[[]any]
+	EncryptionKey               plugin.TValue[*mqlStackitKmsKey]
+	EncryptionKeyRing           plugin.TValue[*mqlStackitKmsKeyRing]
+	EncryptionKeyVersion        plugin.TValue[int64]
+	EncryptionKeyVersionRef     plugin.TValue[*mqlStackitKmsKeyVersion]
+	EncryptionKeyServiceAccount plugin.TValue[*mqlStackitServiceAccount]
 }
 
 // createStackitSecretsManagerInstance creates a new instance of this resource
@@ -14004,6 +14128,74 @@ func (c *mqlStackitSecretsManagerInstance) GetApproles() *plugin.TValue[[]any] {
 		}
 
 		return c.approles()
+	})
+}
+
+func (c *mqlStackitSecretsManagerInstance) GetEncryptionKey() *plugin.TValue[*mqlStackitKmsKey] {
+	return plugin.GetOrCompute[*mqlStackitKmsKey](&c.EncryptionKey, func() (*mqlStackitKmsKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.secretsManager.instance", c.__id, "encryptionKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitKmsKey), nil
+			}
+		}
+
+		return c.encryptionKey()
+	})
+}
+
+func (c *mqlStackitSecretsManagerInstance) GetEncryptionKeyRing() *plugin.TValue[*mqlStackitKmsKeyRing] {
+	return plugin.GetOrCompute[*mqlStackitKmsKeyRing](&c.EncryptionKeyRing, func() (*mqlStackitKmsKeyRing, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.secretsManager.instance", c.__id, "encryptionKeyRing")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitKmsKeyRing), nil
+			}
+		}
+
+		return c.encryptionKeyRing()
+	})
+}
+
+func (c *mqlStackitSecretsManagerInstance) GetEncryptionKeyVersion() *plugin.TValue[int64] {
+	return &c.EncryptionKeyVersion
+}
+
+func (c *mqlStackitSecretsManagerInstance) GetEncryptionKeyVersionRef() *plugin.TValue[*mqlStackitKmsKeyVersion] {
+	return plugin.GetOrCompute[*mqlStackitKmsKeyVersion](&c.EncryptionKeyVersionRef, func() (*mqlStackitKmsKeyVersion, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.secretsManager.instance", c.__id, "encryptionKeyVersionRef")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitKmsKeyVersion), nil
+			}
+		}
+
+		return c.encryptionKeyVersionRef()
+	})
+}
+
+func (c *mqlStackitSecretsManagerInstance) GetEncryptionKeyServiceAccount() *plugin.TValue[*mqlStackitServiceAccount] {
+	return plugin.GetOrCompute[*mqlStackitServiceAccount](&c.EncryptionKeyServiceAccount, func() (*mqlStackitServiceAccount, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.secretsManager.instance", c.__id, "encryptionKeyServiceAccount")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitServiceAccount), nil
+			}
+		}
+
+		return c.encryptionKeyServiceAccount()
 	})
 }
 

--- a/providers/stackit/resources/stackit.lr.versions
+++ b/providers/stackit/resources/stackit.lr.versions
@@ -542,6 +542,11 @@ stackit.secretsManager.instance.apiUrl 13.0.0
 stackit.secretsManager.instance.approles 13.7.2
 stackit.secretsManager.instance.creationFinishedAt 13.2.2
 stackit.secretsManager.instance.creationStartedAt 13.2.2
+stackit.secretsManager.instance.encryptionKey 13.7.2
+stackit.secretsManager.instance.encryptionKeyRing 13.7.2
+stackit.secretsManager.instance.encryptionKeyServiceAccount 13.7.2
+stackit.secretsManager.instance.encryptionKeyVersion 13.7.2
+stackit.secretsManager.instance.encryptionKeyVersionRef 13.7.2
 stackit.secretsManager.instance.id 13.0.0
 stackit.secretsManager.instance.name 13.0.0
 stackit.secretsManager.instance.secretCount 13.0.0
@@ -615,6 +620,7 @@ stackit.server.backupSchedule.volumeIds 13.4.2
 stackit.server.backupSchedule.volumes 13.4.2
 stackit.server.backupSchedules 13.4.2
 stackit.server.backups 13.4.2
+stackit.server.bootVolume 13.7.2
 stackit.server.bootVolumeDeleteOnTermination 13.7.2
 stackit.server.configDrive 13.0.0
 stackit.server.createdAt 13.0.0
@@ -869,6 +875,9 @@ stackit.volume.description 13.0.0
 stackit.volume.encrypted 13.0.0
 stackit.volume.encryptionKey 13.6.2
 stackit.volume.encryptionKeyId 13.0.1
+stackit.volume.encryptionKeyProjectId 13.7.2
+stackit.volume.encryptionKeyRing 13.7.2
+stackit.volume.encryptionKeyServiceAccount 13.7.2
 stackit.volume.encryptionKeyVersion 13.0.1
 stackit.volume.encryptionKeyVersionRef 13.6.2
 stackit.volume.id 13.0.0


### PR DESCRIPTION
## Summary

Item 1 of the STACKIT gap-sweep backlog: the encryption and root-disk edges. Every value here is already on a response the provider fetches; the new accessors resolve lazily and add no calls to the list paths.

**stackit.server**
- `bootVolume()` resolves the volume holding the root disk (from `Server.BootVolume.Id`). Together with the volume's existing `encryptionKey`, `image`, and `sourceVolume`, a policy can now ask about the OS disk specifically instead of the undifferentiated `volumes` set. Null when the server boots straight from an image.

**stackit.volume**
- `encryptionKeyRing()` to `stackit.kms.keyRing` (from `EncryptionParameters.KekKeyringId`).
- `encryptionKeyServiceAccount()` to `stackit.serviceAccount` (from `EncryptionParameters.ServiceAccount`): the identity the platform uses to unwrap the data-encryption key, which is who the key's access is granted to.
- `encryptionKeyProjectId`: set only when the key lives in a different project, which the SDK documents as allowed for privileged internal projects only. A non-empty value means the volume's confidentiality depends on another project's access control. Kept as a scalar since `stackit.project` is the connection's own project and has no init.
- `encryptionKey()` now resolves through the ring the volume names (one ring's key list) instead of the walk over every ring. All three key accessors read null for a cross-project key, whose ring and service account this connection cannot read.
- The extraction is a pure function, `volumeEncryptionOf`, pinned by a table test on response-shaped payloads: same-project key, cross-project key, platform-managed volume (no block at all), nil.

**stackit.secretsManager.instance**
- `encryptionKey()`, `encryptionKeyRing()`, `encryptionKeyVersion`, `encryptionKeyVersionRef()`, and `encryptionKeyServiceAccount()` from `Instance.KmsKey` (`KeyId`, `KeyRingId`, `KeyVersion`, `ServiceAccountEmail`), the same shape and names as the volume edges. Null throughout for platform-managed encryption. The list and `init(id:)` paths now share one builder, so both carry the reference.

**Shared resolvers** (`helpers.go`)
- `kmsKeyRingRef`: ring by id, null on empty, not-found, or denied.
- `kmsKeyInRingRef`: key by id through its ring, falling back to the existing all-rings index when the ring is unknown.
- `serviceAccountRef`: by email against the project's service-account list, null when absent. Used instead of `NewResource` because the service-account init returns an error for an unknown email, and an accessor must report null, not fail.

Typed-reference gate: no raw id fields added; the ring id, service-account email, and boot-volume id are held on Internal structs. `encryptionKeyProjectId` is the one scalar, for the reason above.

All `.lr.versions` entries at 13.7.2 (provider is 13.7.1).

## Verification

Run inside `providers/stackit/`:

- `./mqlr generate` twice (new Internal structs on volume and Secrets Manager instance), no breaking change reported
- `go build ./...`, `go vet ./...` clean
- `go test ./...` passes, including `TestVolumeEncryptionOf`
- `gofmt -l .` empty

Not verified against a live STACKIT project (no credentials on this machine). The typed accessors rest on the existing key-ring, key, and service-account inits, which are exercised by shipped fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
