### PR TITLE
✨ os/windows: add windows.certificates for the Windows certificate stores

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -14299,6 +14299,57 @@ windows.driver @defaults("name running signed") {
   purl string
 }
 
+// Certificates held in the Windows certificate stores
+windows.certificates {
+  []windows.certificate
+}
+
+// Certificate in a Windows certificate store
+//
+// Single certificate as it sits in one store: the `store` holding it, the
+// `location` that scopes it to the machine or to one account, its
+// `thumbprint`, and whether the store also holds the matching private key.
+// `store` carries the trust decision rather than the certificate itself. A
+// certificate in Root is trusted as a certification authority, one in
+// Disallowed is explicitly distrusted, and one in TrustedPublisher lets
+// code it signed run without prompting, so the same certificate means
+// different things in different stores. Read `certificate` for the subject,
+// issuer, validity dates and extensions.
+windows.certificate @defaults("store location thumbprint") {
+  // Store location the certificate was found in
+  //
+  // Either "LocalMachine", the machine-wide store every account on the host
+  // sees, or "CurrentUser", the store belonging to the account the scan runs
+  // as. CurrentUser is not the store of any other user on the machine, so an
+  // audit of machine trust reads LocalMachine.
+  location string
+  // Name of the store the certificate was found in
+  //
+  // For example "Root" for trusted root certification authorities, "CA" for
+  // intermediates, "My" for certificates the host holds an identity for,
+  // "TrustedPublisher" for publishers whose signed code runs without
+  // prompting, and "Disallowed" for certificates that are explicitly
+  // distrusted.
+  store string
+  // SHA-1 hash the store keys the certificate by
+  //
+  // Uppercase hex with no separators. Windows keys certificates by this value
+  // throughout its own tooling, so it is what matches a certificate against a
+  // vendor advisory or a removal instruction.
+  thumbprint string
+  // Whether the store also holds the certificate's private key
+  //
+  // True for a certificate the host can authenticate or sign with, rather
+  // than one it merely trusts. The private key itself is never read.
+  hasPrivateKey bool
+  // Parsed certificate
+  //
+  // Subject, issuer, validity dates, extensions and public key. Null when the
+  // stored bytes could not be parsed, which leaves the store entry reportable
+  // rather than dropping it from the list.
+  certificate() network.certificate
+}
+
 // Windows BitLocker drive encryption
 //
 // BitLocker Drive Encryption state across volumes: the encryption,

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -490,6 +490,8 @@ const (
 	ResourceWindowsPrinterDriver                          string = "windows.printerDriver"
 	ResourceWindowsDrivers                                string = "windows.drivers"
 	ResourceWindowsDriver                                 string = "windows.driver"
+	ResourceWindowsCertificates                           string = "windows.certificates"
+	ResourceWindowsCertificate                            string = "windows.certificate"
 	ResourceWindowsBitlocker                              string = "windows.bitlocker"
 	ResourceWindowsBitlockerPolicy                        string = "windows.bitlocker.policy"
 	ResourceWindowsBitlockerPolicyDriveSettings           string = "windows.bitlocker.policy.driveSettings"
@@ -2536,6 +2538,14 @@ func init() {
 		"windows.driver": {
 			// to override args, implement: initWindowsDriver(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createWindowsDriver,
+		},
+		"windows.certificates": {
+			// to override args, implement: initWindowsCertificates(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createWindowsCertificates,
+		},
+		"windows.certificate": {
+			// to override args, implement: initWindowsCertificate(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createWindowsCertificate,
 		},
 		"windows.bitlocker": {
 			// to override args, implement: initWindowsBitlocker(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -13936,6 +13946,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"windows.driver.purl": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsDriver).GetPurl()).ToDataRes(types.String)
+	},
+	"windows.certificates.list": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsCertificates).GetList()).ToDataRes(types.Array(types.Resource("windows.certificate")))
+	},
+	"windows.certificate.location": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsCertificate).GetLocation()).ToDataRes(types.String)
+	},
+	"windows.certificate.store": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsCertificate).GetStore()).ToDataRes(types.String)
+	},
+	"windows.certificate.thumbprint": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsCertificate).GetThumbprint()).ToDataRes(types.String)
+	},
+	"windows.certificate.hasPrivateKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsCertificate).GetHasPrivateKey()).ToDataRes(types.Bool)
+	},
+	"windows.certificate.certificate": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindowsCertificate).GetCertificate()).ToDataRes(types.Resource("certificate"))
 	},
 	"windows.bitlocker.available": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindowsBitlocker).GetAvailable()).ToDataRes(types.Bool)
@@ -33397,6 +33425,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"windows.driver.purl": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindowsDriver).Purl, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.certificates.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsCertificates).__id, ok = v.Value.(string)
+		return
+	},
+	"windows.certificates.list": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsCertificates).List, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"windows.certificate.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsCertificate).__id, ok = v.Value.(string)
+		return
+	},
+	"windows.certificate.location": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsCertificate).Location, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.certificate.store": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsCertificate).Store, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.certificate.thumbprint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsCertificate).Thumbprint, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"windows.certificate.hasPrivateKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsCertificate).HasPrivateKey, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windows.certificate.certificate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindowsCertificate).Certificate, ok = plugin.RawToTValue[plugin.Resource](v.Value, v.Error)
 		return
 	},
 	"windows.bitlocker.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -85980,6 +86040,143 @@ func (c *mqlWindowsDriver) GetSigner() *plugin.TValue[string] {
 
 func (c *mqlWindowsDriver) GetPurl() *plugin.TValue[string] {
 	return &c.Purl
+}
+
+// mqlWindowsCertificates for the windows.certificates resource
+type mqlWindowsCertificates struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlWindowsCertificatesInternal it will be used here
+	List plugin.TValue[[]any]
+}
+
+// createWindowsCertificates creates a new instance of this resource
+func createWindowsCertificates(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlWindowsCertificates{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("windows.certificates", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlWindowsCertificates) MqlName() string {
+	return "windows.certificates"
+}
+
+func (c *mqlWindowsCertificates) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlWindowsCertificates) GetList() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.List, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("windows.certificates", c.__id, "list")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.list()
+	})
+}
+
+// mqlWindowsCertificate for the windows.certificate resource
+type mqlWindowsCertificate struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlWindowsCertificateInternal
+	Location      plugin.TValue[string]
+	Store         plugin.TValue[string]
+	Thumbprint    plugin.TValue[string]
+	HasPrivateKey plugin.TValue[bool]
+	Certificate   plugin.TValue[plugin.Resource]
+}
+
+// createWindowsCertificate creates a new instance of this resource
+func createWindowsCertificate(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlWindowsCertificate{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("windows.certificate", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlWindowsCertificate) MqlName() string {
+	return "windows.certificate"
+}
+
+func (c *mqlWindowsCertificate) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlWindowsCertificate) GetLocation() *plugin.TValue[string] {
+	return &c.Location
+}
+
+func (c *mqlWindowsCertificate) GetStore() *plugin.TValue[string] {
+	return &c.Store
+}
+
+func (c *mqlWindowsCertificate) GetThumbprint() *plugin.TValue[string] {
+	return &c.Thumbprint
+}
+
+func (c *mqlWindowsCertificate) GetHasPrivateKey() *plugin.TValue[bool] {
+	return &c.HasPrivateKey
+}
+
+func (c *mqlWindowsCertificate) GetCertificate() *plugin.TValue[plugin.Resource] {
+	return plugin.GetOrCompute[plugin.Resource](&c.Certificate, func() (plugin.Resource, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("windows.certificate", c.__id, "certificate")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(plugin.Resource), nil
+			}
+		}
+
+		return c.certificate()
+	})
 }
 
 // mqlWindowsBitlocker for the windows.bitlocker resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -4230,6 +4230,14 @@ windows.bitlocker.volume.persistentVolumeID 9.0.1
 windows.bitlocker.volume.protectionStatus 9.0.1
 windows.bitlocker.volume.version 9.0.1
 windows.bitlocker.volumes 9.0.1
+windows.certificate 13.40.10
+windows.certificate.certificate 13.40.10
+windows.certificate.hasPrivateKey 13.40.10
+windows.certificate.location 13.40.10
+windows.certificate.store 13.40.10
+windows.certificate.thumbprint 13.40.10
+windows.certificates 13.40.10
+windows.certificates.list 13.40.10
 windows.computerInfo 9.0.1
 windows.defender 13.29.1
 windows.defender.asrRule 13.29.1

--- a/providers/os/resources/windows/certificate.go
+++ b/providers/os/resources/windows/certificate.go
@@ -1,0 +1,129 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package windows
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+)
+
+// CertificatesScript enumerates the certificates in the Windows certificate
+// stores, for both the machine-wide location and the location belonging to the
+// account the scan runs as.
+//
+// The provider is walked rather than a fixed list of store names, because the
+// set of stores is not closed: Windows ships Root, CA, My, TrustedPublisher,
+// Disallowed and others, and software adds its own. Enumerating whatever is
+// present reports a store nobody expected, which is the interesting case.
+//
+// The certificate is emitted as base64 DER rather than assembled into PEM
+// here. PowerShell's line wrapping differs between versions and would have to
+// be undone before parsing; Go wraps it once, consistently.
+//
+// A store that cannot be opened is skipped rather than failing the walk.
+// Several stores under CurrentUser are inaccessible to a service account, and
+// a scan that returns nothing because one store was locked is worse than one
+// that returns the rest.
+//
+// ConvertTo-Json is forced to a list with @(): PowerShell serializes a single
+// object as an object rather than a one-element array, which would otherwise
+// need two parse paths.
+const CertificatesScript = `
+$ErrorActionPreference = 'SilentlyContinue'
+@(foreach ($loc in @('LocalMachine','CurrentUser')) {
+  Get-ChildItem -Path ("Cert:\" + $loc) | ForEach-Object {
+    $store = $_.Name
+    Get-ChildItem -Path ("Cert:\" + $loc + "\" + $store) | ForEach-Object {
+      [PSCustomObject]@{
+        Location = $loc
+        Store = $store
+        Thumbprint = $_.Thumbprint
+        HasPrivateKey = [bool]$_.HasPrivateKey
+        Der = [Convert]::ToBase64String($_.RawData)
+      }
+    }
+  }
+}) | ConvertTo-Json -Compress -Depth 3
+`
+
+// Certificate is one certificate as it sits in one Windows store.
+type Certificate struct {
+	// Location is "LocalMachine" or "CurrentUser".
+	Location string `json:"Location"`
+	// Store is the store name, e.g. "Root", "CA", "My", "Disallowed".
+	Store string `json:"Store"`
+	// Thumbprint is the SHA-1 hash Windows keys the certificate by, uppercase
+	// hex with no separators.
+	Thumbprint string `json:"Thumbprint"`
+	// HasPrivateKey reports whether the store also holds the matching private
+	// key. The key itself is never read.
+	HasPrivateKey bool `json:"HasPrivateKey"`
+	// Der is the certificate's raw bytes, base64 encoded. See Pem.
+	Der string `json:"Der"`
+}
+
+// ID is the identity of a store entry.
+//
+// The same certificate legitimately appears in more than one store and in both
+// locations, and it means something different in each: a certificate in Root
+// is trusted while the same one in Disallowed is distrusted. So the thumbprint
+// alone is not the identity. Keying on it would let the second entry collide
+// with the first in the resource cache and silently report the first one's
+// store.
+func (c Certificate) ID() string {
+	return c.Location + "/" + c.Store + "/" + c.Thumbprint
+}
+
+// Pem renders the certificate as PEM, empty when the entry carried no bytes or
+// bytes that are not valid base64.
+//
+// Wrapped at 64 characters, which is what RFC 7468 requires of a generator and
+// what every parser expects. An unwrapped body is accepted by Go's decoder but
+// not by every consumer, so it is not worth emitting.
+func (c Certificate) Pem() string {
+	raw := strings.TrimSpace(c.Der)
+	if raw == "" {
+		return ""
+	}
+	if _, err := base64.StdEncoding.DecodeString(raw); err != nil {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("-----BEGIN CERTIFICATE-----\n")
+	for i := 0; i < len(raw); i += 64 {
+		end := i + 64
+		if end > len(raw) {
+			end = len(raw)
+		}
+		b.WriteString(raw[i:end])
+		b.WriteString("\n")
+	}
+	b.WriteString("-----END CERTIFICATE-----\n")
+	return b.String()
+}
+
+// ParseCertificates reads the script's output.
+//
+// An empty document is not an error: a target whose stores could not be opened
+// legitimately reports nothing.
+func ParseCertificates(r io.Reader) ([]Certificate, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" || trimmed == "null" {
+		return []Certificate{}, nil
+	}
+
+	var certs []Certificate
+	if err := json.Unmarshal([]byte(trimmed), &certs); err != nil {
+		return nil, errors.New("failed to parse certificates: " + err.Error())
+	}
+	return certs, nil
+}

--- a/providers/os/resources/windows/certificate_test.go
+++ b/providers/os/resources/windows/certificate_test.go
@@ -1,0 +1,122 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package windows
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// derFixture is a real, self-signed DER certificate, base64 encoded. It is a
+// throwaway generated for this test, not one taken from a live store, so the
+// fixture carries no host's trust decisions.
+//
+// It is a genuine certificate rather than arbitrary bytes so that Pem's output
+// can be handed to crypto/x509 and actually parse. A fixture of random bytes
+// would let a broken line-wrapping change pass.
+const derFixture = `MIIBjDCCATGgAwIBAgIUPW/qN6XcmF05Hewgb1nO9Qj+zDEwCgYIKoZIzj0EAwIwGzEZMBcGA1UEAwwQbXFsLXRlc3QtZml4dHVyZTAeFw0yNjA5MTExODA0MTJaFw0zNjA5MDgxODA0MTJaMBsxGTAXBgNVBAMMEG1xbC10ZXN0LWZpeHR1cmUwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATM4KDNWkZxeA0kkB4Z9Mkze1SBDOENeAKdCC8gV0PYPXkaAFaOT7aeKBzr48WZW1VgClt+b2nGxCBksKObMt1no1MwUTAdBgNVHQ4EFgQUwb6o6KjwUfuRAIBqBBAfUevQ1bUwHwYDVR0jBBgwFoAUwb6o6KjwUfuRAIBqBBAfUevQ1bUwDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNJADBGAiEAjj9oc8hRpCrFY4WlhqOtltwCoV4pR6XFaJZ9/FbBLCoCIQDI33eVInLxgX0beTkpfNllk0+8qPnmQqtqwogQP4+9Cw==`
+
+func TestParseCertificates(t *testing.T) {
+	in := `[
+ {"Location":"LocalMachine","Store":"Root","Thumbprint":"DF3C24F9BFD666761B268073FE06D1CC8D4F82A4","HasPrivateKey":false,"Der":"` + derFixture + `"},
+ {"Location":"LocalMachine","Store":"My","Thumbprint":"A1B2C3D4E5F60718293A4B5C6D7E8F9001122334","HasPrivateKey":true,"Der":"` + derFixture + `"},
+ {"Location":"CurrentUser","Store":"Disallowed","Thumbprint":"FFEEDDCCBBAA99887766554433221100AABBCCDD","HasPrivateKey":false,"Der":""}
+]`
+	certs, err := ParseCertificates(strings.NewReader(in))
+	require.NoError(t, err)
+	require.Len(t, certs, 3)
+
+	// Every field read by value: a mistyped struct tag yields the zero value
+	// rather than an error, so only comparing the value catches it.
+	assert.Equal(t, "LocalMachine", certs[0].Location)
+	assert.Equal(t, "Root", certs[0].Store)
+	assert.Equal(t, "DF3C24F9BFD666761B268073FE06D1CC8D4F82A4", certs[0].Thumbprint)
+
+	// hasPrivateKey distinguishes a certificate the host can sign with from one
+	// it merely trusts, so it must not read false for both.
+	assert.False(t, certs[0].HasPrivateKey)
+	assert.True(t, certs[1].HasPrivateKey, "a store entry holding a private key must read true")
+}
+
+func TestParseCertificatesEmpty(t *testing.T) {
+	// A target whose stores could not be opened is a normal state, not an error.
+	for _, in := range []string{"", "   ", "null", "[]"} {
+		certs, err := ParseCertificates(strings.NewReader(in))
+		require.NoError(t, err, "input %q", in)
+		assert.Empty(t, certs, "input %q", in)
+	}
+}
+
+func TestParseCertificatesMalformed(t *testing.T) {
+	_, err := ParseCertificates(strings.NewReader(`{"Location":`))
+	assert.Error(t, err)
+}
+
+// TestCertificateID pins the property that keeps the resource cache honest.
+//
+// The same certificate in two stores must not produce the same id. It would
+// collide in the cache, and CreateResource returns the cached first instance
+// for a repeated id, so the Disallowed entry below would silently report
+// itself as living in Root.
+func TestCertificateID(t *testing.T) {
+	const tp = "DF3C24F9BFD666761B268073FE06D1CC8D4F82A4"
+	root := Certificate{Location: "LocalMachine", Store: "Root", Thumbprint: tp}
+	disallowed := Certificate{Location: "LocalMachine", Store: "Disallowed", Thumbprint: tp}
+	user := Certificate{Location: "CurrentUser", Store: "Root", Thumbprint: tp}
+
+	assert.NotEqual(t, root.ID(), disallowed.ID(), "same certificate in two stores must not share an id")
+	assert.NotEqual(t, root.ID(), user.ID(), "same certificate in two locations must not share an id")
+	assert.Equal(t, "LocalMachine/Root/"+tp, root.ID())
+}
+
+func TestCertificatePem(t *testing.T) {
+	c := Certificate{Der: derFixture}
+	got := c.Pem()
+
+	require.True(t, strings.HasPrefix(got, "-----BEGIN CERTIFICATE-----\n"))
+	require.True(t, strings.HasSuffix(got, "-----END CERTIFICATE-----\n"))
+
+	// The body must be wrapped at 64 characters, which is what RFC 7468
+	// requires of a generator.
+	body := strings.Split(strings.TrimSpace(got), "\n")
+	body = body[1 : len(body)-1]
+	for i, line := range body[:len(body)-1] {
+		assert.Len(t, line, 64, "body line %d is not wrapped at 64", i)
+	}
+
+	// The output must actually decode, which is what a downstream parser does
+	// with it. A wrapping bug that still looks like PEM fails here.
+	block, _ := pem.Decode([]byte(got))
+	require.NotNil(t, block, "Pem output did not decode as PEM")
+	assert.Equal(t, "CERTIFICATE", block.Type)
+
+	raw, err := base64.StdEncoding.DecodeString(derFixture)
+	require.NoError(t, err)
+	assert.Equal(t, raw, block.Bytes, "PEM body did not round trip to the original DER")
+}
+
+func TestCertificatePemRejectsUnusableBytes(t *testing.T) {
+	// An entry with no bytes, or bytes that are not base64, yields no PEM
+	// rather than a PEM wrapper around garbage. The resource reports the store
+	// entry with a null certificate, which keeps the entry visible.
+	assert.Empty(t, Certificate{Der: ""}.Pem())
+	assert.Empty(t, Certificate{Der: "   "}.Pem())
+	assert.Empty(t, Certificate{Der: "not!valid!base64!"}.Pem())
+}
+
+// TestCertificatePemParsesAsX509 proves the wrapping is usable by the parser
+// the resource actually hands it to, rather than only looking like PEM.
+func TestCertificatePemParsesAsX509(t *testing.T) {
+	block, _ := pem.Decode([]byte(Certificate{Der: derFixture}.Pem()))
+	require.NotNil(t, block)
+
+	_, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err, "the fixture must be a real certificate for this test to mean anything")
+}

--- a/providers/os/resources/windows_certificate.go
+++ b/providers/os/resources/windows_certificate.go
@@ -1,0 +1,118 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"io"
+
+	"go.mondoo.com/mql/llx"
+	"go.mondoo.com/mql/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/providers/os/connection/shared"
+	"go.mondoo.com/mql/providers/os/resources/powershell"
+	"go.mondoo.com/mql/providers/os/resources/windows"
+)
+
+// mqlWindowsCertificateInternal caches the PEM body between the list walk and
+// the certificate accessor, so the store is read once rather than once per
+// certificate parsed.
+type mqlWindowsCertificateInternal struct {
+	pem string
+}
+
+func (r *mqlWindowsCertificate) id() (string, error) {
+	if r.Thumbprint.Error != nil {
+		return "", r.Thumbprint.Error
+	}
+	// The same certificate appears in more than one store and means something
+	// different in each, so the store and location are part of the identity.
+	// Keying on the thumbprint alone would let the second entry collide with
+	// the first in the resource cache and report the first one's store.
+	if r.Thumbprint.Data == "" {
+		return "", errors.New("windows.certificate has no thumbprint")
+	}
+	return r.Location.Data + "/" + r.Store.Data + "/" + r.Thumbprint.Data, nil
+}
+
+func (r *mqlWindowsCertificates) list() ([]any, error) {
+	conn := r.MqlRuntime.Connection.(shared.Connection)
+
+	cmd, err := conn.RunCommand(powershell.Encode(windows.CertificatesScript))
+	if err != nil {
+		return nil, err
+	}
+	if cmd.ExitStatus != 0 {
+		stderr, err := io.ReadAll(cmd.Stderr)
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New("failed to retrieve certificates: " + string(stderr))
+	}
+
+	certs, err := windows.ParseCertificates(cmd.Stdout)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]any, 0, len(certs))
+	for _, c := range certs {
+		res, err := CreateResource(r.MqlRuntime, "windows.certificate", map[string]*llx.RawData{
+			"location":      llx.StringData(c.Location),
+			"store":         llx.StringData(c.Store),
+			"thumbprint":    llx.StringData(c.Thumbprint),
+			"hasPrivateKey": llx.BoolData(c.HasPrivateKey),
+		})
+		if err != nil {
+			return nil, err
+		}
+		res.(*mqlWindowsCertificate).pem = c.Pem()
+		out = append(out, res)
+	}
+	return out, nil
+}
+
+// certificate parses the stored bytes into the shared certificate type, so a
+// store entry carries the same subject, issuer, validity and extension fields
+// as a certificate read from a file or off a TLS connection.
+func (r *mqlWindowsCertificate) certificate() (plugin.Resource, error) {
+	if r.pem == "" {
+		// Bytes that are absent or not valid base64. The entry itself is still
+		// worth reporting, so the state is set explicitly rather than dropping
+		// the certificate from the list or failing the whole store.
+		r.Certificate.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	sharedRes, err := r.MqlRuntime.CreateSharedResource("certificates", map[string]*llx.RawData{
+		"pem": llx.StringData(r.pem),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	list, err := r.MqlRuntime.GetSharedData("certificates", sharedRes.MqlID(), "list")
+	if err != nil {
+		return nil, err
+	}
+	if list == nil || list.Error != nil {
+		r.Certificate.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	entries, ok := list.Value.([]any)
+	if !ok || len(entries) == 0 {
+		// A store entry whose bytes are well-formed base64 but not a
+		// certificate. Reported as null rather than as an error, so one bad
+		// entry does not blind the store.
+		r.Certificate.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	cert, ok := entries[0].(plugin.Resource)
+	if !ok {
+		r.Certificate.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return cert, nil
+}


### PR DESCRIPTION
## What

Adds `windows.certificates` / `windows.certificate`, covering the Windows certificate stores.

Windows had **no certificate resource at all**. `os.rootCertificates` is gated to Linux and BSD (`os_rootcertificates.go`, the `IsFamily` checks), so a Windows host reported nothing about what it trusts rather than reporting that the question could not be answered. This closes the third of the four gaps identified against osquery's `certificates` table, after #10759 and #10760.

```
windows.certificates.where(store == "Root" && location == "LocalMachine") { certificate.subject }
windows.certificates.where(store == "Root").all(certificate.expiresIn.days > 0)
windows.certificates.where(store == "TrustedPublisher") { certificate.issuer thumbprint }
windows.certificates.where(hasPrivateKey) { store certificate.subject }
```

## Schema

| field | notes |
|---|---|
| `location` | `LocalMachine` or `CurrentUser` |
| `store` | `Root`, `CA`, `My`, `TrustedPublisher`, `Disallowed`, or whatever else is present |
| `thumbprint` | SHA-1 hash Windows keys the certificate by, uppercase hex |
| `hasPrivateKey` | whether the store also holds the matching private key |
| `certificate()` | the parsed certificate, as the shared `network.certificate` type |

## Four decisions worth review

**The stores are enumerated, not listed.** The set of store names is not closed. Windows ships a known handful and software adds its own, so walking the provider reports a store nobody expected, which is the case worth catching. A fixed list would silently miss it.

**`__id` is `location/store/thumbprint`, not the thumbprint.** A certificate legitimately appears in several stores, and the store *is* the trust decision: the same certificate in `Root` is trusted and in `Disallowed` is distrusted. Keying on the thumbprint alone would collide in the resource cache, and since `CreateResource` returns the cached first instance for a repeated id, the `Disallowed` entry would silently report itself as living in `Root`. There is a test pinning this.

**`certificate()` bridges to the shared `network.certificate` type** rather than reimplementing subject, issuer, validity and extensions. This is the first singular use of a cross-provider resource field in this schema — the three existing uses are all `[]network.certificate` lists. Codegen handles it, typing the accessor as `plugin.Resource`. It resolves to null for an entry whose bytes do not parse, which keeps the store entry visible rather than dropping it from the list or failing the whole store.

**Private keys are never read.** `hasPrivateKey` reports only whether the store holds one. The script exports `RawData` (the certificate) and nothing else.

One caveat worth knowing when writing policy: `CurrentUser` is the store of the account the scan runs as, not of any other user on the machine. An audit of machine-wide trust should filter `location == "LocalMachine"`. That is stated in the field's doc comment.

## Tests

Pure-Go coverage in `providers/os/resources/windows/certificate_test.go`:

- decode of every field by value, so a mistyped struct tag is caught rather than silently reading a zero value, including that `hasPrivateKey` does not read false for both a trusted and an identity certificate
- the `__id` property above: the same thumbprint in two stores, and in two locations, must not produce the same id
- PEM assembly wrapped at 64 characters per RFC 7468, decoding as PEM, round-tripping to the original DER, and **parsing as a real certificate via `crypto/x509`**
- unusable bytes (absent, whitespace, non-base64) yield no PEM rather than a wrapper around garbage

The x509 test earned its place immediately: it failed on the first run and caught that my initial hand-written fixture was not a real certificate. The fixture is now a throwaway EC certificate generated with openssl, independent of the code under test. Its private key was generated and discarded, never committed.

`go test ./resources/...` passes, `golangci-lint run` reports 0 issues, `typos` clean.

## Verification status: not yet run against a live Windows host

**This is a blocker, not a disclaimer.** No Windows host was available, so the resource has never executed against a real target. The fixtures are hand-written from the documented `Cert:` provider shape rather than captured from a run, so they cannot catch a mismatch between what the script asks for and what a real host returns.

Specifically unverified:

- whether `Get-ChildItem Cert:\<location>` enumerates stores and `Cert:\<location>\<store>` enumerates certificates as written, which is the part most likely to differ
- the output volume. A real machine holds several hundred certificates across both locations, and each carries a full base64 DER body. The script length is fine (~1.1k characters, well under the 8,191 WinRM cap), but the *response* size has not been measured and may warrant restricting the default walk
- whether `$_.HasPrivateKey` is populated for `My` store entries under a service account that cannot open the key
- which stores are inaccessible under a non-administrative or service account, and therefore silently skipped
- that `Thumbprint` is uppercase hex without separators, as the doc comment states

Happy to provision an Azure Windows Server fixture and run every field, including planting a certificate in `Disallowed` to exercise the `__id` composite against a real duplicate, before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
