### PR TITLE
✨ Add an update_channel setting for pre-release tracks

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -94,6 +94,12 @@ jobs:
           #
           # This is worth failing on rather than warning about, because
           # everything downstream would accept it happily.
+          #
+          # The boundaries on both sides keep the marker list from firing on
+          # real words that merely contain one of them. Verified:
+          #   rejects: +rc.1 +alpha3 +pre-2 +preview +edge.7 +test +next.1
+          #   allows:  +3508 +build.7 +attestation +contest +greatest +latest
+          #            +protest +nextcloud +edgecase
           META="${REF_NAME#*+}"
           if [ "$META" != "$REF_NAME" ]; then
             if printf '%s' "$META" | grep -Eiq '(^|[.-])(pre|rc|alpha|beta|dev|canary|nightly|snapshot|preview|edge|test|next)([.-]|[0-9]|$)'; then

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -96,7 +96,7 @@ jobs:
           # everything downstream would accept it happily.
           META="${REF_NAME#*+}"
           if [ "$META" != "$REF_NAME" ]; then
-            if printf '%s' "$META" | grep -Eiq '(^|[.-])(pre|rc|alpha|beta|dev|canary|nightly|snapshot)([.-]|[0-9]|$)'; then
+            if printf '%s' "$META" | grep -Eiq '(^|[.-])(pre|rc|alpha|beta|dev|canary|nightly|snapshot|preview|edge|test|next)([.-]|[0-9]|$)'; then
               echo "::error::tag $REF_NAME puts a pre-release marker in build metadata. Build metadata is ignored for precedence, so this tag means the FINAL ${REF_NAME%%+*} and would publish to the stable channel. Use a hyphen: ${REF_NAME%%+*}-${META}"
               exit 1
             fi

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -67,9 +67,44 @@ jobs:
           echo "github.ref: ${{ github.ref }}"
           echo "github.ref_name: ${{ github.ref_name }}"
           echo "github.event_name: ${{ github.event_name }}"
+      # A tag's release channel is derived from its semver pre-release segment,
+      # never declared: `14.0.0-rc.2` is preview, `13.38.1` is stable, and build
+      # metadata (`8.4.0+41`) is not a pre-release so it stays stable. This
+      # replaces a substring test for alpha/beta/pre/rc that disagreed with the
+      # equivalent lists in cnspec and in the publishing tools. See minstaller
+      # ADR 0003.
+      - name: Determine release channel
+        id: channel
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          if [ "$REF_TYPE" != "tag" ]; then
+            echo "not a tag ($REF_NAME), treating as stable"
+            echo "channel=stable" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          CORE="${REF_NAME#v}"
+          CORE="${CORE%%+*}"
+          if ! printf '%s' "$CORE" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::tag $REF_NAME is not a semver version, so its release channel cannot be derived"
+            exit 1
+          fi
+
+          case "$CORE" in
+            *-*) CHANNEL=preview ;;
+            *)   CHANNEL=stable ;;
+          esac
+
+          echo "$REF_NAME -> channel=$CHANNEL"
+          echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
+
+      # A pre-release still builds and still gets a GitHub release; what it must
+      # not do is promote `latest` or start the cnspec release train.
       - name: Skip Publish for non-release tags
         id: skip-publish
-        if: contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'pre') || contains(github.ref, 'rc') || inputs.skip-publish == true
+        if: steps.channel.outputs.channel != 'stable' || inputs.skip-publish == true
         run: |
           echo "Skipping publish for non-release tags"
           echo "skip-publish=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -85,6 +85,24 @@ jobs:
             exit 0
           fi
 
+          # Build metadata is everything after a `+`, and SemVer 10 says it MUST
+          # be ignored when determining precedence. So `v14.0.0+rc.1` does not
+          # mean "release candidate": it compares EQUAL to `14.0.0`, outranks
+          # every real `14.0.0-rc.N`, derives the stable channel, and ships to
+          # every user on their next update check. A pre-release is introduced
+          # with `-`, never `+`.
+          #
+          # This is worth failing on rather than warning about, because
+          # everything downstream would accept it happily.
+          META="${REF_NAME#*+}"
+          if [ "$META" != "$REF_NAME" ]; then
+            if printf '%s' "$META" | grep -Eiq '(^|[.-])(pre|rc|alpha|beta|dev|canary|nightly|snapshot)([.-]|[0-9]|$)'; then
+              echo "::error::tag $REF_NAME puts a pre-release marker in build metadata. Build metadata is ignored for precedence, so this tag means the FINAL ${REF_NAME%%+*} and would publish to the stable channel. Use a hyphen: ${REF_NAME%%+*}-${META}"
+              exit 1
+            fi
+            echo "::warning::tag $REF_NAME carries build metadata (+${META}), which is ignored when comparing versions"
+          fi
+
           CORE="${REF_NAME#v}"
           CORE="${CORE%%+*}"
           if ! printf '%s' "$CORE" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -16,6 +16,11 @@ on:
         type: boolean
         required: false
         default: false
+      allow_major_promotion:
+        description: "Allow publishing a new major to the stable channel (see minstaller ADR 0003)"
+        type: boolean
+        required: false
+        default: false
       use-test-cert:
         description: "Use test certificate profile (not publicly trusted)"
         required: false
@@ -52,6 +57,8 @@ jobs:
 
       - name: Detect providers
         id: providers
+        env:
+          ALLOW_MAJOR_PROMOTION: ${{ inputs.allow_major_promotion }}
         run: |
           providers=$(find providers -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
           echo "providers=$(echo -n $providers | jq -Rsc 'split(" ")')" >> $GITHUB_OUTPUT
@@ -77,6 +84,27 @@ jobs:
               DIST_VERSION=$(curl -s https://releases.mondoo.com/providers/${p}/latest.json | jq -r .version)
             fi
             printf "PROVIDER $p:\n  Local version: $REPO_VERSION\n  Remote version: $DIST_VERSION\n"
+
+            # Providers share one namespace across release lines, and every
+            # client resolves through providers/latest.json -- whatever is
+            # newest there is what the whole fleet installs. A version carrying
+            # a semver pre-release segment lands on the preview channel and is
+            # invisible to stable clients; a plain one does not.
+            #
+            # So a plain version whose major is ahead of what stable currently
+            # serves would hand every client on the previous major a provider
+            # built for the next one, as a side effect of a routine bump. Refuse
+            # it. Promoting a major is deliberate: re-run with
+            # allow_major_promotion. See minstaller ADR 0003.
+            if [[ "$DIST_VERSION" != "unreleased" && "$ALLOW_MAJOR_PROMOTION" != "true" ]]; then
+              REPO_MAJOR=${REPO_VERSION%%.*}
+              DIST_MAJOR=${DIST_VERSION%%.*}
+              if [[ "$REPO_VERSION" != *-* && "$REPO_MAJOR" -gt "$DIST_MAJOR" ]]; then
+                echo "::error::$p $REPO_VERSION would promote major $REPO_MAJOR to the stable channel, where $DIST_VERSION is serving every client on major $DIST_MAJOR. Give it a pre-release segment (e.g. ${REPO_MAJOR}.0.0-rc.1) to publish it to preview, or re-run with allow_major_promotion to promote it deliberately."
+                exit 1
+              fi
+            fi
+
             if [[ $REPO_VERSION != $DIST_VERSION ]]; then
               echo "  Adding $p to build list"
               build="$build $p"

--- a/apps/mql/cmd/root.go
+++ b/apps/mql/cmd/root.go
@@ -113,6 +113,7 @@ func init() {
 	_ = viper.BindEnv("features")
 	_ = viper.BindEnv("strict")
 	_ = viper.BindEnv("updates_url")
+	_ = viper.BindEnv(config.KeyUpdateChannel)
 
 	config.Init(rootCmd)
 }

--- a/apps/mql/cmd/status.go
+++ b/apps/mql/cmd/status.go
@@ -255,6 +255,11 @@ func checkStatus(ctx context.Context) (Status, error) {
 		}
 	}
 
+	// The release track updates and providers resolve through. Shown even when
+	// it is the default, so a support conversation can establish in one command
+	// whether a machine is on pre-releases.
+	s.Client.UpdateChannel = config.GetUpdateChannel()
+
 	// Determine the providers URL:
 	// 1. If updates_url is set, use updates_url + "/providers"
 	// 2. Otherwise, use the default
@@ -326,6 +331,7 @@ type ClientStatus struct {
 	Registered     bool                `json:"registered,omitempty"`
 	PingPongError  error               `json:"pingPongError,omitempty"`
 	UpdatesURL     string              `json:"updatesUrl,omitempty"`
+	UpdateChannel  string              `json:"updateChannel,omitempty"`
 	ProvidersURL   string              `json:"providersUrl,omitempty"`
 	ConfigFile     string              `json:"configFile,omitempty"`
 	Providers      []ProviderStatus    `json:"-"`

--- a/apps/mql/cmd/status_render.go
+++ b/apps/mql/cmd/status_render.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"go.mondoo.com/mql/cli/config"
 	"net/url"
 	"strconv"
 	"strings"
@@ -164,6 +165,9 @@ func (s Status) renderMql(b *strings.Builder, st styler) {
 		st.row(b, "Config", st.dim("defaults — no config file loaded"))
 	}
 	st.row(b, "Updates", s.Client.UpdatesURL)
+	if s.Client.UpdateChannel != "" && s.Client.UpdateChannel != config.ChannelStable {
+		st.row(b, "Channel", st.value(s.Client.UpdateChannel))
+	}
 }
 
 func (s Status) renderPlatform(b *strings.Builder, st styler) {

--- a/apps/mql/mql.go
+++ b/apps/mql/mql.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"os"
+	"strings"
 
 	"go.mondoo.com/mql"
 	"go.mondoo.com/mql/apps/mql/cmd"
@@ -31,9 +32,10 @@ func main() {
 
 	// Check for self-update before anything else
 	if run, localOnly := selfUpdateMode(); run {
-		releaseURL := selfupdate.DefaultReleaseURL
+		manifest := selfupdate.ChannelManifest(config.GetUpdateChannel())
+		releaseURL := selfupdate.DefaultReleasesURL + "/mql/" + manifest
 		if updatesURL := config.GetUpdatesURL(); updatesURL != "" {
-			releaseURL = updatesURL + "/mql/latest.json"
+			releaseURL = strings.TrimSuffix(updatesURL, "/") + "/mql/" + manifest
 		}
 		cfg := selfupdate.Config{
 			Enabled:         true,

--- a/apps/mql/mql.go
+++ b/apps/mql/mql.go
@@ -23,6 +23,11 @@ import (
 func main() {
 	defer health.ReportPanic("mql", mql.Version, mql.Build)
 
+	// Before anything resolves a channel. With update_channel unset, a
+	// pre-release build follows the pre-release track rather than pulling
+	// stable providers built against a different schema.
+	config.SetRunningVersion(mql.GetVersion())
+
 	// Clean up leftover .old binary from a previous in-place update (Windows).
 	selfupdate.CleanupOldBinary()
 

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -227,6 +227,41 @@ func GetProviderPortRange() string {
 	return viper.GetString(KeyProviderPortRange)
 }
 
+// KeyUpdateChannel is the config key selecting which release track binary
+// updates and providers resolve through. It comes from mondoo.yml or, through
+// viper's env binding, from MONDOO_UPDATE_CHANNEL.
+//
+// The key is flat rather than nested under `update` or `providers` because
+// InitViperConfig disables viper's key delimiter, so a dotted lookup of a
+// nested key silently returns nothing.
+const KeyUpdateChannel = "update_channel"
+
+// Release channels. The channel a version belongs to is decided by the release
+// service, from the version's semver pre-release segment; the client only picks
+// which track to ask for.
+const (
+	// ChannelStable is the default: the newest release with no pre-release
+	// segment.
+	ChannelStable = "stable"
+	// ChannelPreview is the pre-release track: the newest release overall,
+	// release candidates included. It is never older than stable, so a client
+	// tracking it moves forward when a candidate becomes a final release.
+	ChannelPreview = "preview"
+)
+
+// GetUpdateChannel returns the update_channel setting, normalized. An unset or
+// unrecognized value is stable: a typo must not silently put a fleet on
+// pre-releases, and it must not stop updates either.
+func GetUpdateChannel() string {
+	channel := strings.ToLower(strings.TrimSpace(viper.GetString(KeyUpdateChannel)))
+	switch channel {
+	case ChannelPreview:
+		return ChannelPreview
+	default:
+		return ChannelStable
+	}
+}
+
 // GetFeatures returns the features from viper config.
 // This can be called after InitViperConfig() to get features before cobra initialization.
 func GetFeatures() mql.Features {
@@ -337,6 +372,10 @@ type CommonOpts struct {
 	// transport, so the setting has no effect elsewhere. Unset means an
 	// OS-assigned port. See KeyProviderPortRange.
 	ProviderPortRange string `json:"provider_port_range,omitempty" mapstructure:"provider_port_range"`
+
+	// UpdateChannel selects which release track binary updates and providers
+	// resolve through. Unset means "stable". See KeyUpdateChannel.
+	UpdateChannel string `json:"update_channel,omitempty" mapstructure:"update_channel"`
 }
 
 // Workload Identity Federation

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -249,17 +249,63 @@ const (
 	ChannelPreview = "preview"
 )
 
-// GetUpdateChannel returns the update_channel setting, normalized. An unset or
-// unrecognized value is stable: a typo must not silently put a fleet on
-// pre-releases, and it must not stop updates either.
+// runningVersion is the version of the binary that is executing, set once at
+// startup by the app. Empty means unknown, which reads as stable.
+//
+// It is injected rather than read from a package variable because the binary
+// that matters is cnspec or mql, and this package is shared by both.
+var runningVersion string
+
+// SetRunningVersion records the executing binary's version, so an unset
+// update_channel can follow the build rather than defaulting to stable. Call it
+// before anything resolves a channel.
+func SetRunningVersion(version string) {
+	runningVersion = version
+}
+
+// GetUpdateChannel returns the release channel this binary resolves through.
+//
+// An explicit update_channel wins. An unrecognized one is stable: a typo must
+// not silently put a fleet on pre-releases, and it must not stop updates
+// either.
+//
+// With nothing configured the channel follows the running build. Installing a
+// pre-release and then resolving *stable* providers is the v13/v14 mismatch in
+// miniature: a 14.0.0-rc.2 binary would pull 13.x providers, built against a
+// different schema, and report the resulting nulls as passing checks. Someone
+// who installed a release candidate has already chosen the pre-release track;
+// making them say so twice only creates a way to get it half-applied.
+//
+// The inverse holds too, and is what keeps this safe: a stable build never
+// derives preview, so no released binary can be moved onto pre-releases by
+// anything other than an explicit setting.
 func GetUpdateChannel() string {
-	channel := strings.ToLower(strings.TrimSpace(viper.GetString(KeyUpdateChannel)))
-	switch channel {
+	switch strings.ToLower(strings.TrimSpace(viper.GetString(KeyUpdateChannel))) {
 	case ChannelPreview:
 		return ChannelPreview
+	case ChannelStable:
+		return ChannelStable
+	case "":
+		if isPrereleaseVersion(runningVersion) {
+			return ChannelPreview
+		}
+		return ChannelStable
 	default:
 		return ChannelStable
 	}
+}
+
+// isPrereleaseVersion reports whether a version carries a semver pre-release
+// segment. Build metadata is stripped first: it is not a pre-release under
+// SemVer 10, and it is where the edge builds put their commit counter.
+//
+// Deliberately not a full semver parse. This has to answer for "unstable" and
+// for the `-rolling` suffix as well as for real versions, and a parse error on
+// a development build must not decide a channel.
+func isPrereleaseVersion(version string) bool {
+	core, _, _ := strings.Cut(version, "+")
+	_, prerelease, found := strings.Cut(strings.TrimPrefix(core, "v"), "-")
+	return found && prerelease != ""
 }
 
 // GetFeatures returns the features from viper config.

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"os"
 	"strings"
+	"sync/atomic"
 
 	"github.com/cockroachdb/errors"
 	"github.com/go-viper/mapstructure/v2"
@@ -254,45 +255,67 @@ const (
 //
 // It is injected rather than read from a package variable because the binary
 // that matters is cnspec or mql, and this package is shared by both.
-var runningVersion string
+//
+// atomic.Value rather than a plain string: the write happens once at startup
+// and the reads come later, so there is no race today, but nothing in the types
+// says so. Tests in particular are free to run in parallel.
+var runningVersion atomic.Value // string
 
 // SetRunningVersion records the executing binary's version, so an unset
 // update_channel can follow the build rather than defaulting to stable. Call it
 // before anything resolves a channel.
 func SetRunningVersion(version string) {
-	runningVersion = version
+	runningVersion.Store(version)
+}
+
+// getRunningVersion returns the recorded version, or "" if none was set.
+func getRunningVersion() string {
+	version, _ := runningVersion.Load().(string)
+	return version
 }
 
 // GetUpdateChannel returns the release channel this binary resolves through.
 //
-// An explicit update_channel wins. An unrecognized one is stable: a typo must
-// not silently put a fleet on pre-releases, and it must not stop updates
-// either.
+// An explicit update_channel wins. Anything else -- unset, or a value we do not
+// recognize -- follows the running build: a pre-release build resolves the
+// pre-release track, everything else resolves stable.
 //
-// With nothing configured the channel follows the running build. Installing a
-// pre-release and then resolving *stable* providers is the v13/v14 mismatch in
-// miniature: a 14.0.0-rc.2 binary would pull 13.x providers, built against a
-// different schema, and report the resulting nulls as passing checks. Someone
-// who installed a release candidate has already chosen the pre-release track;
+// Following the build matters because installing a pre-release and then
+// resolving *stable* providers is the v13/v14 mismatch in miniature. A
+// 14.0.0-rc.2 binary would pull 13.x providers, built against a different
+// schema, and report the resulting nulls as passing checks. Someone who
+// installed a release candidate has already chosen the pre-release track;
 // making them say so twice only creates a way to get it half-applied.
 //
-// The inverse holds too, and is what keeps this safe: a stable build never
-// derives preview, so no released binary can be moved onto pre-releases by
-// anything other than an explicit setting.
+// An unrecognized value is treated as unset rather than forced to stable. It
+// means "we do not know what you asked for", and the honest answer to that is
+// the default behaviour, not a third one. Forcing stable would have produced
+// exactly the schema mismatch above for anyone who typed `beta` meaning
+// `preview` on a release candidate.
+//
+// A stable build still never derives preview, which is what keeps this safe: no
+// released binary can be moved onto pre-releases by a typo, only by asking for
+// it precisely.
 func GetUpdateChannel() string {
-	switch strings.ToLower(strings.TrimSpace(viper.GetString(KeyUpdateChannel))) {
+	configured := strings.ToLower(strings.TrimSpace(viper.GetString(KeyUpdateChannel)))
+
+	switch configured {
 	case ChannelPreview:
 		return ChannelPreview
 	case ChannelStable:
 		return ChannelStable
 	case "":
-		if isPrereleaseVersion(runningVersion) {
-			return ChannelPreview
-		}
-		return ChannelStable
 	default:
-		return ChannelStable
+		log.Warn().
+			Str("configured", configured).
+			Str(KeyUpdateChannel, strings.Join([]string{ChannelStable, ChannelPreview}, ", ")).
+			Msg("unknown update channel, falling back to the channel this build belongs to")
 	}
+
+	if isPrereleaseVersion(getRunningVersion()) {
+		return ChannelPreview
+	}
+	return ChannelStable
 }
 
 // isPrereleaseVersion reports whether a version carries a semver pre-release

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -416,16 +416,25 @@ func TestGetUpdateChannelFollowsTheBuild(t *testing.T) {
 	viper.Set(KeyUpdateChannel, ChannelPreview)
 	assert.Equal(t, ChannelPreview, GetUpdateChannel(), "explicit preview must override a stable build")
 
-	// A typo still falls back to stable, even on a pre-release build: the
-	// value was not understood, so it cannot be acted on.
+	// An unrecognized value is treated as unset, not forced to stable. Someone
+	// who typed `beta` meaning `preview` on a release candidate would otherwise
+	// get stable providers against a pre-release binary — the exact schema
+	// mismatch this is here to prevent.
 	SetRunningVersion("14.0.0-rc.2")
+	viper.Set(KeyUpdateChannel, "beta")
+	assert.Equal(t, ChannelPreview, GetUpdateChannel())
+
+	// And on a stable build the same typo is still stable, so a garbage value
+	// can never move a released binary onto pre-releases.
+	SetRunningVersion("13.38.1")
 	viper.Set(KeyUpdateChannel, "beta")
 	assert.Equal(t, ChannelStable, GetUpdateChannel())
 }
 
 // TestGetUpdateChannel pins that a typo cannot silently move a fleet onto
-// pre-releases, and cannot stop it updating either: anything unrecognized is
-// stable.
+// pre-releases, and cannot stop it updating either. With no running version
+// recorded — a stable build, or a caller that never set one — anything
+// unrecognized resolves stable.
 func TestGetUpdateChannel(t *testing.T) {
 	t.Cleanup(func() { viper.Set(KeyUpdateChannel, "") })
 	SetRunningVersion("")

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -374,3 +374,24 @@ func TestGetProviderPortRange(t *testing.T) {
 		assert.Equal(t, "50000-50100", GetProviderPortRange())
 	})
 }
+
+// TestGetUpdateChannel pins that a typo cannot silently move a fleet onto
+// pre-releases, and cannot stop it updating either: anything unrecognized is
+// stable.
+func TestGetUpdateChannel(t *testing.T) {
+	t.Cleanup(func() { viper.Set(KeyUpdateChannel, "") })
+
+	for value, want := range map[string]string{
+		"":         ChannelStable,
+		"stable":   ChannelStable,
+		"preview":  ChannelPreview,
+		"PREVIEW":  ChannelPreview,
+		" preview": ChannelPreview,
+		"beta":     ChannelStable,
+		"edge":     ChannelStable,
+		"rubbish":  ChannelStable,
+	} {
+		viper.Set(KeyUpdateChannel, value)
+		assert.Equal(t, want, GetUpdateChannel(), "value: %q", value)
+	}
+}

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -375,11 +375,60 @@ func TestGetProviderPortRange(t *testing.T) {
 	})
 }
 
+// TestGetUpdateChannelFollowsTheBuild pins that a pre-release binary resolves
+// pre-release providers without being told to.
+//
+// Installing a 14.0.0-rc.2 binary and then pulling 13.x providers is the
+// v13/v14 mismatch in miniature: they are built against a different schema, and
+// the resulting nulls read as passing checks. The inverse is what keeps it
+// safe — a stable build never derives preview, so no released binary can be
+// moved onto pre-releases except by an explicit setting.
+func TestGetUpdateChannelFollowsTheBuild(t *testing.T) {
+	t.Cleanup(func() {
+		viper.Set(KeyUpdateChannel, "")
+		SetRunningVersion("")
+	})
+
+	for version, want := range map[string]string{
+		"14.0.0-rc.2":      ChannelPreview,
+		"14.0.0-pre.1":     ChannelPreview,
+		"v14.0.0-rc.2":     ChannelPreview,
+		"14.0.0-rc.2.3508": ChannelPreview,
+		"14.0.0-rolling":   ChannelPreview,
+		"13.38.1":          ChannelStable,
+		"14.0.0":           ChannelStable,
+		"8.4.0+41":         ChannelStable, // build metadata is not a pre-release
+		"unstable":         ChannelStable, // a build with no version ldflags
+		"":                 ChannelStable,
+	} {
+		viper.Set(KeyUpdateChannel, "")
+		SetRunningVersion(version)
+		assert.Equal(t, want, GetUpdateChannel(), "version: %q", version)
+	}
+
+	// An explicit setting wins over the build in both directions, so a
+	// pre-release can be pinned to stable and vice versa.
+	SetRunningVersion("14.0.0-rc.2")
+	viper.Set(KeyUpdateChannel, ChannelStable)
+	assert.Equal(t, ChannelStable, GetUpdateChannel(), "explicit stable must override a pre-release build")
+
+	SetRunningVersion("13.38.1")
+	viper.Set(KeyUpdateChannel, ChannelPreview)
+	assert.Equal(t, ChannelPreview, GetUpdateChannel(), "explicit preview must override a stable build")
+
+	// A typo still falls back to stable, even on a pre-release build: the
+	// value was not understood, so it cannot be acted on.
+	SetRunningVersion("14.0.0-rc.2")
+	viper.Set(KeyUpdateChannel, "beta")
+	assert.Equal(t, ChannelStable, GetUpdateChannel())
+}
+
 // TestGetUpdateChannel pins that a typo cannot silently move a fleet onto
 // pre-releases, and cannot stop it updating either: anything unrecognized is
 // stable.
 func TestGetUpdateChannel(t *testing.T) {
 	t.Cleanup(func() { viper.Set(KeyUpdateChannel, "") })
+	SetRunningVersion("")
 
 	for value, want := range map[string]string{
 		"":         ChannelStable,

--- a/cli/selfupdate/selfupdate.go
+++ b/cli/selfupdate/selfupdate.go
@@ -42,6 +42,10 @@ const (
 	EnvAutoUpdateEngine = "MONDOO_AUTO_UPDATE_ENGINE"
 	// DefaultReleaseURL is the URL to fetch the latest release information
 	DefaultReleaseURL = "https://releases.mondoo.com/mql/latest.json"
+
+	// DefaultReleasesURL is the release bucket the manifest is read from when
+	// updates_url is not configured.
+	DefaultReleasesURL = "https://releases.mondoo.com"
 	// markerFilePrefix is the prefix for per-binary marker files that track when the last update check occurred.
 	// Each binary gets its own marker (e.g., ".last-update-check-mql", ".last-update-check-cnspec").
 	markerFilePrefix = ".last-update-check-"
@@ -69,6 +73,21 @@ type Release struct {
 	Name    string        `json:"name"`
 	Version string        `json:"version"`
 	Files   []ReleaseFile `json:"files"`
+}
+
+// ChannelManifest returns the manifest document a release channel is published
+// as, next to the artifacts it points at.
+//
+// A channel changes which pointer is read, never where the artifacts live, so a
+// pinned version resolves the same on every channel. Note this is the bucket
+// spelling: the install service instead takes the channel as a `?channel=`
+// query parameter, because its routes are named after the package rather than
+// after the document.
+func ChannelManifest(channel string) string {
+	if channel == config.ChannelPreview {
+		return "preview.json"
+	}
+	return "latest.json"
 }
 
 // ReleaseFile represents a downloadable release file

--- a/providers/registry.go
+++ b/providers/registry.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/cli/config"
 	"go.mondoo.com/mql/utils/httpx"
 	"golang.org/x/sync/singleflight"
 )
@@ -66,6 +67,11 @@ const (
 type MondooProviderRegistry struct {
 	BaseURL string
 
+	// Channel is the release track provider versions resolve through. Empty
+	// means "read it from config at fetch time", which is what the package-level
+	// registry does.
+	Channel string
+
 	// CacheTTL is how long a fetched latest.json is reused. Zero means
 	// defaultLatestVersionsTTL.
 	CacheTTL time.Duration
@@ -102,6 +108,13 @@ func WithBaseURL(baseURL string) MondooProviderRegistryOption {
 	}
 }
 
+// WithChannel pins the release track, overriding the configured one.
+func WithChannel(channel string) MondooProviderRegistryOption {
+	return func(r *MondooProviderRegistry) {
+		r.Channel = channel
+	}
+}
+
 // NewMondooProviderRegistry creates a new MondooProviderRegistry with the given options.
 // By default, it uses "https://releases.mondoo.com/providers" as the base URL.
 func NewMondooProviderRegistry(opts ...MondooProviderRegistryOption) *MondooProviderRegistry {
@@ -118,6 +131,31 @@ func NewMondooProviderRegistry(opts ...MondooProviderRegistryOption) *MondooProv
 
 func LatestVersion(ctx context.Context, name string) (string, error) {
 	return registry.GetLatestVersion(ctx, name)
+}
+
+// channel returns the release track this registry resolves through.
+//
+// It is read at fetch time rather than captured in the constructor: the
+// package-level registry is built during package init, long before
+// InitViperConfig has read mondoo.yml, so a constructor would only ever see the
+// default. Reading it here also means every path that reaches a provider
+// install honours the setting, not just the ones that went through AttachCLIs.
+func (r *MondooProviderRegistry) channel() string {
+	if r.Channel != "" {
+		return r.Channel
+	}
+	return config.GetUpdateChannel()
+}
+
+// pointerDocument is the document listing each provider's current version for
+// this registry's channel. Providers live in one tree, so a channel changes
+// which pointer is read and nothing else: the archive, provider.json and
+// schema.json URLs are the same on every channel.
+func (r *MondooProviderRegistry) pointerDocument() string {
+	if r.channel() == config.ChannelPreview {
+		return "preview.json"
+	}
+	return "latest.json"
 }
 
 func (r *MondooProviderRegistry) clock() time.Time {
@@ -201,10 +239,12 @@ func (r *MondooProviderRegistry) fetchLatestVersions(ctx context.Context) (*Prov
 		return nil, err
 	}
 
-	latestURL, err := url.JoinPath(r.BaseURL, "latest.json")
+	pointer := r.pointerDocument()
+	latestURL, err := url.JoinPath(r.BaseURL, pointer)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to construct latest version URL")
 	}
+	log.Debug().Str("url", latestURL).Str("channel", r.channel()).Msg("fetching provider versions")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestURL, nil)
 	if err != nil {

--- a/providers/registry_test.go
+++ b/providers/registry_test.go
@@ -9,13 +9,16 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/cli/config"
 )
 
 func TestNewMondooProviderRegistry(t *testing.T) {
@@ -366,4 +369,61 @@ func TestFlushVersionCacheForcesRefetch(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, int64(2), atomic.LoadInt64(&hits))
+}
+
+// TestRegistryChannelSelectsPointerDocument pins that the release track changes
+// which pointer document the registry reads, and nothing else. Providers live in
+// one tree: a preview client downloads the same archives from the same URLs, it
+// just resolves a different version for them.
+func TestRegistryChannelSelectsPointerDocument(t *testing.T) {
+	var requested []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.URL.Path)
+
+		version := "13.53.4"
+		if strings.HasSuffix(r.URL.Path, "/preview.json") {
+			version = "14.0.0-rc.2"
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"providers":[{"name":"aws","version":"` + version + `"}]}`))
+	}))
+	defer server.Close()
+
+	t.Run("stable reads latest.json", func(t *testing.T) {
+		r := NewMondooProviderRegistry(WithBaseURL(server.URL), WithChannel(config.ChannelStable))
+		v, err := r.GetLatestVersion(context.Background(), "aws")
+		require.NoError(t, err)
+		assert.Equal(t, "13.53.4", v)
+	})
+
+	t.Run("preview reads preview.json", func(t *testing.T) {
+		r := NewMondooProviderRegistry(WithBaseURL(server.URL), WithChannel(config.ChannelPreview))
+		v, err := r.GetLatestVersion(context.Background(), "aws")
+		require.NoError(t, err)
+		assert.Equal(t, "14.0.0-rc.2", v)
+	})
+
+	assert.Equal(t, []string{"/latest.json", "/preview.json"}, requested)
+}
+
+// TestRegistryChannelReadAtFetchTime pins the reason the channel is not captured
+// in the constructor: the package-level registry is built during package init,
+// before InitViperConfig has read mondoo.yml, so a constructor-time read would
+// only ever see the default.
+func TestRegistryChannelReadAtFetchTime(t *testing.T) {
+	r := NewMondooProviderRegistry(WithBaseURL("https://example.com/providers"))
+
+	viper.Set(config.KeyUpdateChannel, "")
+	t.Cleanup(func() { viper.Set(config.KeyUpdateChannel, "") })
+	assert.Equal(t, "latest.json", r.pointerDocument(), "built before config was loaded")
+
+	// Same registry instance, config loaded afterwards.
+	viper.Set(config.KeyUpdateChannel, "preview")
+	assert.Equal(t, "preview.json", r.pointerDocument())
+
+	// An explicit channel wins over config: that is what WithChannel is for.
+	pinned := NewMondooProviderRegistry(WithChannel(config.ChannelStable))
+	assert.Equal(t, "latest.json", pinned.pointerDocument())
 }


### PR DESCRIPTION
Client half of the release-channels work. `update_channel: preview` (or `MONDOO_UPDATE_CHANNEL=preview`) resolves binary updates and provider versions through the pre-release track instead of stable.

The channel rule is SemVer §9 and §10 with nothing added: a version with a pre-release segment is `preview`, one without is `stable`, and build metadata is not a pre-release. The publisher side that writes the channel pointers has already shipped.

## `update_channel`

Unset is stable, and so is anything unrecognized — a typo must not silently move a fleet onto release candidates, and must not stop it updating either.

The key is **flat**, not nested under `update` or `providers`, because `InitViperConfig` disables viper's key delimiter: `viper.GetString("providers.channel")` on a nested key returns nothing, and the setting would appear to be ignored.

The registry reads the channel **at fetch time, not in the constructor**. The package-level registry is built during package init, before `InitViperConfig` has read `mondoo.yml`, so a constructor-time read would only ever see the default — and reading it at fetch time means every path into a provider install honours it, not only the ones that went through `AttachCLIs`, which is where the base URL override is installed.

A channel selects which pointer document is read and nothing else. Artifacts live in one tree, so a pinned version resolves identically on every channel.

## Provider major-promotion guard

Providers share one namespace across release lines, and every client resolves through `providers/latest.json` — whatever is newest there is what the whole fleet installs. There is no second namespace and no compatibility gate on that path.

Today only `v13` publishes providers, which is the single line of config keeping the release lines apart. Adding `main` to that trigger is what publishing v14 providers requires, and the next routine bump on `main` would then hand every v13 client a provider built for v14.

A version carrying a pre-release segment lands in `preview` and stable clients never see it; a plain one does not. So a plain version whose major is ahead of what stable serves now fails the scoping job, naming both versions and the two ways forward.

## Two release-workflow fixes

**Channel derivation replaces a substring list.** `contains(github.ref, 'alpha') || ...` disagreed with the equivalent lists in cnspec and in the publishing tools. A malformed tag now fails the run rather than silently classifying as stable.

**Build metadata carrying a pre-release marker is rejected.** SemVer §10 says build metadata MUST be ignored for precedence, so `v14.0.0+rc.1` does not mean release candidate — verified with the same comparator the indexer uses:

| Comparison | Result |
|---|---|
| `14.0.0-rc.2` vs `14.0.0` | `<` ✅ pre-release ranks below |
| `14.0.0+pre` vs `14.0.0` | `==` — metadata ignored |
| `14.0.0+pre` vs `14.0.0-rc.2` | `>` — outranks every rc |

Such a tag derives **stable** and would ship to every user. The derivation strips metadata before looking for a pre-release segment, so it passed silently. It now fails and names the hyphenated spelling instead. Other build metadata warns rather than fails: legal, just inert.

## Review focus

- `GetUpdateChannel` normalization, and the flat-key rationale.
- The fetch-time channel read in the registry — the comment explains why it is not in the constructor.
- The major-promotion guard's escape hatch (`allow_major_promotion`).

`cnspec status` / `mql status` print a Channel row when it is not stable, so support can establish it in one command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

