### PR TITLE
✨ providers: add --channel for a one-off override

### DIFF
--- a/apps/mql/cmd/providers.go
+++ b/apps/mql/cmd/providers.go
@@ -15,9 +15,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cockroachdb/errors"
 	"github.com/muesli/termenv"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.mondoo.com/mql/cli/config"
 	"go.mondoo.com/mql/cli/theme"
 	"go.mondoo.com/mql/cli/theme/colors"
 	"go.mondoo.com/mql/providers"
@@ -44,6 +47,44 @@ func init() {
 	installProviderCmd.Flags().String("url", "", "Install a provider via a URL")
 	installProviderCmd.Flags().Bool("schema-only", false, "Install only the provider's config and resource schema, without its binary")
 	deleteProviderCmd.Flags().Bool("yes", false, "Confirm removal of all providers when using the 'all' target")
+
+	for _, cmd := range []*cobra.Command{installProviderCmd, updateProviderCmd} {
+		cmd.Flags().String("channel", "", "Release channel to resolve from: stable or preview (default: the configured update_channel, or the channel this build belongs to)")
+	}
+}
+
+// applyChannelFlag lets a single command resolve from a different release
+// channel without editing mondoo.yml.
+//
+// A stable install is the case this exists for: trying one pre-release provider
+// should not mean reconfiguring the machine and remembering to put it back. The
+// override lasts for this process only.
+//
+// It is applied by setting the config key rather than by threading a parameter
+// down to the registry, because the registry reads the channel at fetch time --
+// so everything that resolves during this command agrees, including the version
+// this command prints back.
+func applyChannelFlag(cmd *cobra.Command) error {
+	channel, _ := cmd.Flags().GetString("channel")
+	if channel == "" {
+		return nil
+	}
+
+	normalized := strings.ToLower(strings.TrimSpace(channel))
+	switch normalized {
+	case config.ChannelStable, config.ChannelPreview:
+	default:
+		// An unknown channel elsewhere falls back to the build, because it came
+		// from a config file someone may not be looking at. Here it was just
+		// typed on the command line, so say so rather than quietly doing
+		// something else.
+		return errors.Newf("unknown channel %q, expected %s or %s",
+			channel, config.ChannelStable, config.ChannelPreview)
+	}
+
+	viper.Set(config.KeyUpdateChannel, normalized)
+	log.Info().Str("channel", normalized).Msg("resolving providers from an overridden release channel")
+	return nil
 }
 
 var ProvidersCmd = &cobra.Command{
@@ -74,9 +115,23 @@ var installProviderCmd = &cobra.Command{
 With --schema-only, only the provider's config and resource schema are
 installed, skipping the (much larger) binary download. That is enough to
 compile queries against the provider's resources, but not to connect to
-assets; for that, install the provider fully.`,
+assets; for that, install the provider fully.
+
+--channel resolves this one command from a different release channel, without
+changing any configuration. It has no effect when a version is pinned
+(NAME@VERSION) or when installing from --file or --url, since none of those
+consult a channel.
+
+Examples:
+  mql providers install aws                     # the configured channel
+  mql providers install aws --channel preview   # one-off, from the pre-release track
+  mql providers install aws@13.53.4             # exact version, channel ignored`,
 	PreRun: func(cmd *cobra.Command, args []string) {},
 	Run: func(cmd *cobra.Command, args []string) {
+		if err := applyChannelFlag(cmd); err != nil {
+			log.Fatal().Err(err).Msg("invalid channel")
+		}
+
 		schemaOnly, _ := cmd.Flags().GetBool("schema-only")
 
 		// Explicit installs of files will ignore version recommendations.
@@ -118,13 +173,22 @@ provider names to update just those. Providers already on the latest version
 are skipped, and naming a provider that isn't installed is reported and skipped
 rather than treated as an error.
 
+--channel resolves this one command from a different release channel, without
+changing any configuration. On a stable install that is how you try a
+pre-release provider: the override lasts for this command only, so the next
+update goes back to whatever is configured.
+
 Examples:
   mql providers update              # update every installed provider
   mql providers update aws          # update just the aws provider
-  mql providers update aws gcp      # update the aws and gcp providers`,
+  mql providers update aws gcp      # update the aws and gcp providers
+  mql providers update aws --channel preview   # one-off, from the pre-release track`,
 	Args:   cobra.ArbitraryArgs,
 	PreRun: func(cmd *cobra.Command, args []string) {},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := applyChannelFlag(cmd); err != nil {
+			return err
+		}
 		return updateProviders(cmd.Root().Name(), args)
 	},
 }

--- a/apps/mql/cmd/providers_channel_test.go
+++ b/apps/mql/cmd/providers_channel_test.go
@@ -1,0 +1,73 @@
+// Copyright Mondoo, Inc. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/cli/config"
+)
+
+func channelCmd(t *testing.T, args ...string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{Use: "update"}
+	cmd.Flags().String("channel", "", "")
+	require.NoError(t, cmd.ParseFlags(args))
+	return cmd
+}
+
+// TestApplyChannelFlag covers the one-off override: a stable install trying a
+// pre-release provider should not have to edit mondoo.yml and remember to put
+// it back.
+func TestApplyChannelFlag(t *testing.T) {
+	t.Cleanup(func() {
+		viper.Set(config.KeyUpdateChannel, "")
+		config.SetRunningVersion("")
+	})
+
+	t.Run("no flag leaves the configured channel alone", func(t *testing.T) {
+		viper.Set(config.KeyUpdateChannel, config.ChannelPreview)
+		require.NoError(t, applyChannelFlag(channelCmd(t)))
+		assert.Equal(t, config.ChannelPreview, config.GetUpdateChannel())
+	})
+
+	t.Run("preview overrides a stable build", func(t *testing.T) {
+		viper.Set(config.KeyUpdateChannel, "")
+		config.SetRunningVersion("13.38.1")
+		require.Equal(t, config.ChannelStable, config.GetUpdateChannel())
+
+		require.NoError(t, applyChannelFlag(channelCmd(t, "--channel", "preview")))
+		assert.Equal(t, config.ChannelPreview, config.GetUpdateChannel())
+	})
+
+	t.Run("stable overrides a pre-release build", func(t *testing.T) {
+		viper.Set(config.KeyUpdateChannel, "")
+		config.SetRunningVersion("14.0.0-rc.2")
+		require.Equal(t, config.ChannelPreview, config.GetUpdateChannel())
+
+		require.NoError(t, applyChannelFlag(channelCmd(t, "--channel", "stable")))
+		assert.Equal(t, config.ChannelStable, config.GetUpdateChannel())
+	})
+
+	t.Run("case and spacing are normalized", func(t *testing.T) {
+		viper.Set(config.KeyUpdateChannel, "")
+		require.NoError(t, applyChannelFlag(channelCmd(t, "--channel", "  PREVIEW ")))
+		assert.Equal(t, config.ChannelPreview, config.GetUpdateChannel())
+	})
+
+	t.Run("an unknown channel is an error, not a fallback", func(t *testing.T) {
+		// Elsewhere an unrecognized channel falls back to the build, because it
+		// came from a config file nobody may be looking at. Here it was typed
+		// on the command line, so it is worth saying so.
+		viper.Set(config.KeyUpdateChannel, "")
+		err := applyChannelFlag(channelCmd(t, "--channel", "beta"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "beta")
+		assert.Contains(t, err.Error(), config.ChannelPreview)
+	})
+}

--- a/apps/mql/cmd/providers_channel_test.go
+++ b/apps/mql/cmd/providers_channel_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package cmd
@@ -21,23 +21,34 @@ func channelCmd(t *testing.T, args ...string) *cobra.Command {
 	return cmd
 }
 
-// TestApplyChannelFlag covers the one-off override: a stable install trying a
-// pre-release provider should not have to edit mondoo.yml and remember to put
-// it back.
-func TestApplyChannelFlag(t *testing.T) {
+// resetChannelState returns the process-global channel inputs to "nothing
+// configured, unknown build". Called by every subtest so none of them depends
+// on what the previous one left behind, and so adding t.Parallel() later does
+// not quietly couple them.
+func resetChannelState(t *testing.T) {
+	t.Helper()
+	viper.Set(config.KeyUpdateChannel, "")
+	config.SetRunningVersion("")
 	t.Cleanup(func() {
 		viper.Set(config.KeyUpdateChannel, "")
 		config.SetRunningVersion("")
 	})
+}
 
+// TestApplyChannelFlag covers the one-off override: a stable install trying a
+// pre-release provider should not have to edit mondoo.yml and remember to put
+// it back.
+func TestApplyChannelFlag(t *testing.T) {
 	t.Run("no flag leaves the configured channel alone", func(t *testing.T) {
+		resetChannelState(t)
 		viper.Set(config.KeyUpdateChannel, config.ChannelPreview)
+
 		require.NoError(t, applyChannelFlag(channelCmd(t)))
 		assert.Equal(t, config.ChannelPreview, config.GetUpdateChannel())
 	})
 
 	t.Run("preview overrides a stable build", func(t *testing.T) {
-		viper.Set(config.KeyUpdateChannel, "")
+		resetChannelState(t)
 		config.SetRunningVersion("13.38.1")
 		require.Equal(t, config.ChannelStable, config.GetUpdateChannel())
 
@@ -46,7 +57,7 @@ func TestApplyChannelFlag(t *testing.T) {
 	})
 
 	t.Run("stable overrides a pre-release build", func(t *testing.T) {
-		viper.Set(config.KeyUpdateChannel, "")
+		resetChannelState(t)
 		config.SetRunningVersion("14.0.0-rc.2")
 		require.Equal(t, config.ChannelPreview, config.GetUpdateChannel())
 
@@ -55,7 +66,8 @@ func TestApplyChannelFlag(t *testing.T) {
 	})
 
 	t.Run("case and spacing are normalized", func(t *testing.T) {
-		viper.Set(config.KeyUpdateChannel, "")
+		resetChannelState(t)
+
 		require.NoError(t, applyChannelFlag(channelCmd(t, "--channel", "  PREVIEW ")))
 		assert.Equal(t, config.ChannelPreview, config.GetUpdateChannel())
 	})
@@ -64,10 +76,14 @@ func TestApplyChannelFlag(t *testing.T) {
 		// Elsewhere an unrecognized channel falls back to the build, because it
 		// came from a config file nobody may be looking at. Here it was typed
 		// on the command line, so it is worth saying so.
-		viper.Set(config.KeyUpdateChannel, "")
+		resetChannelState(t)
+
 		err := applyChannelFlag(channelCmd(t, "--channel", "beta"))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "beta")
 		assert.Contains(t, err.Error(), config.ChannelPreview)
+
+		// And it must not have changed anything on its way out.
+		assert.Equal(t, config.ChannelStable, config.GetUpdateChannel())
 	})
 }


### PR DESCRIPTION
```
cnspec providers update aws --channel preview
```

resolves that one command from the pre-release track, without touching `mondoo.yml`.

## Why

A **stable install** is the case this exists for. Trying one pre-release provider previously meant editing config, running the command, and remembering to put it back — and forgetting leaves the machine resolving pre-releases indefinitely, which is exactly the state `update_channel` is meant to make deliberate.

The override lasts for this process only. The next update goes back to whatever is configured.

## How

Applied by setting the config key rather than threading a parameter down to the registry, because **the registry reads the channel at fetch time**. That way everything resolving during the command agrees — including the version the command prints back afterwards, which would otherwise be able to disagree with the one it installed.

Added to `install` and `update`. No effect when a version is pinned (`NAME@VERSION`) or when installing from `--file`/`--url`, since none of those consult a channel — stated in the help rather than left to be discovered.

## An unknown channel is an error here

Everywhere else an unrecognized channel falls back to the build. That is right for a config file: the value may be sitting in a file nobody is looking at, and silently following the build is the safer reading.

Typed on the command line it is worth saying so:

```
$ cnspec providers update aws --channel beta
unknown channel "beta", expected stable or preview
```

## Verified

```
no flag                          -> configured channel unchanged
--channel preview, stable build  -> preview
--channel stable,  pre-release   -> stable
--channel "  PREVIEW "           -> preview   (normalized)
--channel beta                   -> error naming the valid values
```

Builds on #10758. The channel rule is SemVer §9 and §10 with nothing added: a version with a pre-release segment is `preview`, one without is `stable`, and build metadata is not a pre-release.

Note: `go test ./providers/` needs `make test/generate` first (missing `MockProviderPlugin`) — pre-existing on `main`, not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
