### PR TITLE
👷 edge: publish edge binaries to the bucket, and make them orderable

### DIFF
--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -107,11 +107,12 @@ jobs:
 
           # A malformed version becomes a bucket directory name and a channel
           # pointer, so check the shape here rather than discovering it there.
-          # The hyphen inside the class matters: a pre-release identifier may
-          # contain one (1.0.0-alpha-1 is valid semver), and rejecting those
-          # would fail the build for a perfectly legal base tag. Build metadata
-          # is still rejected, because it must have been folded in by now.
-          if ! printf '%s' "${TAG#v}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+          # Dot-separated identifiers, each non-empty, each allowed to contain
+          # a hyphen: 1.0.0-alpha-1 is valid semver and must not fail the
+          # build, while 14.0.0-rc.. and 14.0.0-rc. are not and must. Build
+          # metadata is still rejected, because it must have been folded in by
+          # this point.
+          if ! printf '%s' "${TAG#v}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'; then
             echo "::error::derived tag '$TAG' is not a semver version"
             exit 1
           fi

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -107,7 +107,11 @@ jobs:
 
           # A malformed version becomes a bucket directory name and a channel
           # pointer, so check the shape here rather than discovering it there.
-          if ! printf '%s' "${TAG#v}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+          # The hyphen inside the class matters: a pre-release identifier may
+          # contain one (1.0.0-alpha-1 is valid semver), and rejecting those
+          # would fail the build for a perfectly legal base tag. Build metadata
+          # is still rejected, because it must have been folded in by now.
+          if ! printf '%s' "${TAG#v}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
             echo "::error::derived tag '$TAG' is not a semver version"
             exit 1
           fi
@@ -182,13 +186,16 @@ jobs:
           # `gsutil -m` can exit 0 with individual transfers having failed, and
           # a half-uploaded directory is worse than none: the indexer would
           # point the edge channel at it and clients would 404 on the missing
-          # platforms. Count what actually landed.
-          uploaded=$(gsutil ls "gs://${BUCKET}/edge/mql/${VERSION}/" | grep -c '[^/]$' || true)
-          if [ "$uploaded" -ne "$expected" ]; then
-            echo "::error::uploaded ${uploaded} objects, expected ${expected}"
+          # platforms. Compare names rather than counting, so the check says
+          # which artifact is missing instead of only that one is.
+          want="$(printf '%s\n' "${archives[@]}" "${checksums[@]}" | sed 's#.*/##' | sort)"
+          got="$(gsutil ls "gs://${BUCKET}/edge/mql/${VERSION}/" | sed 's#.*/##' | sed '/^$/d' | sort)"
+          if [ "$want" != "$got" ]; then
+            echo "::error::uploaded objects do not match what was built"
+            diff <(printf '%s\n' "$want") <(printf '%s\n' "$got") || true
             exit 1
           fi
-          echo "verified ${uploaded} objects"
+          echo "verified ${expected} objects"
 
       # Indexing and pruning live in the installer repo: they need releasr, and
       # this repository is public.

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -76,10 +76,41 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      # `make version` yields v14.0.0-rc.2+3508: the base tag plus a commit
+      # count as semver build metadata. A git tag can hold a `+`, but a Docker
+      # tag cannot, so it has to be folded into the version proper.
+      #
+      # How it is folded decides whether edge builds can be ordered at all.
+      # Folding to `-3508` makes the pre-release segment `rc.2-3508`, whose
+      # second identifier contains a hyphen and is therefore *alphanumeric*,
+      # so semver compares it as text: 359 sorts above 3510, and 9999 above
+      # 10000. Folding to `.3508` makes it its own purely numeric identifier,
+      # which semver compares numerically. Verified against the same
+      # hashicorp/go-version comparison the release indexer uses.
+      #
+      # A base tag with no pre-release segment (v14.0.0) has nowhere to append,
+      # so the counter becomes the pre-release itself.
       - name: Locally tag the current commit
+        id: version
         run: |
-          VERSION=$(make version)
-          git tag ${VERSION/\+/-}
+          VERSION="$(make version)"
+          BASE="${VERSION%%+*}"
+          BUILD="${VERSION#*+}"
+
+          if [ "$BUILD" = "$VERSION" ]; then
+            TAG="$VERSION"
+          elif [ "${BASE#*-}" != "$BASE" ]; then
+            TAG="${BASE}.${BUILD}"
+          else
+            TAG="${BASE}-${BUILD}"
+          fi
+
+          echo "make version: $VERSION -> tag: $TAG"
+          git tag "$TAG"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          # The bucket layout drops the leading v, matching every other product
+          # directory on releases.mondoo.com.
+          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
@@ -99,3 +130,61 @@ jobs:
           name: mql-edge-linux
           path: dist/mql*
           retention-days: 7
+
+      # Edge produced container images and nothing else, so `?channel=edge` on
+      # the install service resolved a bucket path that has never existed for
+      # mql. These are the same archives goreleaser already built for the
+      # images; they were simply discarded.
+      - name: "Authenticate to Google Cloud"
+        if: ${{ inputs.dry-run != true }}
+        uses: "google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093" # v3.0.0
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIP }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: "Set up Cloud SDK"
+        if: ${{ inputs.dry-run != true }}
+        uses: "google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db" # v3.0.1
+
+      - name: Upload edge binaries
+        if: ${{ inputs.dry-run != true }}
+        env:
+          BUCKET: releases-us.mondoo.io
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Fail loudly rather than publishing a version directory with no
+          # artifacts in it, which the indexer would then point a channel at.
+          shopt -s nullglob
+          archives=(dist/*.tar.gz)
+          checksums=(dist/*_SHA256SUMS)
+          if [ ${#archives[@]} -eq 0 ] || [ ${#checksums[@]} -eq 0 ]; then
+            echo "::error::goreleaser produced no archives or no checksum file"
+            exit 1
+          fi
+
+          echo "uploading ${#archives[@]} archives to edge/mql/${VERSION}/"
+          gsutil -m cp "${archives[@]}" "${checksums[@]}" \
+            "gs://${BUCKET}/edge/mql/${VERSION}/"
+
+      # Indexing and pruning live in the installer repo: they need releasr, and
+      # this repository is public.
+      - name: Generate token
+        id: generate-token
+        if: ${{ inputs.dry-run != true }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.MONDOO_MERGEBOT_APP_ID }}
+          private-key: ${{ secrets.MONDOO_MERGEBOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: installer
+
+      - name: Trigger edge index
+        if: ${{ inputs.dry-run != true }}
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          repository: "mondoohq/installer"
+          event-type: edge-published
+          client-payload: >-
+            {"product": "mql", "version": ${{ toJSON(steps.version.outputs.version) }}}

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -105,12 +105,19 @@ jobs:
             TAG="${BASE}-${BUILD}"
           fi
 
+          # A malformed version becomes a bucket directory name and a channel
+          # pointer, so check the shape here rather than discovering it there.
+          if ! printf '%s' "${TAG#v}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+            echo "::error::derived tag '$TAG' is not a semver version"
+            exit 1
+          fi
+
           echo "make version: $VERSION -> tag: $TAG"
           git tag "$TAG"
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           # The bucket layout drops the leading v, matching every other product
           # directory on releases.mondoo.com.
-          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
@@ -155,6 +162,10 @@ jobs:
           set -euo pipefail
           # Fail loudly rather than publishing a version directory with no
           # artifacts in it, which the indexer would then point a channel at.
+          if [ ! -d dist ]; then
+            echo "::error::goreleaser produced no dist/ directory"
+            exit 1
+          fi
           shopt -s nullglob
           archives=(dist/*.tar.gz)
           checksums=(dist/*_SHA256SUMS)

--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -174,9 +174,21 @@ jobs:
             exit 1
           fi
 
-          echo "uploading ${#archives[@]} archives to edge/mql/${VERSION}/"
+          expected=$(( ${#archives[@]} + ${#checksums[@]} ))
+          echo "uploading ${expected} objects to edge/mql/${VERSION}/"
           gsutil -m cp "${archives[@]}" "${checksums[@]}" \
             "gs://${BUCKET}/edge/mql/${VERSION}/"
+
+          # `gsutil -m` can exit 0 with individual transfers having failed, and
+          # a half-uploaded directory is worse than none: the indexer would
+          # point the edge channel at it and clients would 404 on the missing
+          # platforms. Count what actually landed.
+          uploaded=$(gsutil ls "gs://${BUCKET}/edge/mql/${VERSION}/" | grep -c '[^/]$' || true)
+          if [ "$uploaded" -ne "$expected" ]; then
+            echo "::error::uploaded ${uploaded} objects, expected ${expected}"
+            exit 1
+          fi
+          echo "verified ${uploaded} objects"
 
       # Indexing and pruning live in the installer repo: they need releasr, and
       # this repository is public.


### PR DESCRIPTION
`?channel=edge` on the install service returns **503 in production right now** for mql. Not decay — it has never worked:

```
edge/cnquery/latest.json   200  6.16.0-snapshot   (2023)
edge/mondoo/latest.json    200  8.4.0-1
edge/mql/latest.json    404
```

Edge builds containers and nothing else (`release: disable: true`, only `dockers:`). The archives goreleaser already builds for those images were discarded. This uploads them.

## The version had to be fixed first

`make version` yields `v14.0.0-rc.2+3508` — base tag plus commit count as semver build metadata. The `+` has to go, because a **Docker tag cannot contain one**. How it is folded decides whether edge builds can be ordered at all.

Sorted highest-first by the same `hashicorp/go-version` comparison the release indexer uses:

| Versions | Result |
|---|---|
| `rc.2-3508`, `rc.2-3510`, `rc.2-359` | `[359, 3510, 3508]` ❌ **359 wins** |
| `rc.2-9999`, `rc.2-10000` | `[9999, 10000]` ❌ |
| `rc.2.3508`, `rc.2.3510`, `rc.2.359`, `rc.2.10000` | `[10000, 3510, 3508, 359]` ✅ |

Folding to `-3508` makes the pre-release segment `rc.2-3508`, whose second identifier contains a hyphen and is therefore **alphanumeric**, so semver compares it as text — `359` beats `3510` because `9` > `1`. Folding to `.3508` makes it its own purely **numeric** identifier, compared numerically, correct without bound.

```diff
-          git tag ${VERSION/\+/-}
+          # see the comment in the workflow
+          TAG="${BASE}.${BUILD}"      # base has a pre-release segment
+          TAG="${BASE}-${BUILD}"      # base is a final release
```

A base tag with no pre-release segment (`v14.0.0`) has nowhere to append, so there the counter becomes the pre-release itself. Docker tags accept `.`, so the image tags are unaffected in shape (`edge-14.0.0-rc.2.3508`).

## Known limit

Once the base tag is a final release, versions become `14.0.0-3700`, and semver ranks a *numeric* pre-release identifier **below** an alphanumeric one — so those sort under every `14.0.0-rc.2.NNNN` build that preceded them. With retention at ~20 builds that self-corrects in about two days, once per major. Deliberately out of scope here; fixing it means changing what `cnspec version` reports on edge builds.

## Why the indexing is not in this PR

Indexing and pruning need tooling this repository cannot reach. So this uploads and dispatches `edge-published`; mondoohq/installer#769 does the rest — prune to the newest 20 builds, reindex the edge tree, verify `latest.json` names the build just published.

At ~70 pushes a week and ~216 MB a build, that prefix would otherwise grow ~65 GB a month.

## Review focus

- The version folding. `v14.0.0-rc.2+3508` → `v14.0.0-rc.2.3508`, `v14.0.0+3700` → `v14.0.0-3700`, and a version with no `+` passes through unchanged. Verified against all four shapes.
- The upload fails the run if goreleaser produced no archives or no checksum file, rather than publishing an empty version directory for the indexer to point a channel at.
- Platforms stay linux-only, matching what the containers already build. A macOS user still cannot get an edge binary; worth its own decision.

Part of the release-channels work. The channel rule is SemVer §9 and §10 with nothing added: a version with a pre-release segment is `preview`, one without is `stable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

