### PR TITLE
🐛 edge: authenticate with the release service account key, not WIF

### DIFF
--- a/.github/workflows/goreleaser-edge.yml
+++ b/.github/workflows/goreleaser-edge.yml
@@ -32,8 +32,6 @@ jobs:
     permissions:
       # Add "contents" to write release
       contents: "write"
-      # Add "id-token" for google-github-actions/auth
-      id-token: "write"
 
     runs-on:
       group: arc-runners
@@ -153,12 +151,17 @@ jobs:
       # the install service resolved a bucket path that has never existed for
       # mql. These are the same archives goreleaser already built for the
       # images; they were simply discarded.
+      # A service account key, not workload identity federation. The WIF
+      # binding cannot be impersonated from a branch push -- goreleaser.yml
+      # uses it and runs only on tags, while providers.yaml writes this same
+      # bucket from a push to a branch and uses this key to do it. Getting that
+      # backwards fails with `iam.serviceAccounts.getAccessToken denied`, which
+      # reads like a broken grant rather than the wrong credential.
       - name: "Authenticate to Google Cloud"
         if: ${{ inputs.dry-run != true }}
         uses: "google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093" # v3.0.0
         with:
-          workload_identity_provider: ${{ secrets.GCP_WIP }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          credentials_json: ${{ secrets.GCP_RELEASE_SERVICE_ACCOUNT }}
 
       - name: "Set up Cloud SDK"
         if: ${{ inputs.dry-run != true }}


### PR DESCRIPTION
The edge upload still fails after #10762, with the same error:

```
Permission 'iam.serviceAccounts.getAccessToken' denied
CommandException: 8 files/objects could not be transferred.
```

[run 34637644220](https://github.com/mondoohq/mql/actions/runs/34637644220)

## The credential, not the environment

| workflow | auth | trigger | writes this bucket |
|---|---|---|---|
| `goreleaser.yml` | **WIF** (`GCP_WIP` + `GCP_SERVICE_ACCOUNT`) | tags only | yes |
| `providers.yaml` | **`credentials_json`** (`GCP_RELEASE_SERVICE_ACCOUNT`) | **branch push** | yes |
| `goreleaser-edge.yml` | WIF | branch push | denied |

The workload identity binding cannot be impersonated from a branch push. That is precisely why `providers.yaml` uses a key to write `gs://releases-us.mondoo.io/providers/` on a push to `v13` — same bucket, same trigger shape, working today.

`id-token: write` goes with it: that permission exists for WIF, and there is no WIF here any more.

`environment: prod` from #10762 stays, because the secret is scoped to that environment — but it was not the cause.

## I got this wrong once

I diagnosed it as a missing environment first, because both working workflows declare `environment: prod` and the edge one didn't. That was pattern-matching on the wrong attribute: I should have compared how each one *authenticates* before changing anything, and `providers.yaml` — a branch push writing the same bucket — was the case that settles it.

## What is still confirmed working

The version folding and the guards are fine; the run gets all the way to the upload with the right inputs:

```
uploading 8 objects to edge/mql/14.0.0-rc.2.10038/
```

`14.0.0-rc.2.10038` is the dotted form that sorts numerically. It also fails *before* the `edge-published` dispatch, so nothing partial is published and no channel pointer moves.

## After merge

The next push to `main` should produce `edge/mql/<version>/` in the bucket, dispatch `edge-published`, and have mondoohq/installer's edge index job write `edge/mql/latest.json` naming that version — it fails the run if it does not.

Same change is in mondoohq/cnspec#3640, before that one merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)