### PR TITLE
✨ use the operating system's proxy settings on Windows

### DIFF
--- a/.github/workflows/pr-test-windows.yml
+++ b/.github/workflows/pr-test-windows.yml
@@ -6,6 +6,8 @@ on:
       - "providers/os/**"
       # the plugin transport tests pin how go-plugin picks ports on Windows
       - "providers-sdk/v1/plugin/**"
+      # system proxy detection calls WinHTTP; its smoke tests only run here
+      - "utils/sysproxy/**"
       - ".github/workflows/pr-test-windows.yml"
 
 concurrency:
@@ -40,7 +42,7 @@ jobs:
         run: |
           # Find all _windows_test.go files and extract unique package directories
           $repoRoot = (Get-Location).Path -replace '\\','/'
-          $packages = Get-ChildItem -Path providers/os, providers-sdk/v1/plugin -Recurse -Filter "*_windows_test.go" |
+          $packages = Get-ChildItem -Path providers/os, providers-sdk/v1/plugin, utils/sysproxy -Recurse -Filter "*_windows_test.go" |
             ForEach-Object {
               $rel = ($_.DirectoryName -replace '\\','/').Replace($repoRoot + '/', '')
               "./$rel/..."

--- a/apps/mql/cmd/login.go
+++ b/apps/mql/cmd/login.go
@@ -127,11 +127,10 @@ func register(token string, annotations map[string]string, updatesURL string, ti
 	token = strings.TrimSpace(token)
 
 	// NOTE: login is special because we do not have a config yet
-	proxy, err := config.GetAPIProxy()
+	httpClient, err := config.NewHttpClient()
 	if err != nil {
 		return cli_errors.NewCommandError(errors.Wrap(err, "could not parse proxy URL"), 1)
 	}
-	httpClient := ranger.NewHttpClient(ranger.WithProxy(proxy))
 
 	// we handle three cases here:
 	// 1. user has a token provided

--- a/apps/mql/cmd/status.go
+++ b/apps/mql/cmd/status.go
@@ -186,6 +186,16 @@ func checkStatus(ctx context.Context) (Status, error) {
 		return s, cli_errors.NewCommandError(errors.Wrap(err, "failed to set up Mondoo API client"), 1)
 	}
 
+	// Report the proxy the platform calls below go through. Resolving it here
+	// also runs the operating system's setup script, if any, before the checks
+	// start, so the result is cached by the time they need it.
+	if proxy, source, err := opts.EffectiveProxy(opts.UpstreamApiEndpoint()); err != nil {
+		log.Warn().Err(err).Msg("could not determine the proxy for Mondoo Platform")
+	} else if proxy != nil {
+		s.Client.Proxy = proxy.Redacted()
+		s.Client.ProxySource = string(source)
+	}
+
 	// Probe the ingest endpoint alongside the checks below rather than in
 	// series. Uploads go to a different host than the API on a different static
 	// IP, so a firewall can allow the API and blackhole ingest — and a
@@ -328,7 +338,14 @@ type ClientStatus struct {
 	UpdatesURL     string              `json:"updatesUrl,omitempty"`
 	ProvidersURL   string              `json:"providersUrl,omitempty"`
 	ConfigFile     string              `json:"configFile,omitempty"`
-	Providers      []ProviderStatus    `json:"-"`
+	// Proxy is the proxy that platform traffic to the API endpoint goes
+	// through, with credentials redacted, and ProxySource says where it came
+	// from (api_proxy, environment, system). Both are empty for a direct
+	// connection. A proxied Windows machine that cannot reach the platform
+	// is diagnosed from these two fields.
+	Proxy       string           `json:"proxy,omitempty"`
+	ProxySource string           `json:"proxySource,omitempty"`
+	Providers   []ProviderStatus `json:"-"`
 }
 
 // ProviderStatus captures the installed and latest available version of a

--- a/apps/mql/cmd/status_render.go
+++ b/apps/mql/cmd/status_render.go
@@ -169,6 +169,11 @@ func (s Status) renderMql(b *strings.Builder, st styler) {
 func (s Status) renderPlatform(b *strings.Builder, st styler) {
 	st.section(b, "Mondoo Platform")
 	st.row(b, "Endpoint", s.Upstream.API.Endpoint)
+	if s.Client.Proxy != "" {
+		st.row(b, "Proxy", st.value(s.Client.Proxy)+"  "+st.dim("("+s.Client.ProxySource+")"))
+	} else {
+		st.row(b, "Proxy", st.dim("none — direct connection"))
+	}
 
 	statusStr := st.bad(s.Upstream.API.Status)
 	if s.Upstream.API.Status == "SERVING" {

--- a/apps/mql/cmd/status_render_test.go
+++ b/apps/mql/cmd/status_render_test.go
@@ -190,6 +190,22 @@ func TestRenderCli_MqlSection_ConfigFileShown(t *testing.T) {
 	assert.NotContains(t, out, "defaults — no config file")
 }
 
+func TestRenderCli_PlatformSection_Proxy(t *testing.T) {
+	s := healthyRegisteredStatus()
+	s.Client.Proxy = "http://user:xxxxx@proxy.corp:3128"
+	s.Client.ProxySource = "system"
+
+	out := s.RenderCli(RenderOptions{Color: false})
+
+	assert.Contains(t, out, "http://user:xxxxx@proxy.corp:3128")
+	assert.Contains(t, out, "(system)")
+	assert.NotContains(t, out, "direct connection")
+
+	s.Client.Proxy, s.Client.ProxySource = "", ""
+	out = s.RenderCli(RenderOptions{Color: false})
+	assert.Contains(t, out, "direct connection")
+}
+
 func TestRenderCli_MqlSection_UpdateAvailableShowsArrow(t *testing.T) {
 	s := healthyRegisteredStatus()
 	s.Client.Version = "13.22.0"

--- a/apps/mql/cmd/testdata/status_healthy_registered.golden
+++ b/apps/mql/cmd/testdata/status_healthy_registered.golden
@@ -15,6 +15,7 @@
 
   ── Mondoo Platform ──────────────────────────────────────────────
   │  Endpoint   https://us.api.mondoo.com
+  │  Proxy      none — direct connection
   │  Status     SERVING   API v13 ✓ in sync
   │  Time       2026-06-29T21:37:00Z
   │  Ingest     https://ingest.us.mondoo.com   ✓ reachable · 41ms

--- a/apps/mql/cmd/testdata/status_ingest_unreachable.golden
+++ b/apps/mql/cmd/testdata/status_ingest_unreachable.golden
@@ -15,6 +15,7 @@
 
   ── Mondoo Platform ──────────────────────────────────────────────
   │  Endpoint   https://us.api.mondoo.com
+  │  Proxy      none — direct connection
   │  Status     SERVING   API v13 ✓ in sync
   │  Time       2026-06-29T21:37:00Z
   │  Ingest     https://ingest.us.mondoo.com   ✗ unreachable · timeout

--- a/apps/mql/cmd/testdata/status_registered_auth_failed.golden
+++ b/apps/mql/cmd/testdata/status_registered_auth_failed.golden
@@ -15,6 +15,7 @@
 
   ── Mondoo Platform ──────────────────────────────────────────────
   │  Endpoint   https://us.api.mondoo.com
+  │  Proxy      none — direct connection
   │  Status     SERVING   API v13 ✓ in sync
   │  Time       2026-06-29T21:37:00Z
   │  Ingest     https://ingest.us.mondoo.com   ✓ reachable · 41ms

--- a/apps/mql/cmd/testdata/status_stale_not_registered.golden
+++ b/apps/mql/cmd/testdata/status_stale_not_registered.golden
@@ -15,6 +15,7 @@
 
   ── Mondoo Platform ──────────────────────────────────────────────
   │  Endpoint   https://us.api.mondoo.com
+  │  Proxy      none — direct connection
   │  Status     SERVING   API v13 ✓ in sync
   │  Time       2026-06-29T21:37:00Z
   │  Ingest     https://ingest.us.mondoo.com   ✓ reachable · 41ms

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -317,8 +317,16 @@ type CommonOpts struct {
 	// two-state feature flag cannot express.
 	Strict *bool `json:"strict,omitempty" mapstructure:"strict"`
 
-	// API Proxy for communicating with Mondoo Platform API
+	// API Proxy for communicating with Mondoo Platform API. It overrides the
+	// HTTPS_PROXY environment and the operating system's proxy settings.
 	APIProxy string `json:"api_proxy,omitempty" mapstructure:"api_proxy"`
+
+	// SystemProxy controls whether the operating system's proxy settings are
+	// used when neither api_proxy nor the environment names a proxy (on
+	// Windows: Internet Settings and the WinHTTP default proxy). Unset means
+	// on. Set it to false to connect directly, or to honor only the
+	// HTTPS_PROXY environment. See KeySystemProxy.
+	SystemProxy *bool `json:"system_proxy,omitempty" mapstructure:"system_proxy"`
 
 	// labels that will be applied to all assets
 	Labels map[string]string `json:"labels,omitempty" mapstructure:"labels"`

--- a/cli/config/proxy.go
+++ b/cli/config/proxy.go
@@ -9,54 +9,224 @@ import (
 	"os"
 
 	"github.com/spf13/viper"
+	rangerUtils "go.mondoo.com/mql/utils/ranger"
+	"go.mondoo.com/mql/utils/sysproxy"
 	"go.mondoo.com/ranger-rpc"
 )
 
-// GetAPIProxy returns the proxy URL from the environment variable MONDOO_API_PROXY, HTTPS_PROXY and cli flag --api-proxy.
-// It should only be used when the options are not yet parsed, see CommonCliConfig.GetAPIProxy().
-func GetAPIProxy() (*url.URL, error) {
-	proxy, envSet := os.LookupEnv("MONDOO_API_PROXY")
-	if envSet {
-		return url.Parse(proxy)
-	}
+// Proxy selection for Mondoo Platform traffic: API calls, provider and binary
+// downloads, result uploads. Precedence, highest first:
+//
+//  1. --api-proxy, or MONDOO_API_PROXY
+//  2. api_proxy in the config file
+//  3. HTTPS_PROXY / HTTP_PROXY with NO_PROXY, as Go reads them
+//  4. the operating system's proxy settings, unless system_proxy is false
+//     (on Windows: Internet Settings with a manual proxy, a setup script or
+//     auto-detection, then the WinHTTP default set with netsh)
+//  5. a direct connection
+//
+// A proxy in the config file therefore overrides anything the environment or
+// the operating system says. system_proxy: false leaves steps 1 to 3 in place
+// and only stops the operating system's settings from being read, which is
+// how every version before system proxy support behaved.
 
-	proxy = viper.GetString("api_proxy")
-	if proxy != "" {
-		return url.Parse(proxy)
-	}
+// KeySystemProxy is the config key, and through viper's env binding the
+// MONDOO_SYSTEM_PROXY variable, that turns off reading the operating system's
+// proxy settings. Unset means on.
+const KeySystemProxy = "system_proxy"
 
-	proxy, envSet = os.LookupEnv("HTTPS_PROXY")
-	if envSet {
-		return url.Parse(proxy)
-	}
+// EnvAPIProxy is the environment variable that sets the proxy for Mondoo
+// Platform traffic ahead of the config file, on par with --api-proxy.
+const EnvAPIProxy = "MONDOO_API_PROXY"
 
+// ProxySource says where the proxy for a destination came from.
+type ProxySource string
+
+const (
+	// ProxySourceNone is a direct connection.
+	ProxySourceNone ProxySource = ""
+	// ProxySourceConfig is --api-proxy, MONDOO_API_PROXY or api_proxy in the config file.
+	ProxySourceConfig ProxySource = "api_proxy"
+	// ProxySourceEnvironment is HTTPS_PROXY or HTTP_PROXY.
+	ProxySourceEnvironment ProxySource = "environment"
+	// ProxySourceSystem is the operating system's proxy settings.
+	ProxySourceSystem ProxySource = "system"
+)
+
+// explicitAPIProxy returns the proxy configured for Mondoo Platform traffic
+// (steps 1 and 2 above), or nil when there is none. configured is the config
+// file value from a parsed CommonOpts; viper already carries it once it has
+// loaded the file, so it only matters for callers that unmarshalled the config
+// some other way.
+func explicitAPIProxy(configured string) (*url.URL, error) {
+	if proxy := os.Getenv(EnvAPIProxy); proxy != "" {
+		return sysproxy.ParseProxyURL(proxy)
+	}
+	if proxy := viper.GetString("api_proxy"); proxy != "" {
+		return sysproxy.ParseProxyURL(proxy)
+	}
+	if configured != "" {
+		return sysproxy.ParseProxyURL(configured)
+	}
 	return nil, nil
 }
 
+// SystemProxyEnabled reports whether the operating system's proxy settings may
+// be consulted: MONDOO_SYSTEM_PROXY first, then system_proxy in the config,
+// and on when neither says anything.
+func SystemProxyEnabled() bool {
+	return systemProxyEnabled(nil)
+}
+
+// systemProxyEnabled is SystemProxyEnabled with the parsed config value as the
+// last word before the default, for a CommonOpts that did not come from viper.
+func systemProxyEnabled(configured *bool) bool {
+	if v := os.Getenv(sysproxy.EnvSystemProxy); v != "" {
+		return sysproxy.ParseEnabled(v)
+	}
+	if viper.IsSet(KeySystemProxy) {
+		return viper.GetBool(KeySystemProxy)
+	}
+	if configured != nil {
+		return *configured
+	}
+	return true
+}
+
+// ProxyFunc returns the proxy selector for Mondoo Platform traffic, following
+// the precedence documented at the top of this file. It reads viper and the
+// environment, so it works before the config file is unmarshalled into a
+// CommonOpts; prefer CommonOpts.ProxyFunc once one is at hand.
+func ProxyFunc() (func(*http.Request) (*url.URL, error), error) {
+	return proxyFunc("", nil)
+}
+
+// ProxyFunc is the proxy selector for Mondoo Platform traffic with this
+// configuration. See the precedence at the top of this file.
+func (c *CommonOpts) ProxyFunc() (func(*http.Request) (*url.URL, error), error) {
+	return proxyFunc(c.APIProxy, c.SystemProxy)
+}
+
+func proxyFunc(configured string, systemProxy *bool) (func(*http.Request) (*url.URL, error), error) {
+	explicit, err := explicitAPIProxy(configured)
+	if err != nil {
+		return nil, err
+	}
+	if explicit != nil {
+		return http.ProxyURL(explicit), nil
+	}
+	if !systemProxyEnabled(systemProxy) {
+		return sysproxy.EnvironmentProxyFunc(), nil
+	}
+	return sysproxy.ProxyFunc(), nil
+}
+
+// NewHttpClient returns ranger's default HTTP client with ProxyFunc installed,
+// for code that runs before the config file is parsed (login, provider
+// downloads). Use CommonOpts.GetHttpClient once the config is loaded.
+func NewHttpClient() (*http.Client, error) {
+	proxy, err := ProxyFunc()
+	if err != nil {
+		return nil, err
+	}
+	return ranger.NewHttpClient(rangerUtils.WithProxyFunc(proxy)), nil
+}
+
+// GetHttpClient returns ranger's default HTTP client with this configuration's
+// proxy selection installed.
+func (c *CommonOpts) GetHttpClient() (*http.Client, error) {
+	proxy, err := c.ProxyFunc()
+	if err != nil {
+		return nil, err
+	}
+	return ranger.NewHttpClient(rangerUtils.WithProxyFunc(proxy)), nil
+}
+
+// EffectiveProxy reports the proxy that Mondoo Platform traffic to target goes
+// through and where that choice came from, for diagnostics such as the status
+// command. A nil proxy with ProxySourceNone is a direct connection.
+func (c *CommonOpts) EffectiveProxy(target string) (*url.URL, ProxySource, error) {
+	explicit, err := explicitAPIProxy(c.APIProxy)
+	if err != nil {
+		return nil, ProxySourceNone, err
+	}
+	if explicit != nil {
+		return explicit, ProxySourceConfig, nil
+	}
+	u, err := url.Parse(target)
+	if err != nil {
+		return nil, ProxySourceNone, err
+	}
+	selectProxy, err := c.ProxyFunc()
+	if err != nil {
+		return nil, ProxySourceNone, err
+	}
+	proxy, err := selectProxy(&http.Request{URL: u})
+	if err != nil || proxy == nil {
+		return nil, ProxySourceNone, err
+	}
+	if sysproxy.EnvironmentConfigured() {
+		return proxy, ProxySourceEnvironment, nil
+	}
+	return proxy, ProxySourceSystem, nil
+}
+
+// UpstreamApiEndpoint returns the configured Mondoo API endpoint (flag,
+// environment, config file) or the default, without a parsed CommonOpts.
+func UpstreamApiEndpoint() string {
+	if endpoint := viper.GetString("api_endpoint"); endpoint != "" {
+		return endpoint
+	}
+	return defaultAPIendpoint
+}
+
+// ProviderEnvironment returns environment assignments for a provider
+// subprocess so it makes the same proxy decisions as this process. The cloud
+// SDKs inside providers read only HTTP_PROXY, HTTPS_PROXY and NO_PROXY, so a
+// proxy found in the operating system's settings travels that way, and a
+// system_proxy: false opt-out travels as MONDOO_SYSTEM_PROXY=false so the
+// provider's own platform client honors it. api_proxy is not exported: it is
+// scoped to Mondoo Platform traffic and reaches providers through the
+// upstream config instead. Variables the parent already has are never
+// overridden.
+func ProviderEnvironment() []string {
+	if !SystemProxyEnabled() {
+		return []string{sysproxy.EnvSystemProxy + "=false"}
+	}
+	endpoint, err := url.Parse(UpstreamApiEndpoint())
+	if err != nil {
+		endpoint = nil
+	}
+	return sysproxy.Environment(endpoint)
+}
+
+// GetAPIProxy returns the proxy configured explicitly for Mondoo Platform
+// traffic, or HTTPS_PROXY when there is none. It predates system proxy
+// support and returns one fixed URL, so it cannot report a per-destination
+// choice and never sees the operating system's settings.
+//
+// Deprecated: use ProxyFunc or NewHttpClient, which apply every source.
+func GetAPIProxy() (*url.URL, error) {
+	proxy, err := explicitAPIProxy("")
+	if err != nil || proxy != nil {
+		return proxy, err
+	}
+	if proxy, ok := os.LookupEnv("HTTPS_PROXY"); ok && proxy != "" {
+		return url.Parse(proxy)
+	}
+	return nil, nil
+}
+
+// GetAPIProxy is GetAPIProxy with the config file value as a last fallback.
+//
+// Deprecated: use ProxyFunc or GetHttpClient, which apply every source.
 func (c *CommonOpts) GetAPIProxy() (*url.URL, error) {
 	proxy, err := GetAPIProxy()
-	if err != nil {
-		return nil, err
+	if err != nil || proxy != nil {
+		return proxy, err
 	}
-	if proxy != nil {
-		return proxy, nil
-	}
-
-	// fallback to proxy from config file
 	if c.APIProxy != "" {
-		return url.Parse(c.APIProxy)
+		return sysproxy.ParseProxyURL(c.APIProxy)
 	}
-
 	return nil, nil
-}
-
-func (c *CommonOpts) GetHttpClient() (*http.Client, error) {
-	proxy, err := c.GetAPIProxy()
-	if err != nil {
-		return nil, err
-	}
-	if proxy == nil {
-		return ranger.DefaultHttpClient(), nil
-	}
-	return ranger.NewHttpClient(ranger.WithProxy(proxy)), nil
 }

--- a/cli/config/proxy_test.go
+++ b/cli/config/proxy_test.go
@@ -1,0 +1,223 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package config
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/utils/sysproxy"
+)
+
+// clearProxyEnv gives a test a proxy-free environment and a fresh viper, so
+// the machine running the tests cannot leak its own settings in.
+func clearProxyEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{EnvAPIProxy, sysproxy.EnvSystemProxy, "HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "NO_PROXY", "no_proxy"} {
+		t.Setenv(k, "")
+	}
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+}
+
+func resolve(t *testing.T, fn func(*http.Request) (*url.URL, error), target string) string {
+	t.Helper()
+	require.NotNil(t, fn, "a nil selector would mean direct connections for every request")
+	u, err := url.Parse(target)
+	require.NoError(t, err)
+	p, err := fn(&http.Request{URL: u})
+	require.NoError(t, err)
+	if p == nil {
+		return ""
+	}
+	return p.String()
+}
+
+func TestProxyFuncPrecedence(t *testing.T) {
+	const target = "https://us.api.mondoo.com/ping"
+
+	t.Run("config file proxy overrides the environment", func(t *testing.T) {
+		clearProxyEnv(t)
+		t.Setenv("HTTPS_PROXY", "http://env-proxy:3128")
+		viper.Set("api_proxy", "http://config-proxy:3128")
+
+		fn, err := ProxyFunc()
+		require.NoError(t, err)
+		assert.Equal(t, "http://config-proxy:3128", resolve(t, fn, target))
+	})
+
+	t.Run("config file proxy overrides NO_PROXY", func(t *testing.T) {
+		clearProxyEnv(t)
+		t.Setenv("NO_PROXY", "*")
+		viper.Set("api_proxy", "http://config-proxy:3128")
+
+		fn, err := ProxyFunc()
+		require.NoError(t, err)
+		assert.Equal(t, "http://config-proxy:3128", resolve(t, fn, target), "an explicit api_proxy is unconditional")
+	})
+
+	t.Run("parsed config struct is honored when viper has nothing", func(t *testing.T) {
+		clearProxyEnv(t)
+		t.Setenv("HTTPS_PROXY", "http://env-proxy:3128")
+		opts := &CommonOpts{APIProxy: "http://struct-proxy:3128"}
+
+		fn, err := opts.ProxyFunc()
+		require.NoError(t, err)
+		assert.Equal(t, "http://struct-proxy:3128", resolve(t, fn, target))
+	})
+
+	t.Run("MONDOO_API_PROXY overrides the config file", func(t *testing.T) {
+		clearProxyEnv(t)
+		t.Setenv(EnvAPIProxy, "http://env-api-proxy:3128")
+		viper.Set("api_proxy", "http://config-proxy:3128")
+
+		fn, err := ProxyFunc()
+		require.NoError(t, err)
+		assert.Equal(t, "http://env-api-proxy:3128", resolve(t, fn, target))
+	})
+
+	t.Run("a proxy without a scheme is taken as http", func(t *testing.T) {
+		clearProxyEnv(t)
+		viper.Set("api_proxy", "proxy.corp:3128")
+
+		fn, err := ProxyFunc()
+		require.NoError(t, err)
+		assert.Equal(t, "http://proxy.corp:3128", resolve(t, fn, target))
+	})
+
+	t.Run("a broken api_proxy is an error", func(t *testing.T) {
+		clearProxyEnv(t)
+		viper.Set("api_proxy", "ftp://proxy.corp:21")
+
+		_, err := ProxyFunc()
+		require.Error(t, err)
+		_, err = NewHttpClient()
+		require.Error(t, err)
+	})
+
+	t.Run("environment applies without an api_proxy, with NO_PROXY", func(t *testing.T) {
+		clearProxyEnv(t)
+		t.Setenv("HTTPS_PROXY", "http://env-proxy:3128")
+		t.Setenv("NO_PROXY", "us.api.mondoo.com")
+
+		fn, err := ProxyFunc()
+		require.NoError(t, err)
+		assert.Equal(t, "", resolve(t, fn, target))
+		assert.Equal(t, "http://env-proxy:3128", resolve(t, fn, "https://releases.mondoo.com/x"))
+	})
+
+	t.Run("system proxy disabled falls back to the environment", func(t *testing.T) {
+		clearProxyEnv(t)
+		t.Setenv("HTTPS_PROXY", "http://env-proxy:3128")
+		viper.Set(KeySystemProxy, false)
+
+		fn, err := ProxyFunc()
+		require.NoError(t, err)
+		assert.Equal(t, "http://env-proxy:3128", resolve(t, fn, target))
+	})
+
+	t.Run("nothing configured connects directly", func(t *testing.T) {
+		clearProxyEnv(t)
+		viper.Set(KeySystemProxy, false) // keep the machine's own settings out of it
+
+		fn, err := ProxyFunc()
+		require.NoError(t, err)
+		assert.Equal(t, "", resolve(t, fn, target))
+	})
+}
+
+func TestSystemProxyEnabled(t *testing.T) {
+	clearProxyEnv(t)
+	assert.True(t, SystemProxyEnabled(), "on by default")
+
+	viper.Set(KeySystemProxy, false)
+	assert.False(t, SystemProxyEnabled(), "config file turns it off")
+
+	t.Setenv(sysproxy.EnvSystemProxy, "true")
+	assert.True(t, SystemProxyEnabled(), "environment wins over the config file")
+
+	t.Setenv(sysproxy.EnvSystemProxy, "")
+	viper.Reset()
+	off := false
+	assert.False(t, systemProxyEnabled(&off), "a parsed struct counts when viper has nothing")
+	on := true
+	assert.True(t, systemProxyEnabled(&on))
+}
+
+func TestEffectiveProxy(t *testing.T) {
+	const target = "https://us.api.mondoo.com"
+
+	t.Run("config", func(t *testing.T) {
+		clearProxyEnv(t)
+		t.Setenv("HTTPS_PROXY", "http://env-proxy:3128")
+		opts := &CommonOpts{APIProxy: "http://user:secret@config-proxy:3128"}
+		p, source, err := opts.EffectiveProxy(target)
+		require.NoError(t, err)
+		assert.Equal(t, ProxySourceConfig, source)
+		assert.Equal(t, "http://user:xxxxx@config-proxy:3128", p.Redacted())
+	})
+
+	t.Run("environment", func(t *testing.T) {
+		clearProxyEnv(t)
+		t.Setenv("HTTPS_PROXY", "http://env-proxy:3128")
+		p, source, err := (&CommonOpts{}).EffectiveProxy(target)
+		require.NoError(t, err)
+		assert.Equal(t, ProxySourceEnvironment, source)
+		assert.Equal(t, "http://env-proxy:3128", p.String())
+	})
+
+	t.Run("direct", func(t *testing.T) {
+		clearProxyEnv(t)
+		viper.Set(KeySystemProxy, false)
+		p, source, err := (&CommonOpts{}).EffectiveProxy(target)
+		require.NoError(t, err)
+		assert.Equal(t, ProxySourceNone, source)
+		assert.Nil(t, p)
+	})
+}
+
+func TestProviderEnvironment(t *testing.T) {
+	t.Run("opt-out is passed on", func(t *testing.T) {
+		clearProxyEnv(t)
+		viper.Set(KeySystemProxy, false)
+		assert.Equal(t, []string{sysproxy.EnvSystemProxy + "=false"}, ProviderEnvironment())
+	})
+
+	t.Run("an environment proxy is inherited, not re-exported", func(t *testing.T) {
+		clearProxyEnv(t)
+		t.Setenv("HTTPS_PROXY", "http://env-proxy:3128")
+		assert.Empty(t, ProviderEnvironment())
+	})
+}
+
+func TestUpstreamApiEndpoint(t *testing.T) {
+	clearProxyEnv(t)
+	assert.Equal(t, defaultAPIendpoint, UpstreamApiEndpoint())
+	viper.Set("api_endpoint", "https://eu.api.mondoo.com")
+	assert.Equal(t, "https://eu.api.mondoo.com", UpstreamApiEndpoint())
+}
+
+func TestGetAPIProxyStaysCompatible(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTPS_PROXY", "http://env-proxy:3128")
+	p, err := GetAPIProxy()
+	require.NoError(t, err)
+	assert.Equal(t, "http://env-proxy:3128", p.String(), "the deprecated helper still falls back to HTTPS_PROXY")
+
+	viper.Set("api_proxy", "http://config-proxy:3128")
+	p, err = GetAPIProxy()
+	require.NoError(t, err)
+	assert.Equal(t, "http://config-proxy:3128", p.String())
+
+	t.Setenv(EnvAPIProxy, "")
+	viper.Reset()
+	t.Setenv("HTTPS_PROXY", "")
+	p, err = (&CommonOpts{APIProxy: "struct-proxy:3128"}).GetAPIProxy()
+	require.NoError(t, err)
+	assert.Equal(t, "http://struct-proxy:3128", p.String())
+}

--- a/cli/selfupdate/selfupdate.go
+++ b/cli/selfupdate/selfupdate.go
@@ -27,6 +27,7 @@ import (
 	"go.mondoo.com/mql/logger/zerologadapter"
 	"go.mondoo.com/mql/providers/core/resources/versions/semver"
 	"go.mondoo.com/mql/utils/httpx"
+	"go.mondoo.com/mql/utils/sysproxy"
 )
 
 const (
@@ -595,15 +596,13 @@ func checkWritable(path string) error {
 
 // httpClientWithRetry creates an HTTP client with retry capabilities
 func httpClientWithRetry() (*http.Client, error) {
-	var proxyFn func(*http.Request) (*url.URL, error)
-
-	proxy, err := config.GetAPIProxy()
+	// api_proxy, the environment or the operating system's settings, in that
+	// order; see cli/config/proxy.go. A broken api_proxy is reported and the
+	// download proceeds as it would without one.
+	proxyFn, err := config.ProxyFunc()
 	if err != nil {
 		log.Warn().Err(err).Msg("self-update: could not parse proxy URL")
-	}
-
-	if proxy != nil {
-		proxyFn = http.ProxyURL(proxy)
+		proxyFn = sysproxy.EnvironmentProxyFunc()
 	}
 
 	retryClient := retryablehttp.NewClient()

--- a/docs/adr/045-system-proxy.md
+++ b/docs/adr/045-system-proxy.md
@@ -1,0 +1,97 @@
+# ADR 045: System proxy detection
+
+## Status
+
+Accepted, implemented in mql and cnspec (September 2026).
+
+## Context
+
+Every outbound HTTP client in mql and cnspec was built from one of two proxy
+sources: an `api_proxy` set explicitly (config file, `--api-proxy`,
+`MONDOO_API_PROXY`) or the `HTTPS_PROXY` environment convention that Go's
+`net/http` reads. Nothing else was consulted.
+
+Windows machines rarely have `HTTPS_PROXY` set. The proxy lives in the
+operating system: per user in Internet Settings (Settings > Network &
+internet > Proxy), as a manual proxy with an exception list, a setup script
+(PAC) URL, or "automatically detect settings" (WPAD), and per machine in the
+WinHTTP default that administrators set with `netsh winhttp set proxy` so that
+services can reach the internet. Browsers, PowerShell, .NET and Windows Update
+all read these. A freshly installed cnspec did not, so on a proxied Windows
+machine the first `cnspec login` or the `cnspec serve` service failed to reach
+the platform until someone found the `api_proxy` key. That is the opposite of
+the path of least resistance the product promises.
+
+## Decision
+
+1. **Read the operating system's proxy settings and use them when nothing
+   more specific is configured.** A new leaf package, `utils/sysproxy`,
+   detects the settings and answers per destination. On Windows it calls
+   `winhttp.dll` through the lazy DLL loader (no cgo, as the release build
+   requires): `WinHttpGetIEProxyConfigForCurrentUser` for the per-user
+   Internet Settings, the HKLM Internet Settings when group policy stores
+   them per machine (`ProxySettingsPerUser = 0`, which WinHTTP does not
+   read), `WinHttpGetDefaultProxyConfiguration` for the `netsh` default, and
+   `WinHttpGetProxyForUrl` to run a setup script or WPAD discovery. Other
+   platforms report no settings; a macOS reader would slot into the same
+   shape.
+
+2. **Precedence is fixed and documented in one place** (`cli/config/proxy.go`):
+   `--api-proxy` or `MONDOO_API_PROXY`, then `api_proxy` in the config file,
+   then `HTTPS_PROXY`/`HTTP_PROXY` with `NO_PROXY`, then the operating
+   system's settings, then a direct connection. A proxy in the config file
+   therefore overrides anything the environment or the operating system says.
+   Within the operating system's settings the order is the one Windows uses:
+   the script's answer when a script is configured and runs (its DIRECT is
+   final), otherwise the per-user manual proxy with its exceptions, otherwise
+   the machine-wide WinHTTP proxy with its exceptions. Loopback is never
+   proxied unless an exception list says `<-loopback>`, and `NO_PROXY` keeps
+   its meaning next to a system proxy.
+
+3. **One opt-out, `system_proxy: false`** (`MONDOO_SYSTEM_PROXY=false`),
+   restores the previous behavior exactly: steps one to three stay, only the
+   operating system's settings are no longer read. There is no second knob
+   for "direct even if the environment says otherwise"; `NO_PROXY=*` already
+   does that and always has.
+
+4. **Provider subprocesses see the same decision.** The provider's own
+   platform client resolves the system proxy itself, through the same
+   package inside `providers-sdk/v1/upstream`, so PAC answers stay
+   per-destination. The cloud SDKs inside providers only read the
+   environment, so the coordinator exports the system proxy to the provider
+   as `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` (a script is evaluated for
+   the Mondoo API endpoint, the one destination we know matters; the
+   exception list is translated where Go's `NO_PROXY` syntax can express it),
+   and the opt-out as `MONDOO_SYSTEM_PROXY=false`. Variables already in the
+   environment are never overridden. `api_proxy` is not exported: it is
+   scoped to platform traffic and reaches providers through the upstream
+   config, as before.
+
+5. **Cost is bounded.** Detection is cached for five minutes so a
+   long-running `cnspec serve` follows a changed proxy without a restart and
+   a scan pays once. Script evaluation is cached per origin with the same
+   TTL, a failed WPAD discovery is remembered so the Windows default of
+   "automatically detect settings" with no proxy costs one failed probe and
+   not one per host, and a request waits at most fifteen seconds for a
+   script before it falls back to the manual settings. `mql status` and
+   `cnspec status` print the proxy in effect and where it came from.
+
+## Consequences
+
+- A Windows install with a system proxy works with no proxy configuration,
+  for the CLI, the Windows service, and the providers it starts. A machine
+  without a proxy behaves as before, with one WPAD probe on the first
+  platform call if auto-detection is on, answered from the WinHTTP
+  Auto-Discovery Service's cache on most machines.
+- `HTTPS_PROXY` is now read with Go's full semantics (`HTTP_PROXY` for http
+  targets, `NO_PROXY` honored) at every call site, where a few sites had
+  copied only `HTTPS_PROXY` into a fixed proxy URL. `api_proxy` values
+  without a scheme (`proxy.corp:3128`) are accepted as http.
+- `config.GetAPIProxy` stays for compatibility but is deprecated: it returns
+  one fixed URL and cannot express a per-destination answer, so it never
+  reports the system proxy. New code takes `config.ProxyFunc` or
+  `config.NewHttpClient`.
+- The Windows API layer cannot be unit tested off Windows; its smoke tests
+  run in the Windows CI job, and the selection logic, list parsing, bypass
+  matching and `NO_PROXY` translation are pure Go with tests on every
+  platform.

--- a/providers-sdk/v1/upstream/health/errors.go
+++ b/providers-sdk/v1/upstream/health/errors.go
@@ -299,12 +299,11 @@ func sendSlowQuery(product, version, build string, q SlowQueryInfo, ro reportOpt
 
 func sendErrorToMondooPlatform(serviceAccount *upstream.ServiceAccountCredentials, event *SendErrorReq) {
 	// 3. send error to mondoo platform
-	proxy, err := config.GetAPIProxy()
+	httpClient, err := config.NewHttpClient()
 	if err != nil {
 		log.Error().Err(err).Msg("failed to parse proxy setting")
 		return
 	}
-	httpClient := ranger.NewHttpClient(ranger.WithProxy(proxy))
 
 	plugins := []ranger.ClientPlugin{}
 	certAuth, err := upstream.NewServiceAccountRangerPlugin(serviceAccount)

--- a/providers-sdk/v1/upstream/sts.go
+++ b/providers-sdk/v1/upstream/sts.go
@@ -17,12 +17,11 @@ import (
 
 	"go.mondoo.com/mql/providers-sdk/v1/upstream/tokenauth"
 	"go.mondoo.com/mql/providers/os/connection/ssh/signers"
-	"go.mondoo.com/ranger-rpc"
 	"golang.org/x/crypto/ssh"
 )
 
 func ExchangeSSHKey(apiEndpoint string, identityMrn string, resourceMrn string) (*ServiceAccountCredentials, error) {
-	stsClient, err := NewSecureTokenServiceClient(apiEndpoint, ranger.DefaultHttpClient())
+	stsClient, err := NewSecureTokenServiceClient(apiEndpoint, DefaultHttpClient())
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +82,7 @@ func ExchangeExternalToken(apiEndpoint, audience, issuerURI, jwtToken string, to
 		return nil, fmt.Errorf("no identity token to use for an external exchange")
 	}
 
-	stsClient, err := NewSecureTokenServiceClient(apiEndpoint, ranger.DefaultHttpClient())
+	stsClient, err := NewSecureTokenServiceClient(apiEndpoint, DefaultHttpClient())
 	if err != nil {
 		return nil, err
 	}

--- a/providers-sdk/v1/upstream/upstream.go
+++ b/providers-sdk/v1/upstream/upstream.go
@@ -7,13 +7,13 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"net/url"
 
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql"
 	"go.mondoo.com/mql/utils/multierr"
 	rangerUtils "go.mondoo.com/mql/utils/ranger"
+	"go.mondoo.com/mql/utils/sysproxy"
 	"go.mondoo.com/ranger-rpc"
 	guard_cert_auth "go.mondoo.com/ranger-rpc/plugins/authentication/cert"
 	"go.mondoo.com/ranger-rpc/plugins/authentication/statictoken"
@@ -99,11 +99,23 @@ func (c *UpstreamConfig) InitClient(ctx context.Context) (*UpstreamClient, error
 	return &res, nil
 }
 
+// DefaultHttpClient returns ranger's default HTTP client with proxy selection
+// that honors the environment and the operating system's proxy settings (see
+// sysproxy). It is the client for Mondoo Platform traffic whenever no
+// api_proxy is configured, in the CLI and inside provider processes alike, so
+// a provider on a Windows machine with a system proxy reaches the platform
+// the same way the CLI that started it does.
+func DefaultHttpClient() *http.Client {
+	return ranger.NewHttpClient(rangerUtils.WithProxyFunc(sysproxy.ProxyFunc()))
+}
+
 func (c *UpstreamConfig) httpClient() *http.Client {
 	if c.ApiProxy == "" {
-		return ranger.DefaultHttpClient()
+		return DefaultHttpClient()
 	}
-	proxy, err := url.Parse(c.ApiProxy)
+	// An api_proxy is explicit configuration and overrides the environment and
+	// the operating system's settings.
+	proxy, err := sysproxy.ParseProxyURL(c.ApiProxy)
 	if err != nil {
 		log.Fatal().Err(err).Msg("could not parse proxy URL")
 	}

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -409,6 +409,7 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 		pluginCmd := exec.Command(provider.binPath(), []string{"run_as_plugin", "--log-level", zerolog.GlobalLevel().String()}...)
 
 		addColorConfig(pluginCmd)
+		addProxyConfig(pluginCmd)
 
 		pluginLogger := &hclogger{Logger: log.Logger}
 		pluginLogger.SetLevel(hclog.Warn)

--- a/providers/plugin_proxy.go
+++ b/providers/plugin_proxy.go
@@ -1,0 +1,39 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/cli/config"
+)
+
+// addProxyConfig hands this process's proxy decision to a provider subprocess.
+//
+// The cloud SDKs inside providers read only HTTP_PROXY, HTTPS_PROXY and
+// NO_PROXY, so a proxy that came from the operating system's settings (Windows
+// Internet Settings, the WinHTTP default) has to travel as those variables or
+// the provider's AWS, Azure and GCP calls go direct and fail behind the proxy
+// the CLI itself just used. A system_proxy: false opt-out travels as
+// MONDOO_SYSTEM_PROXY=false so the provider's own platform client makes the
+// same choice. See config.ProviderEnvironment for what is and is not exported.
+//
+// go-plugin appends os.Environ() after these assignments and exec keeps the
+// last value of a repeated variable, so anything already in the environment
+// is inherited unchanged.
+func addProxyConfig(cmd *exec.Cmd) {
+	env := config.ProviderEnvironment()
+	if len(env) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(env))
+	for _, kv := range env {
+		// keys only: a proxy URL may carry credentials
+		keys = append(keys, strings.SplitN(kv, "=", 2)[0])
+	}
+	log.Debug().Strs("variables", keys).Msg("passing proxy settings to the provider")
+	cmd.Env = append(cmd.Env, env...)
+}

--- a/providers/plugin_proxy_test.go
+++ b/providers/plugin_proxy_test.go
@@ -1,0 +1,42 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"os/exec"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/utils/sysproxy"
+)
+
+func TestAddProxyConfig(t *testing.T) {
+	t.Run("opt-out travels to the provider", func(t *testing.T) {
+		t.Setenv(sysproxy.EnvSystemProxy, "false")
+		cmd := exec.Command("provider")
+		addProxyConfig(cmd)
+		assert.Equal(t, []string{sysproxy.EnvSystemProxy + "=false"}, cmd.Env)
+	})
+
+	t.Run("nothing is added when the environment already names a proxy", func(t *testing.T) {
+		t.Setenv(sysproxy.EnvSystemProxy, "")
+		t.Setenv("HTTPS_PROXY", "http://env-proxy:3128")
+		cmd := exec.Command("provider")
+		addProxyConfig(cmd)
+		assert.Empty(t, cmd.Env, "the provider inherits HTTPS_PROXY as it is")
+	})
+
+	t.Run("nothing is added without system settings", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("depends on the machine's proxy settings")
+		}
+		t.Setenv(sysproxy.EnvSystemProxy, "")
+		t.Setenv("HTTPS_PROXY", "")
+		t.Setenv("HTTP_PROXY", "")
+		cmd := exec.Command("provider")
+		addProxyConfig(cmd)
+		assert.Empty(t, cmd.Env)
+	})
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -255,15 +254,11 @@ var (
 )
 
 func httpClientWithRetry() (*http.Client, error) {
-	var proxyFn func(*http.Request) (*url.URL, error)
-
-	proxy, err := config.GetAPIProxy()
+	// api_proxy, the environment or the operating system's settings, in that
+	// order; see cli/config/proxy.go.
+	proxyFn, err := config.ProxyFunc()
 	if err != nil {
 		log.Fatal().Err(err).Msg("could not parse proxy URL")
-	}
-
-	if proxy != nil {
-		proxyFn = http.ProxyURL(proxy)
 	}
 
 	retryClient := retryablehttp.NewClient()

--- a/utils/httpx/httpx.go
+++ b/utils/httpx/httpx.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"sync/atomic"
 	"time"
@@ -56,15 +55,11 @@ func DownloadTimeout() time.Duration {
 // lifecycle including body reads. Callers should wrap the response body with
 // NewIdleTimeoutReader to detect stalled transfers.
 func ClientForDownload() (*http.Client, error) {
-	var proxyFn func(*http.Request) (*url.URL, error)
-
-	proxy, err := config.GetAPIProxy()
+	// api_proxy, the environment or the operating system's settings, in that
+	// order; see cli/config/proxy.go.
+	proxyFn, err := config.ProxyFunc()
 	if err != nil {
 		log.Fatal().Err(err).Msg("could not parse proxy URL")
-	}
-
-	if proxy != nil {
-		proxyFn = http.ProxyURL(proxy)
 	}
 
 	retryClient := retryablehttp.NewClient()

--- a/utils/ranger/httpclient.go
+++ b/utils/ranger/httpclient.go
@@ -1,0 +1,24 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package ranger
+
+import (
+	"net/http"
+	"net/url"
+
+	"go.mondoo.com/ranger-rpc"
+)
+
+// WithProxyFunc is a ranger.HttpClientOption that installs proxy as the
+// per-request proxy selector of the client's transport, replacing ranger's
+// default of http.ProxyFromEnvironment. A nil proxy means direct connections.
+// ranger.WithProxy takes a single fixed URL; this is for selectors such as
+// sysproxy.ProxyFunc that decide per destination.
+func WithProxyFunc(proxy func(*http.Request) (*url.URL, error)) ranger.HttpClientOption {
+	return func(c *http.Client) {
+		if t, ok := c.Transport.(*http.Transport); ok {
+			t.Proxy = proxy
+		}
+	}
+}

--- a/utils/sysproxy/sysproxy.go
+++ b/utils/sysproxy/sysproxy.go
@@ -370,17 +370,27 @@ func (s *selector) environment(representative *url.URL) []string {
 
 	var httpProxy, httpsProxy *url.URL
 	var bypass []string
+	scriptAnswered := false
+	if settings.usesScript() && representative != nil && s.script != nil {
+		// A script that runs is the authority: its answer for the
+		// representative is exported as is, a DIRECT included, and it has no
+		// exception list to carry over. A script that cannot run (WPAD on a
+		// network without WPAD, the Windows default) decides nothing, and the
+		// manual settings below apply, as they do for the process itself.
+		if res := s.script(settings, representative); res.err == nil {
+			scriptAnswered = true
+			if res.proxies == "" {
+				return nil
+			}
+			p, err := firstProxy(res.proxies, representative.Scheme)
+			if err != nil || p == nil {
+				return nil
+			}
+			httpProxy, httpsProxy = p, p
+		}
+	}
 	switch {
-	case settings.usesScript():
-		if representative == nil {
-			return nil
-		}
-		// The script is the authority on exceptions; nothing to carry over.
-		p, err := s.systemProxy(settings, representative)
-		if err != nil || p == nil {
-			return nil
-		}
-		httpProxy, httpsProxy = p, p
+	case scriptAnswered:
 	case settings.Proxy != "":
 		httpProxy, _ = proxyForScheme(settings.Proxy, "http")
 		httpsProxy, _ = proxyForScheme(settings.Proxy, "https")
@@ -687,10 +697,10 @@ func ToNoProxy(entries []string) string {
 		if i := strings.IndexByte(e, '/'); i >= 0 {
 			e = e[:i]
 		}
-		switch {
-		case e == "":
+		switch e {
+		case "":
 			continue
-		case e == "*":
+		case "*":
 			return "*"
 		}
 		if cidr, ok := ipv4WildcardToCIDR(e); ok {

--- a/utils/sysproxy/sysproxy.go
+++ b/utils/sysproxy/sysproxy.go
@@ -1,0 +1,755 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package sysproxy selects the proxy for outbound HTTP requests from the
+// process environment and from the operating system's own proxy settings.
+//
+// net/http only understands the HTTP_PROXY, HTTPS_PROXY and NO_PROXY
+// convention. Windows keeps its proxy elsewhere: per user in Internet Settings
+// (Settings > Network & internet > Proxy: a manual proxy with exceptions, a
+// setup script URL, or "automatically detect settings"), and per machine in
+// the WinHTTP default proxy that administrators configure with
+// `netsh winhttp set proxy` for services. Reading both is what lets a client
+// installed on such a machine reach Mondoo Platform without any proxy
+// configuration of its own.
+//
+// Precedence for each request:
+//  1. HTTP_PROXY, HTTPS_PROXY and NO_PROXY when either proxy variable is set
+//     (Go semantics, unchanged from before this package existed)
+//  2. the operating system's settings: the setup script or auto-detected
+//     script when configured, otherwise the per-user manual proxy with its
+//     exceptions, otherwise the machine-wide WinHTTP proxy with its exceptions
+//  3. a direct connection
+//
+// MONDOO_SYSTEM_PROXY=false turns step 2 off. Platforms other than Windows
+// have no settings to read, so step 2 selects nothing there.
+package sysproxy
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"github.com/rs/zerolog/log"
+	"golang.org/x/net/http/httpproxy"
+)
+
+// EnvSystemProxy is the environment variable that disables reading the
+// operating system's proxy settings when set to false, 0, no or off. The CLI
+// sets it for provider subprocesses when mondoo.yml says system_proxy: false,
+// so providers make the same choice as the process that started them.
+const EnvSystemProxy = "MONDOO_SYSTEM_PROXY"
+
+// detectTTL bounds how long detected settings are reused. A process that runs
+// for days (cnspec serve as a Windows service) picks up a changed proxy within
+// this window instead of needing a restart, while a scan never pays for more
+// than one detection.
+const detectTTL = 5 * time.Minute
+
+// Bypass list tokens with a meaning of their own on Windows.
+const (
+	// tokenLocal matches hosts without a dot in their name.
+	tokenLocal = "<local>"
+	// tokenKeepLoopback cancels the implicit exemption of loopback addresses.
+	tokenKeepLoopback = "<-loopback>"
+)
+
+// Settings are the operating system's proxy settings, as configured by the
+// user or an administrator. Windows fills them in; other platforms have none.
+type Settings struct {
+	// AutoDetect is the per-user "Automatically detect settings" switch
+	// (WPAD). Windows turns it on by default, so it is set on most machines,
+	// including ones with no proxy at all.
+	AutoDetect bool
+	// AutoConfigURL is the per-user setup script (PAC) URL.
+	AutoConfigURL string
+	// Proxy is the per-user manual proxy, empty when manual proxying is off.
+	// Either "host:port" for every scheme, or a "scheme=host:port;..." list
+	// as Windows stores it when protocols use different proxies.
+	Proxy string
+	// Bypass are the manual proxy's exceptions in Windows syntax: hostnames
+	// with * wildcards, IP prefixes like "10.*", plus the "<local>" token for
+	// hosts without a dot and "<-loopback>" to stop exempting loopback.
+	Bypass []string
+	// MachineProxy and MachineBypass are the WinHTTP machine-wide defaults
+	// (`netsh winhttp set proxy`), used when the per-user settings select
+	// nothing. A Windows service running as LocalSystem has no proxy of its
+	// own, so this is the layer such a service ends up on.
+	MachineProxy  string
+	MachineBypass []string
+}
+
+// IsZero reports whether nothing at all is configured.
+func (s *Settings) IsZero() bool {
+	return s == nil || (!s.AutoDetect && s.AutoConfigURL == "" && s.Proxy == "" && s.MachineProxy == "")
+}
+
+// usesScript reports whether a setup script or auto-detection is configured.
+func (s *Settings) usesScript() bool {
+	return s != nil && (s.AutoDetect || s.AutoConfigURL != "")
+}
+
+// String summarizes the settings for logs and status output.
+func (s *Settings) String() string {
+	if s.IsZero() {
+		return "none"
+	}
+	var parts []string
+	if s.AutoDetect {
+		parts = append(parts, "auto-detect")
+	}
+	if s.AutoConfigURL != "" {
+		parts = append(parts, "script "+s.AutoConfigURL)
+	}
+	if s.Proxy != "" {
+		parts = append(parts, "proxy "+s.Proxy)
+	}
+	if s.MachineProxy != "" {
+		parts = append(parts, "machine proxy "+s.MachineProxy)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// Enabled reports whether the operating system's settings may be consulted:
+// MONDOO_SYSTEM_PROXY is unset, empty or anything other than false/0/no/off.
+func Enabled() bool {
+	v, ok := os.LookupEnv(EnvSystemProxy)
+	if !ok {
+		return true
+	}
+	return ParseEnabled(v)
+}
+
+// ParseEnabled interprets a MONDOO_SYSTEM_PROXY (or system_proxy) value.
+// Only an explicit false, 0, no, off or disabled turns detection off.
+func ParseEnabled(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "false", "0", "no", "off", "disabled":
+		return false
+	}
+	return true
+}
+
+var (
+	detectMu   sync.Mutex
+	detectedAt time.Time
+	detected   *Settings
+	detectErr  error
+	// detectFn is the platform implementation; tests swap it out.
+	detectFn = detect
+)
+
+// Detect returns the operating system's proxy settings, or nil when none are
+// configured or the platform has none. The result is cached for detectTTL.
+func Detect() (*Settings, error) {
+	detectMu.Lock()
+	defer detectMu.Unlock()
+	if !detectedAt.IsZero() && time.Since(detectedAt) < detectTTL {
+		return detected, detectErr
+	}
+	s, err := detectFn()
+	if err != nil {
+		log.Debug().Err(err).Msg("could not read the operating system's proxy settings")
+	} else if s.IsZero() {
+		s = nil
+	} else {
+		log.Debug().Stringer("settings", s).Msg("read the operating system's proxy settings")
+	}
+	detected, detectErr, detectedAt = s, err, time.Now()
+	return s, err
+}
+
+// resetDetection forgets cached settings so the next Detect reads again.
+func resetDetection() {
+	detectMu.Lock()
+	defer detectMu.Unlock()
+	detectedAt, detected, detectErr = time.Time{}, nil, nil
+}
+
+// EnvironmentConfigured reports whether HTTP_PROXY or HTTPS_PROXY names a
+// proxy, in which case the environment decides and system settings are not
+// consulted.
+func EnvironmentConfigured() bool {
+	return environmentConfigured(httpproxy.FromEnvironment())
+}
+
+func environmentConfigured(cfg *httpproxy.Config) bool {
+	return cfg.HTTPProxy != "" || cfg.HTTPSProxy != ""
+}
+
+// EnvironmentProxyFunc returns a selector that applies HTTP_PROXY, HTTPS_PROXY
+// and NO_PROXY exactly as http.ProxyFromEnvironment does, except that it reads
+// the environment when it is created instead of once per process. It is the
+// selector for "system proxy off", and what tests can exercise without the
+// process-wide snapshot http.ProxyFromEnvironment keeps.
+func EnvironmentProxyFunc() func(*http.Request) (*url.URL, error) {
+	fn := httpproxy.FromEnvironment().ProxyFunc()
+	return func(req *http.Request) (*url.URL, error) {
+		return fn(req.URL)
+	}
+}
+
+// ProxyFunc returns a selector for http.Transport.Proxy that applies the
+// precedence documented for this package. Operating system settings are read
+// lazily on the first request and refreshed every detectTTL.
+func ProxyFunc() func(*http.Request) (*url.URL, error) {
+	return newSelector(httpproxy.FromEnvironment(), Enabled, Detect, evaluateScript).proxyForRequest
+}
+
+// ProxyForURL resolves the proxy for one URL the way ProxyFunc would. It
+// exists for diagnostics such as the status command.
+func ProxyForURL(u *url.URL) (*url.URL, error) {
+	return ProxyFunc()(&http.Request{URL: u})
+}
+
+// Environment returns HTTP_PROXY, HTTPS_PROXY and NO_PROXY assignments that
+// hand the system proxy to a child process which only understands the
+// environment convention (the cloud SDKs inside provider subprocesses). It
+// returns nothing when the environment already names a proxy, when system
+// settings are disabled, or when none are configured. Variables the parent
+// already has are left alone. A setup script can only be represented by its
+// answer for one URL, so representative should be the destination that
+// matters most, the Mondoo API endpoint.
+func Environment(representative *url.URL) []string {
+	return newSelector(httpproxy.FromEnvironment(), Enabled, Detect, evaluateScript).environment(representative)
+}
+
+// scriptResult is what a setup script or auto-detection produced for one URL.
+type scriptResult struct {
+	// proxies is the script's proxy list ("host:port;host2:port"); empty
+	// with a nil err means the script asked for a direct connection.
+	proxies string
+	err     error
+}
+
+// scriptEvaluator runs the configured script for one URL. Windows implements
+// it with WinHTTP; other platforms never get here because they have no
+// settings.
+type scriptEvaluator func(s *Settings, u *url.URL) scriptResult
+
+// selector is ProxyFunc's state. It carries the environment as read when the
+// client was built, matching how http.ProxyFromEnvironment snapshots it, and
+// asks for system settings per request so the detection cache can refresh.
+type selector struct {
+	// envProxy is set when the environment names a proxy and then decides alone.
+	envProxy func(*url.URL) (*url.URL, error)
+	// noProxy applies NO_PROXY, Go's reading of it, to system proxies too. Nil
+	// when NO_PROXY is unset.
+	noProxy func(*url.URL) bool
+	enabled func() bool
+	detect  func() (*Settings, error)
+	script  scriptEvaluator
+}
+
+func newSelector(env *httpproxy.Config, enabled func() bool, detect func() (*Settings, error), script scriptEvaluator) *selector {
+	s := &selector{enabled: enabled, detect: detect, script: script}
+	switch {
+	case environmentConfigured(env):
+		s.envProxy = env.ProxyFunc()
+	case env.NoProxy != "":
+		// Give Go's matcher a stand-in proxy and read "no proxy" back as
+		// "bypass", so NO_PROXY keeps exactly its usual meaning.
+		match := (&httpproxy.Config{
+			HTTPProxy:  "http://no-proxy.invalid",
+			HTTPSProxy: "http://no-proxy.invalid",
+			NoProxy:    env.NoProxy,
+		}).ProxyFunc()
+		s.noProxy = func(u *url.URL) bool {
+			p, _ := match(u)
+			return p == nil
+		}
+	}
+	return s
+}
+
+func (s *selector) proxyForRequest(req *http.Request) (*url.URL, error) {
+	return s.proxyForURL(req.URL)
+}
+
+func (s *selector) proxyForURL(u *url.URL) (*url.URL, error) {
+	if u == nil {
+		return nil, nil
+	}
+	if s.envProxy != nil {
+		return s.envProxy(u)
+	}
+	if !s.enabled() {
+		return nil, nil
+	}
+	settings, err := s.detect()
+	if err != nil || settings == nil {
+		return nil, nil
+	}
+	return s.systemProxy(settings, u)
+}
+
+// announce logs the first proxy that system settings select, once per
+// process. Connectivity problems on a proxied machine are hard to place
+// without knowing that a proxy was picked and where it came from.
+var announce sync.Once
+
+// systemProxy applies the operating system's settings to one URL.
+func (s *selector) systemProxy(settings *Settings, u *url.URL) (*url.URL, error) {
+	host := u.Hostname()
+	if host == "" {
+		return nil, nil
+	}
+	if s.noProxy != nil && s.noProxy(u) {
+		return nil, nil
+	}
+	// Windows never proxies loopback unless a bypass list says "<-loopback>".
+	if isLoopback(host) && !hasToken(settings.Bypass, tokenKeepLoopback) && !hasToken(settings.MachineBypass, tokenKeepLoopback) {
+		return nil, nil
+	}
+
+	if settings.usesScript() && s.script != nil {
+		res := s.script(settings, u)
+		switch {
+		case res.err != nil:
+			// Windows falls back to the manual proxy when the script cannot
+			// be run, so do the same.
+			log.Debug().Err(res.err).Str("url", u.Redacted()).Msg("proxy script unavailable, using the manual proxy settings")
+		case res.proxies == "":
+			return nil, nil // the script asked for a direct connection
+		default:
+			p, err := firstProxy(res.proxies, u.Scheme)
+			if err != nil {
+				return nil, fmt.Errorf("proxy script returned %q: %w", res.proxies, err)
+			}
+			logSelected(p, "proxy script")
+			return p, nil
+		}
+	}
+	if settings.Proxy != "" {
+		return manualProxy(settings.Proxy, settings.Bypass, "Internet Settings", u)
+	}
+	if settings.MachineProxy != "" {
+		return manualProxy(settings.MachineProxy, settings.MachineBypass, "WinHTTP default proxy", u)
+	}
+	return nil, nil
+}
+
+func manualProxy(list string, bypass []string, source string, u *url.URL) (*url.URL, error) {
+	if bypassed(bypass, u) {
+		return nil, nil
+	}
+	p, err := proxyForScheme(list, u.Scheme)
+	if err != nil {
+		return nil, fmt.Errorf("invalid system proxy setting %q: %w", list, err)
+	}
+	logSelected(p, source)
+	return p, nil
+}
+
+func logSelected(p *url.URL, source string) {
+	if p == nil {
+		return
+	}
+	announce.Do(func() {
+		log.Info().Str("proxy", p.Redacted()).Str("source", source).Msg("using the operating system's proxy settings for outbound connections")
+	})
+}
+
+// environment implements Environment for one selector.
+func (s *selector) environment(representative *url.URL) []string {
+	if s.envProxy != nil || !s.enabled() {
+		return nil
+	}
+	settings, err := s.detect()
+	if err != nil || settings == nil {
+		return nil
+	}
+
+	var httpProxy, httpsProxy *url.URL
+	var bypass []string
+	switch {
+	case settings.usesScript():
+		if representative == nil {
+			return nil
+		}
+		// The script is the authority on exceptions; nothing to carry over.
+		p, err := s.systemProxy(settings, representative)
+		if err != nil || p == nil {
+			return nil
+		}
+		httpProxy, httpsProxy = p, p
+	case settings.Proxy != "":
+		httpProxy, _ = proxyForScheme(settings.Proxy, "http")
+		httpsProxy, _ = proxyForScheme(settings.Proxy, "https")
+		bypass = settings.Bypass
+	case settings.MachineProxy != "":
+		httpProxy, _ = proxyForScheme(settings.MachineProxy, "http")
+		httpsProxy, _ = proxyForScheme(settings.MachineProxy, "https")
+		bypass = settings.MachineBypass
+	}
+	if httpProxy == nil && httpsProxy == nil {
+		return nil
+	}
+
+	var env []string
+	if httpProxy != nil {
+		env = append(env, "HTTP_PROXY="+httpProxy.String())
+	}
+	if httpsProxy != nil {
+		env = append(env, "HTTPS_PROXY="+httpsProxy.String())
+	}
+	// envProxy == nil already says neither proxy variable is set; NO_PROXY may
+	// still be, and a value the user set is not overridden.
+	if noProxy := ToNoProxy(bypass); noProxy != "" && os.Getenv("NO_PROXY") == "" && os.Getenv("no_proxy") == "" {
+		env = append(env, "NO_PROXY="+noProxy)
+	}
+	return env
+}
+
+// SplitList splits a Windows proxy or bypass list. Windows writes semicolons;
+// whitespace and commas turn up in hand-edited registry values and netsh
+// output, and no entry legitimately contains any of them.
+func SplitList(s string) []string {
+	fields := strings.FieldsFunc(s, func(r rune) bool {
+		return r == ';' || r == ',' || unicode.IsSpace(r)
+	})
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if f = strings.TrimSpace(f); f != "" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// proxyForScheme picks the proxy for a target scheme out of a Windows proxy
+// list: "host:port" applies to every scheme, "scheme=host:port" only to its
+// own, and "socks=host:port" to schemes without an entry of their own. A
+// scheme with no applicable entry connects directly, which is what WinHTTP
+// does with such a list.
+func proxyForScheme(list, scheme string) (*url.URL, error) {
+	scheme = strings.ToLower(scheme)
+	var generic, specific, socks string
+	for _, entry := range SplitList(list) {
+		key, value, keyed := strings.Cut(entry, "=")
+		if !keyed {
+			if generic == "" {
+				generic = entry
+			}
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case scheme:
+			specific = value
+		case "socks":
+			socks = value
+		}
+	}
+	switch {
+	case specific != "":
+		return normalizeProxyURL(specific, false)
+	case generic != "":
+		return normalizeProxyURL(generic, false)
+	case socks != "":
+		return normalizeProxyURL(socks, true)
+	}
+	return nil, nil
+}
+
+// firstProxy picks the first usable entry out of a script's proxy list.
+// Scripts may name several proxies for failover; http.Transport takes one.
+func firstProxy(list, scheme string) (*url.URL, error) {
+	scheme = strings.ToLower(scheme)
+	var lastErr error
+	for _, entry := range SplitList(list) {
+		candidate, socks := entry, false
+		if key, value, keyed := strings.Cut(entry, "="); keyed {
+			switch strings.ToLower(strings.TrimSpace(key)) {
+			case "socks":
+				candidate, socks = value, true
+			case scheme:
+				candidate = value
+			default:
+				continue
+			}
+		}
+		p, err := normalizeProxyURL(candidate, socks)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if p != nil {
+			return p, nil
+		}
+	}
+	return nil, lastErr
+}
+
+// ParseProxyURL parses a proxy given by a user or by the operating system into
+// a URL http.Transport accepts: "proxy.corp:3128" gets the http scheme it is
+// implied to have, "socks" becomes Go's socks5, and anything without a host or
+// with a scheme http.Transport cannot speak is an error. An empty string is a
+// nil URL.
+func ParseProxyURL(raw string) (*url.URL, error) {
+	return normalizeProxyURL(raw, false)
+}
+
+// normalizeProxyURL turns a Windows proxy entry into a URL http.Transport
+// accepts. Windows writes "host:port" without a scheme; the proxy is spoken
+// to over HTTP (CONNECT for https targets) unless it is a SOCKS proxy.
+func normalizeProxyURL(entry string, socks bool) (*url.URL, error) {
+	entry = strings.TrimSpace(entry)
+	if entry == "" {
+		return nil, nil
+	}
+	if !strings.Contains(entry, "://") {
+		if socks {
+			entry = "socks5://" + entry
+		} else {
+			entry = "http://" + entry
+		}
+	}
+	u, err := url.Parse(entry)
+	if err != nil {
+		return nil, err
+	}
+	u.Scheme = strings.ToLower(u.Scheme)
+	switch u.Scheme {
+	case "http", "https", "socks5", "socks5h":
+	case "socks":
+		u.Scheme = "socks5"
+	default:
+		return nil, fmt.Errorf("unsupported proxy scheme %q", u.Scheme)
+	}
+	if u.Hostname() == "" {
+		return nil, fmt.Errorf("proxy %q has no host", entry)
+	}
+	return u, nil
+}
+
+// bypassed reports whether u matches a Windows bypass list: hostname patterns
+// with * and ? wildcards, IP addresses with the same wildcards ("10.*"),
+// CIDR blocks, an optional scheme:// prefix and an optional :port, and the
+// "<local>" token for hosts without a dot. A pattern without wildcards must
+// match the whole host.
+func bypassed(entries []string, u *url.URL) bool {
+	host := strings.ToLower(u.Hostname())
+	if host == "" {
+		return false
+	}
+	port := u.Port()
+	if port == "" {
+		port = defaultPort(u.Scheme)
+	}
+	ip := net.ParseIP(host)
+	scheme := strings.ToLower(u.Scheme)
+
+	for _, raw := range entries {
+		e := strings.ToLower(strings.TrimSpace(raw))
+		switch e {
+		case "", tokenKeepLoopback:
+			continue
+		case tokenLocal:
+			if ip == nil && !strings.Contains(host, ".") {
+				return true
+			}
+			continue
+		}
+		if i := strings.Index(e, "://"); i >= 0 {
+			if e[:i] != scheme {
+				continue
+			}
+			e = e[i+3:]
+		}
+		if strings.Contains(e, "/") {
+			if _, cidr, err := net.ParseCIDR(e); err == nil {
+				if ip != nil && cidr.Contains(ip) {
+					return true
+				}
+				continue
+			}
+			e = e[:strings.IndexByte(e, '/')]
+		}
+		pattern, patternPort := splitPattern(e)
+		if pattern == "" || (patternPort != "" && patternPort != port) {
+			continue
+		}
+		if strings.HasPrefix(pattern, ".") {
+			pattern = "*" + pattern
+		}
+		if matchGlob(pattern, host) {
+			return true
+		}
+	}
+	return false
+}
+
+// splitPattern separates an optional :port from a bypass pattern. IPv6
+// literals carry brackets when they have a port and several colons when
+// they do not.
+func splitPattern(e string) (host, port string) {
+	if strings.HasPrefix(e, "[") {
+		if h, p, err := net.SplitHostPort(e); err == nil {
+			return h, p
+		}
+		return strings.Trim(e, "[]"), ""
+	}
+	if strings.Count(e, ":") == 1 {
+		h, p, _ := strings.Cut(e, ":")
+		return h, p
+	}
+	return e, ""
+}
+
+func defaultPort(scheme string) string {
+	switch strings.ToLower(scheme) {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	}
+	return ""
+}
+
+// matchGlob matches s against pattern, where * stands for any run of
+// characters, including none, and ? for exactly one.
+func matchGlob(pattern, s string) bool {
+	pi, si := 0, 0
+	star, mark := -1, 0
+	for si < len(s) {
+		switch {
+		case pi < len(pattern) && (pattern[pi] == '?' || pattern[pi] == s[si]):
+			pi++
+			si++
+		case pi < len(pattern) && pattern[pi] == '*':
+			star, mark = pi, si
+			pi++
+		case star >= 0:
+			mark++
+			pi, si = star+1, mark
+		default:
+			return false
+		}
+	}
+	for pi < len(pattern) && pattern[pi] == '*' {
+		pi++
+	}
+	return pi == len(pattern)
+}
+
+func isLoopback(host string) bool {
+	h := strings.ToLower(host)
+	if h == "localhost" || strings.HasSuffix(h, ".localhost") {
+		return true
+	}
+	ip := net.ParseIP(h)
+	return ip != nil && ip.IsLoopback()
+}
+
+func hasToken(entries []string, token string) bool {
+	for _, e := range entries {
+		if strings.EqualFold(strings.TrimSpace(e), token) {
+			return true
+		}
+	}
+	return false
+}
+
+// ToNoProxy converts Windows bypass entries into a NO_PROXY value with the
+// same meaning where Go's syntax can express it. "*.example.com" is
+// understood by Go as is, "10.*" style prefixes become CIDR blocks, and a
+// scheme or path is dropped. "<local>" has no counterpart and is left out;
+// loopback needs no entry because Go never proxies it.
+func ToNoProxy(entries []string) string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(e string) {
+		if !seen[e] {
+			seen[e] = true
+			out = append(out, e)
+		}
+	}
+	for _, raw := range entries {
+		e := strings.ToLower(strings.TrimSpace(raw))
+		if e == "" || e == tokenLocal || e == tokenKeepLoopback {
+			continue
+		}
+		if i := strings.Index(e, "://"); i >= 0 {
+			e = e[i+3:]
+		}
+		if _, _, err := net.ParseCIDR(e); err == nil {
+			add(e)
+			continue
+		}
+		if i := strings.IndexByte(e, '/'); i >= 0 {
+			e = e[:i]
+		}
+		switch {
+		case e == "":
+			continue
+		case e == "*":
+			return "*"
+		}
+		if cidr, ok := ipv4WildcardToCIDR(e); ok {
+			add(cidr)
+			continue
+		}
+		if strings.HasPrefix(e, "*.") {
+			add(e)
+			continue
+		}
+		if strings.HasPrefix(e, "*") {
+			// "*example.com" also matches "myexample.com" on Windows; the
+			// closest Go can get is the domain and its subdomains.
+			if rest := strings.TrimLeft(e, "*"); rest != "" && !strings.ContainsAny(rest, "*?") {
+				add(rest)
+			}
+			continue
+		}
+		if strings.ContainsAny(e, "*?") {
+			continue // no NO_PROXY equivalent
+		}
+		add(e)
+	}
+	return strings.Join(out, ",")
+}
+
+// ipv4WildcardToCIDR turns "10.*", "10.1.*" and "10.1.2.*" into CIDR blocks.
+func ipv4WildcardToCIDR(e string) (string, bool) {
+	if !strings.HasSuffix(e, ".*") {
+		return "", false
+	}
+	octets := strings.Split(strings.TrimSuffix(e, ".*"), ".")
+	if len(octets) == 0 || len(octets) > 3 {
+		return "", false
+	}
+	for _, o := range octets {
+		n, err := strconv.Atoi(o)
+		if err != nil || n < 0 || n > 255 || strconv.Itoa(n) != o {
+			return "", false
+		}
+	}
+	bits := 8 * len(octets)
+	for len(octets) < 4 {
+		octets = append(octets, "0")
+	}
+	return strings.Join(octets, ".") + "/" + strconv.Itoa(bits), true
+}
+
+// Flags in the DefaultConnectionSettings registry blob, which is where
+// Windows keeps the "automatically detect settings" switch. Only the bit this
+// package reads is named.
+const connectionSettingsAutoDetect = 0x08
+
+// connectionSettingsFlags extracts the flags word out of a
+// DefaultConnectionSettings blob: a version DWORD, a change counter DWORD,
+// then the flags. Anything shorter is not a settings blob.
+func connectionSettingsFlags(blob []byte) (uint32, bool) {
+	if len(blob) < 12 {
+		return 0, false
+	}
+	return binary.LittleEndian.Uint32(blob[8:12]), true
+}

--- a/utils/sysproxy/sysproxy_other.go
+++ b/utils/sysproxy/sysproxy_other.go
@@ -1,0 +1,24 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !windows
+
+package sysproxy
+
+import (
+	"errors"
+	"net/url"
+)
+
+// detect reports no settings. Only Windows keeps a system-wide proxy that
+// programs are expected to honor and exposes it through a stable API. macOS
+// has one too, in System Settings; reading it would slot in here.
+func detect() (*Settings, error) {
+	return nil, nil
+}
+
+// evaluateScript is never reached without settings; it exists so the selector
+// compiles identically on every platform.
+func evaluateScript(*Settings, *url.URL) scriptResult {
+	return scriptResult{err: errors.New("proxy setup scripts are not supported on this platform")}
+}

--- a/utils/sysproxy/sysproxy_test.go
+++ b/utils/sysproxy/sysproxy_test.go
@@ -1,0 +1,470 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sysproxy
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http/httpproxy"
+)
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}
+
+func TestParseEnabled(t *testing.T) {
+	for _, v := range []string{"false", "FALSE", " 0 ", "no", "off", "disabled"} {
+		assert.False(t, ParseEnabled(v), v)
+	}
+	for _, v := range []string{"", "true", "1", "yes", "on", "anything"} {
+		assert.True(t, ParseEnabled(v), v)
+	}
+}
+
+func TestEnabled(t *testing.T) {
+	t.Setenv(EnvSystemProxy, "")
+	assert.True(t, Enabled(), "an empty value is not an opt-out")
+	t.Setenv(EnvSystemProxy, "false")
+	assert.False(t, Enabled())
+	t.Setenv(EnvSystemProxy, "true")
+	assert.True(t, Enabled())
+}
+
+func TestSplitList(t *testing.T) {
+	assert.Equal(t, []string{"a:1", "b:2", "c", "d"}, SplitList("a:1;b:2, c\td"))
+	assert.Empty(t, SplitList(" ; , "))
+	assert.Empty(t, SplitList(""))
+}
+
+func TestProxyForScheme(t *testing.T) {
+	tests := []struct {
+		name   string
+		list   string
+		scheme string
+		want   string
+	}{
+		{"plain host applies to every scheme", "proxy.corp:8080", "https", "http://proxy.corp:8080"},
+		{"plain host for http", "proxy.corp:8080", "http", "http://proxy.corp:8080"},
+		{"keyed list picks the target scheme", "http=a:1;https=b:2;ftp=c:3", "https", "http://b:2"},
+		{"keyed list picks http", "http=a:1;https=b:2", "http", "http://a:1"},
+		{"keyed list without an entry for the scheme connects directly", "http=a:1", "https", ""},
+		{"socks covers schemes without an entry", "http=a:1;socks=s:1080", "https", "socks5://s:1080"},
+		{"specific entry beats the generic one", "generic:1;https=specific:2", "https", "http://specific:2"},
+		{"scheme in the value is kept", "https=https://tls-proxy:443", "https", "https://tls-proxy:443"},
+		{"keys are case insensitive", "HTTPS=b:2", "https", "http://b:2"},
+		{"empty list", "", "https", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := proxyForScheme(tt.list, tt.scheme)
+			require.NoError(t, err)
+			if tt.want == "" {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want, got.String())
+		})
+	}
+
+	t.Run("unsupported scheme is an error, not a silent direct connection", func(t *testing.T) {
+		_, err := proxyForScheme("ftp://proxy:21", "https")
+		require.Error(t, err)
+	})
+	t.Run("entry without a host is an error", func(t *testing.T) {
+		_, err := proxyForScheme("http://:8080", "https")
+		require.Error(t, err)
+	})
+}
+
+func TestFirstProxy(t *testing.T) {
+	t.Run("takes the first of a failover list", func(t *testing.T) {
+		p, err := firstProxy("proxy1:8080;proxy2:8080", "https")
+		require.NoError(t, err)
+		assert.Equal(t, "http://proxy1:8080", p.String())
+	})
+	t.Run("skips entries it cannot use", func(t *testing.T) {
+		p, err := firstProxy("ftp://nope:21;proxy2:8080", "https")
+		require.NoError(t, err)
+		assert.Equal(t, "http://proxy2:8080", p.String())
+	})
+	t.Run("socks entry", func(t *testing.T) {
+		p, err := firstProxy("socks=s:1080", "https")
+		require.NoError(t, err)
+		assert.Equal(t, "socks5://s:1080", p.String())
+	})
+	t.Run("entry keyed for another scheme is skipped", func(t *testing.T) {
+		p, err := firstProxy("http=a:1", "https")
+		require.NoError(t, err)
+		assert.Nil(t, p)
+	})
+	t.Run("only unusable entries surface the error", func(t *testing.T) {
+		_, err := firstProxy("ftp://nope:21", "https")
+		require.Error(t, err)
+	})
+}
+
+func TestNormalizeProxyURL(t *testing.T) {
+	p, err := normalizeProxyURL("SOCKS://s:1080", false)
+	require.NoError(t, err)
+	assert.Equal(t, "socks5://s:1080", p.String(), "Windows' socks means SOCKS5 to Go")
+
+	p, err = normalizeProxyURL("  ", false)
+	require.NoError(t, err)
+	assert.Nil(t, p)
+
+	p, err = normalizeProxyURL("user:pass@proxy:8080", false)
+	require.NoError(t, err)
+	assert.Equal(t, "http://user:pass@proxy:8080", p.String())
+	assert.Equal(t, "http://user:xxxxx@proxy:8080", p.Redacted())
+}
+
+func TestBypassed(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []string
+		target  string
+		want    bool
+	}{
+		{"exact host", []string{"intranet.corp"}, "https://intranet.corp/x", true},
+		{"exact host does not match subdomains", []string{"corp.example"}, "https://www.corp.example/", false},
+		{"case insensitive", []string{"INTRANET.CORP"}, "https://Intranet.Corp/", true},
+		{"wildcard subdomain", []string{"*.corp.example"}, "https://git.corp.example/", true},
+		{"wildcard subdomain needs a subdomain", []string{"*.corp.example"}, "https://corp.example/", false},
+		{"leading dot behaves like *.", []string{".corp.example"}, "https://git.corp.example/", true},
+		{"prefix wildcard", []string{"web*"}, "https://webserver/", true},
+		{"question mark", []string{"host?"}, "https://host1/", true},
+		{"question mark is exactly one character", []string{"host?"}, "https://host10/", false},
+		{"ip prefix", []string{"10.*"}, "https://10.20.30.40/", true},
+		{"ip prefix mismatch", []string{"10.*"}, "https://11.0.0.1/", false},
+		{"two octet prefix", []string{"192.168.*"}, "http://192.168.1.5:8080/", true},
+		{"cidr", []string{"10.0.0.0/8"}, "https://10.1.2.3/", true},
+		{"cidr mismatch", []string{"10.0.0.0/8"}, "https://172.16.0.1/", false},
+		{"cidr against a hostname never matches", []string{"10.0.0.0/8"}, "https://ten.example/", false},
+		{"local matches dotless hosts", []string{tokenLocal}, "https://fileserver/", true},
+		{"local does not match qualified hosts", []string{tokenLocal}, "https://fileserver.corp.example/", false},
+		{"local does not match ip addresses", []string{tokenLocal}, "https://10.0.0.1/", false},
+		{"loopback token is not a pattern", []string{tokenKeepLoopback}, "https://-loopback/", false},
+		{"scheme specific entry matches its scheme", []string{"https://secure.corp"}, "https://secure.corp/", true},
+		{"scheme specific entry skips other schemes", []string{"https://secure.corp"}, "http://secure.corp/", false},
+		{"path is ignored", []string{"host.corp/some/path"}, "https://host.corp/other", true},
+		{"port must match when given", []string{"host.corp:8443"}, "https://host.corp:8443/", true},
+		{"port mismatch", []string{"host.corp:8443"}, "https://host.corp/", false},
+		{"default port matches", []string{"host.corp:443"}, "https://host.corp/", true},
+		{"ipv6 literal", []string{"[fd00::1]"}, "https://[fd00::1]/", true},
+		{"ipv6 literal with port", []string{"[fd00::1]:8443"}, "https://[fd00::1]:8443/", true},
+		{"bare ipv6", []string{"fd00::1"}, "https://[fd00::1]/", true},
+		{"empty entries are skipped", []string{"", " "}, "https://host/", false},
+		{"no entries", nil, "https://host/", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, bypassed(tt.entries, mustURL(t, tt.target)))
+		})
+	}
+}
+
+func TestMatchGlob(t *testing.T) {
+	assert.True(t, matchGlob("*", "anything"))
+	assert.True(t, matchGlob("*", ""))
+	assert.True(t, matchGlob("a*c", "abbbc"))
+	assert.True(t, matchGlob("a*c", "ac"))
+	assert.False(t, matchGlob("a*c", "abd"))
+	assert.True(t, matchGlob("*.b.c", "a.b.c"))
+	assert.False(t, matchGlob("*.b.c", "b.c"))
+	assert.True(t, matchGlob("a?c", "abc"))
+	assert.False(t, matchGlob("a?c", "ac"))
+	assert.True(t, matchGlob("**a", "xa"))
+	assert.False(t, matchGlob("", "x"))
+	assert.True(t, matchGlob("", ""))
+}
+
+func TestToNoProxy(t *testing.T) {
+	got := ToNoProxy([]string{
+		"*.corp.example", "10.*", "192.168.1.*", "172.16.0.0/12", "intranet",
+		"host.corp:8443", "https://secure.corp/path", "*example.net", "web*", tokenLocal, tokenKeepLoopback, "",
+		"*.corp.example", // duplicate
+	})
+	assert.Equal(t, "*.corp.example,10.0.0.0/8,192.168.1.0/24,172.16.0.0/12,intranet,host.corp:8443,secure.corp,example.net", got)
+
+	assert.Equal(t, "*", ToNoProxy([]string{"host", "*"}), "a bare star bypasses everything")
+	assert.Equal(t, "", ToNoProxy(nil))
+	assert.Equal(t, "", ToNoProxy([]string{tokenLocal}), "<local> has no NO_PROXY form")
+}
+
+func TestIPv4WildcardToCIDR(t *testing.T) {
+	for in, want := range map[string]string{
+		"10.*":       "10.0.0.0/8",
+		"10.1.*":     "10.1.0.0/16",
+		"10.1.2.*":   "10.1.2.0/24",
+		"192.168.*":  "192.168.0.0/16",
+		"10.*.*":     "",
+		"10.1.2.3.*": "",
+		"256.*":      "",
+		"01.*":       "",
+		"a.*":        "",
+		"10.1.2.3":   "",
+		"*.10":       "",
+	} {
+		got, ok := ipv4WildcardToCIDR(in)
+		assert.Equal(t, want != "", ok, in)
+		assert.Equal(t, want, got, in)
+	}
+}
+
+func TestConnectionSettingsFlags(t *testing.T) {
+	// version 0x46, counter 3, flags: manual proxy (0x02) + auto-detect (0x08)
+	blob := []byte{0x46, 0, 0, 0, 3, 0, 0, 0, 0x0a, 0, 0, 0, 0, 0, 0, 0}
+	flags, ok := connectionSettingsFlags(blob)
+	require.True(t, ok)
+	assert.NotZero(t, flags&connectionSettingsAutoDetect)
+
+	_, ok = connectionSettingsFlags([]byte{0x46, 0, 0, 0, 3, 0, 0, 0, 0x0a})
+	assert.False(t, ok, "a truncated blob must not be read as flags")
+}
+
+// testSelector wires a selector to canned settings and a canned script.
+type testSelector struct {
+	*selector
+	settings    *Settings
+	detectCalls int
+	scriptCalls int
+	script      scriptResult
+	enabled     bool
+}
+
+func newTestSelector(env *httpproxy.Config, settings *Settings) *testSelector {
+	ts := &testSelector{settings: settings, enabled: true}
+	ts.selector = newSelector(env,
+		func() bool { return ts.enabled },
+		func() (*Settings, error) { ts.detectCalls++; return ts.settings, nil },
+		func(*Settings, *url.URL) scriptResult { ts.scriptCalls++; return ts.script },
+	)
+	return ts
+}
+
+func (ts *testSelector) resolve(t *testing.T, raw string) string {
+	t.Helper()
+	p, err := ts.proxyForURL(mustURL(t, raw))
+	require.NoError(t, err)
+	if p == nil {
+		return ""
+	}
+	return p.String()
+}
+
+func TestSelectorPrecedence(t *testing.T) {
+	manual := &Settings{Proxy: "sysproxy.corp:3128", Bypass: []string{"*.corp.example", "10.*"}}
+
+	t.Run("environment proxy decides alone", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{HTTPSProxy: "http://envproxy:9", NoProxy: "skip.example"}, manual)
+		assert.Equal(t, "http://envproxy:9", ts.resolve(t, "https://api.example/"))
+		assert.Equal(t, "", ts.resolve(t, "https://skip.example/"), "NO_PROXY applies to the environment proxy")
+		assert.Equal(t, "", ts.resolve(t, "http://api.example/"), "HTTPS_PROXY alone leaves http targets direct, as Go does")
+		assert.Zero(t, ts.detectCalls, "system settings are not read when the environment names a proxy")
+	})
+
+	t.Run("disabled system proxy connects directly", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, manual)
+		ts.enabled = false
+		assert.Equal(t, "", ts.resolve(t, "https://api.example/"))
+		assert.Zero(t, ts.detectCalls)
+	})
+
+	t.Run("no settings connects directly", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, nil)
+		assert.Equal(t, "", ts.resolve(t, "https://api.example/"))
+		assert.Equal(t, 1, ts.detectCalls)
+	})
+
+	t.Run("manual proxy with exceptions", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, manual)
+		assert.Equal(t, "http://sysproxy.corp:3128", ts.resolve(t, "https://api.example/"))
+		assert.Equal(t, "http://sysproxy.corp:3128", ts.resolve(t, "http://api.example/"))
+		assert.Equal(t, "", ts.resolve(t, "https://git.corp.example/"))
+		assert.Equal(t, "", ts.resolve(t, "https://10.1.1.1/"))
+		assert.Zero(t, ts.scriptCalls, "no script configured, none evaluated")
+	})
+
+	t.Run("loopback is exempt unless the bypass list says otherwise", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, manual)
+		assert.Equal(t, "", ts.resolve(t, "http://localhost:8989/"))
+		assert.Equal(t, "", ts.resolve(t, "http://127.0.0.1:8989/"))
+		assert.Equal(t, "", ts.resolve(t, "http://[::1]:8989/"))
+
+		keep := &Settings{Proxy: "sysproxy.corp:3128", Bypass: []string{tokenKeepLoopback}}
+		ts = newTestSelector(&httpproxy.Config{}, keep)
+		assert.Equal(t, "http://sysproxy.corp:3128", ts.resolve(t, "http://localhost:8989/"))
+	})
+
+	t.Run("NO_PROXY applies to the system proxy too", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{NoProxy: "api.example,.internal.example"}, manual)
+		assert.Equal(t, "", ts.resolve(t, "https://api.example/"))
+		assert.Equal(t, "", ts.resolve(t, "https://svc.internal.example/"))
+		assert.Equal(t, "http://sysproxy.corp:3128", ts.resolve(t, "https://other.example/"))
+	})
+
+	t.Run("script answer wins over the manual proxy", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, &Settings{AutoConfigURL: "http://pac.corp/proxy.pac", Proxy: "manual:1"})
+		ts.script = scriptResult{proxies: "pacproxy:8080;backup:8080"}
+		assert.Equal(t, "http://pacproxy:8080", ts.resolve(t, "https://api.example/"))
+		assert.Equal(t, 1, ts.scriptCalls)
+	})
+
+	t.Run("script DIRECT is direct even with a manual proxy", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, &Settings{AutoDetect: true, Proxy: "manual:1"})
+		ts.script = scriptResult{}
+		assert.Equal(t, "", ts.resolve(t, "https://api.example/"))
+	})
+
+	t.Run("script failure falls back to the manual proxy", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, &Settings{AutoDetect: true, Proxy: "manual:1"})
+		ts.script = scriptResult{err: errors.New("WPAD failed")}
+		assert.Equal(t, "http://manual:1", ts.resolve(t, "https://api.example/"))
+	})
+
+	t.Run("script failure without a manual proxy is direct", func(t *testing.T) {
+		// The Windows default: auto-detect on, nothing else. Must cost nothing
+		// beyond the failed probe and must connect directly.
+		ts := newTestSelector(&httpproxy.Config{}, &Settings{AutoDetect: true})
+		ts.script = scriptResult{err: errors.New("WPAD failed")}
+		assert.Equal(t, "", ts.resolve(t, "https://api.example/"))
+	})
+
+	t.Run("machine proxy applies when the user has none", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, &Settings{AutoDetect: true, MachineProxy: "netsh.corp:8080", MachineBypass: []string{"<local>"}})
+		ts.script = scriptResult{err: errors.New("WPAD failed")}
+		assert.Equal(t, "http://netsh.corp:8080", ts.resolve(t, "https://api.example/"))
+		assert.Equal(t, "", ts.resolve(t, "https://fileserver/"))
+	})
+
+	t.Run("user proxy wins over the machine proxy", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, &Settings{Proxy: "user:1", MachineProxy: "machine:2"})
+		assert.Equal(t, "http://user:1", ts.resolve(t, "https://api.example/"))
+	})
+
+	t.Run("keyed list without an https entry connects https directly", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, &Settings{Proxy: "http=only-http:1"})
+		assert.Equal(t, "", ts.resolve(t, "https://api.example/"))
+		assert.Equal(t, "http://only-http:1", ts.resolve(t, "http://api.example/"))
+	})
+
+	t.Run("broken system proxy setting is reported, not swallowed", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, &Settings{Proxy: "ftp://nope:21"})
+		_, err := ts.proxyForURL(mustURL(t, "https://api.example/"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ftp://nope:21")
+	})
+
+	t.Run("nil URL", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, manual)
+		p, err := ts.proxyForURL(nil)
+		require.NoError(t, err)
+		assert.Nil(t, p)
+	})
+}
+
+func TestSelectorEnvironment(t *testing.T) {
+	t.Setenv("NO_PROXY", "")
+	t.Setenv("no_proxy", "")
+	rep := mustURL(t, "https://us.api.mondoo.com")
+
+	t.Run("nothing when the environment already names a proxy", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{HTTPProxy: "http://env:1"}, &Settings{Proxy: "sys:1"})
+		assert.Nil(t, ts.environment(rep))
+	})
+
+	t.Run("nothing when disabled or unconfigured", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, &Settings{Proxy: "sys:1"})
+		ts.enabled = false
+		assert.Nil(t, ts.environment(rep))
+		ts = newTestSelector(&httpproxy.Config{}, nil)
+		assert.Nil(t, ts.environment(rep))
+	})
+
+	t.Run("manual proxy with exceptions", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, &Settings{Proxy: "sys.corp:3128", Bypass: []string{"*.corp.example", "10.*", "<local>"}})
+		assert.Equal(t, []string{
+			"HTTP_PROXY=http://sys.corp:3128",
+			"HTTPS_PROXY=http://sys.corp:3128",
+			"NO_PROXY=*.corp.example,10.0.0.0/8",
+		}, ts.environment(rep))
+	})
+
+	t.Run("keyed list exports per scheme", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, &Settings{Proxy: "http=a:1;https=b:2"})
+		assert.Equal(t, []string{"HTTP_PROXY=http://a:1", "HTTPS_PROXY=http://b:2"}, ts.environment(rep))
+
+		ts = newTestSelector(&httpproxy.Config{}, &Settings{Proxy: "https=b:2"})
+		assert.Equal(t, []string{"HTTPS_PROXY=http://b:2"}, ts.environment(rep))
+	})
+
+	t.Run("an existing NO_PROXY is left alone", func(t *testing.T) {
+		t.Setenv("NO_PROXY", "mine.example")
+		ts := newTestSelector(&httpproxy.Config{NoProxy: "mine.example"}, &Settings{Proxy: "sys.corp:3128", Bypass: []string{"*.corp.example"}})
+		assert.Equal(t, []string{"HTTP_PROXY=http://sys.corp:3128", "HTTPS_PROXY=http://sys.corp:3128"}, ts.environment(rep))
+	})
+
+	t.Run("script is evaluated for the representative URL", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, &Settings{AutoConfigURL: "http://pac/p.pac", Proxy: "manual:1", Bypass: []string{"*.corp.example"}})
+		ts.script = scriptResult{proxies: "pacproxy:8080"}
+		assert.Equal(t, []string{"HTTP_PROXY=http://pacproxy:8080", "HTTPS_PROXY=http://pacproxy:8080"}, ts.environment(rep))
+	})
+
+	t.Run("script DIRECT for the representative exports nothing", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, &Settings{AutoConfigURL: "http://pac/p.pac", Proxy: "manual:1"})
+		ts.script = scriptResult{}
+		assert.Nil(t, ts.environment(rep))
+	})
+
+	t.Run("script needs a representative", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, &Settings{AutoDetect: true})
+		assert.Nil(t, ts.environment(nil))
+		assert.Zero(t, ts.scriptCalls)
+	})
+
+	t.Run("machine proxy", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, &Settings{MachineProxy: "netsh:8080", MachineBypass: []string{"intranet"}})
+		assert.Equal(t, []string{"HTTP_PROXY=http://netsh:8080", "HTTPS_PROXY=http://netsh:8080", "NO_PROXY=intranet"}, ts.environment(rep))
+	})
+}
+
+func TestDetectCaches(t *testing.T) {
+	calls := 0
+	orig := detectFn
+	detectFn = func() (*Settings, error) {
+		calls++
+		return &Settings{Proxy: "p:1"}, nil
+	}
+	t.Cleanup(func() {
+		detectFn = orig
+		resetDetection()
+	})
+	resetDetection()
+
+	s, err := Detect()
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	_, _ = Detect()
+	assert.Equal(t, 1, calls, "a second call within the TTL is served from the cache")
+
+	detectFn = func() (*Settings, error) { calls++; return &Settings{}, nil }
+	resetDetection()
+	s, err = Detect()
+	require.NoError(t, err)
+	assert.Nil(t, s, "empty settings read as none")
+}
+
+func TestSettingsString(t *testing.T) {
+	assert.Equal(t, "none", (*Settings)(nil).String())
+	assert.Equal(t, "auto-detect, script http://pac/p.pac, proxy p:1, machine proxy m:2",
+		(&Settings{AutoDetect: true, AutoConfigURL: "http://pac/p.pac", Proxy: "p:1", MachineProxy: "m:2"}).String())
+}

--- a/utils/sysproxy/sysproxy_test.go
+++ b/utils/sysproxy/sysproxy_test.go
@@ -177,7 +177,7 @@ func TestMatchGlob(t *testing.T) {
 	assert.True(t, matchGlob("*", ""))
 	assert.True(t, matchGlob("a*c", "abbbc"))
 	assert.True(t, matchGlob("a*c", "ac"))
-	assert.False(t, matchGlob("a*c", "abd"))
+	assert.False(t, matchGlob("a*c", "axd"))
 	assert.True(t, matchGlob("*.b.c", "a.b.c"))
 	assert.False(t, matchGlob("*.b.c", "b.c"))
 	assert.True(t, matchGlob("a?c", "abc"))
@@ -425,10 +425,33 @@ func TestSelectorEnvironment(t *testing.T) {
 		assert.Nil(t, ts.environment(rep))
 	})
 
-	t.Run("script needs a representative", func(t *testing.T) {
+	t.Run("script without a representative exports nothing on its own", func(t *testing.T) {
 		ts := newTestSelector(&httpproxy.Config{}, &Settings{AutoDetect: true})
 		assert.Nil(t, ts.environment(nil))
 		assert.Zero(t, ts.scriptCalls)
+	})
+
+	t.Run("script that cannot run leaves the manual proxy and its exceptions in charge", func(t *testing.T) {
+		// The Windows default: auto-detect on and no WPAD on the network, with a
+		// netsh proxy whose bypass list covers the API host. Found on a real
+		// machine: the representative being bypassed used to export nothing,
+		// sending the provider's cloud SDK traffic direct.
+		ts := newTestSelector(&httpproxy.Config{}, &Settings{AutoDetect: true, MachineProxy: "netsh:8080", MachineBypass: []string{"*.mondoo.com", "<local>"}})
+		ts.script = scriptResult{err: errors.New("WPAD failed")}
+		assert.Equal(t, []string{"HTTP_PROXY=http://netsh:8080", "HTTPS_PROXY=http://netsh:8080", "NO_PROXY=*.mondoo.com"}, ts.environment(rep))
+		assert.Equal(t, 1, ts.scriptCalls)
+	})
+
+	t.Run("script that cannot run without a representative still exports the manual proxy", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, &Settings{AutoDetect: true, Proxy: "manual:1"})
+		ts.script = scriptResult{err: errors.New("WPAD failed")}
+		assert.Equal(t, []string{"HTTP_PROXY=http://manual:1", "HTTPS_PROXY=http://manual:1"}, ts.environment(nil))
+		assert.Zero(t, ts.scriptCalls, "nothing to evaluate the script for")
+	})
+
+	t.Run("manual exceptions covering the representative still export the proxy", func(t *testing.T) {
+		ts := newTestSelector(&httpproxy.Config{}, &Settings{Proxy: "sys:3128", Bypass: []string{"*.mondoo.com"}})
+		assert.Equal(t, []string{"HTTP_PROXY=http://sys:3128", "HTTPS_PROXY=http://sys:3128", "NO_PROXY=*.mondoo.com"}, ts.environment(rep))
 	})
 
 	t.Run("machine proxy", func(t *testing.T) {

--- a/utils/sysproxy/sysproxy_windows.go
+++ b/utils/sysproxy/sysproxy_windows.go
@@ -1,0 +1,361 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build windows
+
+package sysproxy
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"runtime"
+	"sync"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+)
+
+// Everything here goes through winhttp.dll rather than the registry because
+// WinHTTP is what resolves the effective settings: it reads the per-user
+// Internet Settings the way Windows itself does, it knows the machine-wide
+// default that netsh writes, and it is the only supported way to run a setup
+// script or WPAD discovery without a browser engine. The calls go through the
+// lazy DLL loader, so the binary stays free of cgo, as the release build
+// requires (CGO_ENABLED=0).
+
+var (
+	modwinhttp  = windows.NewLazySystemDLL("winhttp.dll")
+	modkernel32 = windows.NewLazySystemDLL("kernel32.dll")
+
+	procWinHttpOpen                           = modwinhttp.NewProc("WinHttpOpen")
+	procWinHttpSetTimeouts                    = modwinhttp.NewProc("WinHttpSetTimeouts")
+	procWinHttpGetIEProxyConfigForCurrentUser = modwinhttp.NewProc("WinHttpGetIEProxyConfigForCurrentUser")
+	procWinHttpGetDefaultProxyConfiguration   = modwinhttp.NewProc("WinHttpGetDefaultProxyConfiguration")
+	procWinHttpGetProxyForUrl                 = modwinhttp.NewProc("WinHttpGetProxyForUrl")
+	procGlobalFree                            = modkernel32.NewProc("GlobalFree")
+)
+
+// Constants from winhttp.h.
+const (
+	winhttpAccessTypeNoProxy    = 1
+	winhttpAccessTypeNamedProxy = 3
+
+	winhttpAutoproxyAutoDetect = 0x00000001
+	winhttpAutoproxyConfigURL  = 0x00000002
+	winhttpAutoDetectTypeDHCP  = 0x00000001
+	winhttpAutoDetectTypeDNSA  = 0x00000002
+
+	// errorWinhttpAutodetectionFailed is what WPAD reports on a network that
+	// has no WPAD, which is most networks.
+	errorWinhttpAutodetectionFailed syscall.Errno = 12180
+)
+
+// winhttpProxyInfo is WINHTTP_PROXY_INFO.
+type winhttpProxyInfo struct {
+	accessType  uint32
+	proxy       *uint16
+	proxyBypass *uint16
+}
+
+// winhttpCurrentUserIEProxyConfig is WINHTTP_CURRENT_USER_IE_PROXY_CONFIG.
+type winhttpCurrentUserIEProxyConfig struct {
+	autoDetect    int32
+	autoConfigURL *uint16
+	proxy         *uint16
+	proxyBypass   *uint16
+}
+
+// winhttpAutoproxyOptions is WINHTTP_AUTOPROXY_OPTIONS.
+type winhttpAutoproxyOptions struct {
+	flags                 uint32
+	autoDetectFlags       uint32
+	autoConfigURL         *uint16
+	reserved              uintptr
+	reservedFlags         uint32
+	autoLogonIfChallenged int32
+}
+
+// takeString copies a WinHTTP-allocated string and frees it. WinHTTP hands
+// out these strings from the global heap and documents GlobalFree for them.
+func takeString(p *uint16) string {
+	if p == nil {
+		return ""
+	}
+	s := windows.UTF16PtrToString(p)
+	_, _, _ = procGlobalFree.Call(uintptr(unsafe.Pointer(p)))
+	return s
+}
+
+// detect reads the per-user Internet Settings, the per-machine Internet
+// Settings when group policy makes them per machine, and the WinHTTP default.
+func detect() (*Settings, error) {
+	s := &Settings{}
+
+	var ie winhttpCurrentUserIEProxyConfig
+	if r, _, err := procWinHttpGetIEProxyConfigForCurrentUser.Call(uintptr(unsafe.Pointer(&ie))); r != 0 {
+		s.AutoDetect = ie.autoDetect != 0
+		s.AutoConfigURL = takeString(ie.autoConfigURL)
+		s.Proxy = takeString(ie.proxy)
+		s.Bypass = SplitList(takeString(ie.proxyBypass))
+	} else {
+		// No profile to read from, which is what a service account looks like.
+		log.Debug().Err(err).Msg("no per-user proxy settings to read")
+	}
+
+	// Group policy can keep the Internet Settings per machine
+	// (ProxySettingsPerUser = 0) under HKLM, where WinHTTP does not look.
+	if s.Proxy == "" && s.AutoConfigURL == "" {
+		if m := readMachineInternetSettings(); m != nil {
+			s.AutoDetect = s.AutoDetect || m.AutoDetect
+			s.AutoConfigURL = m.AutoConfigURL
+			s.Proxy = m.Proxy
+			s.Bypass = m.Bypass
+		}
+	}
+
+	var pi winhttpProxyInfo
+	if r, _, err := procWinHttpGetDefaultProxyConfiguration.Call(uintptr(unsafe.Pointer(&pi))); r != 0 {
+		proxy, bypass := takeString(pi.proxy), takeString(pi.proxyBypass)
+		if pi.accessType == winhttpAccessTypeNamedProxy {
+			s.MachineProxy = proxy
+			s.MachineBypass = SplitList(bypass)
+		}
+	} else {
+		log.Debug().Err(err).Msg("could not read the WinHTTP default proxy")
+	}
+
+	if s.IsZero() {
+		return nil, nil
+	}
+	return s, nil
+}
+
+const (
+	regInternetSettings       = `Software\Microsoft\Windows\CurrentVersion\Internet Settings`
+	regInternetSettingsPolicy = `Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings`
+)
+
+// readMachineInternetSettings returns the HKLM Internet Settings when group
+// policy makes proxy settings per machine, nil otherwise. The value names are
+// the same ones the per-user hive uses.
+func readMachineInternetSettings() *Settings {
+	policy, err := registry.OpenKey(registry.LOCAL_MACHINE, regInternetSettingsPolicy, registry.QUERY_VALUE)
+	if err != nil {
+		return nil
+	}
+	perUser, _, err := policy.GetIntegerValue("ProxySettingsPerUser")
+	policy.Close()
+	if err != nil || perUser != 0 {
+		return nil
+	}
+
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, regInternetSettings, registry.QUERY_VALUE)
+	if err != nil {
+		return nil
+	}
+	defer k.Close()
+
+	s := &Settings{}
+	if enable, _, err := k.GetIntegerValue("ProxyEnable"); err == nil && enable != 0 {
+		s.Proxy, _, _ = k.GetStringValue("ProxyServer")
+		bypass, _, _ := k.GetStringValue("ProxyOverride")
+		s.Bypass = SplitList(bypass)
+	}
+	s.AutoConfigURL, _, _ = k.GetStringValue("AutoConfigURL")
+	if c, err := registry.OpenKey(k, "Connections", registry.QUERY_VALUE); err == nil {
+		blob, _, err := c.GetBinaryValue("DefaultConnectionSettings")
+		c.Close()
+		if err == nil {
+			if flags, ok := connectionSettingsFlags(blob); ok {
+				s.AutoDetect = flags&connectionSettingsAutoDetect != 0
+			}
+		}
+	}
+	if s.IsZero() {
+		return nil
+	}
+	return s
+}
+
+// scriptTimeout bounds one script evaluation as seen by the request waiting
+// on it. WPAD discovery on a network without WPAD takes a few seconds (a DHCP
+// probe and DNS lookups), and a setup script on a dead host must not hang the
+// request behind it. Results are cached, so this is paid once per host.
+const scriptTimeout = 15 * time.Second
+
+// scriptTTL keeps script results long enough to make a scan cheap and short
+// enough for a long-running service to follow a changed script.
+const scriptTTL = 5 * time.Minute
+
+type scriptCacheEntry struct {
+	done chan struct{}
+	res  scriptResult
+	// expires is zero while the evaluation is still running.
+	expires time.Time
+}
+
+// winhttpScript evaluates setup scripts through WinHttpGetProxyForUrl, which
+// downloads and runs the script (and performs WPAD discovery) inside the
+// WinHTTP Web Proxy Auto-Discovery Service, so repeated calls are served from
+// that service's cache.
+type winhttpScript struct {
+	mu      sync.Mutex
+	opened  bool
+	session uintptr
+	sessErr error
+	cache   map[string]*scriptCacheEntry
+	// autoDetectFailedUntil skips WPAD after a failed discovery, the way .NET
+	// does, so a machine that merely left "automatically detect settings" on
+	// (the Windows default) pays for the failed probe once, not once per host.
+	autoDetectFailedUntil time.Time
+}
+
+var script = &winhttpScript{cache: map[string]*scriptCacheEntry{}}
+
+func evaluateScript(s *Settings, u *url.URL) scriptResult {
+	return script.evaluate(s, u)
+}
+
+// evaluate returns the cached answer for u's origin or starts one evaluation
+// per origin and waits for it up to scriptTimeout. A request that gives up
+// waiting leaves the evaluation running so its answer is there for the next
+// one.
+func (w *winhttpScript) evaluate(s *Settings, u *url.URL) scriptResult {
+	// The script sees the origin only. Paths carry nothing a script routes on
+	// in practice, and keeping them out of the cache key and the logs keeps
+	// query strings out of both.
+	target := u.Scheme + "://" + u.Host + "/"
+
+	w.mu.Lock()
+	now := time.Now()
+	if e, ok := w.cache[target]; ok && (e.expires.IsZero() || now.Before(e.expires)) {
+		w.mu.Unlock()
+		return w.wait(e)
+	}
+	w.sweep(now)
+	e := &scriptCacheEntry{done: make(chan struct{})}
+	w.cache[target] = e
+	skipAutoDetect := now.Before(w.autoDetectFailedUntil)
+	w.mu.Unlock()
+
+	go func() {
+		res, autoDetectFailed := w.call(s, target, skipAutoDetect)
+		w.mu.Lock()
+		e.res = res
+		e.expires = time.Now().Add(scriptTTL)
+		if autoDetectFailed {
+			w.autoDetectFailedUntil = time.Now().Add(scriptTTL)
+		}
+		w.mu.Unlock()
+		close(e.done)
+	}()
+	return w.wait(e)
+}
+
+func (w *winhttpScript) wait(e *scriptCacheEntry) scriptResult {
+	select {
+	case <-e.done:
+		return e.res
+	case <-time.After(scriptTimeout):
+		return scriptResult{err: errors.New("proxy script evaluation timed out")}
+	}
+}
+
+// sweep drops expired entries once the cache has grown past a handful of
+// origins. Called with mu held.
+func (w *winhttpScript) sweep(now time.Time) {
+	if len(w.cache) < 256 {
+		return
+	}
+	for k, e := range w.cache {
+		if !e.expires.IsZero() && now.After(e.expires) {
+			delete(w.cache, k)
+		}
+	}
+}
+
+// openSession creates the WinHTTP session the script runs under, once. It
+// uses no proxy of its own: setup scripts live on the intranet and are
+// fetched directly, which is also what browsers do.
+func (w *winhttpScript) openSession() (uintptr, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.opened {
+		return w.session, w.sessErr
+	}
+	w.opened = true
+	h, _, err := procWinHttpOpen.Call(0, winhttpAccessTypeNoProxy, 0, 0, 0)
+	if h == 0 {
+		w.sessErr = fmt.Errorf("WinHttpOpen: %w", err)
+		return 0, w.sessErr
+	}
+	// Resolve, connect, send and receive timeouts for the script download,
+	// in milliseconds. WinHTTP's own defaults run to a minute per stage.
+	_, _, _ = procWinHttpSetTimeouts.Call(h, 5000, 5000, 5000, 10000)
+	w.session = h
+	return h, nil
+}
+
+// call runs WinHttpGetProxyForUrl for target. It reports whether WPAD
+// discovery failed so the caller can stop asking for it for a while.
+func (w *winhttpScript) call(s *Settings, target string, skipAutoDetect bool) (res scriptResult, autoDetectFailed bool) {
+	session, err := w.openSession()
+	if err != nil {
+		return scriptResult{err: err}, false
+	}
+
+	opts := winhttpAutoproxyOptions{autoLogonIfChallenged: 1}
+	if s.AutoDetect && !skipAutoDetect {
+		opts.flags |= winhttpAutoproxyAutoDetect
+		opts.autoDetectFlags = winhttpAutoDetectTypeDHCP | winhttpAutoDetectTypeDNSA
+	}
+	var pac *uint16
+	if s.AutoConfigURL != "" {
+		pac, err = windows.UTF16PtrFromString(s.AutoConfigURL)
+		if err != nil {
+			return scriptResult{err: err}, false
+		}
+		opts.flags |= winhttpAutoproxyConfigURL
+		opts.autoConfigURL = pac
+	}
+	if opts.flags == 0 {
+		return scriptResult{err: errors.New("auto-detection failed recently and no setup script is configured")}, false
+	}
+
+	u16, err := windows.UTF16PtrFromString(target)
+	if err != nil {
+		return scriptResult{err: err}, false
+	}
+
+	var info winhttpProxyInfo
+	r, _, callErr := procWinHttpGetProxyForUrl.Call(session, uintptr(unsafe.Pointer(u16)), uintptr(unsafe.Pointer(&opts)), uintptr(unsafe.Pointer(&info)))
+	if r == 0 {
+		if errno, ok := callErr.(syscall.Errno); ok && errno == errorWinhttpAutodetectionFailed {
+			autoDetectFailed = true
+			if pac != nil {
+				// Discovery failed but a script is configured: ask for the
+				// script alone.
+				opts.flags = winhttpAutoproxyConfigURL
+				opts.autoDetectFlags = 0
+				r, _, callErr = procWinHttpGetProxyForUrl.Call(session, uintptr(unsafe.Pointer(u16)), uintptr(unsafe.Pointer(&opts)), uintptr(unsafe.Pointer(&info)))
+			}
+		}
+		if r == 0 {
+			runtime.KeepAlive(pac)
+			return scriptResult{err: fmt.Errorf("WinHttpGetProxyForUrl: %w", callErr)}, autoDetectFailed
+		}
+	}
+	runtime.KeepAlive(pac)
+
+	proxies := takeString(info.proxy)
+	_ = takeString(info.proxyBypass) // a script has no bypass list; free it regardless
+	if info.accessType != winhttpAccessTypeNamedProxy {
+		return scriptResult{}, autoDetectFailed // DIRECT
+	}
+	return scriptResult{proxies: proxies}, autoDetectFailed
+}

--- a/utils/sysproxy/sysproxy_windows_test.go
+++ b/utils/sysproxy/sysproxy_windows_test.go
@@ -1,0 +1,61 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build windows
+
+package sysproxy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These run against the real WinHTTP API of whatever machine executes them.
+// The machine's settings are not known, so they pin what can be pinned: the
+// calls return, the strings are read and freed without faulting, and a script
+// that cannot be fetched fails within the timeout instead of hanging.
+
+func TestDetectWindows(t *testing.T) {
+	s, err := detect()
+	require.NoError(t, err)
+	t.Logf("settings: %s", s)
+	if s != nil {
+		for _, entry := range append(append([]string{}, s.Bypass...), s.MachineBypass...) {
+			assert.NotEmpty(t, entry, "SplitList must not produce empty entries")
+		}
+	}
+}
+
+func TestReadMachineInternetSettingsDoesNotFault(t *testing.T) {
+	// nil on a machine without the per-machine policy, a Settings otherwise
+	_ = readMachineInternetSettings()
+}
+
+func TestScriptEvaluationFailsFastForUnreachableScript(t *testing.T) {
+	start := time.Now()
+	res := script.evaluate(&Settings{AutoConfigURL: "http://127.0.0.1:9/proxy.pac"}, mustURL(t, "https://example.com/"))
+	require.Error(t, res.err)
+	assert.Less(t, time.Since(start), scriptTimeout)
+
+	// The failed answer is cached for the origin, so the second ask is immediate.
+	start = time.Now()
+	res = script.evaluate(&Settings{AutoConfigURL: "http://127.0.0.1:9/proxy.pac"}, mustURL(t, "https://example.com/"))
+	require.Error(t, res.err)
+	assert.Less(t, time.Since(start), time.Second)
+}
+
+func TestScriptEvaluationTerminatesForAutoDetect(t *testing.T) {
+	// The Windows default configuration. Whether WPAD exists on the runner's
+	// network is unknown; what must hold is that the call comes back.
+	start := time.Now()
+	res := script.evaluate(&Settings{AutoDetect: true}, mustURL(t, "https://autodetect.example/"))
+	assert.Less(t, time.Since(start), scriptTimeout+time.Second)
+	if res.err != nil {
+		t.Logf("auto-detect: %v", res.err)
+	} else {
+		t.Logf("auto-detect proxies: %q", res.proxies)
+	}
+}


### PR DESCRIPTION
## Summary

On Windows the proxy lives in Internet Settings (manual proxy with exceptions, a PAC script URL, or "automatically detect settings") and, for services, in the WinHTTP default that `netsh winhttp set proxy` writes. mql and cnspec only read `HTTPS_PROXY` and `api_proxy`, so a fresh install on a proxied Windows machine could not reach the platform until someone found the `api_proxy` key. With this change it works out of the box, and an explicit proxy in the config file stays authoritative over everything else.

## What changes

- **`utils/sysproxy`** (new leaf package): reads the Windows proxy settings through `winhttp.dll` via the lazy DLL loader, so the `CGO_ENABLED=0` release build is unaffected. It uses `WinHttpGetIEProxyConfigForCurrentUser` (per-user Internet Settings), the HKLM Internet Settings when group policy stores them per machine (`ProxySettingsPerUser = 0`, which WinHTTP does not read), `WinHttpGetDefaultProxyConfiguration` (the `netsh` default that services run on), and `WinHttpGetProxyForUrl` to run a PAC script or WPAD discovery. Bypass lists follow Windows semantics (`*` wildcards, `10.*`, CIDR, `<local>`, `<-loopback>`), loopback is never proxied, `NO_PROXY` keeps its meaning, a script's `DIRECT` is final, and a script that cannot run falls back to the manual proxy. Detection and script answers are cached for five minutes, a failed WPAD probe is remembered so the Windows default of "auto-detect on, no proxy" costs one probe, and a request waits at most 15s for a script. Other platforms report no settings.
- **One resolver, `cli/config/proxy.go`**, used at every HTTP client site (platform API, provider and binary downloads, error reporting, token exchange, login, status). Precedence, highest first:
  1. `--api-proxy` or `MONDOO_API_PROXY`
  2. `api_proxy` in the config file
  3. `HTTPS_PROXY` / `HTTP_PROXY` with `NO_PROXY` (Go semantics)
  4. the operating system's settings, unless `system_proxy: false`
  5. direct
- **A system proxy is used only after it has carried a probe.** Before a system-selected proxy is used for a destination, `sysproxy` connects to it, sends `CONNECT host:443`, and completes a TLS handshake with the destination through the tunnel using the system trust store. A failed probe (unreachable, 407 from an NTLM proxy, a refused destination, an intercepting certificate the machine does not trust) means a direct connection, exactly the pre-14 behavior, with one warning naming the proxy, host and reason. Verdicts are cached per proxy and destination for five minutes and shared by every client in the process; the proxy exported to providers is only one that passed the probe for the API endpoint. This is what keeps existing Windows installations that work directly today working after the upgrade. Explicit `api_proxy` and `HTTPS_PROXY` are never probed or overridden.
- **New config key `system_proxy`** (default on; `MONDOO_SYSTEM_PROXY=false` also works). Turning it off restores the previous behavior exactly.
- **Providers make the same decision.** `upstream.DefaultHttpClient()` is system-proxy aware, so a provider's own platform client resolves the proxy in its own process. The coordinator exports the system proxy to provider subprocesses as `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` for the cloud SDKs (which read nothing else; a PAC is evaluated for the API endpoint and the exception list translated where `NO_PROXY` can express it), and the opt-out as `MONDOO_SYSTEM_PROXY=false`. Variables already in the environment are never overridden. `api_proxy` stays scoped to platform traffic, as before.
- **`mql status`** shows the proxy in effect and its source (`api_proxy`, `environment`, `system`) in the Mondoo Platform section, and as `proxy`/`proxySource` in JSON output. On a machine whose system proxy failed the probe, the row shows the direct connection with the reason (`proxyNote` in JSON).
- `config.GetAPIProxy` is kept for compatibility but deprecated: it returns one fixed URL and cannot report the system proxy.
- ADR 045 records the design. The Windows CI workflow now includes `utils/sysproxy`, whose `_windows_test.go` smoke tests exercise the real WinHTTP calls.

## Behavior notes

- A proxy in the config file overrides `HTTPS_PROXY` and the OS settings (pinned by `TestProxyFuncPrecedence`).
- `HTTPS_PROXY` is now read with Go's full semantics at every site; a few sites used to copy only `HTTPS_PROXY` into a fixed proxy URL and ignored `NO_PROXY`.
- `api_proxy` values without a scheme (`proxy.corp:3128`) are accepted as `http://`.

## Testing

- Unit tests: selection precedence, Windows list parsing, bypass matching, `NO_PROXY` translation, env export for providers, config-file-wins, status rendering (goldens updated for the new row).
- `go test` over the core module, `golangci-lint` clean, `go mod tidy` clean.
- Cross-compiles for windows/amd64 and windows/arm64, including an out-of-tree provider module (jumpcloud).
- Live verification on a Windows Server 2025 EC2 instance behind a Squid proxy, run as SYSTEM through SSM: `netsh winhttp` proxy, Internet Settings manual proxy with and without exceptions, PAC file, group policy per-machine settings, the LocalSystem service check-in, the environment handed to provider subprocesses, and a full `cnspec scan local` upload all went through the proxy; a bogus proxy address makes the same calls fail; `api_proxy` in the config file overrides the environment and the system settings; `system_proxy: false` restores direct connections. Full matrix and Squid access-log evidence: https://github.com/mondoohq/mql/pull/10755#issuecomment-5638529813
- One bug found by that run and fixed in the follow-up commit: with auto-detect on (the Windows default) and the API host in the proxy's bypass list, nothing was exported to provider subprocesses; the manual proxy and its exceptions are now exported whenever the script cannot run.

## Follow-up

- cnspec counterpart: mondoohq/cnspec branch `windows-system-proxy` (needs a `go.mondoo.com/mql` bump after this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
