### PR TITLE
👷 ci: escape the tag for both parsers it reaches

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -332,23 +332,42 @@ jobs:
         run: |
           set -euo pipefail
 
+          # The tag reaches Slack through two different parsers, and it is not
+          # validated anywhere upstream -- git allows `"`, `&`, `<` and `>` in a
+          # ref name. `ref_safe` is escaped for both: backslash and quote so the
+          # value cannot terminate the double-quoted YAML scalar it is pasted
+          # into (that one fails the whole step, not just the rendering), then
+          # the three characters Slack reads as markup. `ref_url` is for the
+          # link target, where percent-encoding rather than escaping is correct.
+          ref_safe=$REF_NAME
+          ref_safe=${ref_safe//\\/\\\\}
+          ref_safe=${ref_safe//\"/\\\"}
+          ref_safe=${ref_safe//&/&amp;}
+          ref_safe=${ref_safe//</&lt;}
+          ref_safe=${ref_safe//>/&gt;}
+          ref_url=$(jq -rn --arg v "$REF_NAME" '$v|@uri')
+          {
+            echo "version=$ref_safe"
+            echo "version_url=$ref_url"
+          } >> "$GITHUB_OUTPUT"
+
           # build_status carries the value alone. Its label and the newline stay
           # in the Slack payload, where `\n` inside a double-quoted YAML scalar
           # is a real escape -- a `\n` that arrives by substitution only renders
           # because of when GitHub interpolates, which is not worth depending on.
           case "$BUILD" in
             success)
-              echo "header=:rocket: mql $REF_NAME released" >> "$GITHUB_OUTPUT"
+              echo "header=:rocket: mql $ref_safe released" >> "$GITHUB_OUTPUT"
               echo "mention=" >> "$GITHUB_OUTPUT"
               echo "build_status=:white_check_mark: Done" >> "$GITHUB_OUTPUT"
               ;;
             skipped)
-              echo "header=:double_vertical_bar: mql $REF_NAME build skipped" >> "$GITHUB_OUTPUT"
+              echo "header=:double_vertical_bar: mql $ref_safe build skipped" >> "$GITHUB_OUTPUT"
               echo "mention=" >> "$GITHUB_OUTPUT"
               echo "build_status=:double_vertical_bar: Skipped" >> "$GITHUB_OUTPUT"
               ;;
             *)
-              echo "header=:x: mql $REF_NAME failed to release" >> "$GITHUB_OUTPUT"
+              echo "header=:x: mql $ref_safe failed to release" >> "$GITHUB_OUTPUT"
               echo "mention=<!here> " >> "$GITHUB_OUTPUT"
               echo "build_status=:x: $BUILD" >> "$GITHUB_OUTPUT"
               ;;
@@ -386,7 +405,7 @@ jobs:
                   - type: "mrkdwn"
                     text: "*Repository:*\n`${{ github.repository }}`"
                   - type: "mrkdwn"
-                    text: "*Version:*\n`${{ github.ref_name }}`"
+                    text: "*Version:*\n`${{ steps.meta.outputs.version }}`"
                   - type: "mrkdwn"
                     text: "*Triggered by:*\n${{ github.actor }}"
                   - type: "mrkdwn"
@@ -394,4 +413,4 @@ jobs:
                   - type: "mrkdwn"
                     text: "*Build:*\n${{ steps.meta.outputs.build_status }}"
                   - type: "mrkdwn"
-                    text: "*Release notes:*\n<https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}|${{ github.ref_name }}>"
+                    text: "*Release notes:*\n<https://github.com/${{ github.repository }}/releases/tag/${{ steps.meta.outputs.version_url }}|${{ steps.meta.outputs.version }}>"


### PR DESCRIPTION
Port of the fix reviewed on mondoohq/cnspec#3645 — it landed there but the same code merged here in #10767 without it.

## The problem

`github.ref_name` is interpolated raw into the Slack payload in two places:

```yaml
text: "*Version:*\n`${{ github.ref_name }}`"
text: "*Release notes:*\n<…/releases/tag/${{ github.ref_name }}|${{ github.ref_name }}>"
```

The payload is a **double-quoted YAML scalar**, and git ref names allow `"`. A tag carrying one doesn't render oddly — it terminates the scalar and fails the step. `&`, `<` and `>` are also legal in a ref name and are Slack markup.

Nothing validates the tag before this point, so there's no upstream guarantee to lean on. (installer has one — mondoohq/installer#776 fixes it at the source there instead, which is the better fix when a validated value is available.)

## The fix

Compose the value once, escaped for both parsers, plus a percent-encoded copy for the link target:

```bash
ref_safe=$REF_NAME
ref_safe=${ref_safe//\\/\\\\}      # YAML: cannot inject an escape
ref_safe=${ref_safe//\"/\\\"}      # YAML: cannot terminate the scalar
ref_safe=${ref_safe//&/&amp;}      # Slack markup
ref_safe=${ref_safe//</&lt;}
ref_safe=${ref_safe//>/&gt;}
ref_url=$(jq -rn --arg v "$REF_NAME" '$v|@uri')
```

Order matters: backslash before quote, or the escape gets doubled; `&` before `<`/`>`, or the entities do.

## Verified

Each round-tripped through a double-quoted YAML scalar:

| tag | `version` | `version_url` |
|---|---|---|
| `v14.0.0-rc.4` | `v14.0.0-rc.4` | `v14.0.0-rc.4` |
| `v13.38.1` | `v13.38.1` | `v13.38.1` |
| `v1.0.0&x` | `v1.0.0&amp;x` | `v1.0.0%26x` |
| `v1<b>0` | `v1&lt;b&gt;0` | `v1%3Cb%3E0` |
| `v1"q"0` | `v1\"q\"0` → parses back to `v1"q"0` | `v1%22q%220` |
| `v1\back` | `v1\\back` → parses back to `v1\back` | `v1%5Cback` |
| `release/v1` | `release/v1` | `release%2Fv1` |

Semver tags come out byte-identical, so nothing changes for a real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)