### PR TITLE
✨ os/windows: add windows.logonSessions for active logon sessions

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -11114,6 +11114,9 @@ windows {
   // Registered Windows Task Scheduler tasks
   scheduledTasks() []windows.scheduledTask
 
+  // Active logon sessions
+  logonSessions() []windows.logonSession
+
   // Device Guard policy (Virtualization-Based Security, HVCI, and Credential Guard)
   deviceGuard() windows.deviceGuard
   // System-wide Windows Exploit Protection configuration
@@ -11440,6 +11443,63 @@ private windows.scheduledTask.settings @defaults("enabled hidden priority") {
   networkId string
   // Name of the network profile the task is tied to
   networkName string
+}
+
+// Windows logon session
+//
+// Single active logon session as the Local Security Authority reports it:
+// the `logonType` that created it, the `authenticationPackage` that
+// authenticated it, the account it runs as, and when it started.
+// `logonType` and its readable form `logonTypeName` carry most of the audit
+// value, since a session's type says how it was established: 10 is an
+// incoming Remote Desktop logon, 3 is a network logon, and 9 is a session
+// created with alternate credentials. `authenticationPackage` reports
+// whether the session was authenticated with Kerberos or fell back to NTLM.
+private windows.logonSession @defaults("logonTypeName accountName authenticationPackage") {
+  // Locally unique identifier the Local Security Authority assigned
+  //
+  // For example "0x3e7". Unique for the life of the boot, and reused after a
+  // restart, so it identifies a session within one scan rather than over time.
+  logonId string
+  // How the session was established
+  //
+  // 2 interactive, 3 network, 4 batch, 5 service, 7 unlock, 8 network
+  // cleartext, 9 new credentials, 10 remote interactive, 11 cached
+  // interactive.
+  logonType int
+  // Readable form of logonType
+  //
+  // For example "RemoteInteractive" for type 10. Empty for a type outside
+  // the documented set, in which case read logonType directly.
+  logonTypeName string
+  // Package that authenticated the session
+  //
+  // For example "Kerberos", "NTLM", or "Negotiate".
+  authenticationPackage string
+  // When the session started
+  //
+  // Null when the Local Security Authority reports no start time, which is
+  // normal for some of the sessions the system creates at boot.
+  startTime time
+  // Account name the session authenticated as
+  accountName string
+  // Domain of the account the session authenticated as
+  //
+  // The machine name for a local account, the domain name for a domain
+  // account, and "NT AUTHORITY" for the accounts the system creates.
+  accountDomain string
+  // Security identifier of the account the session authenticated as
+  //
+  // Empty when the account could not be translated to a SID, which happens
+  // for a domain account while the domain is unreachable.
+  sid string
+  // Local user account the session authenticated as
+  //
+  // Matched on `sid`, so it resolves only for an account that exists on this
+  // machine. Null for a domain account, for the accounts the system creates,
+  // and when the SID could not be translated. Read `accountName` and
+  // `accountDomain` to identify a session whose account is not local.
+  user() user
 }
 
 // macOS system extension

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -11458,8 +11458,11 @@ private windows.scheduledTask.settings @defaults("enabled hidden priority") {
 private windows.logonSession @defaults("logonTypeName accountName authenticationPackage") {
   // Locally unique identifier the Local Security Authority assigned
   //
-  // For example "0x3e7". Unique for the life of the boot, and reused after a
-  // restart, so it identifies a session within one scan rather than over time.
+  // The decimal low part of the LUID, which is the form WMI reports, for
+  // example "999" for the session the system creates at boot. Tools that
+  // print the same identifier in hex show that one as 0x3e7. Unique for the
+  // life of the boot, and reused after a restart, so it identifies a session
+  // within one scan rather than over time.
   logonId string
   // How the session was established
   //

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -422,6 +422,7 @@ const (
 	ResourceWindowsScheduledTaskAction                    string = "windows.scheduledTask.action"
 	ResourceWindowsScheduledTaskTrigger                   string = "windows.scheduledTask.trigger"
 	ResourceWindowsScheduledTaskSettings                  string = "windows.scheduledTask.settings"
+	ResourceWindowsLogonSession                           string = "windows.logonSession"
 	ResourceMacosSystemExtension                          string = "macos.systemExtension"
 	ResourceSafari                                        string = "safari"
 	ResourceSafariExtension                               string = "safari.extension"
@@ -2261,6 +2262,10 @@ func init() {
 		"windows.scheduledTask.settings": {
 			// to override args, implement: initWindowsScheduledTaskSettings(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createWindowsScheduledTaskSettings,
+		},
+		"windows.logonSession": {
+			// to override args, implement: initWindowsLogonSession(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createWindowsLogonSession,
 		},
 		"macos.systemExtension": {
 			// to override args, implement: initMacosSystemExtension(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -11834,6 +11839,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"windows.scheduledTasks": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindows).GetScheduledTasks()).ToDataRes(types.Array(types.Resource("windows.scheduledTask")))
 	},
+	"windows.logonSessions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindows).GetLogonSessions()).ToDataRes(types.Array(types.Resource("windows.logonSession")))
+	},
 	"windows.deviceGuard": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindows).GetDeviceGuard()).ToDataRes(types.Resource("windows.deviceGuard"))
 	},
@@ -12115,6 +12123,33 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"windows.scheduledTask.settings.networkName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsScheduledTaskSettings).GetNetworkName()).ToDataRes(types.String)
+	},
+	"windows.logonSession.logonId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLogonSession).GetLogonId()).ToDataRes(types.String)
+	},
+	"windows.logonSession.logonType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLogonSession).GetLogonType()).ToDataRes(types.Int)
+	},
+	"windows.logonSession.logonTypeName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLogonSession).GetLogonTypeName()).ToDataRes(types.String)
+	},
+	"windows.logonSession.authenticationPackage": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLogonSession).GetAuthenticationPackage()).ToDataRes(types.String)
+	},
+	"windows.logonSession.startTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLogonSession).GetStartTime()).ToDataRes(types.Time)
+	},
+	"windows.logonSession.accountName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLogonSession).GetAccountName()).ToDataRes(types.String)
+	},
+	"windows.logonSession.accountDomain": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLogonSession).GetAccountDomain()).ToDataRes(types.String)
+	},
+	"windows.logonSession.sid": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLogonSession).GetSid()).ToDataRes(types.String)
+	},
+	"windows.logonSession.user": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsLogonSession).GetUser()).ToDataRes(types.Resource("user"))
 	},
 	"macos.systemExtension.identifier": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMacosSystemExtension).GetIdentifier()).ToDataRes(types.String)
@@ -30208,6 +30243,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlWindows).ScheduledTasks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"windows.logonSessions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindows).LogonSessions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"windows.deviceGuard": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindows).DeviceGuard, ok = plugin.RawToTValue[*mqlWindowsDeviceGuard](v.Value, v.Error)
 		return
@@ -30630,6 +30669,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"windows.scheduledTask.settings.networkName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindowsScheduledTaskSettings).NetworkName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.logonSession.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLogonSession).__id, ok = v.Value.(string)
+		return
+	},
+	"windows.logonSession.logonId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLogonSession).LogonId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.logonSession.logonType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLogonSession).LogonType, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"windows.logonSession.logonTypeName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLogonSession).LogonTypeName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.logonSession.authenticationPackage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLogonSession).AuthenticationPackage, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.logonSession.startTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLogonSession).StartTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"windows.logonSession.accountName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLogonSession).AccountName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.logonSession.accountDomain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLogonSession).AccountDomain, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.logonSession.sid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLogonSession).Sid, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.logonSession.user": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsLogonSession).User, ok = plugin.RawToTValue[*mqlUser](v.Value, v.Error)
 		return
 	},
 	"macos.systemExtension.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -77885,6 +77964,7 @@ type mqlWindows struct {
 	ServerFeatures    plugin.TValue[[]any]
 	OptionalFeatures  plugin.TValue[[]any]
 	ScheduledTasks    plugin.TValue[[]any]
+	LogonSessions     plugin.TValue[[]any]
 	DeviceGuard       plugin.TValue[*mqlWindowsDeviceGuard]
 	ExploitProtection plugin.TValue[*mqlWindowsExploitProtection]
 	SmartScreen       plugin.TValue[*mqlWindowsSmartScreen]
@@ -77989,6 +78069,22 @@ func (c *mqlWindows) GetScheduledTasks() *plugin.TValue[[]any] {
 		}
 
 		return c.scheduledTasks()
+	})
+}
+
+func (c *mqlWindows) GetLogonSessions() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.LogonSessions, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("windows", c.__id, "logonSessions")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.logonSessions()
 	})
 }
 
@@ -79100,6 +79196,107 @@ func (c *mqlWindowsScheduledTaskSettings) GetNetworkId() *plugin.TValue[string] 
 
 func (c *mqlWindowsScheduledTaskSettings) GetNetworkName() *plugin.TValue[string] {
 	return &c.NetworkName
+}
+
+// mqlWindowsLogonSession for the windows.logonSession resource
+type mqlWindowsLogonSession struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlWindowsLogonSessionInternal it will be used here
+	LogonId               plugin.TValue[string]
+	LogonType             plugin.TValue[int64]
+	LogonTypeName         plugin.TValue[string]
+	AuthenticationPackage plugin.TValue[string]
+	StartTime             plugin.TValue[*time.Time]
+	AccountName           plugin.TValue[string]
+	AccountDomain         plugin.TValue[string]
+	Sid                   plugin.TValue[string]
+	User                  plugin.TValue[*mqlUser]
+}
+
+// createWindowsLogonSession creates a new instance of this resource
+func createWindowsLogonSession(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlWindowsLogonSession{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("windows.logonSession", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlWindowsLogonSession) MqlName() string {
+	return "windows.logonSession"
+}
+
+func (c *mqlWindowsLogonSession) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlWindowsLogonSession) GetLogonId() *plugin.TValue[string] {
+	return &c.LogonId
+}
+
+func (c *mqlWindowsLogonSession) GetLogonType() *plugin.TValue[int64] {
+	return &c.LogonType
+}
+
+func (c *mqlWindowsLogonSession) GetLogonTypeName() *plugin.TValue[string] {
+	return &c.LogonTypeName
+}
+
+func (c *mqlWindowsLogonSession) GetAuthenticationPackage() *plugin.TValue[string] {
+	return &c.AuthenticationPackage
+}
+
+func (c *mqlWindowsLogonSession) GetStartTime() *plugin.TValue[*time.Time] {
+	return &c.StartTime
+}
+
+func (c *mqlWindowsLogonSession) GetAccountName() *plugin.TValue[string] {
+	return &c.AccountName
+}
+
+func (c *mqlWindowsLogonSession) GetAccountDomain() *plugin.TValue[string] {
+	return &c.AccountDomain
+}
+
+func (c *mqlWindowsLogonSession) GetSid() *plugin.TValue[string] {
+	return &c.Sid
+}
+
+func (c *mqlWindowsLogonSession) GetUser() *plugin.TValue[*mqlUser] {
+	return plugin.GetOrCompute[*mqlUser](&c.User, func() (*mqlUser, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("windows.logonSession", c.__id, "user")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlUser), nil
+			}
+		}
+
+		return c.user()
+	})
 }
 
 // mqlMacosSystemExtension for the macos.systemExtension resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -4664,6 +4664,17 @@ windows.hotfix.hotfixId 9.0.1
 windows.hotfix.installedBy 9.0.1
 windows.hotfix.installedOn 9.0.1
 windows.hotfixes 9.0.1
+windows.logonSession 13.40.10
+windows.logonSession.accountDomain 13.40.10
+windows.logonSession.accountName 13.40.10
+windows.logonSession.authenticationPackage 13.40.10
+windows.logonSession.logonId 13.40.10
+windows.logonSession.logonType 13.40.10
+windows.logonSession.logonTypeName 13.40.10
+windows.logonSession.sid 13.40.10
+windows.logonSession.startTime 13.40.10
+windows.logonSession.user 13.40.10
+windows.logonSessions 13.40.10
 windows.lsa 13.29.1
 windows.lsa.disableDomainCreds 13.29.1
 windows.lsa.everyoneIncludesAnonymous 13.29.1

--- a/providers/os/resources/windows/logonsession.go
+++ b/providers/os/resources/windows/logonsession.go
@@ -1,0 +1,150 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package windows
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"time"
+)
+
+// LogonSessionsScript enumerates the active logon sessions and the account
+// each one authenticated as.
+//
+// Two classes are needed. Win32_LogonSession carries the session itself but
+// names no account; Win32_LoggedOnUser is the association that ties a session
+// to one. The association is read first into a lookup so the sessions are
+// walked once rather than queried per session.
+//
+// A session can be associated with more than one account record. The first
+// wins: the duplicates describe the same principal reached by different
+// paths, so picking between them would report a difference that does not
+// exist.
+//
+// The SID is translated rather than read, because neither class carries one.
+// Translation reaches the domain controller for a domain account and fails
+// when it is unreachable, so it is guarded and the SID is simply absent in
+// that case rather than failing the whole collection.
+//
+// ConvertTo-Json is forced to a list with @(): PowerShell serializes a single
+// object as an object rather than a one-element array, which would otherwise
+// need two parse paths.
+const LogonSessionsScript = `
+$ErrorActionPreference = 'SilentlyContinue'
+$accounts = @{}
+Get-CimInstance -ClassName Win32_LoggedOnUser | ForEach-Object {
+  $id = $_.Dependent.LogonId
+  if ($id -and -not $accounts.ContainsKey($id)) {
+    $accounts[$id] = $_.Antecedent
+  }
+}
+@(Get-CimInstance -ClassName Win32_LogonSession | ForEach-Object {
+  $a = $accounts[$_.LogonId]
+  $sid = $null
+  if ($a -and $a.Name) {
+    try {
+      $nt = New-Object System.Security.Principal.NTAccount($a.Domain, $a.Name)
+      $sid = $nt.Translate([System.Security.Principal.SecurityIdentifier]).Value
+    } catch {}
+  }
+  $start = $null
+  if ($_.StartTime) { $start = $_.StartTime.ToUniversalTime().ToString('o') }
+  [PSCustomObject]@{
+    LogonId = $_.LogonId
+    LogonType = [int]$_.LogonType
+    AuthenticationPackage = $_.AuthenticationPackage
+    StartTime = $start
+    AccountName = $a.Name
+    AccountDomain = $a.Domain
+    Sid = $sid
+  }
+}) | ConvertTo-Json -Compress -Depth 3
+`
+
+// LogonSession is one active logon session as the LSA reports it.
+type LogonSession struct {
+	// LogonId is the LUID the LSA assigned, e.g. "0x3e7". Unique for the life
+	// of the boot and reused after a restart.
+	LogonId string `json:"LogonId"`
+	// LogonType is the documented Win32 logon type. See LogonTypeName.
+	LogonType int64 `json:"LogonType"`
+	// AuthenticationPackage is "Kerberos", "NTLM", "Negotiate" and so on.
+	AuthenticationPackage string `json:"AuthenticationPackage"`
+	// StartTime is nil when the LSA reported no start time, which is normal
+	// for some of the sessions created at boot. It must stay nil rather than
+	// becoming the zero time, which would report a session as having started
+	// in year 1.
+	StartTime     *time.Time `json:"-"`
+	AccountName   string     `json:"AccountName"`
+	AccountDomain string     `json:"AccountDomain"`
+	// Sid is empty when the account could not be translated, which happens for
+	// a domain account while the domain is unreachable.
+	Sid string `json:"Sid"`
+}
+
+// logonTypeNames maps the documented Win32 logon types to their names.
+//
+// The set is closed: these are the values SECURITY_LOGON_TYPE defines, and a
+// type outside it is reported as an empty name rather than guessed at, so a
+// caller can tell an unknown type from a known one.
+//
+// 1 is absent deliberately. It exists in the enumeration as an internal value
+// the LSA never reports on a session.
+var logonTypeNames = map[int64]string{
+	2:  "Interactive",
+	3:  "Network",
+	4:  "Batch",
+	5:  "Service",
+	7:  "Unlock",
+	8:  "NetworkCleartext",
+	9:  "NewCredentials",
+	10: "RemoteInteractive",
+	11: "CachedInteractive",
+}
+
+// LogonTypeName renders a logon type as its documented name, empty for a type
+// outside the documented set.
+func LogonTypeName(logonType int64) string {
+	return logonTypeNames[logonType]
+}
+
+// ParseLogonSessions reads the script's output.
+//
+// An empty document is not an error: a target that reported no sessions
+// legitimately has none to report.
+func ParseLogonSessions(r io.Reader) ([]LogonSession, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" || trimmed == "null" {
+		return []LogonSession{}, nil
+	}
+
+	// StartTime is decoded separately so that an absent value stays nil. A
+	// time.Time field would decode a missing timestamp to the zero time, which
+	// reports every such session as having started in year 1.
+	var raw []struct {
+		LogonSession
+		StartTime *string `json:"StartTime"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &raw); err != nil {
+		return nil, errors.New("failed to parse logon sessions: " + err.Error())
+	}
+
+	out := make([]LogonSession, 0, len(raw))
+	for _, r := range raw {
+		s := r.LogonSession
+		if r.StartTime != nil && strings.TrimSpace(*r.StartTime) != "" {
+			if t, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(*r.StartTime)); err == nil {
+				s.StartTime = &t
+			}
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}

--- a/providers/os/resources/windows/logonsession.go
+++ b/providers/os/resources/windows/logonsession.go
@@ -66,8 +66,9 @@ Get-CimInstance -ClassName Win32_LoggedOnUser | ForEach-Object {
 
 // LogonSession is one active logon session as the LSA reports it.
 type LogonSession struct {
-	// LogonId is the LUID the LSA assigned, e.g. "0x3e7". Unique for the life
-	// of the boot and reused after a restart.
+	// LogonId is the LUID the LSA assigned, as WMI reports it: the decimal
+	// low part, e.g. "999" for the session created at boot. Unique for the
+	// life of the boot and reused after a restart.
 	LogonId string `json:"LogonId"`
 	// LogonType is the documented Win32 logon type. See LogonTypeName.
 	LogonType int64 `json:"LogonType"`

--- a/providers/os/resources/windows/logonsession_test.go
+++ b/providers/os/resources/windows/logonsession_test.go
@@ -22,13 +22,13 @@ import (
 // incoming Remote Desktop logon by a domain account whose SID translated, and
 // a network logon whose SID did not.
 const logonSessionsJSON = `[
- {"LogonId":"0x3e7","LogonType":0,"AuthenticationPackage":"Negotiate","StartTime":null,
+ {"LogonId":"999","LogonType":0,"AuthenticationPackage":"Negotiate","StartTime":null,
   "AccountName":"WIN-SRV01$","AccountDomain":"WORKGROUP","Sid":"S-1-5-18"},
- {"LogonId":"0x1a2b3","LogonType":2,"AuthenticationPackage":"Negotiate","StartTime":"2026-09-11T14:23:11.1234567Z",
+ {"LogonId":"107587","LogonType":2,"AuthenticationPackage":"Negotiate","StartTime":"2026-09-11T14:23:11.1234567Z",
   "AccountName":"Administrator","AccountDomain":"WIN-SRV01","Sid":"S-1-5-21-1004336348-1177238915-682003330-500"},
- {"LogonId":"0x4c5d6","LogonType":10,"AuthenticationPackage":"Kerberos","StartTime":"2026-09-11T15:02:44.0000000Z",
+ {"LogonId":"312790","LogonType":10,"AuthenticationPackage":"Kerberos","StartTime":"2026-09-11T15:02:44.0000000Z",
   "AccountName":"jdoe","AccountDomain":"CONTOSO","Sid":"S-1-5-21-99-88-77-1105"},
- {"LogonId":"0x7e8f9","LogonType":3,"AuthenticationPackage":"NTLM","StartTime":"2026-09-11T15:10:02.5000000Z",
+ {"LogonId":"518393","LogonType":3,"AuthenticationPackage":"NTLM","StartTime":"2026-09-11T15:10:02.5000000Z",
   "AccountName":"svc_backup","AccountDomain":"CONTOSO","Sid":null}
 ]`
 
@@ -40,7 +40,7 @@ func TestParseLogonSessions(t *testing.T) {
 	// Every field read by value: a mistyped struct tag yields the zero value
 	// rather than an error, so only comparing the value catches it.
 	s := sessions[1]
-	assert.Equal(t, "0x1a2b3", s.LogonId)
+	assert.Equal(t, "107587", s.LogonId)
 	assert.Equal(t, int64(2), s.LogonType)
 	assert.Equal(t, "Negotiate", s.AuthenticationPackage)
 	assert.Equal(t, "Administrator", s.AccountName)
@@ -78,11 +78,11 @@ func TestParseLogonSessionsBadTimestamp(t *testing.T) {
 	// A timestamp that does not parse leaves the field null rather than
 	// failing the whole collection or inventing the zero time.
 	sessions, err := ParseLogonSessions(strings.NewReader(
-		`[{"LogonId":"0x1","LogonType":2,"StartTime":"not-a-timestamp"}]`))
+		`[{"LogonId":"1","LogonType":2,"StartTime":"not-a-timestamp"}]`))
 	require.NoError(t, err)
 	require.Len(t, sessions, 1)
 	assert.Nil(t, sessions[0].StartTime)
-	assert.Equal(t, "0x1", sessions[0].LogonId)
+	assert.Equal(t, "1", sessions[0].LogonId)
 }
 
 func TestLogonTypeName(t *testing.T) {

--- a/providers/os/resources/windows/logonsession_test.go
+++ b/providers/os/resources/windows/logonsession_test.go
@@ -1,0 +1,109 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package windows
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// logonSessionsJSON is the shape ConvertTo-Json produces for
+// LogonSessionsScript. Written by hand from the Win32_LogonSession and
+// Win32_LoggedOnUser field sets rather than captured from a run, so that it
+// cannot agree with the decoder by construction.
+//
+// The four records cover what decodes differently: the SYSTEM session the
+// machine creates at boot with no start time, an interactive local logon, an
+// incoming Remote Desktop logon by a domain account whose SID translated, and
+// a network logon whose SID did not.
+const logonSessionsJSON = `[
+ {"LogonId":"0x3e7","LogonType":0,"AuthenticationPackage":"Negotiate","StartTime":null,
+  "AccountName":"WIN-SRV01$","AccountDomain":"WORKGROUP","Sid":"S-1-5-18"},
+ {"LogonId":"0x1a2b3","LogonType":2,"AuthenticationPackage":"Negotiate","StartTime":"2026-09-11T14:23:11.1234567Z",
+  "AccountName":"Administrator","AccountDomain":"WIN-SRV01","Sid":"S-1-5-21-1004336348-1177238915-682003330-500"},
+ {"LogonId":"0x4c5d6","LogonType":10,"AuthenticationPackage":"Kerberos","StartTime":"2026-09-11T15:02:44.0000000Z",
+  "AccountName":"jdoe","AccountDomain":"CONTOSO","Sid":"S-1-5-21-99-88-77-1105"},
+ {"LogonId":"0x7e8f9","LogonType":3,"AuthenticationPackage":"NTLM","StartTime":"2026-09-11T15:10:02.5000000Z",
+  "AccountName":"svc_backup","AccountDomain":"CONTOSO","Sid":null}
+]`
+
+func TestParseLogonSessions(t *testing.T) {
+	sessions, err := ParseLogonSessions(strings.NewReader(logonSessionsJSON))
+	require.NoError(t, err)
+	require.Len(t, sessions, 4)
+
+	// Every field read by value: a mistyped struct tag yields the zero value
+	// rather than an error, so only comparing the value catches it.
+	s := sessions[1]
+	assert.Equal(t, "0x1a2b3", s.LogonId)
+	assert.Equal(t, int64(2), s.LogonType)
+	assert.Equal(t, "Negotiate", s.AuthenticationPackage)
+	assert.Equal(t, "Administrator", s.AccountName)
+	assert.Equal(t, "WIN-SRV01", s.AccountDomain)
+	assert.Equal(t, "S-1-5-21-1004336348-1177238915-682003330-500", s.Sid)
+
+	// A session the LSA reports with no start time must stay null. The zero
+	// time.Time would report it as having started in year 1, which reads as a
+	// real value and would satisfy any age comparison written against it.
+	assert.Nil(t, sessions[0].StartTime, "an absent start time must be null, not the zero time")
+
+	require.NotNil(t, s.StartTime)
+	assert.Equal(t, time.Date(2026, 9, 11, 14, 23, 11, 123456700, time.UTC), s.StartTime.UTC())
+
+	// An untranslatable SID is absent rather than an error on the collection.
+	assert.Empty(t, sessions[3].Sid)
+	assert.Equal(t, "NTLM", sessions[3].AuthenticationPackage)
+}
+
+func TestParseLogonSessionsEmpty(t *testing.T) {
+	// A target that reported no sessions is a normal state, not an error.
+	for _, in := range []string{"", "   ", "null", "[]"} {
+		sessions, err := ParseLogonSessions(strings.NewReader(in))
+		require.NoError(t, err, "input %q", in)
+		assert.Empty(t, sessions, "input %q", in)
+	}
+}
+
+func TestParseLogonSessionsMalformed(t *testing.T) {
+	_, err := ParseLogonSessions(strings.NewReader(`{"LogonId":`))
+	assert.Error(t, err)
+}
+
+func TestParseLogonSessionsBadTimestamp(t *testing.T) {
+	// A timestamp that does not parse leaves the field null rather than
+	// failing the whole collection or inventing the zero time.
+	sessions, err := ParseLogonSessions(strings.NewReader(
+		`[{"LogonId":"0x1","LogonType":2,"StartTime":"not-a-timestamp"}]`))
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.Nil(t, sessions[0].StartTime)
+	assert.Equal(t, "0x1", sessions[0].LogonId)
+}
+
+func TestLogonTypeName(t *testing.T) {
+	// The documented SECURITY_LOGON_TYPE values. These are the names policies
+	// are written against, so a wrong one silently retargets a check.
+	assert.Equal(t, "Interactive", LogonTypeName(2))
+	assert.Equal(t, "Network", LogonTypeName(3))
+	assert.Equal(t, "Batch", LogonTypeName(4))
+	assert.Equal(t, "Service", LogonTypeName(5))
+	assert.Equal(t, "Unlock", LogonTypeName(7))
+	assert.Equal(t, "NetworkCleartext", LogonTypeName(8))
+	assert.Equal(t, "NewCredentials", LogonTypeName(9))
+	assert.Equal(t, "RemoteInteractive", LogonTypeName(10))
+	assert.Equal(t, "CachedInteractive", LogonTypeName(11))
+
+	// Outside the documented set the name is empty rather than guessed, so a
+	// caller can tell an unknown type from a known one. 0 and 1 are reported
+	// by the system for sessions that predate a real logon.
+	assert.Empty(t, LogonTypeName(0))
+	assert.Empty(t, LogonTypeName(1))
+	assert.Empty(t, LogonTypeName(6))
+	assert.Empty(t, LogonTypeName(12))
+	assert.Empty(t, LogonTypeName(-1))
+}

--- a/providers/os/resources/windows_logonsession.go
+++ b/providers/os/resources/windows_logonsession.go
@@ -1,0 +1,112 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"io"
+
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/connection/shared"
+	"go.mondoo.com/mql/providers/os/resources/powershell"
+	"go.mondoo.com/mql/providers/os/resources/windows"
+)
+
+func (r *mqlWindowsLogonSession) id() (string, error) {
+	// The LSA assigns each session a locally unique identifier, which is
+	// unique for the life of the boot.
+	return "windows.logonSession/" + r.LogonId.Data, nil
+}
+
+func (w *mqlWindows) logonSessions() ([]any, error) {
+	conn := w.MqlRuntime.Connection.(shared.Connection)
+
+	executedCmd, err := conn.RunCommand(powershell.Encode(windows.LogonSessionsScript))
+	if err != nil {
+		return nil, err
+	}
+	if executedCmd.ExitStatus != 0 {
+		stderr, err := io.ReadAll(executedCmd.Stderr)
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New("failed to retrieve logon sessions: " + string(stderr))
+	}
+
+	sessions, err := windows.ParseLogonSessions(executedCmd.Stdout)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]any, 0, len(sessions))
+	for _, s := range sessions {
+		res, err := CreateResource(w.MqlRuntime, "windows.logonSession", map[string]*llx.RawData{
+			"logonId":               llx.StringData(s.LogonId),
+			"logonType":             llx.IntData(s.LogonType),
+			"logonTypeName":         llx.StringData(windows.LogonTypeName(s.LogonType)),
+			"authenticationPackage": llx.StringData(s.AuthenticationPackage),
+			// TimeDataPtr preserves a missing start time as null. A zero
+			// time.Time would report the session as having started in year 1.
+			"startTime":     llx.TimeDataPtr(s.StartTime),
+			"accountName":   llx.StringData(s.AccountName),
+			"accountDomain": llx.StringData(s.AccountDomain),
+			"sid":           llx.StringData(s.Sid),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
+// user resolves the session's account to a local user.
+//
+// Matched on SID only. An account name is not unique across a machine and the
+// domains it trusts, so matching on it would confidently return the wrong
+// user for a domain account that shares a name with a local one.
+//
+// Resolution goes through the cached users collection rather than a lookup per
+// session: `user` declares no init, and a per-session lookup would turn one
+// enumeration into one per session.
+func (r *mqlWindowsLogonSession) user() (*mqlUser, error) {
+	if r.Sid.Error != nil {
+		return nil, r.Sid.Error
+	}
+
+	sid := r.Sid.Data
+	if sid == "" {
+		// No SID to match on, which is the domain-unreachable case.
+		r.User.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	obj, err := CreateResource(r.MqlRuntime, "users", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	users := obj.(*mqlUsers)
+
+	list := users.GetList()
+	if list.Error != nil {
+		return nil, list.Error
+	}
+
+	for _, entry := range list.Data {
+		usr, ok := entry.(*mqlUser)
+		if !ok {
+			continue
+		}
+		if usr.Sid.Data == sid {
+			return usr, nil
+		}
+	}
+
+	// A domain account, or one of the accounts the system creates, is not a
+	// local user. The state has to be set explicitly, or the runtime does not
+	// know the field resolved and may re-fetch it.
+	r.User.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
+}

--- a/providers/os/resources/windows_logonsession.go
+++ b/providers/os/resources/windows_logonsession.go
@@ -17,6 +17,18 @@ import (
 func (r *mqlWindowsLogonSession) id() (string, error) {
 	// The LSA assigns each session a locally unique identifier, which is
 	// unique for the life of the boot.
+	//
+	// Both guards exist because an empty id is silently destructive here
+	// rather than merely wrong: every session missing one would share a cache
+	// key, and CreateResource returns the cached first instance for a repeated
+	// id, so the second session would report the first one's values. Failing
+	// loudly is the only outcome that does not invent data.
+	if r.LogonId.Error != nil {
+		return "", r.LogonId.Error
+	}
+	if r.LogonId.Data == "" {
+		return "", errors.New("windows.logonSession has no logonId")
+	}
 	return "windows.logonSession/" + r.LogonId.Data, nil
 }
 


### PR DESCRIPTION
## What

Adds `windows.logonSessions`, listing the active logon sessions as the Local Security Authority reports them.

`user.loggedIn` already answers whether an account has a session, but not what kind. It shells to `query user`, which reports interactive and Remote Desktop sessions only, with no logon type, no authentication package and no start time. Network, batch and service logons are invisible to it.

```
windows.logonSessions.none(authenticationPackage == "NTLM")
windows.logonSessions.where(logonTypeName == "RemoteInteractive") { accountName accountDomain startTime }
windows.logonSessions.where(logonType == 9) { accountName }
```

## Schema

`logonSessions()` hangs off the `windows` root, matching `scheduledTasks()`. `windows.logonSession` is private, so it is reachable through the collection rather than looked up directly, which is right for a record keyed by a LUID nobody writes by hand.

| field | notes |
|---|---|
| `logonId` | the LUID, e.g. `0x3e7`. Unique for the life of the boot |
| `logonType` | documented Win32 logon type |
| `logonTypeName` | readable form, e.g. `RemoteInteractive` for 10 |
| `authenticationPackage` | `Kerberos`, `NTLM`, `Negotiate` |
| `startTime` | nullable |
| `accountName`, `accountDomain` | the principal as the association reports it |
| `sid` | translated, empty when translation failed |
| `user()` | typed reference to the local user, matched on SID |

## Two decisions worth review

**`user()` matches on SID only.** An account name is not unique across a machine and the domains it trusts, so matching on the name would confidently return the wrong user for a domain account that shares a name with a local one. It is null for a domain account, for the accounts the system creates, and when the SID could not be translated, with `accountName` and `accountDomain` carrying those cases. The null state is set explicitly, so the runtime knows the field resolved.

Resolution goes through the cached `users` collection rather than a lookup per session. `user` declares no `init`, and a per-session lookup would turn one enumeration into one per session.

**`startTime` is nullable.** The LSA reports no start time for some of the sessions it creates at boot. A zero `time.Time` would report those as having started in year 1, which reads as a real value and would satisfy any age comparison written against it.

Worth noting for anyone writing policy against this: `authenticationPackage` and `logonTypeName` are the fields the audits want, and both are strings from a closed set. `logonTypeName` is empty for a type outside the documented `SECURITY_LOGON_TYPE` values rather than guessed at, so an unknown type is distinguishable from a known one. The system does report types 0 and 1 on sessions that predate a real logon.

## Tests

Pure-Go coverage in `providers/os/resources/windows/logonsession_test.go`:

- decode of every field by value, so a mistyped struct tag is caught rather than silently reading a zero value
- an absent `StartTime` stays null rather than becoming the zero time, and a timestamp that does not parse leaves the field null rather than failing the collection
- an untranslatable SID is absent rather than an error on the whole collection
- every documented logon type maps to its name, and types outside the set return empty rather than a guess

The null-timestamp case was checked against a deliberately broken implementation to confirm it can fail. `go test ./resources/...` passes, `golangci-lint run` reports 0 issues, `typos` clean.

## Verification status: not yet run against a live Windows host

**This is a blocker, not a disclaimer.** No Windows host was available in this session, so the resource has never executed against a real target. The fixtures are hand-written from the documented `Win32_LogonSession` and `Win32_LoggedOnUser` field sets rather than captured from a run, which means they cannot catch a mismatch between what the script asks for and what a real server returns.

Specifically unverified:

- whether `$_.Dependent.LogonId` and `$_.Antecedent` resolve as written on a real `Win32_LoggedOnUser` association, which is the part most likely to differ
- the `StartTime` round trip through `ToString('o')` and back, including the timezone handling
- whether the SID translation succeeds for local accounts and how it behaves for a domain account on a domain-joined host
- that `LogonType` values 0 and 1 actually appear, which is the assumption behind `logonTypeName` being empty rather than absent
- whether `user()` resolves for a local interactive session, which needs a machine with a real local logon
- the encoded script length against the 8,191-character command-line cap over WinRM (the source is ~1.5k characters, so it should be comfortably under, but that has not been measured)

Happy to provision an Azure Windows Server fixture and run every field, including an RDP session and a network logon, before this merges.

## Note on ordering

Branched from `main` independently of #10759, which also touches `os.lr` and `os.lr.versions` in different regions. Whichever merges second will need a regenerate rather than a textual merge of `os.lr.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
