### PR TITLE
✨ stackit: certificate trust flags, NFS export rule flags, internal service accounts, SQL Server edition and retention

### DIFF
--- a/providers/stackit/resources/certificates.go
+++ b/providers/stackit/resources/certificates.go
@@ -75,6 +75,9 @@ func buildCertificate(runtime *plugin.Runtime, cert *certificates.GetCertificate
 		"notBefore":         llx.TimeDataPtr(parseRFC3339(data.GetNotBefore())),
 		"notAfter":          llx.TimeDataPtr(parseRFC3339(data.GetNotAfter())),
 		"usage":             llx.ArrayData(certificateUsage(cert.GetUsage()), types.Dict),
+		"organization":      llx.StringData(data.GetOrganization()),
+		"isSelfSigned":      llx.BoolDataPtr(optBool(data.GetIsSelfSignedOk())),
+		"isCa":              llx.BoolDataPtr(optBool(data.GetIsCaOk())),
 	}
 	return CreateResource(runtime, "stackit.certificate", args)
 }

--- a/providers/stackit/resources/certificates_test.go
+++ b/providers/stackit/resources/certificates_test.go
@@ -4,11 +4,49 @@
 package resources
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
 	certificates "github.com/stackitcloud/stackit-sdk-go/services/certificates/v2api"
 )
+
+// TestCertificateTrustFlagsStayTriState pins isSelfSigned and isCa to the
+// pointer path: a certificate whose response omits them must read null, not
+// false, since "not self-signed" and "not a CA" are the reassuring answers and
+// must only be reported when the service actually said so.
+func TestCertificateTrustFlagsStayTriState(t *testing.T) {
+	decode := func(payload string) certificates.Data {
+		var d certificates.Data
+		if err := json.Unmarshal([]byte(payload), &d); err != nil {
+			t.Fatalf("decoding certificate data: %v", err)
+		}
+		return d
+	}
+
+	t.Run("flags absent read null", func(t *testing.T) {
+		d := decode(`{"subjectCn": "example.test"}`)
+		if got := optBool(d.GetIsSelfSignedOk()); got != nil {
+			t.Fatalf("isSelfSigned = %v, want null when absent", *got)
+		}
+		if got := optBool(d.GetIsCaOk()); got != nil {
+			t.Fatalf("isCa = %v, want null when absent", *got)
+		}
+	})
+
+	t.Run("flags present are reported as sent", func(t *testing.T) {
+		d := decode(`{"subjectCn": "example.test", "isSelfSigned": true, "isCa": false, "organization": "Example Org"}`)
+		if got := optBool(d.GetIsSelfSignedOk()); got == nil || !*got {
+			t.Fatalf("isSelfSigned = %v, want true", got)
+		}
+		if got := optBool(d.GetIsCaOk()); got == nil || *got {
+			t.Fatalf("isCa = %v, want false (a real false, not null)", got)
+		}
+		if d.GetOrganization() != "Example Org" {
+			t.Fatalf("organization = %q", d.GetOrganization())
+		}
+	})
+}
 
 func TestCertificateUsage(t *testing.T) {
 	strPtr := func(s string) *string { return &s }

--- a/providers/stackit/resources/dbaas.go
+++ b/providers/stackit/resources/dbaas.go
@@ -5,6 +5,8 @@ package resources
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -1765,6 +1767,75 @@ func (r *mqlStackitSqlServerFlexInstance) options() (map[string]any, error) {
 		return map[string]any{}, err
 	}
 	return stringMap(d.GetOptions()), nil
+}
+
+// The SDK documents two keys inside the SQL Server Flex options map
+// (InstanceDocumentationOptions): `edition` and `retentionDays`. They are
+// hoisted here so a policy reads a typed value instead of a string in a map.
+
+// edition reports the SQL Server edition the instance runs (for example
+// developer, express, standard, or enterprise), which decides the feature
+// set available to it. Null when the instance detail could not be read or
+// carries no edition.
+func (r *mqlStackitSqlServerFlexInstance) edition() (string, error) {
+	d, err := r.fetchDetail()
+	if err != nil {
+		return "", err
+	}
+	edition, ok := sqlServerOption(d, "edition")
+	if !ok {
+		r.Edition.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
+	return edition, nil
+}
+
+// backupRetentionDays reports how many days backup files are kept before
+// cleanup, from the instance's `retentionDays` option. Null when the detail
+// could not be read, the option is absent, or it does not parse as a number.
+func (r *mqlStackitSqlServerFlexInstance) backupRetentionDays() (int64, error) {
+	d, err := r.fetchDetail()
+	if err != nil {
+		return 0, err
+	}
+	days, ok := sqlServerRetentionDays(d)
+	if !ok {
+		r.BackupRetentionDays.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return days, nil
+}
+
+// sqlServerOption reads one key from the instance's options map, reporting
+// whether it was present and non-empty.
+func sqlServerOption(d *sqlserverflex.Instance, key string) (string, bool) {
+	if d == nil {
+		return "", false
+	}
+	opts, ok := d.GetOptionsOk()
+	if !ok || opts == nil {
+		return "", false
+	}
+	v, ok := (*opts)[key]
+	if !ok || strings.TrimSpace(v) == "" {
+		return "", false
+	}
+	return v, true
+}
+
+// sqlServerRetentionDays parses the `retentionDays` option, which the API
+// carries as a decimal string, into days. It reports false rather than a
+// zero when the option is absent or malformed, so the field reads null.
+func sqlServerRetentionDays(d *sqlserverflex.Instance) (int64, bool) {
+	raw, ok := sqlServerOption(d, "retentionDays")
+	if !ok {
+		return 0, false
+	}
+	days, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+	if err != nil || days < 0 {
+		return 0, false
+	}
+	return days, true
 }
 
 func initStackitSqlServerFlexInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/stackit/resources/dbaas_sqlserver_test.go
+++ b/providers/stackit/resources/dbaas_sqlserver_test.go
@@ -1,0 +1,69 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+
+	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
+)
+
+// decodeSqlServerInstance builds the SDK instance from a payload shaped like
+// the GetInstance response, so the option keys are read through the same
+// JSON path the provider takes.
+func decodeSqlServerInstance(t *testing.T, payload string) *sqlserverflex.Instance {
+	t.Helper()
+	var inst sqlserverflex.Instance
+	if err := json.Unmarshal([]byte(payload), &inst); err != nil {
+		t.Fatalf("decoding sqlserverflex instance: %v", err)
+	}
+	return &inst
+}
+
+// TestSqlServerRetentionDays pins the parse of the retentionDays option. The
+// API carries it as a decimal string, and a value that is absent or not a
+// number has to read as "not present" so the field reports null rather than a
+// zero-day retention that would fail every retention check.
+func TestSqlServerRetentionDays(t *testing.T) {
+	cases := []struct {
+		name     string
+		payload  string
+		wantDays int64
+		wantOk   bool
+	}{
+		{"documented default", `{"id": "i1", "options": {"edition": "developer", "retentionDays": "32"}}`, 32, true},
+		{"upper bound", `{"id": "i1", "options": {"retentionDays": "365"}}`, 365, true},
+		{"surrounding whitespace", `{"id": "i1", "options": {"retentionDays": " 45 "}}`, 45, true},
+		{"absent option", `{"id": "i1", "options": {"edition": "developer"}}`, 0, false},
+		{"no options at all", `{"id": "i1"}`, 0, false},
+		{"empty string", `{"id": "i1", "options": {"retentionDays": ""}}`, 0, false},
+		{"not a number", `{"id": "i1", "options": {"retentionDays": "thirty"}}`, 0, false},
+		{"negative is rejected", `{"id": "i1", "options": {"retentionDays": "-1"}}`, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := sqlServerRetentionDays(decodeSqlServerInstance(t, tc.payload))
+			if ok != tc.wantOk || got != tc.wantDays {
+				t.Fatalf("sqlServerRetentionDays = (%d, %v), want (%d, %v)", got, ok, tc.wantDays, tc.wantOk)
+			}
+		})
+	}
+
+	t.Run("nil instance", func(t *testing.T) {
+		if _, ok := sqlServerRetentionDays(nil); ok {
+			t.Fatal("nil instance must not report a retention")
+		}
+	})
+}
+
+func TestSqlServerOptionEdition(t *testing.T) {
+	inst := decodeSqlServerInstance(t, `{"id": "i1", "options": {"edition": "standard", "retentionDays": "32"}}`)
+	if got, ok := sqlServerOption(inst, "edition"); !ok || got != "standard" {
+		t.Fatalf("edition = (%q, %v), want (standard, true)", got, ok)
+	}
+	if _, ok := sqlServerOption(decodeSqlServerInstance(t, `{"id": "i1", "options": {"edition": "  "}}`), "edition"); ok {
+		t.Fatal("a blank edition must read as absent")
+	}
+}

--- a/providers/stackit/resources/helpers.go
+++ b/providers/stackit/resources/helpers.go
@@ -385,6 +385,16 @@ func kmsKeyRef(runtime *plugin.Runtime, id string, field *plugin.TValue[*mqlStac
 	return key, nil
 }
 
+// optBool passes an SDK GetXxxOk() bool pair through as a pointer that is nil
+// when the API omitted the field, so the MQL field reads null rather than a
+// false the API never sent.
+func optBool(v *bool, ok bool) *bool {
+	if !ok {
+		return nil
+	}
+	return v
+}
+
 // kmsKeyRingRef resolves a key ring by UUID, marking the field null when the
 // id is empty or the ring is not readable from this project (a ring that lives
 // in another project answers 404 to GetKeyRing).

--- a/providers/stackit/resources/serviceaccount.go
+++ b/providers/stackit/resources/serviceaccount.go
@@ -46,6 +46,7 @@ func buildServiceAccount(runtime *plugin.Runtime, sa *serviceaccount.ServiceAcco
 		"email":     llx.StringData(sa.GetEmail()),
 		"projectId": llx.StringData(sa.GetProjectId()),
 		"id":        llx.StringData(sa.GetId()),
+		"internal":  llx.BoolData(sa.GetInternal()),
 	})
 }
 

--- a/providers/stackit/resources/sfs.go
+++ b/providers/stackit/resources/sfs.go
@@ -455,6 +455,9 @@ func (r *mqlStackitSfsExportPolicy) rules() ([]any, error) {
 			"order":       llx.IntData(rule.GetOrder()),
 			"ipAcl":       strSliceData(rule.GetIpAcl()),
 			"description": llx.StringData(rule.GetDescription()),
+			"readOnly":    llx.BoolDataPtr(optBool(rule.GetReadOnlyOk())),
+			"superUser":   llx.BoolDataPtr(optBool(rule.GetSuperUserOk())),
+			"setUuid":     llx.BoolDataPtr(optBool(rule.GetSetUuidOk())),
 			"createdAt":   llx.TimeDataPtr(timeOrNil(rule.GetCreatedAtOk())),
 		})
 		if err != nil {

--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -1458,6 +1458,21 @@ private stackit.sfs.exportPolicy.rule @defaults("order ipAcl") {
   ipAcl []string
   // Optional rule description
   description string
+  // Whether matching clients may only mount the share read-only
+  //
+  // False means clients matching this rule can write to the share. Null
+  // when the service reports nothing for the rule.
+  readOnly bool
+  // Whether matching clients keep root privileges on the share
+  //
+  // True grants root access to clients matching the rule, the NFS
+  // equivalent of no_root_squash. Null when the service reports nothing.
+  superUser bool
+  // Whether set-user-ID bits are honored on the export
+  //
+  // True lets executables on the share run with their file owner's
+  // privileges. Null when the service reports nothing.
+  setUuid bool
   // Creation timestamp
   createdAt time
 }
@@ -1812,6 +1827,17 @@ private stackit.sqlServerFlex.instance @defaults("id name version status") {
   backupSchedule() string
   // Operator-tunable engine options as key/value pairs
   options() map[string]string
+  // SQL Server edition the instance runs
+  //
+  // The edition from the instance options (for example developer,
+  // express, standard, or enterprise), which decides the feature set
+  // available to the instance. Null when the options carry no edition.
+  edition() string
+  // Days backup files are kept before cleanup
+  //
+  // From the retentionDays instance option, which the service accepts in
+  // the range 30 to 365. Null when the option is absent or not numeric.
+  backupRetentionDays() int
   // Whether the instance accepts connections from any address
   //
   // True only when the connection ACL explicitly admits a default route
@@ -2717,6 +2743,13 @@ private stackit.serviceAccount @defaults("email projectId") {
   projectId string
   // Internal service-account ID (UUID), if returned by the API
   id string
+  // Whether the account is a platform-managed internal service account
+  //
+  // True for service accounts STACKIT itself creates and operates on the
+  // project's behalf, false for accounts a user created for their own
+  // automation. Filter on it to keep platform identities out of a review
+  // of stale or over-privileged automation credentials.
+  internal bool
   // Long-lived access tokens issued for this service account
   //
   // Deprecated in favor of keys. STACKIT retired long-lived service
@@ -2836,6 +2869,20 @@ private stackit.certificate @defaults("id name region") {
   // with `loadBalancerName` and the `listenerNames` on that load
   // balancer using it ([{loadBalancerName, listenerNames}]).
   usage []dict
+  // Organization named in the certificate subject
+  organization string
+  // Whether the certificate is signed by its own private key
+  //
+  // True when the certificate was signed by its own key rather than by a
+  // trusted third-party certificate authority, as reported by the
+  // service. Null when the service reports nothing.
+  isSelfSigned bool
+  // Whether the certificate is a certificate authority
+  //
+  // True when the certificate can sign other certificates. A CA
+  // certificate uploaded to serve as a server certificate is a finding.
+  // Null when the service reports nothing.
+  isCa bool
 }
 
 // STACKIT Application Load Balancer

--- a/providers/stackit/resources/stackit.lr.go
+++ b/providers/stackit/resources/stackit.lr.go
@@ -1806,6 +1806,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.sfs.exportPolicy.rule.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitSfsExportPolicyRule).GetDescription()).ToDataRes(types.String)
 	},
+	"stackit.sfs.exportPolicy.rule.readOnly": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitSfsExportPolicyRule).GetReadOnly()).ToDataRes(types.Bool)
+	},
+	"stackit.sfs.exportPolicy.rule.superUser": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitSfsExportPolicyRule).GetSuperUser()).ToDataRes(types.Bool)
+	},
+	"stackit.sfs.exportPolicy.rule.setUuid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitSfsExportPolicyRule).GetSetUuid()).ToDataRes(types.Bool)
+	},
 	"stackit.sfs.exportPolicy.rule.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitSfsExportPolicyRule).GetCreatedAt()).ToDataRes(types.Time)
 	},
@@ -2087,6 +2096,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"stackit.sqlServerFlex.instance.options": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitSqlServerFlexInstance).GetOptions()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"stackit.sqlServerFlex.instance.edition": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitSqlServerFlexInstance).GetEdition()).ToDataRes(types.String)
+	},
+	"stackit.sqlServerFlex.instance.backupRetentionDays": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitSqlServerFlexInstance).GetBackupRetentionDays()).ToDataRes(types.Int)
 	},
 	"stackit.sqlServerFlex.instance.internetReachable": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitSqlServerFlexInstance).GetInternetReachable()).ToDataRes(types.Bool)
@@ -2676,6 +2691,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.serviceAccount.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitServiceAccount).GetId()).ToDataRes(types.String)
 	},
+	"stackit.serviceAccount.internal": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitServiceAccount).GetInternal()).ToDataRes(types.Bool)
+	},
 	"stackit.serviceAccount.accessTokens": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitServiceAccount).GetAccessTokens()).ToDataRes(types.Array(types.Dict))
 	},
@@ -2762,6 +2780,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"stackit.certificate.usage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitCertificate).GetUsage()).ToDataRes(types.Array(types.Dict))
+	},
+	"stackit.certificate.organization": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitCertificate).GetOrganization()).ToDataRes(types.String)
+	},
+	"stackit.certificate.isSelfSigned": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitCertificate).GetIsSelfSigned()).ToDataRes(types.Bool)
+	},
+	"stackit.certificate.isCa": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitCertificate).GetIsCa()).ToDataRes(types.Bool)
 	},
 	"stackit.alb.loadBalancer.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitAlbLoadBalancer).GetName()).ToDataRes(types.String)
@@ -4953,6 +4980,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlStackitSfsExportPolicyRule).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"stackit.sfs.exportPolicy.rule.readOnly": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitSfsExportPolicyRule).ReadOnly, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"stackit.sfs.exportPolicy.rule.superUser": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitSfsExportPolicyRule).SuperUser, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"stackit.sfs.exportPolicy.rule.setUuid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitSfsExportPolicyRule).SetUuid, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"stackit.sfs.exportPolicy.rule.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitSfsExportPolicyRule).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
@@ -5375,6 +5414,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"stackit.sqlServerFlex.instance.options": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitSqlServerFlexInstance).Options, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"stackit.sqlServerFlex.instance.edition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitSqlServerFlexInstance).Edition, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.sqlServerFlex.instance.backupRetentionDays": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitSqlServerFlexInstance).BackupRetentionDays, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"stackit.sqlServerFlex.instance.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6269,6 +6316,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlStackitServiceAccount).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"stackit.serviceAccount.internal": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitServiceAccount).Internal, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"stackit.serviceAccount.accessTokens": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitServiceAccount).AccessTokens, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -6391,6 +6442,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"stackit.certificate.usage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitCertificate).Usage, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"stackit.certificate.organization": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitCertificate).Organization, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.certificate.isSelfSigned": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitCertificate).IsSelfSigned, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"stackit.certificate.isCa": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitCertificate).IsCa, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"stackit.alb.loadBalancer.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11711,6 +11774,9 @@ type mqlStackitSfsExportPolicyRule struct {
 	Order       plugin.TValue[int64]
 	IpAcl       plugin.TValue[[]any]
 	Description plugin.TValue[string]
+	ReadOnly    plugin.TValue[bool]
+	SuperUser   plugin.TValue[bool]
+	SetUuid     plugin.TValue[bool]
 	CreatedAt   plugin.TValue[*time.Time]
 }
 
@@ -11765,6 +11831,18 @@ func (c *mqlStackitSfsExportPolicyRule) GetIpAcl() *plugin.TValue[[]any] {
 
 func (c *mqlStackitSfsExportPolicyRule) GetDescription() *plugin.TValue[string] {
 	return &c.Description
+}
+
+func (c *mqlStackitSfsExportPolicyRule) GetReadOnly() *plugin.TValue[bool] {
+	return &c.ReadOnly
+}
+
+func (c *mqlStackitSfsExportPolicyRule) GetSuperUser() *plugin.TValue[bool] {
+	return &c.SuperUser
+}
+
+func (c *mqlStackitSfsExportPolicyRule) GetSetUuid() *plugin.TValue[bool] {
+	return &c.SetUuid
 }
 
 func (c *mqlStackitSfsExportPolicyRule) GetCreatedAt() *plugin.TValue[*time.Time] {
@@ -12792,19 +12870,21 @@ type mqlStackitSqlServerFlexInstance struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlStackitSqlServerFlexInstanceInternal
-	Id                plugin.TValue[string]
-	Name              plugin.TValue[string]
-	Status            plugin.TValue[string]
-	Region            plugin.TValue[string]
-	Version           plugin.TValue[string]
-	Flavor            plugin.TValue[any]
-	Acl               plugin.TValue[[]any]
-	Replicas          plugin.TValue[int64]
-	Storage           plugin.TValue[any]
-	BackupSchedule    plugin.TValue[string]
-	Options           plugin.TValue[map[string]any]
-	InternetReachable plugin.TValue[bool]
-	Users             plugin.TValue[[]any]
+	Id                  plugin.TValue[string]
+	Name                plugin.TValue[string]
+	Status              plugin.TValue[string]
+	Region              plugin.TValue[string]
+	Version             plugin.TValue[string]
+	Flavor              plugin.TValue[any]
+	Acl                 plugin.TValue[[]any]
+	Replicas            plugin.TValue[int64]
+	Storage             plugin.TValue[any]
+	BackupSchedule      plugin.TValue[string]
+	Options             plugin.TValue[map[string]any]
+	Edition             plugin.TValue[string]
+	BackupRetentionDays plugin.TValue[int64]
+	InternetReachable   plugin.TValue[bool]
+	Users               plugin.TValue[[]any]
 }
 
 // createStackitSqlServerFlexInstance creates a new instance of this resource
@@ -12899,6 +12979,18 @@ func (c *mqlStackitSqlServerFlexInstance) GetBackupSchedule() *plugin.TValue[str
 func (c *mqlStackitSqlServerFlexInstance) GetOptions() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.Options, func() (map[string]any, error) {
 		return c.options()
+	})
+}
+
+func (c *mqlStackitSqlServerFlexInstance) GetEdition() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Edition, func() (string, error) {
+		return c.edition()
+	})
+}
+
+func (c *mqlStackitSqlServerFlexInstance) GetBackupRetentionDays() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.BackupRetentionDays, func() (int64, error) {
+		return c.backupRetentionDays()
 	})
 }
 
@@ -15334,6 +15426,7 @@ type mqlStackitServiceAccount struct {
 	Email                      plugin.TValue[string]
 	ProjectId                  plugin.TValue[string]
 	Id                         plugin.TValue[string]
+	Internal                   plugin.TValue[bool]
 	AccessTokens               plugin.TValue[[]any]
 	Keys                       plugin.TValue[[]any]
 	FederatedIdentityProviders plugin.TValue[[]any]
@@ -15386,6 +15479,10 @@ func (c *mqlStackitServiceAccount) GetProjectId() *plugin.TValue[string] {
 
 func (c *mqlStackitServiceAccount) GetId() *plugin.TValue[string] {
 	return &c.Id
+}
+
+func (c *mqlStackitServiceAccount) GetInternal() *plugin.TValue[bool] {
+	return &c.Internal
 }
 
 func (c *mqlStackitServiceAccount) GetAccessTokens() *plugin.TValue[[]any] {
@@ -15526,6 +15623,9 @@ type mqlStackitCertificate struct {
 	NotBefore         plugin.TValue[*time.Time]
 	NotAfter          plugin.TValue[*time.Time]
 	Usage             plugin.TValue[[]any]
+	Organization      plugin.TValue[string]
+	IsSelfSigned      plugin.TValue[bool]
+	IsCa              plugin.TValue[bool]
 }
 
 // createStackitCertificate creates a new instance of this resource
@@ -15639,6 +15739,18 @@ func (c *mqlStackitCertificate) GetNotAfter() *plugin.TValue[*time.Time] {
 
 func (c *mqlStackitCertificate) GetUsage() *plugin.TValue[[]any] {
 	return &c.Usage
+}
+
+func (c *mqlStackitCertificate) GetOrganization() *plugin.TValue[string] {
+	return &c.Organization
+}
+
+func (c *mqlStackitCertificate) GetIsSelfSigned() *plugin.TValue[bool] {
+	return &c.IsSelfSigned
+}
+
+func (c *mqlStackitCertificate) GetIsCa() *plugin.TValue[bool] {
+	return &c.IsCa
 }
 
 // mqlStackitAlbLoadBalancer for the stackit.alb.loadBalancer resource

--- a/providers/stackit/resources/stackit.lr.versions
+++ b/providers/stackit/resources/stackit.lr.versions
@@ -83,6 +83,8 @@ stackit.certificate.extendedKeyUsage 13.4.2
 stackit.certificate.fingerprintSha1 13.4.2
 stackit.certificate.fingerprintSha256 13.4.2
 stackit.certificate.id 13.0.1
+stackit.certificate.isCa 13.7.2
+stackit.certificate.isSelfSigned 13.7.2
 stackit.certificate.issuer 13.4.2
 stackit.certificate.keyAlgorithm 13.4.2
 stackit.certificate.keyBitSize 13.4.2
@@ -91,6 +93,7 @@ stackit.certificate.labels 13.4.2
 stackit.certificate.name 13.0.1
 stackit.certificate.notAfter 13.4.2
 stackit.certificate.notBefore 13.4.2
+stackit.certificate.organization 13.7.2
 stackit.certificate.publicKey 13.0.1
 stackit.certificate.region 13.0.1
 stackit.certificate.serialNumber 13.4.2
@@ -680,6 +683,7 @@ stackit.serviceAccount.federatedIdentityProvider.serviceAccount 13.5.2
 stackit.serviceAccount.federatedIdentityProvider.updatedAt 13.5.2
 stackit.serviceAccount.federatedIdentityProviders 13.5.2
 stackit.serviceAccount.id 13.0.0
+stackit.serviceAccount.internal 13.7.2
 stackit.serviceAccount.keys 13.0.0
 stackit.serviceAccount.projectId 13.0.0
 stackit.serviceAccounts 13.0.0
@@ -696,6 +700,9 @@ stackit.sfs.exportPolicy.rule.description 13.0.2
 stackit.sfs.exportPolicy.rule.id 13.0.2
 stackit.sfs.exportPolicy.rule.ipAcl 13.0.2
 stackit.sfs.exportPolicy.rule.order 13.0.2
+stackit.sfs.exportPolicy.rule.readOnly 13.7.2
+stackit.sfs.exportPolicy.rule.setUuid 13.7.2
+stackit.sfs.exportPolicy.rule.superUser 13.7.2
 stackit.sfs.exportPolicy.rules 13.0.2
 stackit.sfs.exportPolicy.sharesUsingExportPolicy 13.0.2
 stackit.sfs.lockId 13.0.2
@@ -810,7 +817,9 @@ stackit.snapshots 13.0.0
 stackit.sqlServerFlex 13.0.1
 stackit.sqlServerFlex.instance 13.0.1
 stackit.sqlServerFlex.instance.acl 13.0.1
+stackit.sqlServerFlex.instance.backupRetentionDays 13.7.2
 stackit.sqlServerFlex.instance.backupSchedule 13.0.1
+stackit.sqlServerFlex.instance.edition 13.7.2
 stackit.sqlServerFlex.instance.flavor 13.0.1
 stackit.sqlServerFlex.instance.id 13.0.1
 stackit.sqlServerFlex.instance.internetReachable 13.0.6


### PR DESCRIPTION
## Summary

Item 2 of the STACKIT gap-sweep backlog: posture flags that are already on responses the provider fetches. No new API calls.

**stackit.certificate**
- `isSelfSigned`: signed by its own key rather than a trusted CA, as computed by the service (`Data.IsSelfSigned`).
- `isCa`: can sign other certificates (`Data.IsCa`); a CA certificate serving as a server certificate is a finding.
- `organization`: subject O (`Data.Organization`).
- Both booleans go through the pointer path and read null when the service omits them, so "not self-signed" is only reported when the service said so. Pinned by `TestCertificateTrustFlagsStayTriState` on response-shaped payloads.

**stackit.sfs.exportPolicy.rule**
- `readOnly`, `superUser` (root access for matching clients, the NFS `no_root_squash` equivalent), `setUuid` (set-user-ID bits honored). Tri-state through the same helper. Without `superUser`, `ipAcl` alone could not tell a read-only export from a root-writable one.

**stackit.serviceAccount**
- `internal`: platform-managed service accounts versus user-created ones (`ServiceAccount.Internal`, a required bool). Lets a stale-credential or over-privilege review skip identities STACKIT operates itself.

**stackit.sqlServerFlex.instance**
- `edition()` and `backupRetentionDays()` hoisted from the two keys the SDK documents inside the `options` map (`InstanceDocumentationOptions`: `edition`, `retentionDays` as a decimal string, 30 to 365). Both read from the instance detail the resource already fetches for `options`, and report null when the key is absent, blank, or not numeric. The parser is pure (`sqlServerRetentionDays`, `sqlServerOption`) and pinned by a table test covering the documented default, bounds, whitespace, absent option, no options, blank, non-numeric, and negative.

**Helper**
- `optBool(v *bool, ok bool) *bool` in `helpers.go`: passes an SDK `GetXxxOk` pair through as a pointer that is nil when the API omitted the field. Used by the certificate and export-rule flags; the same shape the server posture fields already hand-roll.

Typed-reference gate: nothing here names another resource. All `.lr.versions` entries at 13.7.2 (provider is 13.7.1).

## Verification

Run inside `providers/stackit/`:

- `./mqlr generate` clean, no breaking change reported
- `go build ./...`, `go vet ./...` clean
- `go test ./...` passes, including the two new test files' cases
- `gofmt -l .` empty

Not verified against a live STACKIT project (no credentials on this machine). The certificate and export-rule flags rest on the SDK's documented response fields; the SQL Server keys rest on the SDK's `InstanceDocumentationOptions` model, which is the API's own documentation of the options map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
