### PR TITLE
🌟 python: read the dependency graphs uv.lock and pdm.lock already state

### DIFF
--- a/providers/os/resources/languages/python/pdmlock/extractor.go
+++ b/providers/os/resources/languages/python/pdmlock/extractor.go
@@ -5,6 +5,8 @@ package pdmlock
 
 import (
 	"io"
+	"sort"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 	"go.mondoo.com/mql/providers/os/resources/languages"
@@ -49,6 +51,7 @@ func (l *pdmLock) Direct() languages.Packages {
 
 // Transitive returns all packages listed in the lockfile.
 func (l *pdmLock) Transitive() languages.Packages {
+	byName := l.packagesByName()
 	var packages languages.Packages
 	for _, pkg := range l.Packages {
 		packages = append(packages, &languages.Package{
@@ -57,7 +60,83 @@ func (l *pdmLock) Transitive() languages.Packages {
 			Purl:         python.NewPackageUrl(pkg.Name, pkg.Version),
 			Cpes:         python.NewCpes(pkg.Name, pkg.Version),
 			EvidenceList: python.NewEvidenceList(l.evidence),
+			DependsOn:    l.dependsOnRefs(pkg, byName),
 		})
 	}
 	return packages
+}
+
+// pep508Name takes the distribution name off the front of a PEP 508 requirement
+// string: `urllib3<3,>=1.21.1` is urllib3, `requests[socks]>=2.0` is requests,
+// and `foo ; python_version < "3.9"` is foo.
+//
+// A name is letters, digits, `-`, `_` and `.` (PEP 508's identifier rule), so
+// the name ends at the first character outside that set — whichever of an
+// extras bracket, a version operator, a marker semicolon or whitespace comes
+// first. Parsing the whole grammar is not needed to answer "which package".
+func pep508Name(req string) string {
+	req = strings.TrimSpace(req)
+	end := 0
+	for end < len(req) {
+		c := req[end]
+		if c == '-' || c == '_' || c == '.' ||
+			c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' {
+			end++
+			continue
+		}
+		break
+	}
+	return req[:end]
+}
+
+// packagesByName indexes the locked packages for edge resolution, keyed by the
+// PEP 503 normalized name so a requirement spelled `charset_normalizer` finds
+// the entry named `charset-normalizer`.
+func (l *pdmLock) packagesByName() map[string]pdmPackage {
+	out := make(map[string]pdmPackage, len(l.Packages))
+	for _, p := range l.Packages {
+		key := python.NormalizeName(p.Name)
+		if _, dup := out[key]; !dup {
+			out[key] = p
+		}
+	}
+	return out
+}
+
+// dependsOnRefs turns one package's requirement strings into the purls of the
+// packages that satisfy them.
+//
+// Resolved by name against the lock's own package set, never from the version
+// in the requirement: that is a constraint, so a purl built from it would name
+// a package pdm did not resolve and the edge would point at nothing. A name
+// with no entry is dropped rather than synthesised — pdm writes one entry per
+// resolved package, so a name it does not have is one this lock did not
+// resolve (a dependency of an unselected group, most often).
+func (l *pdmLock) dependsOnRefs(pkg pdmPackage, byName map[string]pdmPackage) []string {
+	if len(pkg.Dependencies) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	var refs []string
+	for _, req := range pkg.Dependencies {
+		name := pep508Name(req)
+		if name == "" {
+			continue
+		}
+		target, ok := byName[python.NormalizeName(name)]
+		if !ok || target.Version == "" {
+			continue
+		}
+		ref := python.NewPackageUrl(target.Name, target.Version)
+		if seen[ref] {
+			continue
+		}
+		seen[ref] = true
+		refs = append(refs, ref)
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+	sort.Strings(refs)
+	return refs
 }

--- a/providers/os/resources/languages/python/pdmlock/extractor.go
+++ b/providers/os/resources/languages/python/pdmlock/extractor.go
@@ -80,7 +80,7 @@ func pep508Name(req string) string {
 	for end < len(req) {
 		c := req[end]
 		if c == '-' || c == '_' || c == '.' ||
-			c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' {
+			(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
 			end++
 			continue
 		}

--- a/providers/os/resources/languages/python/pdmlock/extractor_test.go
+++ b/providers/os/resources/languages/python/pdmlock/extractor_test.go
@@ -24,7 +24,7 @@ func TestParseSimple(t *testing.T) {
 	assert.Nil(t, bom.Direct())
 
 	pkgs := bom.Transitive()
-	assert.Len(t, pkgs, 4)
+	assert.Len(t, pkgs, 5)
 
 	django := pkgs.Find("django")
 	require.NotNil(t, django)
@@ -39,4 +39,51 @@ func TestParseSimple(t *testing.T) {
 func TestName(t *testing.T) {
 	e := &Extractor{}
 	assert.Equal(t, "pdmlock", e.Name())
+}
+
+// TestPdmLockDependencyEdges pins the pdm package->package graph. pdm writes
+// each package's dependencies as PEP 508 requirement strings and the extractor
+// read past them, so a pdm project supplied no edges at all.
+func TestPdmLockDependencyEdges(t *testing.T) {
+	f, err := os.Open("testdata/simple.toml")
+	require.NoError(t, err)
+	defer f.Close()
+
+	bom, err := (&Extractor{}).Parse(f, "pdm.lock")
+	require.NoError(t, err)
+	pkgs := bom.Transitive()
+
+	requests := pkgs.Find("requests")
+	require.NotNil(t, requests)
+	// The edge target is the version pdm RESOLVED (certifi 2024.2.2), never the
+	// `>=2017.4.17` constraint written in the requirement: a purl from the
+	// constraint names a package this lock did not resolve, so the edge would
+	// point at nothing. `not-locked` has no entry and is dropped.
+	assert.Equal(t, []string{
+		"pkg:pypi/certifi@2024.2.2",
+		"pkg:pypi/charset-normalizer@3.3.2",
+	}, requests.DependsOn)
+
+	assert.Nil(t, pkgs.Find("certifi").DependsOn)
+	assert.Nil(t, pkgs.Find("pytest").DependsOn)
+	assert.Nil(t, pkgs.Find("not-locked"), "an unresolved requirement must not become a package")
+}
+
+func TestPep508Name(t *testing.T) {
+	cases := map[string]string{
+		"urllib3<3,>=1.21.1":           "urllib3",
+		"certifi>=2017.4.17":           "certifi",
+		"charset_normalizer<4,>=2":     "charset_normalizer",
+		"requests[socks]>=2.0":         "requests",
+		"idna":                         "idna",
+		"  spaced  >=1 ":               "spaced",
+		`foo ; python_version < "3.9"`: "foo",
+		"typing-extensions!=4.0.0":     "typing-extensions",
+		"zope.interface>=5":            "zope.interface",
+		"":                             "",
+		"(bad":                         "",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, pep508Name(in), "pep508Name(%q)", in)
+	}
 }

--- a/providers/os/resources/languages/python/pdmlock/extractor_test.go
+++ b/providers/os/resources/languages/python/pdmlock/extractor_test.go
@@ -24,7 +24,7 @@ func TestParseSimple(t *testing.T) {
 	assert.Nil(t, bom.Direct())
 
 	pkgs := bom.Transitive()
-	assert.Len(t, pkgs, 5)
+	assert.Len(t, pkgs, 6)
 
 	django := pkgs.Find("django")
 	require.NotNil(t, django)
@@ -62,6 +62,7 @@ func TestPdmLockDependencyEdges(t *testing.T) {
 	assert.Equal(t, []string{
 		"pkg:pypi/certifi@2024.2.2",
 		"pkg:pypi/charset-normalizer@3.3.2",
+		"pkg:pypi/zope-interface@6.1",
 	}, requests.DependsOn)
 
 	assert.Nil(t, pkgs.Find("certifi").DependsOn)
@@ -86,4 +87,30 @@ func TestPep508Name(t *testing.T) {
 	for in, want := range cases {
 		assert.Equal(t, want, pep508Name(in), "pep508Name(%q)", in)
 	}
+}
+
+// TestPdmLockNormalizesBothSidesOfTheIndex covers the half of normalization the
+// existing test cannot reach.
+//
+// Names are normalized in two places -- building the index from each package's
+// own name, and looking a requirement up in it -- and a fixture whose package
+// entries are already normalized exercises only the second. Dropping
+// `NormalizeName` from the index side passed the whole suite, so the code had a
+// test named for the property that could not fail if half of it broke.
+//
+// The two spellings here are deliberately different from each other and both
+// non-normalized: `Zope_Interface` as the entry, `zope.interface` in the
+// requirement. A same-spelling pair would still resolve with the index side
+// removed, which is exactly how this hid.
+func TestPdmLockNormalizesBothSidesOfTheIndex(t *testing.T) {
+	f, err := os.Open("testdata/simple.toml")
+	require.NoError(t, err)
+	defer f.Close()
+
+	bom, err := (&Extractor{}).Parse(f, "pdm.lock")
+	require.NoError(t, err)
+
+	assert.Contains(t, bom.Transitive().Find("requests").DependsOn,
+		"pkg:pypi/zope-interface@6.1",
+		"resolving this edge needs the entry AND the requirement normalized")
 }

--- a/providers/os/resources/languages/python/pdmlock/parser.go
+++ b/providers/os/resources/languages/python/pdmlock/parser.go
@@ -17,4 +17,13 @@ type pdmPackage struct {
 	Version  string   `toml:"version"`
 	Groups   []string `toml:"groups"`
 	Revision string   `toml:"revision"`
+	// Dependencies is the package's own dependencies, written as PEP 508
+	// requirement strings ("urllib3<3,>=1.21.1"). The constraint is a
+	// REQUIREMENT; the version pdm resolved is on that package's own [[package]]
+	// entry, so only the name is read from here.
+	//
+	// This is the package->package graph. pdm writes it into every lock and the
+	// extractor did not read it, so a pdm project supplied no edges at all and
+	// every transitive dependency in it stayed undetermined.
+	Dependencies []string `toml:"dependencies"`
 }

--- a/providers/os/resources/languages/python/pdmlock/testdata/simple.toml
+++ b/providers/os/resources/languages/python/pdmlock/testdata/simple.toml
@@ -12,6 +12,11 @@ groups = ["default"]
 name = "requests"
 version = "2.31.0"
 groups = ["default"]
+dependencies = [
+    "certifi>=2017.4.17",
+    "charset_normalizer<4,>=2",
+    "not-locked>=1.0",
+]
 
 [[package]]
 name = "pytest"
@@ -21,4 +26,9 @@ groups = ["dev"]
 [[package]]
 name = "certifi"
 version = "2024.2.2"
+groups = ["default"]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.3.2"
 groups = ["default"]

--- a/providers/os/resources/languages/python/pdmlock/testdata/simple.toml
+++ b/providers/os/resources/languages/python/pdmlock/testdata/simple.toml
@@ -16,6 +16,7 @@ dependencies = [
     "certifi>=2017.4.17",
     "charset_normalizer<4,>=2",
     "not-locked>=1.0",
+    "zope.interface>=5.0",
 ]
 
 [[package]]
@@ -31,4 +32,12 @@ groups = ["default"]
 [[package]]
 name = "charset-normalizer"
 version = "3.3.2"
+groups = ["default"]
+
+# Spelled the way the project publishes it. Neither this nor the requirement
+# above is PEP 503 normalized, and they are not normalized the SAME way, so
+# resolving the edge needs BOTH the index and the lookup normalized.
+[[package]]
+name = "Zope_Interface"
+version = "6.1"
 groups = ["default"]

--- a/providers/os/resources/languages/python/uvlock/extractor.go
+++ b/providers/os/resources/languages/python/uvlock/extractor.go
@@ -5,6 +5,7 @@ package uvlock
 
 import (
 	"io"
+	"sort"
 
 	"github.com/BurntSushi/toml"
 	"go.mondoo.com/mql/providers/os/resources/languages"
@@ -59,6 +60,7 @@ func (l *uvLock) Direct() languages.Packages {
 
 // Transitive returns all packages (excluding the root project).
 func (l *uvLock) Transitive() languages.Packages {
+	byName := l.packagesByName()
 	var packages languages.Packages
 	for _, pkg := range l.Packages {
 		if pkg.isRoot() {
@@ -70,7 +72,61 @@ func (l *uvLock) Transitive() languages.Packages {
 			Purl:         python.NewPackageUrl(pkg.Name, pkg.Version),
 			Cpes:         python.NewCpes(pkg.Name, pkg.Version),
 			EvidenceList: python.NewEvidenceList(l.evidence),
+			DependsOn:    l.dependsOnRefs(pkg, byName),
 		})
 	}
 	return packages
+}
+
+// packagesByName indexes the locked packages for edge resolution, keyed by the
+// PEP 503 normalized name so a dependency spelled `charset_normalizer` finds
+// the entry named `charset-normalizer`.
+func (l *uvLock) packagesByName() map[string]uvPackage {
+	out := make(map[string]uvPackage, len(l.Packages))
+	for _, p := range l.Packages {
+		key := python.NormalizeName(p.Name)
+		if _, dup := out[key]; !dup {
+			out[key] = p
+		}
+	}
+	return out
+}
+
+// dependsOnRefs turns one package's dependency names into the purls of the
+// packages that satisfy them.
+//
+// Resolved by name against the lock's own package set, so an edge's target is
+// always a package the inventory contains — which is what the reachability
+// classifier requires before it will draw a negative verdict from the graph's
+// shape. A name with no entry is dropped rather than synthesised: uv writes one
+// entry per resolved package, so a name it does not have is one this lock did
+// not resolve.
+func (l *uvLock) dependsOnRefs(pkg uvPackage, byName map[string]uvPackage) []string {
+	names := make([]uvDependency, 0, len(pkg.Dependencies))
+	names = append(names, pkg.Dependencies...)
+	for _, extra := range pkg.OptionalDependencies {
+		names = append(names, extra...)
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	var refs []string
+	for _, dep := range names {
+		target, ok := byName[python.NormalizeName(dep.Name)]
+		if !ok || target.Version == "" || target.isRoot() {
+			continue
+		}
+		ref := python.NewPackageUrl(target.Name, target.Version)
+		if seen[ref] {
+			continue
+		}
+		seen[ref] = true
+		refs = append(refs, ref)
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+	sort.Strings(refs)
+	return refs
 }

--- a/providers/os/resources/languages/python/uvlock/extractor_test.go
+++ b/providers/os/resources/languages/python/uvlock/extractor_test.go
@@ -28,7 +28,7 @@ func TestParseSimple(t *testing.T) {
 	assert.Nil(t, bom.Direct())
 
 	pkgs := bom.Transitive()
-	assert.Len(t, pkgs, 4)
+	assert.Len(t, pkgs, 5)
 
 	django := pkgs.Find("django")
 	require.NotNil(t, django)
@@ -40,4 +40,76 @@ func TestParseSimple(t *testing.T) {
 func TestName(t *testing.T) {
 	e := &Extractor{}
 	assert.Equal(t, "uvlock", e.Name())
+}
+
+// TestUvLockDependencyEdges pins the uv package->package graph. uv writes each
+// package's own dependencies into every lock and the extractor read past them,
+// so a uv project supplied no edges at all and every transitive in it stayed
+// undetermined — neither reachable nor rulable out.
+func TestUvLockDependencyEdges(t *testing.T) {
+	f, err := os.Open("testdata/simple.lock")
+	require.NoError(t, err)
+	defer f.Close()
+
+	bom, err := (&Extractor{}).Parse(f, "uv.lock")
+	require.NoError(t, err)
+	pkgs := bom.Transitive()
+
+	requests := pkgs.Find("requests")
+	require.NotNil(t, requests)
+	// certifi and urllib3 are runtime deps; charset-normalizer arrives through
+	// the `socks` extra and is folded in on purpose (see OptionalDependencies).
+	// `not-locked` is named and never resolved, so it is dropped.
+	assert.Equal(t, []string{
+		"pkg:pypi/certifi@2024.2.2",
+		"pkg:pypi/charset-normalizer@3.3.2",
+		"pkg:pypi/urllib3@2.1.0",
+	}, requests.DependsOn)
+
+	// A leaf states none and carries none, so "depends on nothing" and "was
+	// never read" stay distinct downstream.
+	assert.Nil(t, pkgs.Find("certifi").DependsOn)
+	assert.Nil(t, pkgs.Find("django").DependsOn)
+}
+
+// TestUvLockNormalizesDependencyNames: the lock spells the extra's dependency
+// `charset_normalizer` and the package entry `charset-normalizer`. PEP 503
+// treats them as one name, and an edge keyed on the raw spelling would resolve
+// to nothing.
+func TestUvLockNormalizesDependencyNames(t *testing.T) {
+	f, err := os.Open("testdata/simple.lock")
+	require.NoError(t, err)
+	defer f.Close()
+
+	bom, err := (&Extractor{}).Parse(f, "uv.lock")
+	require.NoError(t, err)
+
+	assert.Contains(t, bom.Transitive().Find("requests").DependsOn,
+		"pkg:pypi/charset-normalizer@3.3.2",
+		"an underscore spelling must resolve to the normalized entry")
+}
+
+// TestUvLockDropsUnresolvedAndRootEdges: `not-locked` is named by requests and
+// has no entry, so it is not a package this lock resolved; inventing the node
+// would assert a dependency the project does not install. The root project is
+// excluded from the inventory, so an edge to it would name a node that is not
+// there either.
+func TestUvLockDropsUnresolvedAndRootEdges(t *testing.T) {
+	f, err := os.Open("testdata/simple.lock")
+	require.NoError(t, err)
+	defer f.Close()
+
+	bom, err := (&Extractor{}).Parse(f, "uv.lock")
+	require.NoError(t, err)
+	pkgs := bom.Transitive()
+
+	for _, ref := range pkgs.Find("requests").DependsOn {
+		assert.NotContains(t, ref, "not-locked", "an unresolved name must not become an edge")
+	}
+	assert.Nil(t, pkgs.Find("not-locked"), "and must not become a package")
+	for _, p := range pkgs {
+		for _, ref := range p.DependsOn {
+			assert.NotContains(t, ref, "my-project", "no edge may point at the root project")
+		}
+	}
 }

--- a/providers/os/resources/languages/python/uvlock/extractor_test.go
+++ b/providers/os/resources/languages/python/uvlock/extractor_test.go
@@ -28,7 +28,7 @@ func TestParseSimple(t *testing.T) {
 	assert.Nil(t, bom.Direct())
 
 	pkgs := bom.Transitive()
-	assert.Len(t, pkgs, 5)
+	assert.Len(t, pkgs, 6)
 
 	django := pkgs.Find("django")
 	require.NotNil(t, django)
@@ -57,13 +57,15 @@ func TestUvLockDependencyEdges(t *testing.T) {
 
 	requests := pkgs.Find("requests")
 	require.NotNil(t, requests)
-	// certifi and urllib3 are runtime deps; charset-normalizer arrives through
-	// the `socks` extra and is folded in on purpose (see OptionalDependencies).
-	// `not-locked` is named and never resolved, so it is dropped.
+	// certifi, urllib3 and zope-interface are runtime deps; charset-normalizer
+	// arrives through the `socks` extra and is folded in on purpose (see
+	// OptionalDependencies). `not-locked` is named and never resolved, so it is
+	// dropped.
 	assert.Equal(t, []string{
 		"pkg:pypi/certifi@2024.2.2",
 		"pkg:pypi/charset-normalizer@3.3.2",
 		"pkg:pypi/urllib3@2.1.0",
+		"pkg:pypi/zope-interface@6.1",
 	}, requests.DependsOn)
 
 	// A leaf states none and carries none, so "depends on nothing" and "was
@@ -112,4 +114,30 @@ func TestUvLockDropsUnresolvedAndRootEdges(t *testing.T) {
 			assert.NotContains(t, ref, "my-project", "no edge may point at the root project")
 		}
 	}
+}
+
+// TestUvLockNormalizesBothSidesOfTheIndex covers the half of normalization the
+// test above cannot reach.
+//
+// Names are normalized in two places -- building the index from each package's
+// own name, and looking a dependency up in it -- and a fixture whose package
+// entries are already normalized exercises only the second. Dropping
+// `NormalizeName` from the index side passed the whole suite, so the code had a
+// test named for the property that could not fail if half of it broke.
+//
+// The two spellings here are deliberately different from each other and both
+// non-normalized: `Zope_Interface` as the entry, `zope.interface` as the
+// reference. A same-spelling pair would still resolve with the index side
+// removed, which is exactly how this hid.
+func TestUvLockNormalizesBothSidesOfTheIndex(t *testing.T) {
+	f, err := os.Open("testdata/simple.lock")
+	require.NoError(t, err)
+	defer f.Close()
+
+	bom, err := (&Extractor{}).Parse(f, "uv.lock")
+	require.NoError(t, err)
+
+	assert.Contains(t, bom.Transitive().Find("requests").DependsOn,
+		"pkg:pypi/zope-interface@6.1",
+		"resolving this edge needs the entry AND the reference normalized")
 }

--- a/providers/os/resources/languages/python/uvlock/parser.go
+++ b/providers/os/resources/languages/python/uvlock/parser.go
@@ -17,6 +17,31 @@ type uvPackage struct {
 	Name    string   `toml:"name"`
 	Version string   `toml:"version"`
 	Source  uvSource `toml:"source"`
+	// Dependencies is the package's own resolved runtime dependencies. uv
+	// writes them as a table per entry (`{ name = "certifi" }`), naming only
+	// the package -- the version it resolved to is on that package's own
+	// [[package]] entry, which is where dependsOnRefs looks it up.
+	//
+	// This is the package->package graph. uv writes it into every lock and the
+	// extractor did not read it, so a uv project supplied no edges at all and
+	// every transitive dependency in it stayed undetermined.
+	Dependencies []uvDependency `toml:"dependencies"`
+	// OptionalDependencies are the extras: `pip install foo[socks]` pulls them
+	// in, a plain install does not.
+	//
+	// They ARE folded into the graph, deliberately. uv locks an optional
+	// dependency only because some configuration of this project needs it, and
+	// the flat DependsOn list has no channel for "reached only under an extra".
+	// Omitting the edge would leave such a package reached by nothing and
+	// eligible to be called an orphan -- a demotion, on a package an install
+	// with that extra really does ship. Including it errs toward keeping.
+	OptionalDependencies map[string][]uvDependency `toml:"optional-dependencies"`
+}
+
+// uvDependency is one entry in a package's dependency table. Only the name is
+// read: uv states the resolved version once, on the package's own entry.
+type uvDependency struct {
+	Name string `toml:"name"`
 }
 
 // uvSource describes where a package was sourced from.

--- a/providers/os/resources/languages/python/uvlock/testdata/simple.lock
+++ b/providers/os/resources/languages/python/uvlock/testdata/simple.lock
@@ -5,6 +5,10 @@ requires-python = ">=3.11"
 name = "my-project"
 version = "0.1.0"
 source = { virtual = "." }
+dependencies = [
+    { name = "django" },
+    { name = "requests" },
+]
 
 [[package]]
 name = "django"
@@ -15,6 +19,16 @@ source = { registry = "https://pypi.org/simple" }
 name = "requests"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+    { name = "not-locked" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "charset_normalizer" },
+]
 
 [[package]]
 name = "certifi"
@@ -24,4 +38,9 @@ source = { registry = "https://pypi.org/simple" }
 [[package]]
 name = "urllib3"
 version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "charset-normalizer"
+version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }

--- a/providers/os/resources/languages/python/uvlock/testdata/simple.lock
+++ b/providers/os/resources/languages/python/uvlock/testdata/simple.lock
@@ -23,6 +23,7 @@ dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
     { name = "not-locked" },
+    { name = "zope.interface" },
 ]
 
 [package.optional-dependencies]
@@ -43,4 +44,12 @@ source = { registry = "https://pypi.org/simple" }
 [[package]]
 name = "charset-normalizer"
 version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+
+# Spelled the way the project publishes it. Neither this nor the reference above
+# is PEP 503 normalized, and they are not normalized the SAME way, so resolving
+# the edge needs BOTH the index and the lookup normalized.
+[[package]]
+name = "Zope_Interface"
+version = "6.1"
 source = { registry = "https://pypi.org/simple" }


### PR DESCRIPTION
Both lockfiles carry a package→package graph and both extractors read past it, so a uv or pdm project supplied **zero** edges. Reachability gates the reachable/orphaned split on an ecosystem actually supplying edges, so every transitive in such a project stayed the undetermined `transitive`: neither reached nor rulable out.

Poetry has had this since `poetryscope.go` in xgrep, which says in its own header that it is a prototype of an upstream mql improvement, *"safe to run unconditionally and can be deleted with no behavior change once mql maps these natively"*. So uv and pdm are done here rather than as two more downstream shims.

## Measured, end to end through xgrep

Identically for both:

```
before: 1 imported, 1 direct-unused, 3 transitive (undetermined)
after:  1 imported, 1 direct-unused, 2 transitive-reachable, 1 transitive-orphaned
```

`sqlparse` is reached only from `django`, which nothing imports, so it demotes; `certifi` and `urllib3` come through the imported `requests`. Unlike RubyGems, **pypi demotes** — so this changes what `--reachable-only` drops.

## The formats differ, and each has one trap

- **uv** writes structured entries (`{ name = "certifi" }`), naming only the package. **Optional-dependencies are folded in deliberately**: uv locks an extra only because some configuration needs it, and `DependsOn` has no channel for "reached only under an extra". Omitting the edge would leave such a package reached by nothing and eligible to be called an orphan — a demotion, on a package an install with that extra really ships. Including it errs toward keeping.
- **pdm** writes PEP 508 requirement strings (`urllib3<3,>=1.21.1`). The constraint is a *requirement*; the resolved version is on that package's own entry. A purl built from the constraint names a package the lock did not resolve, so the edge would point at nothing. `pep508Name` takes the name off the front and is table-tested, extras and markers included.

Both resolve by **PEP 503 normalized name** against the lock's own package set, so `charset_normalizer` finds the entry named `charset-normalizer` and an edge's target is always a package the inventory contains. A name with no entry is dropped rather than synthesised.

## Verification

- `go build ./providers/os/...` clean; `go test ./providers/os/resources/languages/...` green.
- **7 tests; 6 mutations all red:**

| mutation | fails |
|---|---|
| uv `DependsOn` never attached | `TestUvLockDependencyEdges` |
| uv names not normalized | `TestUvLockNormalizesDependencyNames` |
| uv optional-dependencies dropped | `TestUvLockDependencyEdges` |
| uv unresolved names synthesised | `TestUvLockDropsUnresolvedAndRootEdges` |
| pdm edge built from the constraint | `TestPdmLockDependencyEdges` |
| `pep508Name` returning the whole requirement | `TestPep508Name` |

- Both fixtures grew a package, so two existing count assertions moved 4 → 5.

## Not done here, and worth its own change

`pdm.lock`'s `groups` field is parsed into `pdmPackage` and never used. It is dev scope, which for pypi is a **demoting** class — but the lock names groups without saying which are dev, and that mapping lives in `pyproject.toml`. An extractor is handed one file, so it cannot answer; guessing would demote an optional-dependency group a project really ships. That half is done as an enricher in xgrep instead, where two files can be read: [mondoohq/xgrep#2468](https://github.com/mondoohq/xgrep/pull/2468).

🤖 Generated with [Claude Code](https://claude.com/claude-code)