### PR TITLE
🐛 edge: run in the prod environment so GCP auth resolves

### DIFF
--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -37,6 +37,12 @@ jobs:
 
     runs-on:
       group: arc-runners
+    # The GCP credentials are environment secrets scoped to prod, and the
+    # workload identity binding is scoped with them. goreleaser.yml and
+    # providers.yaml both declare this; without it the upload fails with
+    # `iam.serviceAccounts.getAccessToken denied`, which reads like a broken
+    # IAM grant rather than a missing environment.
+    environment: prod
     timeout-minutes: 120
     steps:
       - name: Checkout


### PR DESCRIPTION
Follow-up to #10757. The first live edge build after it merged **failed at the upload**:

```
('Unable to acquire impersonated credentials',
  "Permission 'iam.serviceAccounts.getAccessToken' denied on resource")
CommandException: 8 files/objects could not be transferred.
```

[run 34633720843](https://github.com/mondoohq/mql/actions/runs/34633720843)

## Cause

The GCP credentials are **environment secrets scoped to `prod`**, and the workload identity binding is scoped with them. Both workflows that already write to this bucket declare it:

| workflow | `environment: prod` | writes the bucket |
|---|---|---|
| `goreleaser.yml` | :56 | yes |
| `providers.yaml` | :110 | yes |
| `goreleaser-edge.yml` | **missing** | yes, as of #10757 |

`providers.yaml` is the useful comparison: it also runs on a **branch push**, not a tag, so this is not about tag refs — it is the environment.

The error reads like a broken IAM grant, which is why the comment in the diff says what it actually was.

## What did work

The version folding from #10757 is correct and confirmed live. The run produced:

```
mql_14.0.0-rc.2.10036_linux_arm64.tar.gz
```

`14.0.0-rc.2.10036` — the dotted form, where `10036` is its own numeric identifier and sorts numerically. Under the old `+` → `-` folding this would have been `14.0.0-rc.2-10036`, compared as text.

It also failed in the right place: at the upload, **before** the `edge-published` dispatch, so nothing partial was published and no channel pointer moved. The guard that fails on a mismatched upload never had to fire because the transfer itself errored.

## Verification after merge

The next push to `main` triggers an edge build. Expect `edge/mql/<version>/` in the bucket, an `edge-published` dispatch, and `edge/mql/latest.json` naming that version — the index job fails the run if it does not.

Same fix is in mondoohq/cnspec#3640, applied before that one merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)