### PR TITLE
📄 point securityGroupIdHandler at its definition in aws.go

### DIFF
--- a/.claude/skills/new-resource/references/implementation-patterns.md
+++ b/.claude/skills/new-resource/references/implementation-patterns.md
@@ -88,7 +88,7 @@ func (a *mqlAwsDocumentdbSnapshot) vpc() (*mqlAwsVpc, error) {
 
 Run `./mqlr generate` a **second time** after adding an `Internal` struct; the first pass does not see it. Same on removal, or the stale embed fails the build with `undefined: mql<Name>Internal`. Name cache fields so they cannot collide with a generated accessor (`cachePath`, not `path`).
 
-**`securityGroupIdHandler`** (`providers/aws/resources/aws_ec2.go`) is a reusable embedded struct that turns a list of security group IDs into typed `[]aws.ec2.securitygroup` references:
+**`securityGroupIdHandler`** (`providers/aws/resources/aws.go`) is a reusable embedded struct that turns a list of security group IDs into typed `[]aws.ec2.securitygroup` references:
 
 ```go
 type mqlAwsRdsProxyInternal struct {


### PR DESCRIPTION
Follow-up to #10746. The review bot flagged that `implementation-patterns.md` said `securityGroupIdHandler` lives in `providers/aws/resources/aws_ec2.go`. It is defined in `providers/aws/resources/aws.go` (line 631); the wrong path was carried over verbatim from the old CLAUDE.md. #10746 auto-merged before the fix commit was pushed to its branch, so this lands it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)