### PR TITLE
✨ aws: report cross-zone load balancing on every load balancer family

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -7175,6 +7175,15 @@ private aws.elb.loadbalancer @defaults("name region elbType scheme dnsName") {
   enforcesTls() bool
   // Typed attributes for ALB/NLB load balancers
   attribute() aws.elb.loadbalancer.attribute
+  // Whether cross-zone load balancing is enabled
+  //
+  // When enabled, each load balancer node distributes traffic across the
+  // registered targets in every enabled availability zone; when disabled, a
+  // node only reaches targets in its own zone, so an imbalanced zone becomes a
+  // capacity and availability problem. Always true for application load
+  // balancers, which cannot turn it off. Reported for classic, application,
+  // network, and gateway load balancers alike.
+  crossZoneLoadBalancing() bool
   // Classic load balancer health check
   //
   // Health check configuration for a Classic Load Balancer, null for
@@ -7378,9 +7387,11 @@ private aws.elb.loadbalancer.attribute {
   deletionProtectionEnabled bool
   // Cross-zone load balancing setting
   //
-  // Value of the `load_balancing.cross_zone.enabled` attribute, either
-  // `true` or `false`. Always `true` for application load balancers.
-  crossZoneEnabled string
+  // Deprecated in favor of aws.elb.loadbalancer.crossZoneLoadBalancing, which
+  // reports a boolean and covers classic load balancers as well. Value of the
+  // `load_balancing.cross_zone.enabled` attribute, either `true` or `false`.
+  // Always `true` for application load balancers.
+  crossZoneEnabled @maturity("deprecated") @replaced_by("aws.elb.loadbalancer.crossZoneLoadBalancing") string
   // Whether access logs are enabled
   accessLogsEnabled bool
   // S3 bucket for access logs

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -12393,6 +12393,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.elb.loadbalancer.attribute": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbLoadbalancer).GetAttribute()).ToDataRes(types.Resource("aws.elb.loadbalancer.attribute"))
 	},
+	"aws.elb.loadbalancer.crossZoneLoadBalancing": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsElbLoadbalancer).GetCrossZoneLoadBalancing()).ToDataRes(types.Bool)
+	},
 	"aws.elb.loadbalancer.healthCheck": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbLoadbalancer).GetHealthCheck()).ToDataRes(types.Dict)
 	},
@@ -48258,6 +48261,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.elb.loadbalancer.attribute": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElbLoadbalancer).Attribute, ok = plugin.RawToTValue[*mqlAwsElbLoadbalancerAttribute](v.Value, v.Error)
+		return
+	},
+	"aws.elb.loadbalancer.crossZoneLoadBalancing": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsElbLoadbalancer).CrossZoneLoadBalancing, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.elb.loadbalancer.healthCheck": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -113424,6 +113431,7 @@ type mqlAwsElbLoadbalancer struct {
 	Listeners                                            plugin.TValue[[]any]
 	EnforcesTls                                          plugin.TValue[bool]
 	Attribute                                            plugin.TValue[*mqlAwsElbLoadbalancerAttribute]
+	CrossZoneLoadBalancing                               plugin.TValue[bool]
 	HealthCheck                                          plugin.TValue[any]
 }
 
@@ -113675,6 +113683,12 @@ func (c *mqlAwsElbLoadbalancer) GetAttribute() *plugin.TValue[*mqlAwsElbLoadbala
 		}
 
 		return c.attribute()
+	})
+}
+
+func (c *mqlAwsElbLoadbalancer) GetCrossZoneLoadBalancing() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.CrossZoneLoadBalancing, func() (bool, error) {
+		return c.crossZoneLoadBalancing()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -5058,6 +5058,7 @@ aws.elb.loadbalancer.attributes 11.15.2
 aws.elb.loadbalancer.availabilityZones 11.15.2
 aws.elb.loadbalancer.cloudformationStack 13.39.2
 aws.elb.loadbalancer.createdAt 11.15.2
+aws.elb.loadbalancer.crossZoneLoadBalancing 13.53.4
 aws.elb.loadbalancer.dnsName 11.15.2
 aws.elb.loadbalancer.elbType 11.15.2
 aws.elb.loadbalancer.enforceSecurityGroupInboundRulesOnPrivateLinkTraffic 13.53.4

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -266,10 +266,47 @@ type mqlAwsElbLoadbalancerInternal struct {
 	v2AttrsFetched bool
 	v2AttrsLock    sync.Mutex
 
+	// Cached v1 DescribeLoadBalancerAttributes response, shared between attributes()
+	// and crossZoneLoadBalancing() so a classic load balancer is described once.
+	cachedV1Attrs  *elbv1types.LoadBalancerAttributes
+	v1AttrsFetched bool
+	v1AttrsLock    sync.Mutex
+
 	// Tag caching for the filter guard pattern during listing.
 	cacheTags   map[string]any
 	tagsFetched bool
 	tagsLock    sync.Mutex
+}
+
+// fetchV1Attrs fetches and caches classic load balancer attributes with
+// double-check locking.
+func (a *mqlAwsElbLoadbalancer) fetchV1Attrs() (*elbv1types.LoadBalancerAttributes, error) {
+	if a.v1AttrsFetched {
+		return a.cachedV1Attrs, nil
+	}
+	a.v1AttrsLock.Lock()
+	defer a.v1AttrsLock.Unlock()
+	if a.v1AttrsFetched {
+		return a.cachedV1Attrs, nil
+	}
+
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	region, err := GetRegionFromArn(a.Arn.Data)
+	if err != nil {
+		return nil, err
+	}
+	name := a.Name.Data
+	svc := conn.Elb(region)
+
+	resp, err := svc.DescribeLoadBalancerAttributes(context.Background(),
+		&elasticloadbalancing.DescribeLoadBalancerAttributesInput{LoadBalancerName: &name})
+	if err != nil {
+		return nil, err
+	}
+
+	a.cachedV1Attrs = resp.LoadBalancerAttributes
+	a.v1AttrsFetched = true
+	return a.cachedV1Attrs, nil
 }
 
 // fetchV2Attrs fetches and caches v2 load balancer attributes with double-check locking.
@@ -584,23 +621,12 @@ func (a *mqlAwsElbLoadbalancer) listenerDescriptions() ([]any, error) {
 }
 
 func (a *mqlAwsElbLoadbalancer) attributes() ([]any, error) {
-	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	arnVal := a.Arn.Data
-	name := a.Name.Data
-
-	region, err := GetRegionFromArn(arnVal)
-	if err != nil {
-		return nil, err
-	}
-
-	if isV1LoadBalancerArn(arnVal) {
-		svc := conn.Elb(region)
-		ctx := context.Background()
-		attributes, err := svc.DescribeLoadBalancerAttributes(ctx, &elasticloadbalancing.DescribeLoadBalancerAttributesInput{LoadBalancerName: &name})
+	if isV1LoadBalancerArn(a.Arn.Data) {
+		attributes, err := a.fetchV1Attrs()
 		if err != nil {
 			return nil, err
 		}
-		j, err := convert.JsonToDict(attributes.LoadBalancerAttributes)
+		j, err := convert.JsonToDict(attributes)
 		if err != nil {
 			return nil, err
 		}
@@ -1435,6 +1461,42 @@ func attrMapInt(m map[string]string, key string) int64 {
 
 func (a *mqlAwsElbLoadbalancerAttribute) id() (string, error) {
 	return a.LoadBalancerArn.Data + "/attributes", nil
+}
+
+// crossZoneLoadBalancing reports whether cross-zone load balancing is on. The
+// setting lives in a different place for each load balancer family: classic
+// load balancers carry a dedicated CrossZoneLoadBalancing struct, while ELBv2
+// load balancers carry the load_balancing.cross_zone.enabled attribute.
+func (a *mqlAwsElbLoadbalancer) crossZoneLoadBalancing() (bool, error) {
+	if isV1LoadBalancerArn(a.Arn.Data) {
+		attrs, err := a.fetchV1Attrs()
+		if err != nil {
+			return false, err
+		}
+		if attrs == nil || attrs.CrossZoneLoadBalancing == nil {
+			return false, nil
+		}
+		return attrs.CrossZoneLoadBalancing.Enabled, nil
+	}
+
+	attrs, err := a.fetchV2Attrs()
+	if err != nil {
+		return false, err
+	}
+	return crossZoneEnabledFromV2Attrs(attrs), nil
+}
+
+// crossZoneEnabledFromV2Attrs reads load_balancing.cross_zone.enabled out of an
+// ELBv2 attribute list. The attribute is absent on load balancer types that do
+// not carry the setting, which reads as disabled.
+func crossZoneEnabledFromV2Attrs(attrs []elbtypes.LoadBalancerAttribute) bool {
+	for _, attr := range attrs {
+		if attr.Key == nil || *attr.Key != "load_balancing.cross_zone.enabled" {
+			continue
+		}
+		return attr.Value != nil && *attr.Value == "true"
+	}
+	return false
 }
 
 func (a *mqlAwsElbLoadbalancer) attribute() (*mqlAwsElbLoadbalancerAttribute, error) {

--- a/providers/aws/resources/aws_elb_test.go
+++ b/providers/aws/resources/aws_elb_test.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -75,4 +76,56 @@ func TestIsV1LoadBalancerArn(t *testing.T) {
 			assert.Equal(t, tt.want, isV1LoadBalancerArn(tt.arn))
 		})
 	}
+}
+
+// TestCrossZoneEnabledFromV2Attrs verifies that the cross-zone attribute is
+// read by exact key and only the literal "true" counts as enabled. The
+// attribute is absent on load balancer types that do not carry the setting,
+// which must read as disabled rather than as an error.
+func TestCrossZoneEnabledFromV2Attrs(t *testing.T) {
+	key := "load_balancing.cross_zone.enabled"
+	other := "deletion_protection.enabled"
+
+	t.Run("enabled", func(t *testing.T) {
+		assert.True(t, crossZoneEnabledFromV2Attrs([]elbtypes.LoadBalancerAttribute{
+			{Key: &key, Value: aws.String("true")},
+		}))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		assert.False(t, crossZoneEnabledFromV2Attrs([]elbtypes.LoadBalancerAttribute{
+			{Key: &key, Value: aws.String("false")},
+		}))
+	})
+
+	t.Run("attribute absent reads as disabled", func(t *testing.T) {
+		assert.False(t, crossZoneEnabledFromV2Attrs([]elbtypes.LoadBalancerAttribute{
+			{Key: &other, Value: aws.String("true")},
+		}))
+	})
+
+	t.Run("does not match on a different key carrying true", func(t *testing.T) {
+		prefixed := "routing." + key
+		assert.False(t, crossZoneEnabledFromV2Attrs([]elbtypes.LoadBalancerAttribute{
+			{Key: &prefixed, Value: aws.String("true")},
+		}))
+	})
+
+	t.Run("nil value reads as disabled", func(t *testing.T) {
+		assert.False(t, crossZoneEnabledFromV2Attrs([]elbtypes.LoadBalancerAttribute{
+			{Key: &key, Value: nil},
+		}))
+	})
+
+	t.Run("nil key is skipped, later match still wins", func(t *testing.T) {
+		assert.True(t, crossZoneEnabledFromV2Attrs([]elbtypes.LoadBalancerAttribute{
+			{Key: nil, Value: aws.String("false")},
+			{Key: &key, Value: aws.String("true")},
+		}))
+	})
+
+	t.Run("empty and nil attribute lists read as disabled", func(t *testing.T) {
+		assert.False(t, crossZoneEnabledFromV2Attrs([]elbtypes.LoadBalancerAttribute{}))
+		assert.False(t, crossZoneEnabledFromV2Attrs(nil))
+	})
 }


### PR DESCRIPTION
Closes #10697.

## What was missing

The issue asks for `aws.elb.loadbalancer.crossZoneLoadBalancing`. The setting was *partly* reachable already, which is why this is narrower than it first looks:

| load balancer family | before this PR |
|---|---|
| application / network / gateway | `attribute.crossZoneEnabled` — a **string** `"true"`/`"false"` |
| classic | **unreachable typed.** `attribute` is null for classic load balancers, so the value was only available by digging through the raw `attributes` dict |

So `ELB_CROSS_ZONE_LOAD_BALANCING_ENABLED` could not be written as one query across both families.

## What this adds

`crossZoneLoadBalancing() bool` on `aws.elb.loadbalancer`, covering every family:

```mql
aws.elb.loadBalancers.all(crossZoneLoadBalancing == true)
aws.elb.classicLoadBalancers.all(crossZoneLoadBalancing == true)
```

`attribute.crossZoneEnabled` is **deprecated in favor of** the new field rather than retyped — per CLAUDE.md §5 a shipped field's type never changes, so the string keeps resolving for existing queries.

Classic load balancers read `CrossZoneLoadBalancing.Enabled` from the v1 `DescribeLoadBalancerAttributes` response. That response is now cached on the resource the same way the v2 one already was, so `attributes()` and the new field share a single API call instead of describing the load balancer twice.

## Verified against live infrastructure

Three load balancers in `us-east-1`, each read in **both** states where the setting is toggleable (an ALB cannot disable cross-zone):

| load balancer | type | setting | `crossZoneLoadBalancing` |
|---|---|---|---|
| `mqlverify-clb` | classic | off | `false` *(was `null` before this PR)* |
| `mqlverify-clb` | classic | **flipped on** | `true` |
| `mqlverify-nlb` | network | off | `false` |
| `mqlverify-nlb` | network | **flipped on** | `true` |
| `mqlverify-alb` | application | always on | `true` |

The classic row is the point: before this PR that value had no typed path at all.

Infrastructure was created for this run and destroyed afterwards.

## Tests

`TestCrossZoneEnabledFromV2Attrs` covers the ELBv2 attribute-list walk: enabled, disabled, attribute absent, a *different* key carrying `"true"`, nil value, nil key, and empty/nil lists.

Confirmed the tests can fail — relaxing the check to `attr.Value != nil` (any present value counts as enabled) fails the `disabled` case.

## Checklist

- `gofmt` clean; `go test ./resources/` passes; `go mod tidy` no diff
- Codegen report: **3 additive, 0 breaking**
- `.lr.versions` entry at `13.53.4`, next patch after the provider's `13.53.3`
- `aws.permissions.json` unchanged (no new client; `Elb` was already used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
